### PR TITLE
[PM-41874] refactor(crypto): move tools callers to @bitwarden/legacy-crypto

### DIFF
--- a/apps/cli/src/tools/send/commands/get.command.ts
+++ b/apps/cli/src/tools/send/commands/get.command.ts
@@ -6,13 +6,14 @@ import { firstValueFrom } from "rxjs";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SendView } from "@bitwarden/common/tools/send/models/view/send.view";
 import { SendService } from "@bitwarden/common/tools/send/services/send.service.abstraction";
 import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { isGuid } from "@bitwarden/guid";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService } from "@bitwarden/legacy-crypto";
 
 import { DownloadCommand } from "../../../commands/download.command";
 import { Response } from "../../../models/response";

--- a/apps/cli/src/tools/send/commands/receive.command.spec.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.spec.ts
@@ -5,8 +5,6 @@ import { of } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { SendTokenService, SendAccessToken } from "@bitwarden/common/auth/send-access";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { PRODUCTION_REGIONS } from "@bitwarden/common/platform/services/default-environment.service";
@@ -15,7 +13,11 @@ import { SendAccessResponse } from "@bitwarden/common/tools/send/models/response
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  CryptoFunctionService,
+  EncryptService,
+  LegacyCompatKeyService,
+} from "@bitwarden/legacy-crypto";
 
 import { Response } from "../../../models/response";
 

--- a/apps/cli/src/tools/send/commands/receive.command.ts
+++ b/apps/cli/src/tools/send/commands/receive.command.ts
@@ -20,20 +20,22 @@ import {
   GetSendAccessTokenError,
   SendAccessDomainCredentials,
 } from "@bitwarden/common/auth/send-access";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SendAccess } from "@bitwarden/common/tools/send/models/domain/send-access";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { AuthType } from "@bitwarden/common/tools/send/types/auth-type";
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  CryptoFunctionService,
+  EncArrayBuffer,
+  EncryptService,
+  LegacyCompatKeyService,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import { NodeUtils } from "@bitwarden/node/node-utils";
 
 import { DownloadCommand } from "../../../commands/download.command";

--- a/apps/web/src/app/tools/send/send-access/send-access-file.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-access-file.component.ts
@@ -5,15 +5,14 @@
 import { ChangeDetectionStrategy, Component, input } from "@angular/core";
 
 import { SendAccessToken } from "@bitwarden/common/auth/send-access";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SendAccessView } from "@bitwarden/common/tools/send/models/view/send-access.view";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
 import { ToastService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer, EncryptService, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { SharedModule } from "../../../shared";
 

--- a/apps/web/src/app/tools/send/send-access/send-auth.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-auth.component.ts
@@ -16,12 +16,13 @@ import {
   SendOtp,
   SendTokenService,
 } from "@bitwarden/common/auth/send-access";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { SEND_KDF_ITERATIONS } from "@bitwarden/common/tools/send/send-kdf";
 import { AuthType } from "@bitwarden/common/tools/send/types/auth-type";
 import { AnonLayoutWrapperDataService, ToastService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService } from "@bitwarden/legacy-crypto";
 
 import { SharedModule } from "../../../shared";
 

--- a/apps/web/src/app/tools/send/send-access/send-view.component.ts
+++ b/apps/web/src/app/tools/send/send-access/send-view.component.ts
@@ -14,7 +14,6 @@ import { SendAccessToken } from "@bitwarden/common/auth/send-access";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { SendAccess } from "@bitwarden/common/tools/send/models/domain/send-access";
 import { SendAccessView } from "@bitwarden/common/tools/send/models/view/send-access.view";
 import { SendApiService } from "@bitwarden/common/tools/send/services/send-api.service.abstraction";
@@ -25,7 +24,7 @@ import {
   ToastService,
 } from "@bitwarden/components";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { LegacyCompatKeyService, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { SharedModule } from "../../../shared";
 

--- a/libs/angular/src/tools/send/add-edit.component.ts
+++ b/libs/angular/src/tools/send/add-edit.component.ts
@@ -24,7 +24,6 @@ import { MessagingService } from "@bitwarden/common/platform/abstractions/messag
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { EncArrayBuffer } from "@bitwarden/common/platform/models/domain/enc-array-buffer";
 import { Send } from "@bitwarden/common/tools/send/models/domain/send";
 import { SendFileView } from "@bitwarden/common/tools/send/models/view/send-file.view";
 import { SendTextView } from "@bitwarden/common/tools/send/models/view/send-text.view";
@@ -34,6 +33,8 @@ import { SendService } from "@bitwarden/common/tools/send/services/send.service.
 import { SendType } from "@bitwarden/common/tools/send/types/send-type";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
 import { DialogService, ToastService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 import { SendPolicyService } from "@bitwarden/send-ui";
 
 // Value = hours

--- a/libs/common/src/models/export/bank-account.export.ts
+++ b/libs/common/src/models/export/bank-account.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { BankAccount as BankAccountDomain } from "../../vault/models/domain/bank-account";
 import { BankAccountView } from "../../vault/models/view/bank-account.view";
 

--- a/libs/common/src/models/export/card.export.ts
+++ b/libs/common/src/models/export/card.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { Card as CardDomain } from "../../vault/models/domain/card";
 import { CardView } from "../../vault/models/view/card.view";
 

--- a/libs/common/src/models/export/cipher.export.ts
+++ b/libs/common/src/models/export/cipher.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { CipherRepromptType } from "../../vault/enums/cipher-reprompt-type";
 import { CipherType } from "../../vault/enums/cipher-type";
 import { Cipher as CipherDomain } from "../../vault/models/domain/cipher";

--- a/libs/common/src/models/export/collection.export.ts
+++ b/libs/common/src/models/export/collection.export.ts
@@ -1,10 +1,12 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import {
   CollectionView,
   Collection as CollectionDomain,
 } from "../../admin-console/models/collections";
-import { EncString } from "../../key-management/crypto/models/enc-string";
 import { CollectionId, emptyGuid, OrganizationId } from "../../types/guid";
 
 import { safeGetString } from "./utils";

--- a/libs/common/src/models/export/drivers-license.export.ts
+++ b/libs/common/src/models/export/drivers-license.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { DriversLicense as DriversLicenseDomain } from "../../vault/models/domain/drivers-license";
 import { DriversLicenseView } from "../../vault/models/view/drivers-license.view";
 

--- a/libs/common/src/models/export/fido2-credential.export.ts
+++ b/libs/common/src/models/export/fido2-credential.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { Fido2Credential } from "../../vault/models/domain/fido2-credential";
 import { Fido2CredentialView } from "../../vault/models/view/fido2-credential.view";
 

--- a/libs/common/src/models/export/field.export.ts
+++ b/libs/common/src/models/export/field.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { FieldType, LinkedIdType } from "../../vault/enums";
 import { Field as FieldDomain } from "../../vault/models/domain/field";
 import { FieldView } from "../../vault/models/view/field.view";

--- a/libs/common/src/models/export/folder.export.ts
+++ b/libs/common/src/models/export/folder.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { Folder as FolderDomain } from "../../vault/models/domain/folder";
 import { FolderView } from "../../vault/models/view/folder.view";
 

--- a/libs/common/src/models/export/identity.export.ts
+++ b/libs/common/src/models/export/identity.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { Identity as IdentityDomain } from "../../vault/models/domain/identity";
 import { IdentityView } from "../../vault/models/view/identity.view";
 

--- a/libs/common/src/models/export/login-uri.export.ts
+++ b/libs/common/src/models/export/login-uri.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { UriMatchStrategySetting } from "../../models/domain/domain-service";
 import { LoginUri as LoginUriDomain } from "../../vault/models/domain/login-uri";
 import { LoginUriView } from "../../vault/models/view/login-uri.view";

--- a/libs/common/src/models/export/login.export.ts
+++ b/libs/common/src/models/export/login.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { Login as LoginDomain } from "../../vault/models/domain/login";
 import { LoginView } from "../../vault/models/view/login.view";
 

--- a/libs/common/src/models/export/passport.export.ts
+++ b/libs/common/src/models/export/passport.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { Passport as PassportDomain } from "../../vault/models/domain/passport";
 import { PassportView } from "../../vault/models/view/passport.view";
 

--- a/libs/common/src/models/export/password-history.export.ts
+++ b/libs/common/src/models/export/password-history.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { Password } from "../../vault/models/domain/password";
 import { PasswordHistoryView } from "../../vault/models/view/password-history.view";
 

--- a/libs/common/src/models/export/ssh-key.export.ts
+++ b/libs/common/src/models/export/ssh-key.export.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { SshKey as SshKeyDomain } from "../../vault/models/domain/ssh-key";
 import { SshKeyView as SshKeyView } from "../../vault/models/view/ssh-key.view";
 

--- a/libs/common/src/models/export/utils.ts
+++ b/libs/common/src/models/export/utils.ts
@@ -1,4 +1,5 @@
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
 
 export function safeGetString(value: string | EncString | undefined | null): string | undefined {
   if (value == null) {

--- a/libs/common/src/tools/cryptography/key-service-legacy-encryptor-provider.spec.ts
+++ b/libs/common/src/tools/cryptography/key-service-legacy-encryptor-provider.spec.ts
@@ -4,11 +4,10 @@ import { BehaviorSubject, Subject } from "rxjs";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { CsprngArray, EncryptService, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
-import { EncryptService } from "../../key-management/crypto/abstractions/encrypt.service";
 import { SdkService } from "../../platform/abstractions/sdk/sdk.service";
-import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
-import { CsprngArray } from "../../types/csprng";
 import { OrganizationId, UserId } from "../../types/guid";
 import { OrgKey } from "../../types/key";
 import { OrganizationBound, UserBound } from "../dependencies";

--- a/libs/common/src/tools/cryptography/key-service-legacy-encryptor-provider.ts
+++ b/libs/common/src/tools/cryptography/key-service-legacy-encryptor-provider.ts
@@ -15,8 +15,9 @@ import {
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService } from "@bitwarden/legacy-crypto";
 
-import { EncryptService } from "../../key-management/crypto/abstractions/encrypt.service";
 import { SdkService } from "../../platform/abstractions/sdk/sdk.service";
 import { OrganizationId } from "../../types/guid";
 import {

--- a/libs/common/src/tools/cryptography/organization-encryptor.abstraction.ts
+++ b/libs/common/src/tools/cryptography/organization-encryptor.abstraction.ts
@@ -2,7 +2,9 @@
 // @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { OrganizationId } from "../../types/guid";
 
 /** An encryption strategy that protects a type's secrets with

--- a/libs/common/src/tools/cryptography/organization-key-encryptor.spec.ts
+++ b/libs/common/src/tools/cryptography/organization-key-encryptor.spec.ts
@@ -1,9 +1,13 @@
 import { mock } from "jest-mock-extended";
 
-import { EncryptService } from "../../key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "../../key-management/crypto/models/enc-string";
-import { SymmetricCryptoKey } from "../../platform/models/domain/symmetric-crypto-key";
-import { CsprngArray } from "../../types/csprng";
+// eslint-disable-next-line no-restricted-imports
+import {
+  CsprngArray,
+  EncryptService,
+  EncString,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
+
 import { OrganizationId } from "../../types/guid";
 import { OrgKey } from "../../types/key";
 import { DataPacker } from "../state/data-packer.abstraction";

--- a/libs/common/src/tools/cryptography/organization-key-encryptor.ts
+++ b/libs/common/src/tools/cryptography/organization-key-encryptor.ts
@@ -2,8 +2,9 @@
 // @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
-import { EncryptService } from "../../key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, EncString } from "@bitwarden/legacy-crypto";
+
 import { OrganizationId } from "../../types/guid";
 import { OrgKey } from "../../types/key";
 import { DataPacker } from "../state/data-packer.abstraction";

--- a/libs/common/src/tools/cryptography/user-encryptor.abstraction.ts
+++ b/libs/common/src/tools/cryptography/user-encryptor.abstraction.ts
@@ -2,7 +2,9 @@
 // @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { UserId } from "../../types/guid";
 
 /** An encryption strategy that protects a type's secrets with

--- a/libs/common/src/tools/cryptography/user-key-encryptor.spec.ts
+++ b/libs/common/src/tools/cryptography/user-key-encryptor.spec.ts
@@ -1,8 +1,10 @@
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { makeEncString } from "../../../spec";
-import { EncString } from "../../key-management/crypto/models/enc-string";
 import { SdkService } from "../../platform/abstractions/sdk/sdk.service";
 import { UserId } from "../../types/guid";
 import { DataPacker } from "../state/data-packer.abstraction";

--- a/libs/common/src/tools/cryptography/user-key-encryptor.ts
+++ b/libs/common/src/tools/cryptography/user-key-encryptor.ts
@@ -3,7 +3,9 @@
 import { firstValueFrom, map } from "rxjs";
 import { Jsonify } from "type-fest";
 
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { SdkService } from "../../platform/abstractions/sdk/sdk.service";
 import { UserId } from "../../types/guid";
 import { DataPacker } from "../state/data-packer.abstraction";

--- a/libs/common/src/tools/send/models/domain/send-access.ts
+++ b/libs/common/src/tools/send/models/domain/send-access.ts
@@ -1,8 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { EncString } from "../../../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+
 import Domain from "../../../../platform/models/domain/domain-base";
-import { SymmetricCryptoKey } from "../../../../platform/models/domain/symmetric-crypto-key";
 import { SendType } from "../../types/send-type";
 import { SendAccessResponse } from "../response/send-access.response";
 import { SendAccessView } from "../view/send-access.view";

--- a/libs/common/src/tools/send/models/domain/send-file.ts
+++ b/libs/common/src/tools/send/models/domain/send-file.ts
@@ -2,11 +2,11 @@
 // @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncString, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { SendFile as SdkSendFile } from "@bitwarden/sdk-internal";
 
-import { EncString } from "../../../../key-management/crypto/models/enc-string";
 import Domain from "../../../../platform/models/domain/domain-base";
-import { SymmetricCryptoKey } from "../../../../platform/models/domain/symmetric-crypto-key";
 import { SendFileData } from "../data/send-file.data";
 import { SendFileView } from "../view/send-file.view";
 

--- a/libs/common/src/tools/send/models/domain/send-text.ts
+++ b/libs/common/src/tools/send/models/domain/send-text.ts
@@ -2,11 +2,11 @@
 // @ts-strict-ignore
 import { Jsonify } from "type-fest";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncString, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { SendText as SdkSendText } from "@bitwarden/sdk-internal";
 
-import { EncString } from "../../../../key-management/crypto/models/enc-string";
 import Domain from "../../../../platform/models/domain/domain-base";
-import { SymmetricCryptoKey } from "../../../../platform/models/domain/symmetric-crypto-key";
 import { SendTextData } from "../data/send-text.data";
 import { SendTextView } from "../view/send-text.view";
 

--- a/libs/common/src/tools/send/models/domain/send.spec.ts
+++ b/libs/common/src/tools/send/models/domain/send.spec.ts
@@ -5,11 +5,13 @@ import { of } from "rxjs";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  EncryptService,
+  LegacyCompatKeyService,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 
 import { makeStaticByteArray, mockContainerService, mockEnc } from "../../../../../spec";
-import { EncryptService } from "../../../../key-management/crypto/abstractions/encrypt.service";
-import { SymmetricCryptoKey } from "../../../../platform/models/domain/symmetric-crypto-key";
 import { ContainerService } from "../../../../platform/services/container.service";
 import { emptyGuid, UserId } from "../../../../types/guid";
 import { UserKey } from "../../../../types/key";

--- a/libs/common/src/tools/send/models/domain/send.ts
+++ b/libs/common/src/tools/send/models/domain/send.ts
@@ -3,6 +3,8 @@
 import { firstValueFrom } from "rxjs";
 import { Jsonify } from "type-fest";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
 import {
   AuthType as SdkAuthType,
   Send as SdkSend,
@@ -10,7 +12,6 @@ import {
   SendType as SdkSendType,
 } from "@bitwarden/sdk-internal";
 
-import { EncString } from "../../../../key-management/crypto/models/enc-string";
 import { asUuid, uuidAsString } from "../../../../platform/abstractions/sdk/sdk.service";
 import { Utils } from "../../../../platform/misc/utils";
 import Domain from "../../../../platform/models/domain/domain-base";

--- a/libs/common/src/tools/send/models/request/send.request.spec.ts
+++ b/libs/common/src/tools/send/models/request/send.request.spec.ts
@@ -1,4 +1,6 @@
-import { EncString } from "../../../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { SendType } from "../../types/send-type";
 import { Send } from "../domain/send";
 import { SendText } from "../domain/send-text";

--- a/libs/common/src/tools/send/models/view/send.view.ts
+++ b/libs/common/src/tools/send/models/view/send.view.ts
@@ -1,8 +1,10 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+
 import { View } from "../../../../models/view/view";
 import { Utils } from "../../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../../platform/models/domain/symmetric-crypto-key";
 import { DeepJsonify } from "../../../../types/deep-jsonify";
 import { AuthType } from "../../types/auth-type";
 import { SendType } from "../../types/send-type";

--- a/libs/common/src/tools/send/services/send-api-service.selector.spec.ts
+++ b/libs/common/src/tools/send/services/send-api-service.selector.spec.ts
@@ -1,10 +1,12 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { SendAccessToken } from "../../../auth/send-access";
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
 import { SendAccessView } from "../models/view/send-access.view";
 import { AuthType } from "../types/auth-type";

--- a/libs/common/src/tools/send/services/send-api-service.selector.ts
+++ b/libs/common/src/tools/send/services/send-api-service.selector.ts
@@ -1,10 +1,12 @@
 import { Observable, firstValueFrom, map, shareReplay } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { SendAccessToken } from "../../../auth/send-access";
 import { FeatureFlag } from "../../../enums/feature-flag.enum";
 import { ListResponse } from "../../../models/response/list.response";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
 import { SendAccessResponse } from "../models/response/send-access.response";
 import { SendFileDownloadDataResponse } from "../models/response/send-file-download-data.response";

--- a/libs/common/src/tools/send/services/send-api.service.abstraction.ts
+++ b/libs/common/src/tools/send/services/send-api.service.abstraction.ts
@@ -1,6 +1,8 @@
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { SendAccessToken } from "../../../auth/send-access";
 import { ListResponse } from "../../../models/response/list.response";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { Send } from "../models/domain/send";
 import { SendAccessResponse } from "../models/response/send-access.response";
 import { SendFileDownloadDataResponse } from "../models/response/send-file-download-data.response";

--- a/libs/common/src/tools/send/services/send-api.service.ts
+++ b/libs/common/src/tools/send/services/send-api.service.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
+
 import { ApiService } from "../../../abstractions/api.service";
 import { SendAccessToken } from "../../../auth/send-access";
 import { ErrorResponse } from "../../../models/response/error.response";
@@ -6,7 +9,6 @@ import {
   FileUploadApiMethods,
   FileUploadService,
 } from "../../../platform/abstractions/file-upload/file-upload.service";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { SendData } from "../models/data/send.data";
 import { Send } from "../models/domain/send";
 import { SendRequest } from "../models/request/send.request";

--- a/libs/common/src/tools/send/services/send-sdk-api.service.spec.ts
+++ b/libs/common/src/tools/send/services/send-sdk-api.service.spec.ts
@@ -1,6 +1,8 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 import {
   AuthEdit,
   SendAddRequest,
@@ -14,7 +16,6 @@ import { AccountService } from "../../../auth/abstractions/account.service";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
 import { Utils } from "../../../platform/misc/utils";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { UserId } from "../../../types/guid";
 import { Send } from "../models/domain/send";
 import { SendResponse } from "../models/response/send.response";

--- a/libs/common/src/tools/send/services/send-sdk-api.service.ts
+++ b/libs/common/src/tools/send/services/send-sdk-api.service.ts
@@ -1,5 +1,7 @@
 import { catchError, firstValueFrom, switchMap } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer } from "@bitwarden/legacy-crypto";
 import {
   AuthEdit,
   PasswordManagerClient,
@@ -17,7 +19,6 @@ import { getUserId } from "../../../auth/services/account.service";
 import { ListResponse } from "../../../models/response/list.response";
 import { LogService } from "../../../platform/abstractions/log.service";
 import { SdkService, asUuid } from "../../../platform/abstractions/sdk/sdk.service";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
 import { UserId } from "../../../types/guid";
 import { SendData } from "../models/data/send.data";
 import { Send } from "../models/domain/send";

--- a/libs/common/src/tools/send/services/send.service.abstraction.ts
+++ b/libs/common/src/tools/send/services/send.service.abstraction.ts
@@ -3,9 +3,9 @@ import { Observable } from "rxjs";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
 import { UserKeyRotationDataProvider } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncArrayBuffer, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";
 import { SendData } from "../models/data/send.data";

--- a/libs/common/src/tools/send/services/send.service.spec.ts
+++ b/libs/common/src/tools/send/services/send.service.spec.ts
@@ -5,7 +5,13 @@ import { firstValueFrom, of } from "rxjs";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
-import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import {
+  EncryptService,
+  EncString,
+  KeyGenerationService,
+  LegacyCompatKeyService,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 
 import {
   FakeAccountService,
@@ -15,14 +21,10 @@ import {
   mockAccountServiceWith,
   mockAccountInfoWith,
 } from "../../../../spec";
-import { KeyGenerationService } from "../../../key-management/crypto";
-import { EncryptService } from "../../../key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "../../../key-management/crypto/models/enc-string";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { EnvironmentService } from "../../../platform/abstractions/environment.service";
 import { I18nService } from "../../../platform/abstractions/i18n.service";
 import { Utils } from "../../../platform/misc/utils";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { ContainerService } from "../../../platform/services/container.service";
 import { SelfHostedEnvironment } from "../../../platform/services/default-environment.service";
 import { UserId } from "../../../types/guid";

--- a/libs/common/src/tools/send/services/send.service.ts
+++ b/libs/common/src/tools/send/services/send.service.ts
@@ -4,17 +4,21 @@ import { Observable, concatMap, distinctUntilChanged, firstValueFrom, map } from
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { PBKDF2KdfConfig, KeyService } from "@bitwarden/key-management";
+import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import {
+  EncArrayBuffer,
+  EncryptService,
+  EncString,
+  KeyGenerationService,
+  PBKDF2KdfConfig,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
-import { KeyGenerationService } from "../../../key-management/crypto";
-import { EncryptService } from "../../../key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "../../../key-management/crypto/models/enc-string";
 import { ConfigService } from "../../../platform/abstractions/config/config.service";
 import { I18nService } from "../../../platform/abstractions/i18n.service";
 import { Utils } from "../../../platform/misc/utils";
-import { EncArrayBuffer } from "../../../platform/models/domain/enc-array-buffer";
-import { SymmetricCryptoKey } from "../../../platform/models/domain/symmetric-crypto-key";
 import { UserId } from "../../../types/guid";
 import { UserKey } from "../../../types/key";
 import { SendData } from "../models/data/send.data";

--- a/libs/common/src/tools/send/services/test-data/send-tests.data.ts
+++ b/libs/common/src/tools/send/services/test-data/send-tests.data.ts
@@ -1,6 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { EncString } from "../../../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { SendTextApi } from "../../models/api/send-text.api";
 import { SendTextData } from "../../models/data/send-text.data";
 import { SendData } from "../../models/data/send.data";

--- a/libs/common/src/tools/state/secret-state.spec.ts
+++ b/libs/common/src/tools/state/secret-state.spec.ts
@@ -2,13 +2,15 @@ import { mock } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom, from, Observable } from "rxjs";
 import { Jsonify } from "type-fest";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import {
   FakeStateProvider,
   makeEncString,
   mockAccountServiceWith,
   awaitAsync,
 } from "../../../spec";
-import { EncString } from "../../key-management/crypto/models/enc-string";
 import { GENERATOR_DISK } from "../../platform/state";
 import { UserId } from "../../types/guid";
 import { UserEncryptor } from "../cryptography/user-encryptor.abstraction";

--- a/libs/common/src/tools/state/secret-state.ts
+++ b/libs/common/src/tools/state/secret-state.ts
@@ -2,7 +2,9 @@
 // @ts-strict-ignore
 import { Observable, map, concatMap, share, ReplaySubject, timer, combineLatest, of } from "rxjs";
 
-import { EncString } from "../../key-management/crypto/models/enc-string";
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import {
   SingleUserState,
   StateProvider,

--- a/libs/common/src/tools/state/user-state-subject.ts
+++ b/libs/common/src/tools/state/user-state-subject.ts
@@ -29,8 +29,10 @@ import {
   switchMap,
 } from "rxjs";
 
+// eslint-disable-next-line no-restricted-imports
+import { EncString } from "@bitwarden/legacy-crypto";
+
 import { Account } from "../../auth/abstractions/account.service";
-import { EncString } from "../../key-management/crypto/models/enc-string";
 import { SingleUserState, UserKeyDefinition } from "../../platform/state";
 import { UserEncryptor } from "../cryptography/user-encryptor.abstraction";
 import { SemanticLogger } from "../log";

--- a/libs/importer/src/components/importer-providers.ts
+++ b/libs/importer/src/components/importer-providers.ts
@@ -7,8 +7,6 @@ import { safeProvider, SafeProvider } from "@bitwarden/angular/platform/utils/sa
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -26,6 +24,8 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, KeyGenerationService } from "@bitwarden/legacy-crypto";
 import { StateProvider } from "@bitwarden/state";
 import { SafeInjectionToken } from "@bitwarden/ui-common";
 

--- a/libs/importer/src/components/lastpass/lastpass-direct-import.service.spec.ts
+++ b/libs/importer/src/components/lastpass/lastpass-direct-import.service.spec.ts
@@ -4,7 +4,6 @@ import * as oauth from "oauth4webapi";
 import { of } from "rxjs";
 
 import { ClientType } from "@bitwarden/common/enums";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { AppIdService } from "@bitwarden/common/platform/abstractions/app-id.service";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
 import {
@@ -14,6 +13,8 @@ import {
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { DialogService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import { LastPassDirectImportUIService } from "./lastpass-direct-import-ui.service";

--- a/libs/importer/src/components/lastpass/lastpass-direct-import.service.ts
+++ b/libs/importer/src/components/lastpass/lastpass-direct-import.service.ts
@@ -5,7 +5,6 @@ import * as oauth from "oauth4webapi";
 import { Subject, firstValueFrom } from "rxjs";
 
 import { ClientType } from "@bitwarden/common/enums";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { AppIdService } from "@bitwarden/common/platform/abstractions/app-id.service";
 import { BroadcasterService } from "@bitwarden/common/platform/abstractions/broadcaster.service";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
@@ -13,6 +12,8 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { DialogService } from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 
 import { ClientInfo, Vault } from "../../importers/lastpass/access";

--- a/libs/importer/src/importers/bitwarden/bitwarden-encrypted-json-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-encrypted-json-importer.ts
@@ -4,8 +4,6 @@ import { filter, firstValueFrom } from "rxjs";
 
 import { Collection } from "@bitwarden/common/admin-console/models/collections";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import {
   CipherWithIdExport,
   CollectionWithIdExport,
@@ -16,6 +14,8 @@ import { OrgKey, UserKey } from "@bitwarden/common/types/key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, EncString } from "@bitwarden/legacy-crypto";
 import { UserId } from "@bitwarden/user-core";
 import {
   BitwardenEncryptedIndividualJsonExport,

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.spec.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.spec.ts
@@ -2,15 +2,15 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
 import { emptyGuid, OrganizationId } from "@bitwarden/common/types/guid";
 import { OrgKey, UserKey } from "@bitwarden/common/types/key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { KdfType, KeyService } from "@bitwarden/key-management";
+import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, KdfType, KeyGenerationService } from "@bitwarden/legacy-crypto";
 import { UserId } from "@bitwarden/user-core";
 
 import { emptyAccountEncrypted } from "../spec-data/bitwarden-json/account-encrypted.json";

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
@@ -1,19 +1,20 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
 import {
   Argon2KdfConfig,
+  EncryptService,
+  EncString,
   KdfConfig,
-  PBKDF2KdfConfig,
-  KeyService,
   KdfType,
-} from "@bitwarden/key-management";
+  KeyGenerationService,
+  PBKDF2KdfConfig,
+  SymmetricCryptoKey,
+} from "@bitwarden/legacy-crypto";
 import {
   BitwardenJsonExport,
   BitwardenPasswordProtectedFileFormat,

--- a/libs/importer/src/importers/lastpass/access/services/crypto-utils.ts
+++ b/libs/importer/src/importers/lastpass/access/services/crypto-utils.ts
@@ -1,9 +1,10 @@
-import {
-  DANGEROUS_aesEcbDecryptLastpassImport,
-  DANGEROUS_aesCbcDecryptLastpassImport,
-} from "@bitwarden/common/key-management/crypto";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+// eslint-disable-next-line no-restricted-imports
+import {
+  CryptoFunctionService,
+  DANGEROUS_aesCbcDecryptLastpassImport,
+  DANGEROUS_aesEcbDecryptLastpassImport,
+} from "@bitwarden/legacy-crypto";
 
 export class CryptoUtils {
   constructor(private cryptoFunctionService: CryptoFunctionService) {}

--- a/libs/importer/src/importers/lastpass/access/services/parser.ts
+++ b/libs/importer/src/importers/lastpass/access/services/parser.ts
@@ -1,7 +1,8 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService } from "@bitwarden/legacy-crypto";
 
 import { Account, Chunk, ParserOptions, SharedFolder } from "../models";
 

--- a/libs/importer/src/importers/lastpass/access/vault.ts
+++ b/libs/importer/src/importers/lastpass/access/vault.ts
@@ -4,8 +4,9 @@ import * as papa from "papaparse";
 
 import { decodeJwtTokenToJson } from "@bitwarden/auth/common";
 import { HttpStatusCode } from "@bitwarden/common/enums";
-import { CryptoFunctionService } from "@bitwarden/common/key-management/crypto/abstractions/crypto-function.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
+// eslint-disable-next-line no-restricted-imports
+import { CryptoFunctionService } from "@bitwarden/legacy-crypto";
 
 import { IdpProvider } from "./enums";
 import {

--- a/libs/importer/src/services/import.service.spec.ts
+++ b/libs/importer/src/services/import.service.spec.ts
@@ -14,9 +14,6 @@ import {
   CollectionTypes,
 } from "@bitwarden/common/admin-console/models/collections";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import { EncString } from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -30,6 +27,8 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, EncString, KeyGenerationService } from "@bitwarden/legacy-crypto";
 
 import { BitwardenPasswordProtectedImporter } from "../importers";
 import { Importer } from "../importers/importer";

--- a/libs/importer/src/services/import.service.ts
+++ b/libs/importer/src/services/import.service.ts
@@ -11,8 +11,6 @@ import {
 } from "@bitwarden/common/admin-console/models/collections";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { ImportCiphersRequest } from "@bitwarden/common/models/request/import-ciphers.request";
 import { ImportOrganizationCiphersRequest } from "@bitwarden/common/models/request/import-organization-ciphers.request";
 import { KvpRequest } from "@bitwarden/common/models/request/kvp.request";
@@ -31,6 +29,8 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, KeyGenerationService } from "@bitwarden/legacy-crypto";
 
 import {
   ArcCsvImporter,

--- a/libs/tools/export-vault-core/src/services/base-vault-export.service.ts
+++ b/libs/tools/export-vault-core/src/services/base-vault-export.service.ts
@@ -1,13 +1,13 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-import { KdfConfig, KdfConfigService, KdfType } from "@bitwarden/key-management";
+import { KdfConfigService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, KdfConfig, KdfType, KeyGenerationService } from "@bitwarden/legacy-crypto";
 import { SdkRandomNumberClient } from "@bitwarden/sdk-internal";
 
 import { BitwardenCsvExportType, BitwardenPasswordProtectedFileFormat } from "../types";

--- a/libs/tools/export-vault-core/src/services/individual-vault-export.service.spec.ts
+++ b/libs/tools/export-vault-core/src/services/individual-vault-export.service.spec.ts
@@ -3,12 +3,6 @@ import * as JSZip from "jszip";
 import { BehaviorSubject, of } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
-import {
-  EncryptedString,
-  EncString,
-} from "@bitwarden/common/key-management/crypto/models/enc-string";
 import { CipherWithIdExport } from "@bitwarden/common/models/export/cipher-with-ids.export";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
@@ -33,13 +27,17 @@ import {
   RestrictedCipherType,
   RestrictedItemTypesService,
 } from "@bitwarden/common/vault/services/restricted-item-types.service";
+import { KdfConfigService, KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
 import {
   DEFAULT_KDF_CONFIG,
-  PBKDF2KdfConfig,
-  KdfConfigService,
-  KeyService,
+  EncryptedString,
+  EncryptService,
+  EncString,
   KdfType,
-} from "@bitwarden/key-management";
+  KeyGenerationService,
+  PBKDF2KdfConfig,
+} from "@bitwarden/legacy-crypto";
 import { SdkRandomNumberClient } from "@bitwarden/sdk-internal";
 
 import {

--- a/libs/tools/export-vault-core/src/services/individual-vault-export.service.ts
+++ b/libs/tools/export-vault-core/src/services/individual-vault-export.service.ts
@@ -5,8 +5,6 @@ import * as papa from "papaparse";
 import { firstValueFrom } from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { CipherWithIdExport, FolderWithIdExport } from "@bitwarden/common/models/export";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
@@ -20,6 +18,8 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { KdfConfigService, KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, KeyGenerationService } from "@bitwarden/legacy-crypto";
 
 import {
   BitwardenCsvIndividualExportType,

--- a/libs/tools/export-vault-core/src/services/org-vault-export.service.ts
+++ b/libs/tools/export-vault-core/src/services/org-vault-export.service.ts
@@ -10,11 +10,8 @@ import {
   Collection,
   CollectionData,
 } from "@bitwarden/common/admin-console/models/collections";
-import { KeyGenerationService } from "@bitwarden/common/key-management/crypto";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { CipherWithIdExport, CollectionWithIdExport } from "@bitwarden/common/models/export";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
-import { SymmetricCryptoKey } from "@bitwarden/common/platform/models/domain/symmetric-crypto-key";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
@@ -24,6 +21,8 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { newGuid } from "@bitwarden/guid";
 import { KdfConfigService, KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService, KeyGenerationService, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import {
   BitwardenCsvOrgExportType,

--- a/libs/tools/generator/components/src/generator-services.module.ts
+++ b/libs/tools/generator/components/src/generator-services.module.ts
@@ -6,7 +6,6 @@ import { safeProvider } from "@bitwarden/angular/platform/utils/safe-provider";
 import { SafeInjectionToken } from "@bitwarden/angular/services/injection-tokens";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -38,6 +37,8 @@ import {
   DefaultCredentialGeneratorService,
 } from "@bitwarden/generator-core";
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService } from "@bitwarden/legacy-crypto";
 
 export const RANDOMIZER = new SafeInjectionToken<Randomizer>("Randomizer");
 const GENERATOR_SERVICE_PROVIDER = new SafeInjectionToken<providers.CredentialGeneratorProviders>(


### PR DESCRIPTION
move callers for tools from the barrel-re-export to the legacy-crypto module directly. The re-exports will be removed in a follow-up PR.

Ticket: https://bitwarden.atlassian.net/browse/PM-41874
