### PR TITLE
[PM-41854] fix: skip collections coachmark step for users without collections

### DIFF
--- a/apps/web/src/app/vault/components/coachmark/coachmark-step.ts
+++ b/apps/web/src/app/vault/components/coachmark/coachmark-step.ts
@@ -29,6 +29,9 @@ export interface CoachmarkStep {
   /** Whether this step is only shown to organizational users */
   requiresOrganization?: boolean;
 
+  /** Whether this step is only shown to users with at least one collection */
+  requiresCollections?: boolean;
+
   /** Route to navigate to before showing this step */
   route?: string;
 }
@@ -59,6 +62,7 @@ export const COACHMARK_STEPS: CoachmarkStep[] = [
     position: "right-center",
     learnMoreUrl: "https://bitwarden.com/help/about-collections/",
     requiresOrganization: true,
+    requiresCollections: true,
     route: "/vault",
   },
   {

--- a/apps/web/src/app/vault/components/coachmark/coachmark.service.spec.ts
+++ b/apps/web/src/app/vault/components/coachmark/coachmark.service.spec.ts
@@ -2,7 +2,9 @@ import { TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { BehaviorSubject, of } from "rxjs";
 
+import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -23,6 +25,7 @@ describe("CoachmarkService", () => {
   const setUserState = jest.fn().mockResolvedValue(undefined);
   const navigate = jest.fn().mockResolvedValue(true);
   const hasOrganizations = jest.fn().mockReturnValue(of(false));
+  const decryptedCollections$ = jest.fn().mockReturnValue(of([{} as CollectionView]));
   const t = jest.fn((key: string) => key);
   const vfo1Enabled = jest.fn().mockReturnValue(false);
 
@@ -40,6 +43,7 @@ describe("CoachmarkService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     vfo1Enabled.mockReturnValue(false);
+    decryptedCollections$.mockReturnValue(of([{} as CollectionView]));
 
     activeAccount$ = new BehaviorSubject<Account | null>(createAccount());
     serverSettings$ = new BehaviorSubject<ServerSettings | null>(new ServerSettings());
@@ -54,6 +58,7 @@ describe("CoachmarkService", () => {
         { provide: Router, useValue: { navigate } },
         { provide: ConfigService, useValue: { serverSettings$: serverSettings$.asObservable() } },
         { provide: Vfo1TerminologyService, useValue: { enabled: vfo1Enabled } },
+        { provide: CollectionService, useValue: { decryptedCollections$ } },
       ],
     });
 
@@ -192,11 +197,23 @@ describe("CoachmarkService", () => {
     it("should include org-only steps for org users", fakeAsync(() => {
       getUserState$.mockReturnValue(of(false));
       hasOrganizations.mockReturnValue(of(true));
+      decryptedCollections$.mockReturnValue(of([{} as CollectionView]));
 
       void service.startTour();
       tick(200);
 
       expect(service.totalSteps()).toBe(4);
+    }));
+
+    it("should exclude collection-only steps for org users without collections", fakeAsync(() => {
+      getUserState$.mockReturnValue(of(false));
+      hasOrganizations.mockReturnValue(of(true));
+      decryptedCollections$.mockReturnValue(of([]));
+
+      void service.startTour();
+      tick(200);
+
+      expect(service.totalSteps()).toBe(3);
     }));
 
     it("should exclude org-only steps for non-org users", fakeAsync(() => {

--- a/apps/web/src/app/vault/components/coachmark/coachmark.service.ts
+++ b/apps/web/src/app/vault/components/coachmark/coachmark.service.ts
@@ -3,6 +3,7 @@ import { Router } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 import { map } from "rxjs/operators";
 
+import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -45,7 +46,7 @@ export class CoachmarkService {
   /** Whether the tour is currently running */
   readonly isRunning = computed(() => this.activeStepId() !== null);
 
-  /** The applicable steps for the current user (filtered by organization membership) */
+  /** The applicable steps for the current user (filtered by organization membership and collection access) */
   private readonly applicableSteps = signal<CoachmarkStep[]>([]);
 
   constructor(
@@ -56,6 +57,7 @@ export class CoachmarkService {
     private router: Router,
     private configService: ConfigService,
     private vfo1TerminologyService: Vfo1TerminologyService,
+    private collectionService: CollectionService,
   ) {}
 
   /**
@@ -113,7 +115,8 @@ export class CoachmarkService {
 
   /**
    * Starts the coachmark tour if it hasn't been completed yet.
-   * The tour will display steps based on user type (org vs non-org).
+   * The tour will display steps the user can reach, based on organization membership
+   * and whether they have any collections.
    */
   async startTour(): Promise<void> {
     if (this.isRunning()) {
@@ -140,11 +143,20 @@ export class CoachmarkService {
       return;
     }
 
-    const hasOrganizations = await firstValueFrom(
-      this.organizationService.hasOrganizations(account.id),
-    );
+    const [hasOrganizations, hasCollections] = await Promise.all([
+      firstValueFrom(this.organizationService.hasOrganizations(account.id)),
+      firstValueFrom(
+        this.collectionService
+          .decryptedCollections$(account.id)
+          .pipe(map((collections) => collections.length > 0)),
+      ),
+    ]);
 
-    const steps = COACHMARK_STEPS.filter((step) => !step.requiresOrganization || hasOrganizations);
+    const steps = COACHMARK_STEPS.filter(
+      (step) =>
+        (!step.requiresOrganization || hasOrganizations) &&
+        (!step.requiresCollections || hasCollections),
+    );
 
     if (steps.length === 0) {
       return;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41854

## 📔 Objective

The new-user coachmark tour silently ended after step 2 for an organization member with no collections.

Step 3 (`shareWithCollections`) anchors to the collections section header, which only renders when the user has at least one collection. `startTour()` filtered steps only on `requiresOrganization`, so the step stayed in the list while its anchor never rendered — the tour sat on an invisible step 3 and step 4 was unreachable.

This adds a `requiresCollections` flag to `CoachmarkStep`, mirroring `requiresOrganization`. Filtering up front keeps the "Step X of Y" indicator accurate.


## 📸 Screenshots

https://github.com/user-attachments/assets/e6486504-4b7e-464d-8f45-32a004fffa0f

