### PR TITLE
[PM-36628] Browser: Add clean state to Health at risk category detail view

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -7773,5 +7773,17 @@
         "example": "6"
       }
     }
+  },
+  "exposedPasswordsEmpty": {
+    "message": "None of your passwords were found in data breaches."
+  },  
+  "weakPasswordsEmpty": {
+    "message": "All of your passwords are strong."
+  },
+  "reusedPasswordsEmpty": {
+    "message": "All of your passwords are unique."
+  },
+  "youreAllSet": {
+    "message": "You're all set!"
   }
 }

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
@@ -72,5 +72,14 @@
         }
       }
     </bit-section>
+  } @else {
+    <div class="tw-flex tw-flex-col tw-justify-center tw-h-full tw-items-center">
+      <bit-no-items [icon]="emptyIcon()" class="tw-text-main">
+        <ng-container slot="title">{{ "youreAllSet" | i18n }}</ng-container>
+        <ng-container slot="description">
+          <p bitTypography="body2" class="tw-mx-6 tw-mt-2">{{ contentKeys().emptyKey | i18n }}</p>
+        </ng-container>
+      </bit-no-items>
+    </div>
   }
 </popup-page>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.html
@@ -74,10 +74,10 @@
     </bit-section>
   } @else {
     <div class="tw-flex tw-flex-col tw-justify-center tw-h-full tw-items-center">
-      <bit-no-items [icon]="emptyIcon()" class="tw-text-main">
+      <bit-no-items [icon]="contentKeys?.emptyIcon" class="tw-text-main">
         <ng-container slot="title">{{ "youreAllSet" | i18n }}</ng-container>
         <ng-container slot="description">
-          <p bitTypography="body2" class="tw-mx-6 tw-mt-2">{{ contentKeys().emptyKey | i18n }}</p>
+          <p bitTypography="body2" class="tw-mx-6 tw-mt-2">{{ contentKeys?.emptyKey | i18n }}</p>
         </ng-container>
       </bit-no-items>
     </div>

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
@@ -204,6 +204,10 @@ describe("HealthRiskCategoryDetailComponent", () => {
     return rows()[index].querySelector("button[bit-item-content]")!;
   }
 
+  function noItems(): HTMLElement | null {
+    return fixture.nativeElement.querySelector("bit-no-items");
+  }
+
   /** The row's change password CTA, or `undefined` when the row does not render one. */
   function changePasswordButton(index: number): HTMLButtonElement | undefined {
     return Array.from(
@@ -516,6 +520,38 @@ describe("HealthRiskCategoryDetailComponent", () => {
       await fixture.whenStable();
 
       expect(router.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("empty state", () => {
+    beforeEach(() => {
+      setReport(RiskCategory.Exposed, []);
+    });
+
+    it.each(categories.map((c) => [c.category, c.icon] as const))(
+      "renders the %s empty state icon",
+      async (category, icon) => {
+        params$.next({ category });
+
+        await initComponent();
+
+        expect(noItems()).not.toBeNull();
+        expect(noItemsIcon()).toBe(icon);
+      },
+    );
+
+    it("renders the shared empty state title", async () => {
+      await initComponent();
+
+      expect(text()).toContain("youreAllSet");
+    });
+
+    it("replaces the item list and count with the empty state", async () => {
+      await initComponent();
+
+      expect(rows()).toHaveLength(0);
+      expect(itemCount()).toBeUndefined();
+      expect(text()).not.toContain("exposedPasswordsDescription");
     });
   });
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
@@ -565,7 +565,6 @@ describe("HealthRiskCategoryDetailComponent", () => {
 
         await initComponent();
 
-        expect(noItems()).not.toBeNull();
         expect(noItemsIcon()).toBe(icon);
       },
     );

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.spec.ts
@@ -6,6 +6,12 @@ import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
 import { IconComponent as AppVaultIconComponent } from "@bitwarden/angular/vault/components/icon.component";
+import {
+  BitSvg,
+  ReportExposedPasswords,
+  UnlockedIcon,
+  NoCredentialsIcon,
+} from "@bitwarden/assets/svg";
 import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
 import {
   RiskCategory,
@@ -97,16 +103,22 @@ const categories = [
     category: RiskCategory.Exposed,
     titleKey: "exposedPasswordsTitle",
     descriptionKey: "exposedPasswordsDescription",
+    emptyKey: "exposedPasswordsEmpty",
+    icon: ReportExposedPasswords,
   },
   {
     category: RiskCategory.Weak,
     titleKey: "weakPasswordsTitle",
     descriptionKey: "weakPasswordsDescription",
+    emptyKey: "weakPasswordsEmpty",
+    icon: UnlockedIcon,
   },
   {
     category: RiskCategory.Reused,
     titleKey: "reusedPasswordsTitle",
     descriptionKey: "reusedPasswordsDescription",
+    emptyKey: "reusedPasswordsEmpty",
+    icon: NoCredentialsIcon,
   },
 ] as const;
 
@@ -204,8 +216,9 @@ describe("HealthRiskCategoryDetailComponent", () => {
     return rows()[index].querySelector("button[bit-item-content]")!;
   }
 
-  function noItems(): HTMLElement | null {
-    return fixture.nativeElement.querySelector("bit-no-items");
+  /** The icon bound to the empty state, read off the component input rather than the rendered SVG. */
+  function noItemsIcon(): BitSvg | undefined {
+    return fixture.debugElement.query(By.css("bit-no-items"))?.componentInstance.icon();
   }
 
   /** The row's change password CTA, or `undefined` when the row does not render one. */
@@ -351,6 +364,18 @@ describe("HealthRiskCategoryDetailComponent", () => {
       },
     );
 
+    it.each(categories.map((c) => [c.category, c.emptyKey] as const))(
+      "renders the %s empty copy when the category has no items",
+      async (category, emptyKey) => {
+        params$.next({ category });
+        setReport(category, []);
+
+        await initComponent();
+
+        expect(text()).toContain(emptyKey);
+      },
+    );
+
     it.each(categories.map((c) => c.category))(
       "shows only the %s bucket, not the logins at risk in other categories",
       async (category) => {
@@ -374,7 +399,7 @@ describe("HealthRiskCategoryDetailComponent", () => {
       },
     );
 
-    it("swaps the title and description when the category changes", async () => {
+    it("swaps the title, description and empty icon when the category changes", async () => {
       params$.next({ category: RiskCategory.Exposed });
       await initComponent();
       expect(pageTitle()).toBe("exposedPasswordsTitle");
@@ -387,6 +412,11 @@ describe("HealthRiskCategoryDetailComponent", () => {
       expect(pageTitle()).toBe("reusedPasswordsTitle");
       expect(text()).toContain("reusedPasswordsDescription");
       expect(text()).not.toContain("exposedPasswordsDescription");
+
+      setReport(RiskCategory.Reused, []);
+      fixture.detectChanges();
+
+      expect(noItemsIcon()).toBe(NoCredentialsIcon);
     });
   });
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -102,8 +102,11 @@ export class HealthRiskCategoryDetailComponent {
   readonly items = computed(() => {
     const category = this.category();
     const report = this.report();
+    if (!category || !report) {
+      return [];
+    }
 
-    return category && report ? report.categoryItems[category] : [];
+    return report.categoryItems[category] ?? [];
   });
   readonly cipherMap = toSignal(
     this.accountService.activeAccount$.pipe(

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -30,6 +30,7 @@ import {
   IconModule,
   DialogService,
   CenterPositionStrategy,
+  NoItemsModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { PasswordRepromptService } from "@bitwarden/vault";
@@ -60,6 +61,7 @@ const HEALTH_OVERVIEW_ROUTE = "/tabs/health";
     I18nPipe,
     MenuModule,
     IconModule,
+    NoItemsModule,
   ],
 })
 export class HealthRiskCategoryDetailComponent {
@@ -100,56 +102,18 @@ export class HealthRiskCategoryDetailComponent {
   readonly items = computed(() => {
     const category = this.category();
     const report = this.report();
-    if (!category || !report) {
-      return [];
-    }
 
-    switch (category) {
-      case RiskCategory.Exposed:
-        return report.categoryItems.exposed;
-      case RiskCategory.Weak:
-        return report.categoryItems.weak;
-      case RiskCategory.Reused:
-        return report.categoryItems.reused;
-      default:
-        return [];
-    }
+    return category && report ? report.categoryItems[category] : [];
   });
-  readonly contentKeys = computed<{
-    titleKey?: string;
-    descriptionKey?: string;
-    emptyKey?: string;
-  }>(() => {
-    const keys: { titleKey?: string; descriptionKey?: string; emptyKey?: string } = {};
-    switch (this.category()) {
-      case RiskCategory.Exposed:
-        keys.titleKey = "exposedPasswordsTitle";
-        keys.descriptionKey = "exposedPasswordsDescription";
-        keys.emptyKey = "exposedPasswordsEmpty";
-        break;
-      case RiskCategory.Weak:
-        keys.titleKey = "weakPasswordsTitle";
-        keys.descriptionKey = "weakPasswordsDescription";
-        keys.emptyKey = "weakPasswordsEmpty";
-        break;
-      case RiskCategory.Reused:
-        keys.titleKey = "reusedPasswordsTitle";
-        keys.descriptionKey = "reusedPasswordsDescription";
-        keys.emptyKey = "reusedPasswordsEmpty";
-        break;
-    }
-    return keys;
-  });
-  readonly emptyIcon = computed(() => {
-    switch (this.category()) {
-      case RiskCategory.Exposed:
-        return ReportExposedPasswords;
-      case RiskCategory.Weak:
-        return UnlockedIcon;
-      case RiskCategory.Reused:
-        return NoCredentialsIcon;
-    }
-  });
+  readonly cipherMap = toSignal(
+    this.accountService.activeAccount$.pipe(
+      getUserId,
+      switchMap((userId) => this.cipherService.cipherViews$(userId)),
+      filterOutNullish(),
+      map((ciphers) => new Map<string, CipherView>(ciphers.map((cipher) => [cipher.id, cipher]))),
+    ),
+    { initialValue: new Map<string, CipherView>() },
+  );
 
   readonly onChangePassword = async (item: CipherView) => {
     const changePasswordUrl = await this.changeLoginPasswordService.getChangePasswordUrl(item);
@@ -187,14 +151,20 @@ export class HealthRiskCategoryDetailComponent {
     [RiskCategory.Exposed]: {
       titleKey: "exposedPasswordsTitle",
       descriptionKey: "exposedPasswordsDescription",
+      emptyKey: "exposedPasswordsEmpty",
+      emptyIcon: ReportExposedPasswords,
     },
     [RiskCategory.Weak]: {
       titleKey: "weakPasswordsTitle",
       descriptionKey: "weakPasswordsDescription",
+      emptyKey: "weakPasswordsEmpty",
+      emptyIcon: UnlockedIcon,
     },
     [RiskCategory.Reused]: {
       titleKey: "reusedPasswordsTitle",
       descriptionKey: "reusedPasswordsDescription",
+      emptyKey: "reusedPasswordsEmpty",
+      emptyIcon: NoCredentialsIcon,
     },
   };
 }

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { map, switchMap } from "rxjs/operators";
 
 import { IconComponent as AppVaultIconComponent } from "@bitwarden/angular/vault/components/icon.component";
+import { NoCredentialsIcon, ReportExposedPasswords, UnlockedIcon } from "@bitwarden/assets/svg";
 import { CipherHealthView } from "@bitwarden/bit-common/dirt/access-intelligence/models/view/cipher-health.view";
 import { RiskCategory } from "@bitwarden/bit-common/dirt/vault-health/models";
 import { VaultHealthReportService } from "@bitwarden/bit-common/dirt/vault-health/services";
@@ -103,17 +104,52 @@ export class HealthRiskCategoryDetailComponent {
       return [];
     }
 
-    return report.categoryItems[category] ?? [];
+    switch (category) {
+      case RiskCategory.Exposed:
+        return report.categoryItems.exposed;
+      case RiskCategory.Weak:
+        return report.categoryItems.weak;
+      case RiskCategory.Reused:
+        return report.categoryItems.reused;
+      default:
+        return [];
+    }
   });
-  readonly cipherMap = toSignal(
-    this.accountService.activeAccount$.pipe(
-      getUserId,
-      switchMap((userId) => this.cipherService.cipherViews$(userId)),
-      filterOutNullish(),
-      map((ciphers) => new Map<string, CipherView>(ciphers.map((cipher) => [cipher.id, cipher]))),
-    ),
-    { initialValue: new Map<string, CipherView>() },
-  );
+  readonly contentKeys = computed<{
+    titleKey?: string;
+    descriptionKey?: string;
+    emptyKey?: string;
+  }>(() => {
+    const keys: { titleKey?: string; descriptionKey?: string; emptyKey?: string } = {};
+    switch (this.category()) {
+      case RiskCategory.Exposed:
+        keys.titleKey = "exposedPasswordsTitle";
+        keys.descriptionKey = "exposedPasswordsDescription";
+        keys.emptyKey = "exposedPasswordsEmpty";
+        break;
+      case RiskCategory.Weak:
+        keys.titleKey = "weakPasswordsTitle";
+        keys.descriptionKey = "weakPasswordsDescription";
+        keys.emptyKey = "weakPasswordsEmpty";
+        break;
+      case RiskCategory.Reused:
+        keys.titleKey = "reusedPasswordsTitle";
+        keys.descriptionKey = "reusedPasswordsDescription";
+        keys.emptyKey = "reusedPasswordsEmpty";
+        break;
+    }
+    return keys;
+  });
+  readonly emptyIcon = computed(() => {
+    switch (this.category()) {
+      case RiskCategory.Exposed:
+        return ReportExposedPasswords;
+      case RiskCategory.Weak:
+        return UnlockedIcon;
+      case RiskCategory.Reused:
+        return NoCredentialsIcon;
+    }
+  });
 
   readonly onChangePassword = async (item: CipherView) => {
     const changePasswordUrl = await this.changeLoginPasswordService.getChangePasswordUrl(item);


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-36628

## 📔 Objective
In the browser extension, when a vault Health scan detects no items (ciphers) at risk in any of the 3 possible categories, the detail view for the category will display a clean state to notify the user that none of their passwords were flagged for the respective category. 

Changes to implement include updating the HealthRiskCategoryDetail component to include the clean state.

## 📸 Screenshots
<img width="482" height="602" alt="image" src="https://github.com/user-attachments/assets/5f0788ae-d06c-4e9e-986f-8b99b20967cc" />

<img width="481" height="606" alt="image" src="https://github.com/user-attachments/assets/8ca71e04-d66d-4305-8498-776068175bf5" />

<img width="487" height="611" alt="image" src="https://github.com/user-attachments/assets/570db118-d4ec-4fae-891c-391eced26c0c" />

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>