### PR TITLE
[PM-41902] Member Access Report terminology changes

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -13866,7 +13866,7 @@
     "message": "Audit organization member access across groups, collections, and collection items. The CSV export provides a detailed breakdown per member, including information on collection permissions and account configurations."
   },
   "memberAccessReportPageDescV2": {
-    "message": "Audit member access across groups, collections, and collection items. The CSV export provides a detailed breakdown per member, including information on collection permissions and account configurations."
+    "message": "Audit member access across groups, shared folders, and items. The CSV export provides a detailed breakdown per member, including information on permissions and account configurations."
   },
   "memberAccessReportNoCollection": {
     "message": "(No Collection)"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -13866,6 +13866,9 @@
     "message": "Audit organization member access across groups, collections, and collection items. The CSV export provides a detailed breakdown per member, including information on collection permissions and account configurations."
   },
   "memberAccessReportPageDescV2": {
+    "message": "Audit member access across groups, collections, and collection items. The CSV export provides a detailed breakdown per member, including information on collection permissions and account configurations."
+  },
+  "memberAccessReportPageDescV3": {
     "message": "Audit member access across groups, shared folders, and items. The CSV export provides a detailed breakdown per member, including information on permissions and account configurations."
   },
   "memberAccessReportNoCollection": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -13865,9 +13865,6 @@
   "memberAccessReportPageDesc": {
     "message": "Audit organization member access across groups, collections, and collection items. The CSV export provides a detailed breakdown per member, including information on collection permissions and account configurations."
   },
-  "memberAccessReportPageDescV2": {
-    "message": "Audit member access across groups, collections, and collection items. The CSV export provides a detailed breakdown per member, including information on collection permissions and account configurations."
-  },
   "memberAccessReportPageDescV3": {
     "message": "Audit member access across groups, shared folders, and items. The CSV export provides a detailed breakdown per member, including information on permissions and account configurations."
   },

--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/member-access-report.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/member-access-report.component.html
@@ -40,7 +40,7 @@
       <th bitCell bitSortable="email" default>{{ "members" | i18n }}</th>
       <th bitCell bitSortable="groupsCount" class="tw-w-[278px]">{{ "groups" | i18n }}</th>
       <th bitCell bitSortable="collectionsCount" class="tw-w-[278px]">
-        {{ "collections" | i18n }}
+        {{ "collections" | vfo1I18n: "sharedFolders" }}
       </th>
       <th bitCell bitSortable="itemsCount" class="tw-w-[278px]">{{ "items" | i18n }}</th>
     </ng-container>

--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/member-access-report.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/member-access-report.component.html
@@ -21,7 +21,7 @@
 
 <div class="tw-max-w-4xl">
   <p bitTypography="body1">
-    {{ "memberAccessReportPageDesc" | vfo1I18n: "memberAccessReportPageDescV2" }}
+    {{ "memberAccessReportPageDesc" | vfo1I18n: "memberAccessReportPageDescV3" }}
   </p>
 </div>
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41902

## 📔 Objective

Fixes up the terminology for VFO 1 on the Member Access Report which was missed in initial scope

## 📸 Screenshots

<img width="1419" height="902" alt="image" src="https://github.com/user-attachments/assets/e245c5cd-fdec-4839-827c-316da4b3053c" />

