### PR TITLE
[PM-41974] fix(vault): serialize legacy cipher data field before passing to SDK

### DIFF
--- a/libs/common/src/vault/models/domain/cipher.spec.ts
+++ b/libs/common/src/vault/models/domain/cipher.spec.ts
@@ -1036,6 +1036,45 @@ describe("Cipher DTO", () => {
       });
     });
 
+    it("should serialize a legacy object `data` field to a JSON string", () => {
+      const legacyData = { name: "EncryptedString", notes: null };
+      const cipherData: CipherData = {
+        id: "2afb03fd-0d8e-4c08-a316-18b2f0efa618",
+        edit: true,
+        viewPassword: true,
+        organizationUseTotp: false,
+        favorite: false,
+        revisionDate: "2022-01-31T12:00:00.000Z",
+        type: CipherType.Login,
+        name: "EncryptedString",
+        creationDate: "2022-01-01T12:00:00.000Z",
+        data: legacyData as any,
+      };
+
+      const sdkCipher = new Cipher(cipherData).toSdkCipher();
+
+      expect(sdkCipher.data).toBe(JSON.stringify(legacyData));
+    });
+
+    it("should pass through a string `data` field unchanged", () => {
+      const cipherData: CipherData = {
+        id: "2afb03fd-0d8e-4c08-a316-18b2f0efa618",
+        edit: true,
+        viewPassword: true,
+        organizationUseTotp: false,
+        favorite: false,
+        revisionDate: "2022-01-31T12:00:00.000Z",
+        type: CipherType.Login,
+        name: "EncryptedString",
+        creationDate: "2022-01-01T12:00:00.000Z",
+        data: '{"name":"EncryptedString"}',
+      };
+
+      const sdkCipher = new Cipher(cipherData).toSdkCipher();
+
+      expect(sdkCipher.data).toBe('{"name":"EncryptedString"}');
+    });
+
     it("should map from SDK Cipher", () => {
       jest.restoreAllMocks();
       const sdkCipher: SdkCipher = {

--- a/libs/common/src/vault/models/domain/cipher.ts
+++ b/libs/common/src/vault/models/domain/cipher.ts
@@ -495,7 +495,15 @@ export class Cipher extends Domain implements Decryptable<CipherView> {
       bankAccount: undefined,
       driversLicense: undefined,
       passport: undefined,
-      data: this.data,
+      // The legacy `data` field is a JSON string in the SDK type, but some sources
+      // (e.g. Vaultwarden) persist it as a deserialized object. The SDK's serde
+      // layer rejects objects where it expects a string, so normalize it here.
+      data:
+        this.data == null
+          ? undefined
+          : typeof this.data === "string"
+            ? this.data
+            : JSON.stringify(this.data),
     };
 
     switch (this.type) {


### PR DESCRIPTION
## 🎟️ Tracking

No ticket — community-reported issue affecting self-hosted (Vaultwarden) users.

## 📔 Objective

Fix the browser extension vault getting stuck on skeleton loaders for vaults served by Vaultwarden.

Vaultwarden persists the cipher `data` field as a deserialized JSON object (the legacy flat cipher view: `name`, `notes`, `password`, `username`, `uri`, `uris`, etc.). `Cipher.toSdkCipher()` forwarded that object verbatim to the SDK, whose `Cipher.data` field is a JSON string. The SDK's serde layer rejects the object:

```
Uncaught Error: invalid type: JsValue(Object({...})), expected a string
```

That error rejects the vault decrypt call, so `loading$` never resolves and the vault shows skeleton loaders indefinitely.

This change normalizes `data` at the SDK boundary: `undefined` when null, the string unchanged when already a string, and `JSON.stringify(...)` otherwise.

## 📸 Screenshots

N/A (no UI change).