### PR TITLE
desktop-autofill: Refactor FIDO2 modals

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
@@ -26,28 +26,34 @@
   </bit-section>
 
   <bit-section class="tw-bg-background-alt tw-p-4 tw-flex tw-flex-col">
-    <div *ngIf="(ciphers$ | async)?.length === 0; else hasCiphers">
-      <div class="tw-flex tw-items-center tw-flex-col tw-p-12 tw-gap-4">
-        <bit-svg [content]="Icons.NoResults" class="tw-text-main"></bit-svg>
-        <div class="tw-flex tw-flex-col tw-gap-2">
-          {{ "noMatchingLoginsForSite" | i18n }}
-        </div>
-        <button bitButton type="button" buttonType="primary" (click)="confirmPasskey()">
-          {{ "savePasskeyNewLogin" | i18n }}
-        </button>
-      </div>
-    </div>
-    <ng-template #hasCiphers>
-      <bit-item *ngFor="let c of ciphers$ | async" class="">
-        <button type="button" bit-item-content (click)="addCredentialToCipher(c)">
-          <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
-          <button bitLink [title]="c.name" type="button">
-            {{ c.name }}
+    @let ciphers = ciphers$ | async;
+    @if (ciphers == null) {
+      <!-- Loading matching ciphers; render nothing until the list resolves. -->
+    } @else if (ciphers.length === 0) {
+      <div>
+        <div class="tw-flex tw-items-center tw-flex-col tw-p-12 tw-gap-4">
+          <bit-svg [content]="Icons.NoResults" class="tw-text-main"></bit-svg>
+          <div class="tw-flex tw-flex-col tw-gap-2">
+            {{ "noMatchingLoginsForSite" | i18n }}
+          </div>
+          <button bitButton type="button" buttonType="primary" (click)="confirmPasskey()">
+            {{ "savePasskeyNewLogin" | i18n }}
           </button>
-          <span slot="secondary">{{ c.subTitle }}</span>
-          <span bitBadge slot="end">{{ "save" | i18n }}</span>
-        </button>
-      </bit-item>
+        </div>
+      </div>
+    } @else {
+      @for (c of ciphers; track c.id) {
+        <bit-item>
+          <button type="button" bit-item-content (click)="addCredentialToCipher(c)">
+            <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
+            <button bitLink [title]="c.name" type="button">
+              {{ c.name }}
+            </button>
+            <span slot="secondary">{{ c.subTitle }}</span>
+            <span bitBadge slot="end">{{ "save" | i18n }}</span>
+          </button>
+        </bit-item>
+      }
       <bit-item>
         <button type="button" bit-item-content (click)="confirmPasskey()">
           <a bitLink linkType="primary" class="tw-font-medium tw-text-base">
@@ -55,6 +61,6 @@
           </a>
         </button>
       </bit-item>
-    </ng-template>
+    }
   </bit-section>
 </div>

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
@@ -61,9 +61,21 @@ describe("Fido2CreateComponent", () => {
     mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(mockSession);
     mockAccountService.activeAccount$ = activeAccountSubject;
 
+    // RP ID and the registration request are read synchronously when the
+    // component builds its `ciphers$` stream at construction.
+    Object.defineProperty(mockSession, "rpId", {
+      get: () => "example.com",
+      configurable: true,
+    });
+    Object.defineProperty(mockDesktopAutofillService, "lastRegistrationRequest", {
+      get: () => ({ userHandle: new Uint8Array([1, 2, 3]) }),
+      configurable: true,
+    });
+    mockDomainSettingsService.getUrlEquivalentDomains.mockReturnValue(of(new Set<string>()));
+    mockCipherService.getAllDecrypted.mockResolvedValue([]);
+
     await TestBed.configureTestingModule({
       providers: [
-        Fido2CreateComponent,
         { provide: DesktopSettingsService, useValue: mockDesktopSettingsService },
         { provide: DesktopFido2UserInterfaceService, useValue: mockFido2UserInterfaceService },
         { provide: AccountService, useValue: mockAccountService },
@@ -77,8 +89,12 @@ describe("Fido2CreateComponent", () => {
       ],
     }).compileComponents();
 
-    component = TestBed.inject(Fido2CreateComponent);
+    component = createComponent();
   });
+
+  function createComponent(): Fido2CreateComponent {
+    return TestBed.runInInjectionContext(() => new Fido2CreateComponent());
+  }
 
   afterEach(() => {
     jest.restoreAllMocks();
@@ -104,32 +120,17 @@ describe("Fido2CreateComponent", () => {
   }
 
   describe("ngOnInit", () => {
-    beforeEach(() => {
-      mockSession.getRpId.mockResolvedValue("example.com");
-      Object.defineProperty(mockDesktopAutofillService, "lastRegistrationRequest", {
-        get: jest.fn().mockReturnValue({
-          userHandle: new Uint8Array([1, 2, 3]),
-        }),
-        configurable: true,
-      });
-      mockDomainSettingsService.getUrlEquivalentDomains.mockReturnValue(of(new Set<string>()));
-    });
-
-    it("should initialize session and set show header to false", async () => {
-      const mockCiphers = createMockCiphers();
-      mockCipherService.getAllDecrypted.mockResolvedValue(mockCiphers);
-
-      await component.ngOnInit();
-
+    it("uses the current session", () => {
       expect(mockFido2UserInterfaceService.getCurrentSession).toHaveBeenCalled();
       expect(component.session).toBe(mockSession);
     });
 
     it("should show error dialog when no active session found", async () => {
-      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(null);
+      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(undefined);
       mockDialogService.openSimpleDialog.mockResolvedValue(false);
 
-      await component.ngOnInit();
+      const componentWithoutSession = createComponent();
+      await componentWithoutSession.ngOnInit();
 
       expect(mockDialogService.openSimpleDialog).toHaveBeenCalledWith({
         title: { key: "unableToSavePasskey" },
@@ -143,10 +144,6 @@ describe("Fido2CreateComponent", () => {
   });
 
   describe("addCredentialToCipher", () => {
-    beforeEach(() => {
-      component.session = mockSession;
-    });
-
     it("should add passkey to cipher", async () => {
       const cipher = createMockCiphers()[0];
 
@@ -186,10 +183,6 @@ describe("Fido2CreateComponent", () => {
   });
 
   describe("confirmPasskey", () => {
-    beforeEach(() => {
-      component.session = mockSession;
-    });
-
     it("should confirm passkey creation successfully", async () => {
       await component.confirmPasskey();
 
@@ -197,10 +190,11 @@ describe("Fido2CreateComponent", () => {
     });
 
     it("should call openSimpleDialog when session is null", async () => {
-      component.session = null;
+      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(undefined);
       mockDialogService.openSimpleDialog.mockResolvedValue(false);
 
-      await component.confirmPasskey();
+      const componentWithoutSession = createComponent();
+      await componentWithoutSession.confirmPasskey();
 
       expect(mockDialogService.openSimpleDialog).toHaveBeenCalledWith({
         title: { key: "unableToSavePasskey" },
@@ -215,8 +209,6 @@ describe("Fido2CreateComponent", () => {
 
   describe("closeModal", () => {
     it("should close modal and notify session", async () => {
-      component.session = mockSession;
-
       await component.closeModal();
 
       expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
@@ -14,7 +14,6 @@ import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
 
-import { DesktopAutofillService } from "../../../autofill/services/desktop-autofill.service";
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
 import {
   DesktopFido2UserInterfaceService,
@@ -29,7 +28,6 @@ describe("Fido2CreateComponent", () => {
   let mockFido2UserInterfaceService: MockProxy<DesktopFido2UserInterfaceService>;
   let mockAccountService: MockProxy<AccountService>;
   let mockCipherService: MockProxy<CipherService>;
-  let mockDesktopAutofillService: MockProxy<DesktopAutofillService>;
   let mockDialogService: MockProxy<DialogService>;
   let mockDomainSettingsService: MockProxy<DomainSettingsService>;
   let mockLogService: MockProxy<LogService>;
@@ -50,7 +48,6 @@ describe("Fido2CreateComponent", () => {
     mockFido2UserInterfaceService = mock<DesktopFido2UserInterfaceService>();
     mockAccountService = mock<AccountService>();
     mockCipherService = mock<CipherService>();
-    mockDesktopAutofillService = mock<DesktopAutofillService>();
     mockDialogService = mock<DialogService>();
     mockDomainSettingsService = mock<DomainSettingsService>();
     mockLogService = mock<LogService>();
@@ -61,14 +58,14 @@ describe("Fido2CreateComponent", () => {
     mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(mockSession);
     mockAccountService.activeAccount$ = activeAccountSubject;
 
-    // RP ID and the registration request are read synchronously when the
+    // RP ID and user handle are read synchronously from the session when the
     // component builds its `ciphers$` stream at construction.
     Object.defineProperty(mockSession, "rpId", {
       get: () => "example.com",
       configurable: true,
     });
-    Object.defineProperty(mockDesktopAutofillService, "lastRegistrationRequest", {
-      get: () => ({ userHandle: new Uint8Array([1, 2, 3]) }),
+    Object.defineProperty(mockSession, "userHandle", {
+      get: () => [1, 2, 3],
       configurable: true,
     });
     mockDomainSettingsService.getUrlEquivalentDomains.mockReturnValue(of(new Set<string>()));
@@ -80,7 +77,6 @@ describe("Fido2CreateComponent", () => {
         { provide: DesktopFido2UserInterfaceService, useValue: mockFido2UserInterfaceService },
         { provide: AccountService, useValue: mockAccountService },
         { provide: CipherService, useValue: mockCipherService },
-        { provide: DesktopAutofillService, useValue: mockDesktopAutofillService },
         { provide: DialogService, useValue: mockDialogService },
         { provide: DomainSettingsService, useValue: mockDomainSettingsService },
         { provide: LogService, useValue: mockLogService },

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
@@ -212,7 +212,7 @@ describe("Fido2CreateComponent", () => {
       await component.closeModal();
 
       expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
-      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(null);
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -26,7 +26,6 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
-import { DesktopAutofillService } from "../../../autofill/services/desktop-autofill.service";
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
 import { DesktopFido2UserInterfaceService } from "../../services/desktop-fido2-user-interface.service";
 
@@ -55,7 +54,6 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
   private readonly fido2UserInterfaceService = inject(DesktopFido2UserInterfaceService);
   private readonly accountService = inject(AccountService);
   private readonly cipherService = inject(CipherService);
-  private readonly desktopAutofillService = inject(DesktopAutofillService);
   private readonly dialogService = inject(DialogService);
   private readonly domainSettingsService = inject(DomainSettingsService);
   private readonly router = inject(Router);
@@ -144,17 +142,17 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
   }
 
   private buildCiphers$(): Observable<CipherView[] | null> {
-    const lastRegistrationRequest = this.desktopAutofillService.lastRegistrationRequest;
     const rpid = this.session?.rpId;
+    const userHandleBytes = this.session?.userHandle;
 
     // Emit `null` (loading/unavailable) until we have everything needed to
     // resolve matching ciphers. The template treats `null` as a distinct state
     // from an empty list so it doesn't flash the wrong branch.
-    if (!this.session || !lastRegistrationRequest || !rpid) {
+    if (!this.session || !rpid || !userHandleBytes) {
       return of(null);
     }
 
-    const userHandle = Fido2Utils.arrayToString(new Uint8Array(lastRegistrationRequest.userHandle));
+    const userHandle = Fido2Utils.arrayToString(new Uint8Array(userHandleBytes));
 
     return combineLatest([
       this.accountService.activeAccount$.pipe(map((a) => a?.id)),

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, inject } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
@@ -137,7 +135,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
     // Let the session clean up the modal, if present.
     if (this.session) {
       this.session.notifyConfirmCreateCredential(false);
-      this.session.confirmChosenCipher(null);
+      this.session.confirmChosenCipher(undefined);
     } else {
       await this.desktopSettingsService.setModalMode(false);
       await this.accountService.setShowHeader(true);

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -1,11 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-// FIXME(https://bitwarden.atlassian.net/browse/CL-1062): `OnPush` components should not use mutable properties
-/* eslint-disable @bitwarden/components/enforce-readonly-angular-properties */
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy } from "@angular/core";
+import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, inject } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
-import { combineLatest, map, Observable, Subject, switchMap } from "rxjs";
+import { combineLatest, map, Observable, of, switchMap } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { BitwardenShield, NoResults } from "@bitwarden/assets/svg";
@@ -32,10 +30,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 
 import { DesktopAutofillService } from "../../../autofill/services/desktop-autofill.service";
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
-import {
-  DesktopFido2UserInterfaceService,
-  DesktopFido2UserInterfaceSession,
-} from "../../services/desktop-fido2-user-interface.service";
+import { DesktopFido2UserInterfaceService } from "../../services/desktop-fido2-user-interface.service";
 
 @Component({
   standalone: true,
@@ -58,9 +53,17 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Fido2CreateComponent implements OnInit, OnDestroy {
-  session?: DesktopFido2UserInterfaceSession = null;
-  ciphers$: Observable<CipherView[]>;
-  private destroy$ = new Subject<void>();
+  private readonly desktopSettingsService = inject(DesktopSettingsService);
+  private readonly fido2UserInterfaceService = inject(DesktopFido2UserInterfaceService);
+  private readonly accountService = inject(AccountService);
+  private readonly cipherService = inject(CipherService);
+  private readonly desktopAutofillService = inject(DesktopAutofillService);
+  private readonly dialogService = inject(DialogService);
+  private readonly domainSettingsService = inject(DomainSettingsService);
+  private readonly router = inject(Router);
+
+  readonly session = this.fido2UserInterfaceService.getCurrentSession();
+  readonly ciphers$: Observable<CipherView[] | null> = this.buildCiphers$();
   readonly Icons = { BitwardenShield, NoResults };
 
   private get DIALOG_MESSAGES() {
@@ -89,31 +92,13 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
     } as const satisfies Record<string, SimpleDialogOptions>;
   }
 
-  constructor(
-    private readonly desktopSettingsService: DesktopSettingsService,
-    private readonly fido2UserInterfaceService: DesktopFido2UserInterfaceService,
-    private readonly accountService: AccountService,
-    private readonly cipherService: CipherService,
-    private readonly desktopAutofillService: DesktopAutofillService,
-    private readonly dialogService: DialogService,
-    private readonly domainSettingsService: DomainSettingsService,
-    private readonly router: Router,
-  ) {}
-
   async ngOnInit(): Promise<void> {
-    this.session = this.fido2UserInterfaceService.getCurrentSession();
-
-    if (this.session) {
-      const rpid = await this.session.getRpId();
-      this.initializeCiphersObservable(rpid);
-    } else {
+    if (!this.session) {
       await this.showErrorDialog(this.DIALOG_MESSAGES.unableToSavePasskey);
     }
   }
 
   async ngOnDestroy(): Promise<void> {
-    this.destroy$.next();
-    this.destroy$.complete();
     await this.closeModal();
   }
 
@@ -160,16 +145,20 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
     }
   }
 
-  private initializeCiphersObservable(rpid: string): void {
+  private buildCiphers$(): Observable<CipherView[] | null> {
     const lastRegistrationRequest = this.desktopAutofillService.lastRegistrationRequest;
+    const rpid = this.session?.rpId;
 
-    if (!lastRegistrationRequest || !rpid) {
-      return;
+    // Emit `null` (loading/unavailable) until we have everything needed to
+    // resolve matching ciphers. The template treats `null` as a distinct state
+    // from an empty list so it doesn't flash the wrong branch.
+    if (!this.session || !lastRegistrationRequest || !rpid) {
+      return of(null);
     }
 
     const userHandle = Fido2Utils.arrayToString(new Uint8Array(lastRegistrationRequest.userHandle));
 
-    this.ciphers$ = combineLatest([
+    return combineLatest([
       this.accountService.activeAccount$.pipe(map((a) => a?.id)),
       this.domainSettingsService.getUrlEquivalentDomains(rpid),
     ]).pipe(

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.spec.ts
@@ -46,9 +46,13 @@ describe("Fido2ExcludedCiphersComponent", () => {
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
+    createComponent();
+  });
+
+  function createComponent(): void {
     fixture = TestBed.createComponent(Fido2ExcludedCiphersComponent);
     component = fixture.componentInstance;
-  });
+  }
 
   afterEach(() => {
     jest.restoreAllMocks();
@@ -66,7 +70,7 @@ describe("Fido2ExcludedCiphersComponent", () => {
       await component.closeModal();
 
       expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
-      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(null);
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(undefined);
       expect(mockSession.hideUi).toHaveBeenCalled();
 
       // The session owns this teardown; the component must not duplicate it.
@@ -77,6 +81,7 @@ describe("Fido2ExcludedCiphersComponent", () => {
 
     it("should reset the window itself when there is no session to hand off to", async () => {
       mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(undefined);
+      createComponent();
 
       await component.closeModal();
 

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.spec.ts
@@ -54,19 +54,15 @@ describe("Fido2ExcludedCiphersComponent", () => {
     jest.restoreAllMocks();
   });
 
-  describe("ngOnInit", () => {
-    it("should initialize session", async () => {
-      await component.ngOnInit();
-
+  describe("session", () => {
+    it("uses the current session", () => {
       expect(mockFido2UserInterfaceService.getCurrentSession).toHaveBeenCalled();
       expect(component.session).toBe(mockSession);
     });
   });
 
   describe("closeModal", () => {
-    it("should notify the session and let it reset the window when a session exists", async () => {
-      component.session = mockSession;
-
+    it("should close modal and notify session when session exists", async () => {
       await component.closeModal();
 
       expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
@@ -80,7 +76,7 @@ describe("Fido2ExcludedCiphersComponent", () => {
     });
 
     it("should reset the window itself when there is no session to hand off to", async () => {
-      component.session = null;
+      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(undefined);
 
       await component.closeModal();
 

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
@@ -1,9 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-// FIXME(https://bitwarden.atlassian.net/browse/CL-1062): `OnPush` components should not use mutable properties
-/* eslint-disable @bitwarden/components/enforce-readonly-angular-properties */
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy } from "@angular/core";
+import { ChangeDetectionStrategy, Component, OnDestroy, inject } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
 
 import { BitwardenShield, NoResults } from "@bitwarden/assets/svg";
@@ -22,10 +20,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
-import {
-  DesktopFido2UserInterfaceService,
-  DesktopFido2UserInterfaceSession,
-} from "../../services/desktop-fido2-user-interface.service";
+import { DesktopFido2UserInterfaceService } from "../../services/desktop-fido2-user-interface.service";
 
 @Component({
   standalone: true,
@@ -46,20 +41,14 @@ import {
   templateUrl: "fido2-excluded-ciphers.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Fido2ExcludedCiphersComponent implements OnInit, OnDestroy {
-  session?: DesktopFido2UserInterfaceSession = null;
+export class Fido2ExcludedCiphersComponent implements OnDestroy {
+  private readonly desktopSettingsService = inject(DesktopSettingsService);
+  private readonly fido2UserInterfaceService = inject(DesktopFido2UserInterfaceService);
+  private readonly accountService = inject(AccountService);
+  private readonly router = inject(Router);
+
+  readonly session = this.fido2UserInterfaceService.getCurrentSession();
   readonly Icons = { BitwardenShield, NoResults };
-
-  constructor(
-    private readonly desktopSettingsService: DesktopSettingsService,
-    private readonly fido2UserInterfaceService: DesktopFido2UserInterfaceService,
-    private readonly accountService: AccountService,
-    private readonly router: Router,
-  ) {}
-
-  async ngOnInit(): Promise<void> {
-    this.session = this.fido2UserInterfaceService.getCurrentSession();
-  }
 
   async ngOnDestroy(): Promise<void> {
     await this.closeModal();

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, OnDestroy, inject } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
@@ -58,7 +56,7 @@ export class Fido2ExcludedCiphersComponent implements OnDestroy {
     if (this.session) {
       // Clean up session state
       this.session.notifyConfirmCreateCredential(false);
-      this.session.confirmChosenCipher(null);
+      this.session.confirmChosenCipher(undefined);
 
       // The session knows whether this ceremony showed any UI, so let it decide
       // whether the window needs to be reset and navigated away from.

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.html
@@ -23,15 +23,17 @@
   </bit-section>
 
   <bit-section class="tw-bg-background-alt tw-p-4 tw-flex tw-flex-col tw-grow">
-    <bit-item *ngFor="let c of ciphers$ | async" class="">
-      <button type="button" bit-item-content (click)="chooseCipher(c)">
-        <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
-        <button bitLink [title]="c.name" type="button">
-          {{ c.name }}
+    @for (c of ciphers$ | async; track c.id) {
+      <bit-item>
+        <button type="button" bit-item-content (click)="chooseCipher(c)">
+          <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
+          <button bitLink [title]="c.name" type="button">
+            {{ c.name }}
+          </button>
+          <span slot="secondary">{{ c.subTitle }}</span>
+          <span bitBadge slot="end">{{ "select" | i18n }}</span>
         </button>
-        <span slot="secondary">{{ c.subTitle }}</span>
-        <span bitBadge slot="end">{{ "select" | i18n }}</span>
-      </button>
-    </bit-item>
+      </bit-item>
+    }
   </bit-section>
 </div>

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.html
@@ -30,7 +30,7 @@
           <button bitLink [title]="c.name" type="button">
             {{ c.name }}
           </button>
-          <span slot="secondary">{{ c.subTitle }}</span>
+          <span slot="secondary">{{ CipherViewLikeUtils.subtitle(c) }}</span>
           <span bitBadge slot="end">{{ "select" | i18n }}</span>
         </button>
       </bit-item>

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
@@ -66,9 +66,13 @@ describe("Fido2VaultComponent", () => {
       .overrideProvider(DialogService, { useValue: mock<DialogService>() })
       .compileComponents();
 
+    createComponent();
+  });
+
+  function createComponent(): void {
     fixture = TestBed.createComponent(Fido2VaultComponent);
     component = fixture.componentInstance;
-  });
+  }
 
   const mockCiphers: any[] = [
     {
@@ -103,53 +107,48 @@ describe("Fido2VaultComponent", () => {
     },
   ];
 
-  describe("ngOnInit", () => {
-    it("should initialize session and load ciphers successfully", async () => {
+  describe("ciphers$", () => {
+    it("loads ciphers for the active account", () => {
       mockCipherService.cipherListViews$ = jest.fn().mockReturnValue(of(mockCiphers));
+      createComponent();
 
-      await component.ngOnInit();
+      let ciphersResult: CipherView[] = [];
+      component.ciphers$.subscribe((ciphers) => (ciphersResult = ciphers));
 
       expect(mockFido2UserInterfaceService.getCurrentSession).toHaveBeenCalled();
       expect(component.session).toBe(mockSession);
-      expect(component.cipherIds$).toBe(mockSession.availableCipherIds$);
       expect(mockCipherService.cipherListViews$).toHaveBeenCalledWith(mockActiveAccount.id);
+      expect(ciphersResult).toHaveLength(3);
     });
 
-    it("should handle when no active session found", async () => {
-      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(undefined);
-
-      await component.ngOnInit();
-
-      expect(component.session).toBeUndefined();
-    });
-
-    it("should filter out deleted ciphers", async () => {
+    it("filters out deleted ciphers", () => {
       const ciphersWithDeleted = [
         ...mockCiphers.slice(0, 1),
         { ...mockCiphers[1], deletedDate: new Date() },
         ...mockCiphers.slice(2),
       ];
       mockCipherService.cipherListViews$ = jest.fn().mockReturnValue(of(ciphersWithDeleted));
-
-      await component.ngOnInit();
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      createComponent();
 
       let ciphersResult: CipherView[] = [];
-      component.ciphers$.subscribe((ciphers) => {
-        ciphersResult = ciphers;
-      });
+      component.ciphers$.subscribe((ciphers) => (ciphersResult = ciphers));
 
       expect(ciphersResult).toHaveLength(2);
       expect(ciphersResult.every((cipher) => !cipher.deletedDate)).toBe(true);
     });
   });
 
+  describe("session", () => {
+    it("is undefined when no active session found", () => {
+      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(undefined);
+      createComponent();
+
+      expect(component.session).toBeUndefined();
+    });
+  });
+
   describe("chooseCipher", () => {
     const cipher = mockCiphers[0];
-
-    beforeEach(() => {
-      component.session = mockSession;
-    });
 
     it("hands the chosen cipher to the session", async () => {
       await component.chooseCipher(cipher);
@@ -159,7 +158,9 @@ describe("Fido2VaultComponent", () => {
     });
 
     it("closes the modal if the session is not found when cipher is chosen ", async () => {
-      component.session = undefined;
+      mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(undefined);
+      createComponent();
+
       await component.chooseCipher(cipher);
 
       // Verification (master-password reprompt or OS) is handled by the session.
@@ -170,8 +171,6 @@ describe("Fido2VaultComponent", () => {
 
   describe("closeModal", () => {
     it("should close modal and notify session", async () => {
-      component.session = mockSession;
-
       await component.closeModal();
 
       expect(mockRouter.navigate).not.toHaveBeenCalled();

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.spec.ts
@@ -175,7 +175,7 @@ describe("Fido2VaultComponent", () => {
 
       expect(mockRouter.navigate).not.toHaveBeenCalled();
       expect(mockSession.notifyConfirmCreateCredential).toHaveBeenCalledWith(false);
-      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(null);
+      expect(mockSession.confirmChosenCipher).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -1,5 +1,3 @@
-// FIXME: Update this file to be type safe and remove this and next line
-// @ts-strict-ignore
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
@@ -10,7 +8,10 @@ import { BitwardenShield } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import {
+  CipherViewLike,
+  CipherViewLikeUtils,
+} from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import {
   BadgeModule,
   ButtonModule,
@@ -58,10 +59,11 @@ export class Fido2VaultComponent {
   private readonly router = inject(Router);
 
   readonly session = this.fido2UserInterfaceService.getCurrentSession();
-  readonly ciphers$: Observable<CipherView[]> = this.buildCiphers$();
+  readonly ciphers$: Observable<CipherViewLike[]> = this.buildCiphers$();
   readonly Icons = { BitwardenShield };
+  protected readonly CipherViewLikeUtils = CipherViewLikeUtils;
 
-  async chooseCipher(cipher: CipherView): Promise<void> {
+  async chooseCipher(cipher: CipherViewLike): Promise<void> {
     if (!this.session) {
       await this.dialogService.openSimpleDialog({
         title: { key: "unexpectedErrorShort" },
@@ -83,7 +85,7 @@ export class Fido2VaultComponent {
   async closeModal(): Promise<void> {
     if (this.session) {
       this.session.notifyConfirmCreateCredential(false);
-      this.session.confirmChosenCipher(null);
+      this.session.confirmChosenCipher(undefined);
     } else {
       await this.desktopSettingsService.setModalMode(false);
       await this.accountService.setShowHeader(true);
@@ -91,25 +93,28 @@ export class Fido2VaultComponent {
     }
   }
 
-  private buildCiphers$(): Observable<CipherView[]> {
+  private buildCiphers$(): Observable<CipherViewLike[]> {
     return this.accountService.activeAccount$.pipe(
       map((account) => account?.id),
       switchMap((activeUserId) => {
         if (!activeUserId) {
-          return of<CipherView[]>([]);
+          return of<CipherViewLike[]>([]);
         }
 
         // Combine the cipher list with the optional cipher IDs filter the
         // session made available for this ceremony.
         return combineLatest([
           this.cipherService.cipherListViews$(activeUserId),
-          this.session?.availableCipherIds$ ?? of(null),
+          this.session?.availableCipherIds$ ?? of(null as string[] | null),
         ]).pipe(
-          map(([ciphers, cipherIds]) => {
+          map(([ciphers, cipherIds]): CipherViewLike[] => {
             const activeCiphers = ciphers.filter((cipher) => !cipher.deletedDate);
 
-            if (cipherIds?.length > 0) {
-              return activeCiphers.filter((cipher) => cipherIds.includes(cipher.id as string));
+            if (cipherIds != null && cipherIds.length > 0) {
+              return activeCiphers.filter((cipher) => {
+                const id = cipher.id?.toString();
+                return id != null && cipherIds.includes(id);
+              });
             }
 
             return activeCiphers;
@@ -118,8 +123,8 @@ export class Fido2VaultComponent {
       }),
       catchError((error: unknown) => {
         this.logService.error("Failed to load ciphers", error);
-        return of<CipherView[]>([]);
+        return of<CipherViewLike[]>([]);
       }),
-    ) as Observable<CipherView[]>;
+    );
   }
 }

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -1,20 +1,9 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-// FIXME(https://bitwarden.atlassian.net/browse/CL-1062): `OnPush` components should not use mutable properties
-/* eslint-disable @bitwarden/components/enforce-readonly-angular-properties */
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
-import {
-  firstValueFrom,
-  map,
-  combineLatest,
-  of,
-  BehaviorSubject,
-  Observable,
-  Subject,
-  takeUntil,
-} from "rxjs";
+import { map, combineLatest, of, Observable, switchMap, catchError } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { BitwardenShield } from "@bitwarden/assets/svg";
@@ -37,10 +26,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { DesktopSettingsService } from "../../../platform/services/desktop-settings.service";
-import {
-  DesktopFido2UserInterfaceService,
-  DesktopFido2UserInterfaceSession,
-} from "../../services/desktop-fido2-user-interface.service";
+import { DesktopFido2UserInterfaceService } from "../../services/desktop-fido2-user-interface.service";
 
 @Component({
   standalone: true,
@@ -62,34 +48,18 @@ import {
   templateUrl: "fido2-vault.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Fido2VaultComponent implements OnInit, OnDestroy {
-  session?: DesktopFido2UserInterfaceSession = null;
-  private destroy$ = new Subject<void>();
-  private ciphersSubject = new BehaviorSubject<CipherView[]>([]);
-  ciphers$: Observable<CipherView[]> = this.ciphersSubject.asObservable();
-  cipherIds$: Observable<string[]> | undefined;
+export class Fido2VaultComponent {
+  private readonly desktopSettingsService = inject(DesktopSettingsService);
+  private readonly fido2UserInterfaceService = inject(DesktopFido2UserInterfaceService);
+  private readonly cipherService = inject(CipherService);
+  private readonly accountService = inject(AccountService);
+  private readonly dialogService = inject(DialogService);
+  private readonly logService = inject(LogService);
+  private readonly router = inject(Router);
+
+  readonly session = this.fido2UserInterfaceService.getCurrentSession();
+  readonly ciphers$: Observable<CipherView[]> = this.buildCiphers$();
   readonly Icons = { BitwardenShield };
-
-  constructor(
-    private readonly desktopSettingsService: DesktopSettingsService,
-    private readonly fido2UserInterfaceService: DesktopFido2UserInterfaceService,
-    private readonly cipherService: CipherService,
-    private readonly accountService: AccountService,
-    private readonly dialogService: DialogService,
-    private readonly logService: LogService,
-    private readonly router: Router,
-  ) {}
-
-  async ngOnInit(): Promise<void> {
-    this.session = this.fido2UserInterfaceService.getCurrentSession();
-    this.cipherIds$ = this.session?.availableCipherIds$;
-    await this.loadCiphers();
-  }
-
-  async ngOnDestroy(): Promise<void> {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
 
   async chooseCipher(cipher: CipherView): Promise<void> {
     if (!this.session) {
@@ -121,34 +91,35 @@ export class Fido2VaultComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async loadCiphers(): Promise<void> {
-    const activeUserId = await firstValueFrom(
-      this.accountService.activeAccount$.pipe(map((a) => a?.id)),
-    );
+  private buildCiphers$(): Observable<CipherView[]> {
+    return this.accountService.activeAccount$.pipe(
+      map((account) => account?.id),
+      switchMap((activeUserId) => {
+        if (!activeUserId) {
+          return of<CipherView[]>([]);
+        }
 
-    if (!activeUserId) {
-      return;
-    }
+        // Combine the cipher list with the optional cipher IDs filter the
+        // session made available for this ceremony.
+        return combineLatest([
+          this.cipherService.cipherListViews$(activeUserId),
+          this.session?.availableCipherIds$ ?? of(null),
+        ]).pipe(
+          map(([ciphers, cipherIds]) => {
+            const activeCiphers = ciphers.filter((cipher) => !cipher.deletedDate);
 
-    // Combine cipher list with optional cipher IDs filter
-    combineLatest([this.cipherService.cipherListViews$(activeUserId), this.cipherIds$ || of(null)])
-      .pipe(
-        map(([ciphers, cipherIds]) => {
-          // Filter out deleted ciphers
-          const activeCiphers = ciphers.filter((cipher) => !cipher.deletedDate);
+            if (cipherIds?.length > 0) {
+              return activeCiphers.filter((cipher) => cipherIds.includes(cipher.id as string));
+            }
 
-          // If specific IDs provided, filter by them
-          if (cipherIds?.length > 0) {
-            return activeCiphers.filter((cipher) => cipherIds.includes(cipher.id as string));
-          }
-
-          return activeCiphers;
-        }),
-        takeUntil(this.destroy$),
-      )
-      .subscribe({
-        next: (ciphers) => this.ciphersSubject.next(ciphers as CipherView[]),
-        error: (error: unknown) => this.logService.error("Failed to load ciphers", error),
-      });
+            return activeCiphers;
+          }),
+        );
+      }),
+      catchError((error: unknown) => {
+        this.logService.error("Failed to load ciphers", error);
+        return of<CipherView[]>([]);
+      }),
+    ) as Observable<CipherView[]>;
   }
 }

--- a/apps/desktop/src/autofill/services/desktop-autofill.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autofill.service.ts
@@ -58,7 +58,6 @@ import type { NativeWindowObject } from "./desktop-fido2-user-interface.service"
 @Injectable()
 export class DesktopAutofillService implements OnDestroy {
   private destroy$ = new Subject<void>();
-  private registrationRequest?: PasskeyRegistrationRequest;
   private featureFlag?:
     typeof FeatureFlag.MacOsNativeCredentialSync | typeof FeatureFlag.WindowsNativeCredentialSync;
   private isEnabled: boolean = false;
@@ -232,10 +231,6 @@ export class DesktopAutofillService implements OnDestroy {
     });
   }
 
-  get lastRegistrationRequest() {
-    return this.registrationRequest;
-  }
-
   async doCancelRequest(context: string): Promise<void> {
     const controller = this.inFlightRequests[context];
     if (controller) {
@@ -260,8 +255,6 @@ export class DesktopAutofillService implements OnDestroy {
     request: PasskeyRegistrationRequest,
     abortController: AbortController,
   ): Promise<PasskeyRegistrationResponse> {
-    this.registrationRequest = request;
-
     const response = await this.fido2AuthenticatorService.makeCredential(
       this.convertRegistrationRequest(request),
       await this.nativeWindowObject(request),
@@ -319,6 +312,8 @@ export class DesktopAutofillService implements OnDestroy {
       appWindowHandle: await ipc.autofill.desktopAutofill.getAppWindowHandle(),
       rpId: request.rpId,
       requestContext: request.context,
+      // Discoverable credential requests don't contain a userHandle.
+      userHandle: "userHandle" in request ? request.userHandle : undefined,
     };
   }
 

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -188,7 +188,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     take(1),
   );
 
-  private chosenCipherSubject = new Subject<CipherView | undefined>();
+  private chosenCipherSubject = new Subject<CipherViewLike | undefined>();
 
   /**
    * Whether this ceremony took over the app window to show UI. Some ceremonies
@@ -248,7 +248,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
         { signal: abortSignal },
       );
 
-      return { cipherId: chosenCipher.id, userVerified };
+      return { cipherId: chosenCipher.id?.toString(), userVerified };
     } catch (error) {
       throw this.mapUserVerificationCancellation(error);
     } finally {
@@ -261,7 +261,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     return this.windowObject.rpId;
   }
 
-  confirmChosenCipher(cipher?: CipherView): void {
+  confirmChosenCipher(cipher?: CipherViewLike): void {
     this.chosenCipherSubject.next(cipher);
     this.chosenCipherSubject.complete();
   }
@@ -372,7 +372,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     signal,
   }: {
     signal: AbortSignal;
-  }): Promise<CipherView | undefined> {
+  }): Promise<CipherViewLike | undefined> {
     try {
       signal.throwIfAborted();
       return await firstValueFrom(this.chosenCipherSubject.pipe(throwOnAbort(signal)));

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -81,6 +81,12 @@ export type NativeWindowObject = {
    * RP ID of the request.
    */
   rpId: string;
+
+  /**
+   * User handle for the credential. Absent for discoverable credential
+   * requests, which don't contain a userHandle.
+   */
+  userHandle?: number[];
 };
 
 /**
@@ -259,6 +265,10 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
 
   get rpId(): string {
     return this.windowObject.rpId;
+  }
+
+  get userHandle(): number[] | undefined {
+    return this.windowObject.userHandle;
   }
 
   confirmChosenCipher(cipher?: CipherViewLike): void {

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -179,7 +179,6 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
    * already verifies the user, so the OS is not asked to do it a second time.
    */
   private vaultUnlockedDuringCeremony: boolean = false;
-  private rpId = new BehaviorSubject<string | null>(null);
   private availableCipherIdsSubject = new BehaviorSubject<string[]>([""]);
   /**
    * Observable that emits available cipher IDs once they're confirmed by the UI
@@ -258,8 +257,8 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     }
   }
 
-  async getRpId(): Promise<string> {
-    return firstValueFrom(this.rpId.pipe(filter((id) => id != null)));
+  get rpId(): string {
+    return this.windowObject.rpId;
   }
 
   confirmChosenCipher(cipher?: CipherView): void {
@@ -448,7 +447,6 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       needsUserVerification,
       rpId,
     );
-    this.rpId.next(rpId);
 
     const abortSignal = this.abortController.signal;
     try {


### PR DESCRIPTION
## 🎟️ Tracking

Fixes [PM-29943](https://bitwarden.atlassian.net/browse/PM-29943)

## 📔 Objective

Begins cleaning up the FIDO2 desktop modal components by removing all ignored eslint and TypeScript rules. It also moves `userHandle` into the `NativeWindowObject` request context, allowing us to remove the cached `lastRegistrationRequest` from `DesktopAutofillService` and to remove the dependencies on `DesktopAutofillService` and `DesktopFido2UserInterfaceService` from the modal components.

Only visible change is that UI glitch, where "no matching login screen" flashes before the "save a new passkey login" appears is now gone.

[PM-29943]: https://bitwarden.atlassian.net/browse/PM-29943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ