### PR TITLE
[PM-40333] Hide side-nav vault filter on desktop

### DIFF
--- a/apps/desktop/src/app/layout/desktop-layout.component.html
+++ b/apps/desktop/src/app/layout/desktop-layout.component.html
@@ -2,7 +2,9 @@
   <app-side-nav slot="side-nav">
     <bit-nav-logo [openIcon]="logo" route="." [label]="'passwordManager' | i18n" />
 
-    <app-vault-filter />
+    @if (!vfo1Foundation()) {
+      <app-vault-filter />
+    }
     @if (sendEnabled()) {
       <app-send-filters-nav />
     }

--- a/apps/desktop/src/app/layout/desktop-layout.component.ts
+++ b/apps/desktop/src/app/layout/desktop-layout.component.ts
@@ -4,6 +4,8 @@ import { RouterModule } from "@angular/router";
 import { map } from "rxjs";
 
 import { PasswordManagerLogo } from "@bitwarden/assets/svg";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { DialogService, LayoutComponent, NavigationModule } from "@bitwarden/components";
 import { SendPolicyService } from "@bitwarden/send-ui";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -34,12 +36,18 @@ import { DesktopSideNavComponent } from "./desktop-side-nav.component";
 export class DesktopLayoutComponent {
   private dialogService = inject(DialogService);
   private sendPolicyService = inject(SendPolicyService);
+  private configService = inject(ConfigService);
 
   protected readonly logo = PasswordManagerLogo;
 
   protected readonly sendEnabled = toSignal(
     this.sendPolicyService.disableSend$.pipe(map((disableSend) => !disableSend)),
     { initialValue: true },
+  );
+
+  protected readonly vfo1Foundation = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.VFO1Foundation),
+    { initialValue: false },
   );
 
   protected openGenerator() {

--- a/libs/vault/src/components/vault-items-table/vault-items-table.component.html
+++ b/libs/vault/src/components/vault-items-table/vault-items-table.component.html
@@ -119,7 +119,7 @@
   </bit-no-items>
 
   <!-- Name -->
-  <bit-column sortable defaultSort="asc" width="minmax(200px, 2fr)">
+  <bit-column sortable defaultSort="asc" width="minmax(240px, 480px)">
     <bit-header-cell>{{ "name" | i18n }}</bit-header-cell>
 
     <bit-cell *bitCellDef="table.columns.name; let row">
@@ -173,7 +173,7 @@
   </bit-column>
 
   <!-- Vault -->
-  <bit-column sortable [sortFn]="sortByVault" width="minmax(140px, 1fr)">
+  <bit-column sortable [sortFn]="sortByVault" width="minmax(176px, 280px)">
     <bit-header-cell>{{ "vault" | i18n }}</bit-header-cell>
     <bit-cell *bitCellDef="table.columns.vault; let row">
       <bit-icon
@@ -186,7 +186,7 @@
   </bit-column>
 
   <!-- Shared folders -->
-  <bit-column sortable [sortFn]="sortBySharedFolders" width="minmax(140px, 1fr)">
+  <bit-column sortable [sortFn]="sortBySharedFolders" width="minmax(176px, 280px)">
     <bit-header-cell>{{ "sharedFolders" | i18n }}</bit-header-cell>
     <bit-cell *bitCellDef="table.columns.sharedFolders; let row">
       <vault-items-table-chips-cell


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40333](https://bitwarden.atlassian.net/browse/PM-40333)

## 📔 Objective

Hides the side-nav `<app-vault-filter />` in the desktop layout when the `vfo1-foundation` feature flag is enabled. When VFO1 is active the vault filter is no longer needed in the side nav (vault filtering moves to the main content area via the table component added in [PM-40330](https://bitwarden.atlassian.net/browse/PM-40330)).

**Changes:**
- Injected `ConfigService` into `DesktopLayoutComponent` and added a `vfo1Foundation` signal
- Wrapped `<app-vault-filter />` in `@if (!vfo1Foundation())` — Send and all other nav items are untouched

**Design Review feedback**
- Adjusts column of the vault table to match expected min-max values, see [feedback in ticket](https://bitwarden.atlassian.net/browse/PM-40333?focusedCommentId=171345)

## 📸 Screenshots

|Before|After|
|-|-|
|<img width="1575" height="1018" alt="Screenshot 2026-08-14 at 10 19 13 AM" src="https://github.com/user-attachments/assets/b45f44f5-b864-40d8-9370-ecd3319e59bd" />|<img width="1476" height="974" alt="Screenshot 2026-08-14 at 10 02 31 AM" src="https://github.com/user-attachments/assets/8b08d554-5e82-4333-9838-44dc37849087" /> | 

[PM-40333]: https://bitwarden.atlassian.net/browse/PM-40333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-40330]: https://bitwarden.atlassian.net/browse/PM-40330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ