### PR TITLE
desktop-autofill: Skip registration confirmation

### DIFF
--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -58,6 +58,7 @@ import { TokenService } from "@bitwarden/common/auth/abstractions/token.service"
 import { WebAuthnLoginPrfKeyServiceAbstraction } from "@bitwarden/common/auth/abstractions/webauthn/webauthn-login-prf-key.service.abstraction";
 import { PendingAuthRequestsStateService } from "@bitwarden/common/auth/services/auth-request-answering/pending-auth-requests.state";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { ClientType, DeviceType } from "@bitwarden/common/enums";
 import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
@@ -472,6 +473,7 @@ const safeProviders: SafeProvider[] = [
       DesktopSettingsService,
       DesktopFido2UserVerificationService,
       PasswordRepromptService,
+      DomainSettingsService,
     ],
   }),
   safeProvider({

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
@@ -1,15 +1,13 @@
 import { TestBed } from "@angular/core/testing";
 import { Router } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject, of } from "rxjs";
+import { BehaviorSubject } from "rxjs";
 
 import { AccountService, Account } from "@bitwarden/common/auth/abstractions/account.service";
-import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
-import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService } from "@bitwarden/components";
@@ -27,9 +25,7 @@ describe("Fido2CreateComponent", () => {
   let mockDesktopSettingsService: MockProxy<DesktopSettingsService>;
   let mockFido2UserInterfaceService: MockProxy<DesktopFido2UserInterfaceService>;
   let mockAccountService: MockProxy<AccountService>;
-  let mockCipherService: MockProxy<CipherService>;
   let mockDialogService: MockProxy<DialogService>;
-  let mockDomainSettingsService: MockProxy<DomainSettingsService>;
   let mockLogService: MockProxy<LogService>;
   let mockRouter: MockProxy<Router>;
   let mockSession: MockProxy<DesktopFido2UserInterfaceSession>;
@@ -47,9 +43,7 @@ describe("Fido2CreateComponent", () => {
     mockDesktopSettingsService = mock<DesktopSettingsService>();
     mockFido2UserInterfaceService = mock<DesktopFido2UserInterfaceService>();
     mockAccountService = mock<AccountService>();
-    mockCipherService = mock<CipherService>();
     mockDialogService = mock<DialogService>();
-    mockDomainSettingsService = mock<DomainSettingsService>();
     mockLogService = mock<LogService>();
     mockRouter = mock<Router>();
     mockSession = mock<DesktopFido2UserInterfaceSession>();
@@ -58,27 +52,16 @@ describe("Fido2CreateComponent", () => {
     mockFido2UserInterfaceService.getCurrentSession.mockReturnValue(mockSession);
     mockAccountService.activeAccount$ = activeAccountSubject;
 
-    // RP ID and user handle are read synchronously from the session when the
-    // component builds its `ciphers$` stream at construction.
-    Object.defineProperty(mockSession, "rpId", {
-      get: () => "example.com",
-      configurable: true,
-    });
-    Object.defineProperty(mockSession, "userHandle", {
-      get: () => [1, 2, 3],
-      configurable: true,
-    });
-    mockDomainSettingsService.getUrlEquivalentDomains.mockReturnValue(of(new Set<string>()));
-    mockCipherService.getAllDecrypted.mockResolvedValue([]);
+    // The component reads its cipher list from the session, which is the single
+    // source of truth for the logins the new passkey could be added to.
+    mockSession.getMatchingLogins.mockResolvedValue([]);
 
     await TestBed.configureTestingModule({
       providers: [
         { provide: DesktopSettingsService, useValue: mockDesktopSettingsService },
         { provide: DesktopFido2UserInterfaceService, useValue: mockFido2UserInterfaceService },
         { provide: AccountService, useValue: mockAccountService },
-        { provide: CipherService, useValue: mockCipherService },
         { provide: DialogService, useValue: mockDialogService },
-        { provide: DomainSettingsService, useValue: mockDomainSettingsService },
         { provide: LogService, useValue: mockLogService },
         { provide: Router, useValue: mockRouter },
         { provide: I18nService, useValue: mockI18nService },

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -1,15 +1,11 @@
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, inject } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
-import { combineLatest, map, Observable, of, switchMap } from "rxjs";
+import { catchError, from, Observable, of } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { BitwardenShield, NoResults } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
-import { Fido2Utils } from "@bitwarden/common/platform/services/fido2/fido2-utils";
-import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherType } from "@bitwarden/common/vault/enums/cipher-type";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   DialogService,
@@ -53,9 +49,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
   private readonly desktopSettingsService = inject(DesktopSettingsService);
   private readonly fido2UserInterfaceService = inject(DesktopFido2UserInterfaceService);
   private readonly accountService = inject(AccountService);
-  private readonly cipherService = inject(CipherService);
   private readonly dialogService = inject(DialogService);
-  private readonly domainSettingsService = inject(DomainSettingsService);
   private readonly router = inject(Router);
 
   readonly session = this.fido2UserInterfaceService.getCurrentSession();
@@ -142,42 +136,23 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
   }
 
   private buildCiphers$(): Observable<CipherView[] | null> {
-    const rpid = this.session?.rpId;
-    const userHandleBytes = this.session?.userHandle;
-
-    // Emit `null` (loading/unavailable) until we have everything needed to
-    // resolve matching ciphers. The template treats `null` as a distinct state
-    // from an empty list so it doesn't flash the wrong branch.
-    if (!this.session || !rpid || !userHandleBytes) {
+    // Emit `null` (loading/unavailable) until the list resolves. The template
+    // treats `null` as a distinct state from an empty list so it doesn't flash
+    // the wrong branch.
+    if (!this.session) {
       return of(null);
     }
 
-    const userHandle = Fido2Utils.arrayToString(new Uint8Array(userHandleBytes));
-
-    return combineLatest([
-      this.accountService.activeAccount$.pipe(map((a) => a?.id)),
-      this.domainSettingsService.getUrlEquivalentDomains(rpid),
-    ]).pipe(
-      switchMap(async ([activeUserId, equivalentDomains]) => {
-        if (!activeUserId) {
-          return [];
-        }
-
-        try {
-          const allCiphers = await this.cipherService.getAllDecrypted(activeUserId);
-          return allCiphers.filter(
-            (cipher) =>
-              cipher != null &&
-              cipher.type == CipherType.Login &&
-              cipher.login?.matchesUri(rpid, equivalentDomains) &&
-              Fido2Utils.cipherHasNoOtherPasskeys(cipher, userHandle) &&
-              !cipher.deletedDate,
-          );
-        } catch {
-          await this.showErrorDialog(this.DIALOG_MESSAGES.unexpectedErrorShort);
-          return [];
-        }
-      }),
+    // The session computes the matching logins once and shares them, so this
+    // list always agrees with the session's decision to show this picker.
+    return from(this.session.getMatchingLogins()).pipe(
+      catchError(() =>
+        from(
+          this.showErrorDialog(this.DIALOG_MESSAGES.unexpectedErrorShort).then(
+            () => [] as CipherView[],
+          ),
+        ),
+      ),
     );
   }
 

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -5,11 +5,13 @@ import { BehaviorSubject, of } from "rxjs";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { Fido2AuthenticatorErrorCode } from "@bitwarden/common/platform/abstractions/fido2/fido2-authenticator.service.abstraction";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherRepromptType } from "@bitwarden/common/vault/enums";
+import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { CipherListView } from "@bitwarden/sdk-internal";
 import { PasswordRepromptService } from "@bitwarden/vault";
 
@@ -32,6 +34,13 @@ const timeoutReason = () => new DOMException("The operation timed out.", "Timeou
 const repromptCipher = (id: string) =>
   Object.assign(new CipherView(), { id, reprompt: CipherRepromptType.Password });
 
+/** A login the new passkey could be added to: matches the RP and holds no passkeys. */
+const matchingLogin = () =>
+  Object.assign(new CipherView(), {
+    type: CipherType.Login,
+    login: Object.assign(new LoginView(), { matchesUri: () => true, fido2Credentials: [] }),
+  });
+
 describe("DesktopFido2UserInterfaceSession", () => {
   let authService: MockProxy<AuthService>;
   let cipherService: MockProxy<CipherService>;
@@ -41,6 +50,7 @@ describe("DesktopFido2UserInterfaceSession", () => {
   let desktopSettingsService: MockProxy<DesktopSettingsService>;
   let userVerificationService: MockProxy<DesktopFido2UserVerificationService>;
   let passwordRepromptService: MockProxy<PasswordRepromptService>;
+  let domainSettingsService: MockProxy<DomainSettingsService>;
 
   let activeAccountStatus$: BehaviorSubject<AuthenticationStatus>;
   let abortController: AbortController;
@@ -72,13 +82,21 @@ describe("DesktopFido2UserInterfaceSession", () => {
     passwordRepromptService = mock<PasswordRepromptService>();
     passwordRepromptService.enabled.mockResolvedValue(true);
 
+    domainSettingsService = mock<DomainSettingsService>();
+    domainSettingsService.getUrlEquivalentDomains.mockReturnValue(of(new Set<string>()));
+
     activeAccountStatus$ = new BehaviorSubject<AuthenticationStatus>(AuthenticationStatus.Unlocked);
     authService.activeAccountStatus$ = activeAccountStatus$;
     accountService.activeAccount$ = new BehaviorSubject({ id: "user-1" } as any);
 
-    // Default to a vault with no credentials. Tests that need the ceremony to
-    // find one stub this with the cipher they expect it to retrieve.
+    // The assertion flow reads the vault through `cipherListViews$`; default to
+    // empty. Tests that need the ceremony to find one stub this with the cipher
+    // they expect it to retrieve.
     cipherService.cipherListViews$.mockReturnValue(of([]));
+    // The registration flow reads the vault through `getAllDecrypted` to decide
+    // whether to show the picker. Default to a login the new passkey could be
+    // added to, so the picker is shown unless a test opts out with an empty vault.
+    cipherService.getAllDecrypted.mockResolvedValue([matchingLogin()]);
 
     desktopSettingsService.modalMode$ = new BehaviorSubject<ModalModeState>({
       isModalModeActive: false,
@@ -124,9 +142,11 @@ describe("DesktopFido2UserInterfaceSession", () => {
         windowXy: { x: 0, y: 0 },
         appWindowHandle: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
         clientWindowHandle: new Uint8Array([8, 7, 6, 5, 4, 3, 2, 1]),
+        userHandle: [1, 2, 3],
       },
       userVerificationService,
       passwordRepromptService,
+      domainSettingsService,
     );
   });
 
@@ -299,6 +319,60 @@ describe("DesktopFido2UserInterfaceSession", () => {
       expect(logService.warning).toHaveBeenCalledWith(
         "Request was cancelled before the user confirmed a cipher",
       );
+    });
+
+    it("shows the picker when a login the passkey could be added to exists", async () => {
+      // `getAllDecrypted` defaults to a matching login.
+      userVerificationService.verify.mockResolvedValue(true);
+
+      const result = session.confirmNewCredential(params);
+      await tick();
+
+      expect(router.navigate).toHaveBeenCalledWith([
+        "/fido2-creation",
+        { "disable-redirect": null },
+      ]);
+
+      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+      await result;
+    });
+
+    describe("when there is no login to add the passkey to", () => {
+      beforeEach(() => {
+        cipherService.getAllDecrypted.mockResolvedValue([]);
+        cipherService.createWithServer.mockResolvedValue({} as any);
+        cipherService.encrypt.mockResolvedValue({ cipher: { id: "new-cipher" } } as any);
+      });
+
+      it("skips the picker and creates the credential after user verification", async () => {
+        userVerificationService.verify.mockResolvedValue(true);
+
+        const result = await session.confirmNewCredential(params);
+
+        expect(result).toEqual({ cipherId: "new-cipher", userVerified: true });
+        expect(userVerificationService.verify).toHaveBeenCalled();
+        expect(cipherService.createWithServer).toHaveBeenCalled();
+        // The picker UI is never shown.
+        expect(router.navigate).not.toHaveBeenCalled();
+      });
+
+      it("skips the picker and creates the credential even when verification is not required", async () => {
+        const result = await session.confirmNewCredential({ ...params, userVerification: false });
+
+        expect(result).toEqual({ cipherId: "new-cipher", userVerified: false });
+        expect(userVerificationService.verify).not.toHaveBeenCalled();
+        expect(cipherService.createWithServer).toHaveBeenCalled();
+        expect(router.navigate).not.toHaveBeenCalled();
+      });
+
+      it("creates nothing when required verification fails", async () => {
+        userVerificationService.verify.mockResolvedValue(false);
+
+        const result = await session.confirmNewCredential(params);
+
+        expect(result).toEqual({ cipherId: undefined, userVerified: false });
+        expect(cipherService.createWithServer).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.spec.ts
@@ -8,9 +8,11 @@ import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authenticatio
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { Fido2AuthenticatorErrorCode } from "@bitwarden/common/platform/abstractions/fido2/fido2-authenticator.service.abstraction";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { Fido2Utils } from "@bitwarden/common/platform/services/fido2/fido2-utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { Fido2CredentialView } from "@bitwarden/common/vault/models/view/fido2-credential.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 import { CipherListView } from "@bitwarden/sdk-internal";
 import { PasswordRepromptService } from "@bitwarden/vault";
@@ -39,6 +41,24 @@ const matchingLogin = () =>
   Object.assign(new CipherView(), {
     type: CipherType.Login,
     login: Object.assign(new LoginView(), { matchesUri: () => true, fido2Credentials: [] }),
+  });
+
+/** The user handle for the ceremony, matching `windowObject.userHandle` below. */
+const userHandle = Fido2Utils.arrayToString(new Uint8Array([1, 2, 3]));
+
+/**
+ * A login whose URI does NOT match the RP but that already holds a passkey for
+ * this RP and user handle — reached only through the existing-passkey rpId match.
+ */
+const rpIdMatchLogin = () =>
+  Object.assign(new CipherView(), {
+    type: CipherType.Login,
+    login: Object.assign(new LoginView(), {
+      matchesUri: () => false,
+      fido2Credentials: [
+        Object.assign(new Fido2CredentialView(), { rpId: "example.com", userHandle }),
+      ],
+    }),
   });
 
 describe("DesktopFido2UserInterfaceSession", () => {
@@ -337,6 +357,23 @@ describe("DesktopFido2UserInterfaceSession", () => {
       await result;
     });
 
+    it("shows the picker when a login already holds a passkey for this RP", async () => {
+      // URI doesn't match; the login is reached only via the existing-passkey rpId match.
+      cipherService.getAllDecrypted.mockResolvedValue([rpIdMatchLogin()]);
+      userVerificationService.verify.mockResolvedValue(true);
+
+      const result = session.confirmNewCredential(params);
+      await tick();
+
+      expect(router.navigate).toHaveBeenCalledWith([
+        "/fido2-creation",
+        { "disable-redirect": null },
+      ]);
+
+      session.notifyConfirmCreateCredential(true, Object.assign(new CipherView(), { id: "c1" }));
+      await result;
+    });
+
     describe("when there is no login to add the passkey to", () => {
       beforeEach(() => {
         cipherService.getAllDecrypted.mockResolvedValue([]);
@@ -373,6 +410,56 @@ describe("DesktopFido2UserInterfaceSession", () => {
         expect(result).toEqual({ cipherId: undefined, userVerified: false });
         expect(cipherService.createWithServer).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe("getMatchingLogins", () => {
+    it("includes a login whose URI matches the relying party", async () => {
+      cipherService.getAllDecrypted.mockResolvedValue([matchingLogin()]);
+
+      await expect(session.getMatchingLogins()).resolves.toHaveLength(1);
+    });
+
+    it("includes a login that already holds a passkey for the RP even when its URI doesn't match", async () => {
+      const login = rpIdMatchLogin();
+      cipherService.getAllDecrypted.mockResolvedValue([login]);
+
+      await expect(session.getMatchingLogins()).resolves.toEqual([login]);
+    });
+
+    it("excludes a login whose only passkey belongs to a different user handle", async () => {
+      const login = Object.assign(new CipherView(), {
+        type: CipherType.Login,
+        login: Object.assign(new LoginView(), {
+          matchesUri: () => true,
+          fido2Credentials: [
+            Object.assign(new Fido2CredentialView(), {
+              rpId: "example.com",
+              userHandle: "someone-else",
+            }),
+          ],
+        }),
+      });
+      cipherService.getAllDecrypted.mockResolvedValue([login]);
+
+      await expect(session.getMatchingLogins()).resolves.toEqual([]);
+    });
+
+    it("excludes deleted logins", async () => {
+      const login = matchingLogin();
+      login.deletedDate = new Date();
+      cipherService.getAllDecrypted.mockResolvedValue([login]);
+
+      await expect(session.getMatchingLogins()).resolves.toEqual([]);
+    });
+
+    it("computes the list once and caches it across calls", async () => {
+      cipherService.getAllDecrypted.mockResolvedValue([matchingLogin()]);
+
+      await session.getMatchingLogins();
+      await session.getMatchingLogins();
+
+      expect(cipherService.getAllDecrypted).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -564,9 +564,6 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     );
     const ciphers = await this.cipherService.getAllDecrypted(activeUserId);
 
-    // TODO: Add tests for when matching logins exist and the overwrite/add
-    // picker should be shown, covering both the URI match and the
-    // existing-passkey rpId match below.
     return ciphers.filter(
       (cipher) =>
         cipher != null &&

--- a/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-fido2-user-interface.service.ts
@@ -16,6 +16,7 @@ import {
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import {
   Fido2AuthenticatorError,
   Fido2AuthenticatorErrorCode,
@@ -28,6 +29,7 @@ import {
 } from "@bitwarden/common/platform/abstractions/fido2/fido2-user-interface.service.abstraction";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { Fido2Utils } from "@bitwarden/common/platform/services/fido2/fido2-utils";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherRepromptType, CipherType, SecureNoteType } from "@bitwarden/common/vault/enums";
 import { Cipher } from "@bitwarden/common/vault/models/domain/cipher";
@@ -124,6 +126,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
     private desktopSettingsService: DesktopSettingsService,
     private userVerificationService: DesktopFido2UserVerificationService,
     private passwordRepromptService: PasswordRepromptService,
+    private domainSettingsService: DomainSettingsService,
   ) {}
   private currentSession: any;
 
@@ -155,6 +158,7 @@ export class DesktopFido2UserInterfaceService implements Fido2UserInterfaceServi
       nativeWindowObject,
       this.userVerificationService,
       this.passwordRepromptService,
+      this.domainSettingsService,
     );
 
     this.currentSession = session;
@@ -174,6 +178,7 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     private windowObject: NativeWindowObject,
     private userVerificationService: DesktopFido2UserVerificationService,
     private passwordRepromptService: PasswordRepromptService,
+    private domainSettingsService: DomainSettingsService,
   ) {}
 
   private confirmCredentialSubject = new Subject<boolean>();
@@ -461,14 +466,21 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
     const abortSignal = this.abortController.signal;
     try {
       abortSignal.throwIfAborted();
-      await this.showUi("/fido2-creation", this.windowObject.windowXy, false);
 
-      // Wait for the UI to wrap up
-      const confirmation = await this.waitForUiNewCredentialConfirmation({
-        signal: abortSignal,
-      });
-      if (!confirmation) {
-        return { cipherId: undefined, userVerified: false };
+      // The picker only exists to let the user add this passkey to an existing
+      // login (or overwrite one). When nothing matches, there's no such choice
+      // to make and the OS has already confirmed the user's intent to create the
+      // passkey, so skip our UI and go straight to verification and creation.
+      if ((await this.getMatchingLogins()).length > 0) {
+        await this.showUi("/fido2-creation", this.windowObject.windowXy, false);
+
+        // Wait for the UI to wrap up
+        const confirmation = await this.waitForUiNewCredentialConfirmation({
+          signal: abortSignal,
+        });
+        if (!confirmation) {
+          return { cipherId: undefined, userVerified: false };
+        }
       }
 
       // Confirming in our own UI establishes user presence, so we only verify
@@ -516,6 +528,54 @@ export class DesktopFido2UserInterfaceSession implements Fido2UserInterfaceSessi
       // Make sure to clean up so the app is never stuck in modal mode
       await this.hideUi();
     }
+  }
+
+  /**
+   * The logins this passkey could be added to: Login ciphers that match the
+   * relying party — by URI or by an existing passkey's rpId — and that don't
+   * already hold a passkey for this user handle. This is the single source of
+   * truth for both the creation picker's list and the decision (in
+   * {@link confirmNewCredential}) to skip that picker, so the two never
+   * disagree. Computed once per ceremony and cached.
+   */
+  getMatchingLogins(): Promise<CipherView[]> {
+    return (this.matchingLogins ??= this.computeMatchingLogins());
+  }
+  private matchingLogins?: Promise<CipherView[]>;
+
+  private async computeMatchingLogins(): Promise<CipherView[]> {
+    const rpId = this.windowObject.rpId;
+    const userHandleBytes = this.windowObject.userHandle;
+    if (!userHandleBytes) {
+      return [];
+    }
+    const userHandle = Fido2Utils.arrayToString(new Uint8Array(userHandleBytes));
+
+    const activeUserId = await firstValueFrom(
+      this.accountService.activeAccount$.pipe(map((a) => a?.id)),
+    );
+
+    if (!activeUserId) {
+      return [];
+    }
+
+    const equivalentDomains = await firstValueFrom(
+      this.domainSettingsService.getUrlEquivalentDomains(rpId),
+    );
+    const ciphers = await this.cipherService.getAllDecrypted(activeUserId);
+
+    // TODO: Add tests for when matching logins exist and the overwrite/add
+    // picker should be shown, covering both the URI match and the
+    // existing-passkey rpId match below.
+    return ciphers.filter(
+      (cipher) =>
+        cipher != null &&
+        cipher.type === CipherType.Login &&
+        (cipher.login?.matchesUri(rpId, equivalentDomains) ||
+          cipher.login?.fido2Credentials?.some((cred) => cred.rpId === rpId)) &&
+        Fido2Utils.cipherHasNoOtherPasskeys(cipher, userHandle) &&
+        !cipher.deletedDate,
+    );
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41980](https://bitwarden.atlassian.net/browse/PM-41980)

## 📔 Objective

- Skips the passkey registration confirmation screen if UV is shown
- Shows ciphers that don't have matching URIs but do have FIDO credentials with matching RP ID in the passkey attach/overwrite list.

## 📸 Screenshots

https://github.com/user-attachments/assets/64bb8dae-0de1-496c-8103-922375f82b50



[PM-41980]: https://bitwarden.atlassian.net/browse/PM-41980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ