### PR TITLE
desktop-autofill: FIDO2 selection modal UI improvements

### DIFF
--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
@@ -4,11 +4,9 @@
     class="tw-sticky tw-top-0 tw-z-10 tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
   >
     <bit-section-header class="tw-app-region-drag tw-bg-background">
-      <div class="tw-flex tw-items-center">
-        <bit-svg [content]="Icons.BitwardenShield" class="tw-w-10 tw-mt-2 tw-ml-2"></bit-svg>
-
+      <div class="tw-flex tw-items-center tw-pl-4">
         <h2 bitTypography="h4" class="tw-font-semibold tw-text-lg">
-          {{ "savePasskeyQuestion" | i18n }}
+          {{ "savePasskey" | i18n }}
         </h2>
       </div>
 
@@ -16,7 +14,7 @@
         type="button"
         bitIconButton="bwi-close"
         slot="end"
-        class="tw-app-region-no-drag tw-mb-4 tw-mr-2"
+        class="tw-app-region-no-drag tw-mr-2"
         (click)="closeModal()"
         [label]="'close' | i18n"
       >
@@ -33,7 +31,7 @@
       <div>
         <div class="tw-flex tw-items-center tw-flex-col tw-p-12 tw-gap-4">
           <bit-svg [content]="Icons.NoResults" class="tw-text-main"></bit-svg>
-          <div class="tw-flex tw-flex-col tw-gap-2">
+          <div class="tw-flex tw-flex-col tw-gap-2 tw-text-lg">
             {{ "noMatchingLoginsForSite" | i18n }}
           </div>
           <button bitButton type="button" buttonType="primary" (click)="confirmPasskey()">
@@ -46,19 +44,15 @@
         <bit-item>
           <button type="button" bit-item-content (click)="addCredentialToCipher(c)">
             <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
-            <button bitLink [title]="c.name" type="button">
-              {{ c.name }}
-            </button>
+            <span [title]="c.name">{{ c.name }}</span>
             <span slot="secondary">{{ c.subTitle }}</span>
             <span bitBadge slot="end">{{ "save" | i18n }}</span>
           </button>
         </bit-item>
       }
       <bit-item>
-        <button type="button" bit-item-content (click)="confirmPasskey()">
-          <a bitLink linkType="primary" class="tw-font-medium tw-text-base">
-            {{ "saveNewPasskey" | i18n }}
-          </a>
+        <button type="button" bit-item-content class="!tw-py-4" (click)="confirmPasskey()">
+          <span class="tw-text-fg-brand tw-font-semibold">{{ "saveNewPasskey" | i18n }}</span>
         </button>
       </bit-item>
     }

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.html
@@ -28,17 +28,18 @@
     @if (ciphers == null) {
       <!-- Loading matching ciphers; render nothing until the list resolves. -->
     } @else if (ciphers.length === 0) {
-      <div>
-        <div class="tw-flex tw-items-center tw-flex-col tw-p-12 tw-gap-4">
-          <bit-svg [content]="Icons.NoResults" class="tw-text-main"></bit-svg>
-          <div class="tw-flex tw-flex-col tw-gap-2 tw-text-lg">
-            {{ "noMatchingLoginsForSite" | i18n }}
-          </div>
-          <button bitButton type="button" buttonType="primary" (click)="confirmPasskey()">
-            {{ "savePasskeyNewLogin" | i18n }}
-          </button>
-        </div>
-      </div>
+      <bit-no-items [icon]="Icons.NoResults">
+        <ng-container slot="title">{{ "noMatchingLoginsForSite" | i18n }}</ng-container>
+        <button
+          bitButton
+          buttonType="primary"
+          slot="button"
+          type="button"
+          (click)="confirmPasskey()"
+        >
+          {{ "savePasskeyNewLogin" | i18n }}
+        </button>
+      </bit-no-items>
     } @else {
       @for (c of ciphers; track c.id) {
         <bit-item>

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.spec.ts
@@ -141,7 +141,7 @@ describe("Fido2CreateComponent", () => {
       await component.addCredentialToCipher(cipher);
 
       expect(mockDialogService.openSimpleDialog).toHaveBeenCalledWith({
-        title: { key: "overwritePasskey" },
+        title: { key: "overwritePasskey2" },
         content: { key: "alreadyContainsPasskey" },
         type: "warning",
       });

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -4,7 +4,7 @@ import { RouterModule, Router } from "@angular/router";
 import { catchError, from, Observable, of } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
-import { BitwardenShield, NoResults } from "@bitwarden/assets/svg";
+import { NoResults } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
@@ -12,7 +12,7 @@ import {
   BadgeModule,
   ButtonModule,
   DialogModule,
-  SvgModule,
+  NoItemsModule,
   ItemModule,
   SectionComponent,
   TableModule,
@@ -34,7 +34,7 @@ import { DesktopFido2UserInterfaceService } from "../../services/desktop-fido2-u
     BitIconButtonComponent,
     TableModule,
     I18nPipe,
-    SvgModule,
+    NoItemsModule,
     ButtonModule,
     DialogModule,
     SectionComponent,
@@ -54,7 +54,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
 
   readonly session = this.fido2UserInterfaceService.getCurrentSession();
   readonly ciphers$: Observable<CipherView[] | null> = this.buildCiphers$();
-  readonly Icons = { BitwardenShield, NoResults };
+  readonly Icons = { NoResults };
 
   private get DIALOG_MESSAGES() {
     return {

--- a/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-create.component.ts
@@ -75,7 +75,7 @@ export class Fido2CreateComponent implements OnInit, OnDestroy {
         acceptAction: async () => this.dialogService.closeAll(),
       },
       overwritePasskey: {
-        title: { key: "overwritePasskey" },
+        title: { key: "overwritePasskey2" },
         content: { key: "alreadyContainsPasskey" },
         type: "warning",
       },

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.html
@@ -4,11 +4,9 @@
     class="tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
   >
     <bit-section-header class="tw-app-region-drag tw-bg-background">
-      <div class="tw-flex tw-items-center">
-        <bit-svg [content]="Icons.BitwardenShield" class="tw-w-10 tw-mt-2 tw-ml-2"></bit-svg>
-
+      <div class="tw-flex tw-items-center tw-pl-4">
         <h2 bitTypography="h4" class="tw-font-semibold tw-text-lg">
-          {{ "savePasskeyQuestion" | i18n }}
+          {{ "savePasskey" | i18n }}
         </h2>
       </div>
 
@@ -16,7 +14,7 @@
         type="button"
         bitIconButton="bwi-close"
         slot="end"
-        class="tw-app-region-no-drag tw-mb-4 tw-mr-2"
+        class="tw-app-region-no-drag tw-mr-2"
         (click)="closeModal()"
         [label]="'close' | i18n"
       >

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.html
@@ -27,16 +27,15 @@
     <bit-section
       class="tw-flex tw-bg-background-alt tw-flex-col tw-justify-start tw-items-center tw-gap-2 tw-h-full tw-px-5"
     >
-      <div class="tw-flex tw-items-center tw-flex-col tw-p-12 tw-gap-4">
-        <bit-svg [content]="Icons.NoResults" class="tw-text-main"></bit-svg>
-        <div class="tw-flex tw-flex-col tw-gap-2">
-          <b>{{ "passkeyAlreadyExists" | i18n }}</b>
-          {{ "applicationDoesNotSupportDuplicates" | i18n }}
-        </div>
-        <button bitButton type="button" buttonType="primary" (click)="closeModal()">
+      <bit-no-items [icon]="Icons.NoResults">
+        <ng-container slot="title">{{ "passkeyAlreadyExists" | i18n }}</ng-container>
+        <ng-container slot="description">{{
+          "applicationDoesNotSupportDuplicates" | i18n
+        }}</ng-container>
+        <button bitButton buttonType="primary" slot="button" type="button" (click)="closeModal()">
           {{ "close" | i18n }}
         </button>
-      </div>
+      </bit-no-items>
     </bit-section>
   </div>
 </div>

--- a/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-excluded-ciphers.component.ts
@@ -2,13 +2,13 @@ import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, OnDestroy, inject } from "@angular/core";
 import { RouterModule, Router } from "@angular/router";
 
-import { BitwardenShield, NoResults } from "@bitwarden/assets/svg";
+import { NoResults } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import {
   BadgeModule,
   ButtonModule,
   DialogModule,
-  SvgModule,
+  NoItemsModule,
   ItemModule,
   SectionComponent,
   TableModule,
@@ -29,7 +29,7 @@ import { DesktopFido2UserInterfaceService } from "../../services/desktop-fido2-u
     BitIconButtonComponent,
     TableModule,
     I18nPipe,
-    SvgModule,
+    NoItemsModule,
     ButtonModule,
     DialogModule,
     SectionComponent,
@@ -46,7 +46,7 @@ export class Fido2ExcludedCiphersComponent implements OnDestroy {
   private readonly router = inject(Router);
 
   readonly session = this.fido2UserInterfaceService.getCurrentSession();
-  readonly Icons = { BitwardenShield, NoResults };
+  readonly Icons = { NoResults };
 
   async ngOnDestroy(): Promise<void> {
     await this.closeModal();

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.html
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.html
@@ -4,16 +4,14 @@
     class="tw-sticky tw-top-0 tw-z-10 tw-border-0 tw-border-b tw-border-solid tw-border-secondary-300"
   >
     <bit-section-header class="tw-app-region-drag tw-bg-background">
-      <div class="tw-flex tw-items-center">
-        <bit-svg [content]="Icons.BitwardenShield" class="tw-w-10 tw-mt-2 tw-ml-2"></bit-svg>
-
-        <h2 bitTypography="h4" class="tw-font-semibold tw-text-lg">{{ "passkeyLogin" | i18n }}</h2>
+      <div class="tw-flex tw-items-center tw-pl-4">
+        <h2 bitTypography="h4" class="tw-font-semibold tw-text-lg">{{ "passkeyLogin2" | i18n }}</h2>
       </div>
       <button
         type="button"
         bitIconButton="bwi-close"
         slot="end"
-        class="tw-app-region-no-drag tw-mb-4 tw-mr-2"
+        class="tw-app-region-no-drag tw-mr-2"
         (click)="closeModal()"
         [label]="'close' | i18n"
       >
@@ -27,9 +25,7 @@
       <bit-item>
         <button type="button" bit-item-content (click)="chooseCipher(c)">
           <app-vault-icon [cipher]="c" slot="start"></app-vault-icon>
-          <button bitLink [title]="c.name" type="button">
-            {{ c.name }}
-          </button>
+          <span [title]="c.name">{{ c.name }}</span>
           <span slot="secondary">{{ CipherViewLikeUtils.subtitle(c) }}</span>
           <span bitBadge slot="end">{{ "select" | i18n }}</span>
         </button>

--- a/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
+++ b/apps/desktop/src/autofill/modal/credentials/fido2-vault.component.ts
@@ -4,7 +4,6 @@ import { RouterModule, Router } from "@angular/router";
 import { map, combineLatest, of, Observable, switchMap, catchError } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
-import { BitwardenShield } from "@bitwarden/assets/svg";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -17,7 +16,6 @@ import {
   ButtonModule,
   DialogModule,
   DialogService,
-  SvgModule,
   ItemModule,
   SectionComponent,
   TableModule,
@@ -38,7 +36,6 @@ import { DesktopFido2UserInterfaceService } from "../../services/desktop-fido2-u
     BitIconButtonComponent,
     TableModule,
     I18nPipe,
-    SvgModule,
     ButtonModule,
     DialogModule,
     SectionComponent,
@@ -60,7 +57,6 @@ export class Fido2VaultComponent {
 
   readonly session = this.fido2UserInterfaceService.getCurrentSession();
   readonly ciphers$: Observable<CipherViewLike[]> = this.buildCiphers$();
-  readonly Icons = { BitwardenShield };
   protected readonly CipherViewLikeUtils = CipherViewLikeUtils;
 
   async chooseCipher(cipher: CipherViewLike): Promise<void> {

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -5222,10 +5222,17 @@
     "message": "Change account email"
   },
   "passkeyLogin": {
-    "message": "Log in with passkey?"
+    "message": "Log in with passkey?",
+    "description": "Deprecated; we shouldn't use a question mark. Use passkeyLogin2 instead."
+  },
+  "passkeyLogin2": {
+    "message": "Log in with passkey"
   },
   "savePasskeyQuestion": {
     "message": "Save passkey?"
+  },
+  "savePasskey": {
+    "message": "Save passkey"
   },
   "saveNewPasskey": {
     "message": "Save as new login"
@@ -5237,7 +5244,11 @@
     "message": "No matching logins for this site"
   },
   "overwritePasskey": {
-    "message": "Overwrite passkey?"
+    "message": "Overwrite passkey?",
+    "description": "Deprecated; we shouldn't use a question mark. Use overwritePasskey2 instead."
+  },
+  "overwritePasskey2": {
+    "message": "Overwrite passkey"
   },
   "unableToSavePasskey": {
     "message": "Unable to save passkey"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29924](https://bitwarden.atlassian.net/browse/PM-29924)

## 📔 Objective

- Remove Bitwarden icon from credential selection header
- Align header padding with button
- Make entire cipher row in credential selection UIs clickable
- Remove question marks at the header prompts

## 📸 Screenshots

<img width="712" height="712" alt="Credential selection UI showing clickable rows and modified headers" src="https://github.com/user-attachments/assets/ac91ea01-13be-4470-8bb8-663dbe795f88" />



[PM-29924]: https://bitwarden.atlassian.net/browse/PM-29924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ