### PR TITLE
[PM-42038] Add desktop biometric unlock support to the CLI

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -63,6 +63,16 @@ bw list --help
 bw create --help
 ```
 
+### Unlock with desktop biometrics
+
+When `bw unlock` is run interactively without a password, the CLI first attempts to unlock through
+the Bitwarden desktop app. This requires Bitwarden Desktop 2026.7.0 or newer to be running, with
+biometric unlock enabled for the same account. If desktop biometric unlock is unavailable or is
+cancelled, the CLI falls back to the master password prompt.
+
+Passing a password, `--passwordenv`, or `--passwordfile` skips the biometric attempt. Biometric
+unlock is also skipped when `BW_NOINTERACTION=true`.
+
 ### Help Center
 
 We provide detailed documentation and examples for using the CLI in our help center at https://help.bitwarden.com/article/cli/.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -66,12 +66,15 @@ bw create --help
 ### Unlock with desktop biometrics
 
 When `bw unlock` is run interactively without a password, the CLI first attempts to unlock through
-the Bitwarden desktop app. This requires Bitwarden Desktop 2026.7.0 or newer to be running, with
+the Bitwarden desktop app. This requires Bitwarden Desktop 2026.9.0 or newer to be running, with
 biometric unlock enabled for the same account. If desktop biometric unlock is unavailable or is
 cancelled, the CLI falls back to the master password prompt.
 
 Passing a password, `--passwordenv`, or `--passwordfile` skips the biometric attempt. Biometric
 unlock is also skipped when `BW_NOINTERACTION=true`.
+
+If the desktop app is installed in a non-standard location, set
+`BITWARDEN_DESKTOP_PROXY_PATH` to the path of its `desktop_proxy` executable.
 
 ### Help Center
 

--- a/apps/cli/src/base-program.ts
+++ b/apps/cli/src/base-program.ts
@@ -187,6 +187,7 @@ export abstract class BaseProgram {
         this.serviceContainer.i18nService,
         this.serviceContainer.encryptedMigrator,
         this.serviceContainer.unlockService,
+        this.serviceContainer.biometricsService,
       );
       const response = await command.run(null, null);
       if (!response.success) {

--- a/apps/cli/src/bw.ts
+++ b/apps/cli/src/bw.ts
@@ -9,15 +9,34 @@ import { ServiceContainer } from "./service-container/service-container";
 
 async function main() {
   const serviceContainer = new ServiceContainer();
-  await serviceContainer.init();
+  let disposed = false;
+  const dispose = () => {
+    if (disposed) {
+      return;
+    }
 
-  await registerOssPrograms(serviceContainer);
+    disposed = true;
+    serviceContainer.dispose();
+  };
 
-  // ServeProgram is registered separately so it can be overridden by bit-cli
-  const serveConfigurator = new OssServeConfigurator(serviceContainer);
-  new ServeProgram(serviceContainer, serveConfigurator).register();
+  // Some existing command guards call process.exit(), which does not unwind
+  // through finally. Ensure Desktop IPC is also closed on those paths.
+  process.once("exit", dispose);
 
-  program.parse(process.argv);
+  try {
+    await serviceContainer.init();
+
+    await registerOssPrograms(serviceContainer);
+
+    // ServeProgram is registered separately so it can be overridden by bit-cli
+    const serveConfigurator = new OssServeConfigurator(serviceContainer);
+    new ServeProgram(serviceContainer, serveConfigurator).register();
+
+    await program.parseAsync(process.argv);
+  } finally {
+    process.removeListener("exit", dispose);
+    dispose();
+  }
 }
 
 // Node does not support top-level await statements until ES2022, esnext, etc which we don't use yet

--- a/apps/cli/src/key-management/cli-biometrics-service.spec.ts
+++ b/apps/cli/src/key-management/cli-biometrics-service.spec.ts
@@ -1,0 +1,109 @@
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { UserKey } from "@bitwarden/common/types/key";
+import { BiometricsStatus, KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+import {
+  BiometricsStatus as SdkBiometricsStatus,
+  IpcClient,
+  SymmetricKey,
+  ipcRequestAuthenticateBiometrics,
+  ipcRequestGetBiometricsStatus,
+  ipcRequestUnlockBiometrics,
+} from "@bitwarden/sdk-internal";
+
+import { CliIpcService } from "../platform/services/cli-ipc.service";
+
+import { CliBiometricsService } from "./cli-biometrics-service";
+
+jest.mock("@bitwarden/sdk-internal", () => ({
+  ...jest.requireActual("@bitwarden/sdk-internal"),
+  ipcRequestAuthenticateBiometrics: jest.fn(),
+  ipcRequestGetBiometricsStatus: jest.fn(),
+  ipcRequestUnlockBiometrics: jest.fn(),
+}));
+
+describe("CliBiometricsService", () => {
+  const userId = "user-id" as UserId;
+  const accountService = mock<AccountService>();
+  const keyService = mock<KeyService>();
+  const logService = mock<LogService>();
+  const ipcService = mock<CliIpcService>();
+  const ipcClient = mock<IpcClient>();
+
+  let service: CliBiometricsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    accountService.activeAccount$ = of({ id: userId } as never);
+    ipcService.verifyDesktopConnection.mockResolvedValue("2026.7.0");
+    Object.defineProperty(ipcService, "client", { configurable: true, value: ipcClient });
+    service = new CliBiometricsService(accountService, keyService, logService, ipcService);
+  });
+
+  it("returns the desktop biometric status for the active account", async () => {
+    jest.mocked(ipcRequestGetBiometricsStatus).mockResolvedValue(SdkBiometricsStatus.Available);
+
+    await expect(service.getBiometricsStatus()).resolves.toBe(BiometricsStatus.Available);
+    expect(ipcService.verifyDesktopConnection).toHaveBeenCalled();
+  });
+
+  it("maps desktop NotEnabled to NotEnabledInConnectedDesktopApp", async () => {
+    jest.mocked(ipcRequestGetBiometricsStatus).mockResolvedValue(SdkBiometricsStatus.NotEnabled);
+
+    await expect(service.getBiometricsStatusForUser(userId)).resolves.toBe(
+      BiometricsStatus.NotEnabledInConnectedDesktopApp,
+    );
+  });
+
+  it("reports DesktopDisconnected when the SDK IPC handshake fails", async () => {
+    ipcService.verifyDesktopConnection.mockRejectedValue(new Error("Desktop is too old"));
+
+    await expect(service.getBiometricsStatusForUser(userId)).resolves.toBe(
+      BiometricsStatus.DesktopDisconnected,
+    );
+    expect(logService.info).toHaveBeenCalledWith(
+      "Could not query Bitwarden Desktop biometric status",
+      expect.any(Error),
+    );
+  });
+
+  it("returns a validated user key from desktop biometric unlock", async () => {
+    const sdkKey = mock<SymmetricKey>();
+    const userKey = mock<UserKey>();
+    jest.mocked(ipcRequestUnlockBiometrics).mockResolvedValue({ user_key: sdkKey });
+    jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(userKey);
+    keyService.validateUserKey.mockResolvedValue(true);
+
+    await expect(service.unlockWithBiometricsForUser(userId)).resolves.toBe(userKey);
+    expect(keyService.validateUserKey).toHaveBeenCalledWith(userKey, userId);
+  });
+
+  it("rejects an invalid user key returned by desktop", async () => {
+    const sdkKey = mock<SymmetricKey>();
+    const userKey = mock<UserKey>();
+    jest.mocked(ipcRequestUnlockBiometrics).mockResolvedValue({ user_key: sdkKey });
+    jest.spyOn(SymmetricCryptoKey, "fromSdk").mockReturnValue(userKey);
+    keyService.validateUserKey.mockResolvedValue(false);
+
+    await expect(service.unlockWithBiometricsForUser(userId)).resolves.toBeNull();
+  });
+
+  it("authenticates through desktop SDK IPC", async () => {
+    jest.mocked(ipcRequestAuthenticateBiometrics).mockResolvedValue(true);
+
+    await expect(service.authenticateWithBiometrics()).resolves.toBe(true);
+    expect(ipcService.verifyDesktopConnection).toHaveBeenCalled();
+  });
+
+  it("disconnects the desktop transport", () => {
+    service.disconnect();
+
+    expect(ipcService.disconnect).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/key-management/cli-biometrics-service.spec.ts
+++ b/apps/cli/src/key-management/cli-biometrics-service.spec.ts
@@ -41,16 +41,14 @@ describe("CliBiometricsService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     accountService.activeAccount$ = of({ id: userId } as never);
-    ipcService.verifyDesktopConnection.mockResolvedValue("2026.7.0");
     Object.defineProperty(ipcService, "client", { configurable: true, value: ipcClient });
-    service = new CliBiometricsService(accountService, keyService, logService, ipcService);
+    service = new CliBiometricsService(accountService, () => keyService, logService, ipcService);
   });
 
   it("returns the desktop biometric status for the active account", async () => {
     jest.mocked(ipcRequestGetBiometricsStatus).mockResolvedValue(SdkBiometricsStatus.Available);
 
     await expect(service.getBiometricsStatus()).resolves.toBe(BiometricsStatus.Available);
-    expect(ipcService.verifyDesktopConnection).toHaveBeenCalled();
   });
 
   it("maps desktop NotEnabled to NotEnabledInConnectedDesktopApp", async () => {
@@ -62,7 +60,7 @@ describe("CliBiometricsService", () => {
   });
 
   it("reports DesktopDisconnected when the SDK IPC handshake fails", async () => {
-    ipcService.verifyDesktopConnection.mockRejectedValue(new Error("Desktop is too old"));
+    jest.mocked(ipcRequestGetBiometricsStatus).mockRejectedValue(new Error("Desktop disconnected"));
 
     await expect(service.getBiometricsStatusForUser(userId)).resolves.toBe(
       BiometricsStatus.DesktopDisconnected,
@@ -98,12 +96,5 @@ describe("CliBiometricsService", () => {
     jest.mocked(ipcRequestAuthenticateBiometrics).mockResolvedValue(true);
 
     await expect(service.authenticateWithBiometrics()).resolves.toBe(true);
-    expect(ipcService.verifyDesktopConnection).toHaveBeenCalled();
-  });
-
-  it("disconnects the desktop transport", () => {
-    service.disconnect();
-
-    expect(ipcService.disconnect).toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/key-management/cli-biometrics-service.ts
+++ b/apps/cli/src/key-management/cli-biometrics-service.ts
@@ -1,24 +1,102 @@
+import { firstValueFrom } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { toTsBiometricsStatus } from "@bitwarden/common/key-management/biometrics-status-mapper";
+import { fromTsUserId } from "@bitwarden/common/key-management/utils";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
-import { BiometricsService, BiometricsStatus } from "@bitwarden/key-management";
+import { BiometricsService, BiometricsStatus, KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+import {
+  ipcRequestAuthenticateBiometrics,
+  ipcRequestGetBiometricsStatus,
+  ipcRequestUnlockBiometrics,
+} from "@bitwarden/sdk-internal";
+
+import { CliIpcService } from "../platform/services/cli-ipc.service";
 
 export class CliBiometricsService extends BiometricsService {
+  private readonly noInteractionTimeout = 5_000;
+  private readonly interactionTimeout = 60_000;
+
+  constructor(
+    private accountService: AccountService,
+    private keyService: () => KeyService,
+    private logService: LogService,
+    private ipcService: CliIpcService,
+  ) {
+    super();
+  }
+
   async authenticateWithBiometrics(): Promise<boolean> {
-    return false;
+    try {
+      await this.ipcService.verifyDesktopConnection();
+      return await ipcRequestAuthenticateBiometrics(
+        this.ipcService.client,
+        AbortSignal.timeout(this.interactionTimeout),
+      );
+    } catch (error) {
+      this.logService.info("CLI biometric authentication failed", error);
+      return false;
+    }
   }
 
   async getBiometricsStatus(): Promise<BiometricsStatus> {
-    return BiometricsStatus.PlatformUnsupported;
+    const account = await firstValueFrom(this.accountService.activeAccount$);
+    return account == null
+      ? BiometricsStatus.NotEnabledLocally
+      : await this.getBiometricsStatusForUser(account.id);
   }
 
   async unlockWithBiometricsForUser(userId: UserId): Promise<UserKey | null> {
-    return null;
+    try {
+      await this.ipcService.verifyDesktopConnection();
+      const response = await ipcRequestUnlockBiometrics(
+        this.ipcService.client,
+        fromTsUserId(userId),
+        AbortSignal.timeout(this.interactionTimeout),
+      );
+
+      if (response.user_key == null) {
+        return null;
+      }
+
+      const userKey = SymmetricCryptoKey.fromSdk(response.user_key) as UserKey;
+      if (!(await this.keyService().validateUserKey(userKey, userId))) {
+        this.logService.info("CLI biometric unlock failed: desktop returned an invalid user key");
+        return null;
+      }
+
+      return userKey;
+    } catch (error) {
+      this.logService.info("CLI biometric unlock failed", error);
+      return null;
+    }
   }
 
   async getBiometricsStatusForUser(userId: UserId): Promise<BiometricsStatus> {
-    return BiometricsStatus.PlatformUnsupported;
+    try {
+      const desktopVersion = await this.ipcService.verifyDesktopConnection();
+      this.logService.info(`[IPC] Connected to Bitwarden Desktop ${desktopVersion}`);
+      const status = await ipcRequestGetBiometricsStatus(
+        this.ipcService.client,
+        fromTsUserId(userId),
+        AbortSignal.timeout(this.noInteractionTimeout),
+      );
+      const mappedStatus = toTsBiometricsStatus(status);
+      return mappedStatus === BiometricsStatus.NotEnabledLocally
+        ? BiometricsStatus.NotEnabledInConnectedDesktopApp
+        : mappedStatus;
+    } catch (error) {
+      this.logService.info("Could not query Bitwarden Desktop biometric status", error);
+      return BiometricsStatus.DesktopDisconnected;
+    }
+  }
+
+  disconnect(): void {
+    this.ipcService.disconnect();
   }
 
   async getShouldAutopromptNow(): Promise<boolean> {
@@ -27,7 +105,7 @@ export class CliBiometricsService extends BiometricsService {
 
   async setShouldAutopromptNow(value: boolean): Promise<void> {}
   async canEnableBiometricUnlock(): Promise<boolean> {
-    return false;
+    return (await this.getBiometricsStatus()) === BiometricsStatus.Available;
   }
   async setBiometricProtectedUnlockKeyForUser(
     userId: UserId,

--- a/apps/cli/src/key-management/cli-biometrics-service.ts
+++ b/apps/cli/src/key-management/cli-biometrics-service.ts
@@ -32,7 +32,6 @@ export class CliBiometricsService extends BiometricsService {
 
   async authenticateWithBiometrics(): Promise<boolean> {
     try {
-      await this.ipcService.verifyDesktopConnection();
       return await ipcRequestAuthenticateBiometrics(
         this.ipcService.client,
         AbortSignal.timeout(this.interactionTimeout),
@@ -52,7 +51,6 @@ export class CliBiometricsService extends BiometricsService {
 
   async unlockWithBiometricsForUser(userId: UserId): Promise<UserKey | null> {
     try {
-      await this.ipcService.verifyDesktopConnection();
       const response = await ipcRequestUnlockBiometrics(
         this.ipcService.client,
         fromTsUserId(userId),
@@ -78,8 +76,6 @@ export class CliBiometricsService extends BiometricsService {
 
   async getBiometricsStatusForUser(userId: UserId): Promise<BiometricsStatus> {
     try {
-      const desktopVersion = await this.ipcService.verifyDesktopConnection();
-      this.logService.info(`[IPC] Connected to Bitwarden Desktop ${desktopVersion}`);
       const status = await ipcRequestGetBiometricsStatus(
         this.ipcService.client,
         fromTsUserId(userId),
@@ -93,10 +89,6 @@ export class CliBiometricsService extends BiometricsService {
       this.logService.info("Could not query Bitwarden Desktop biometric status", error);
       return BiometricsStatus.DesktopDisconnected;
     }
-  }
-
-  disconnect(): void {
-    this.ipcService.disconnect();
   }
 
   async getShouldAutopromptNow(): Promise<boolean> {

--- a/apps/cli/src/key-management/commands/unlock.command.spec.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.spec.ts
@@ -9,6 +9,8 @@ import { EnvironmentService } from "@bitwarden/common/platform/abstractions/envi
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { mockAccountInfoWith } from "@bitwarden/common/spec";
+import { UserKey } from "@bitwarden/common/types/key";
+import { BiometricsStatus } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { CsprngArray } from "@bitwarden/legacy-crypto";
 import { ConsoleLogService } from "@bitwarden/logging";
@@ -18,6 +20,8 @@ import { UserId } from "@bitwarden/user-core";
 
 import { MessageResponse } from "../../models/response/message.response";
 import { I18nService } from "../../platform/services/i18n.service";
+import { CliUtils } from "../../utils";
+import { CliBiometricsService } from "../cli-biometrics-service";
 import { ConvertToKeyConnectorCommand } from "../convert-to-key-connector.command";
 
 import { UnlockCommand } from "./unlock.command";
@@ -34,6 +38,7 @@ describe("UnlockCommand", () => {
   const i18nService = mock<I18nService>();
   const encryptedMigrator = mock<EncryptedMigrator>();
   const unlockService = mock<UnlockService>();
+  const biometricsService = mock<CliBiometricsService>();
 
   const mockMasterPassword = "testExample";
   const activeAccount: Account = {
@@ -62,7 +67,11 @@ describe("UnlockCommand", () => {
   expectedSuccessMessage.raw = b64sessionKey;
 
   beforeEach(async () => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
+    delete process.env.BW_NOINTERACTION;
+    delete process.env.BW_QUIET;
+    delete process.env.BW_RESPONSE;
 
     i18nService.t.mockImplementation((key: string) => key);
     accountService.activeAccount$ = of(activeAccount);
@@ -87,6 +96,7 @@ describe("UnlockCommand", () => {
       i18nService,
       encryptedMigrator,
       unlockService,
+      biometricsService,
     );
   });
 
@@ -133,6 +143,71 @@ describe("UnlockCommand", () => {
         activeAccount.id,
         mockMasterPassword,
       );
+      expect(biometricsService.getBiometricsStatusForUser).not.toHaveBeenCalled();
+    });
+
+    it("unlocks with a desktop biometric user key when no password was provided", async () => {
+      process.env.BW_QUIET = "true";
+      const userKey = mock<UserKey>();
+      biometricsService.getBiometricsStatusForUser.mockResolvedValue(BiometricsStatus.Available);
+      biometricsService.unlockWithBiometricsForUser.mockResolvedValue(userKey);
+      unlockService.unlockWithDecryptedUserKey.mockResolvedValue(undefined);
+
+      const response = await command.run(null, {});
+
+      expect(response.success).toEqual(true);
+      expect(biometricsService.unlockWithBiometricsForUser).toHaveBeenCalledWith(activeAccount.id);
+      expect(unlockService.unlockWithDecryptedUserKey).toHaveBeenCalledWith(
+        activeAccount.id,
+        userKey,
+      );
+      expect(unlockService.unlockWithMasterPassword).not.toHaveBeenCalled();
+      expect(encryptedMigrator.runMigrations).not.toHaveBeenCalled();
+      expect(biometricsService.disconnect).toHaveBeenCalled();
+    });
+
+    it("falls back to the master password prompt when desktop biometrics is unavailable", async () => {
+      biometricsService.getBiometricsStatusForUser.mockResolvedValue(
+        BiometricsStatus.DesktopDisconnected,
+      );
+      jest.spyOn(CliUtils, "getPassword").mockResolvedValue(mockMasterPassword);
+      unlockService.unlockWithMasterPassword.mockResolvedValue(undefined);
+
+      const response = await command.run(null, {});
+
+      expect(response.success).toEqual(true);
+      expect(unlockService.unlockWithMasterPassword).toHaveBeenCalledWith(
+        activeAccount.id,
+        mockMasterPassword,
+      );
+      expect(biometricsService.unlockWithBiometricsForUser).not.toHaveBeenCalled();
+      expect(biometricsService.disconnect).toHaveBeenCalled();
+    });
+
+    it("falls back when desktop biometric unlock is cancelled", async () => {
+      process.env.BW_QUIET = "true";
+      biometricsService.getBiometricsStatusForUser.mockResolvedValue(BiometricsStatus.Available);
+      biometricsService.unlockWithBiometricsForUser.mockResolvedValue(null);
+      jest.spyOn(CliUtils, "getPassword").mockResolvedValue(mockMasterPassword);
+      unlockService.unlockWithMasterPassword.mockResolvedValue(undefined);
+
+      const response = await command.run(null, {});
+
+      expect(response.success).toEqual(true);
+      expect(unlockService.unlockWithMasterPassword).toHaveBeenCalledWith(
+        activeAccount.id,
+        mockMasterPassword,
+      );
+      expect(biometricsService.disconnect).toHaveBeenCalled();
+    });
+
+    it("does not attempt biometrics in non-interactive mode", async () => {
+      process.env.BW_NOINTERACTION = "true";
+
+      const response = await command.run(null, {});
+
+      expect(response.success).toEqual(false);
+      expect(biometricsService.getBiometricsStatusForUser).not.toHaveBeenCalled();
     });
 
     it("returns error response if unlockWithMasterPassword fails", async () => {

--- a/apps/cli/src/key-management/commands/unlock.command.spec.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.spec.ts
@@ -163,7 +163,6 @@ describe("UnlockCommand", () => {
       );
       expect(unlockService.unlockWithMasterPassword).not.toHaveBeenCalled();
       expect(encryptedMigrator.runMigrations).not.toHaveBeenCalled();
-      expect(biometricsService.disconnect).toHaveBeenCalled();
     });
 
     it("falls back to the master password prompt when desktop biometrics is unavailable", async () => {
@@ -181,7 +180,6 @@ describe("UnlockCommand", () => {
         mockMasterPassword,
       );
       expect(biometricsService.unlockWithBiometricsForUser).not.toHaveBeenCalled();
-      expect(biometricsService.disconnect).toHaveBeenCalled();
     });
 
     it("falls back when desktop biometric unlock is cancelled", async () => {
@@ -198,7 +196,6 @@ describe("UnlockCommand", () => {
         activeAccount.id,
         mockMasterPassword,
       );
-      expect(biometricsService.disconnect).toHaveBeenCalled();
     });
 
     it("does not attempt biometrics in non-interactive mode", async () => {

--- a/apps/cli/src/key-management/commands/unlock.command.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.ts
@@ -9,6 +9,8 @@ import { KeyConnectorService } from "@bitwarden/common/key-management/key-connec
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { ConsoleLogService } from "@bitwarden/common/platform/services/console-log.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { BiometricsStatus } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { PureCrypto } from "@bitwarden/sdk-internal";
@@ -18,6 +20,7 @@ import { Response } from "../../models/response";
 import { MessageResponse } from "../../models/response/message.response";
 import { I18nService } from "../../platform/services/i18n.service";
 import { CliUtils } from "../../utils";
+import { CliBiometricsService } from "../cli-biometrics-service";
 import { ConvertToKeyConnectorCommand } from "../convert-to-key-connector.command";
 
 export class UnlockCommand {
@@ -31,10 +34,34 @@ export class UnlockCommand {
     private i18nService: I18nService,
     private encryptedMigrator: EncryptedMigrator,
     private unlockService: UnlockService,
+    private biometricsService: CliBiometricsService,
   ) {}
 
   async run(password: string, cmdOptions: Record<string, any>) {
     const normalizedOptions = new Options(cmdOptions);
+    const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
+    if (activeAccount == null) {
+      return Response.error("No active account found");
+    }
+    const userId = activeAccount.id;
+
+    const passwordWasProvided =
+      (password != null && password !== "") ||
+      normalizedOptions.passwordEnv != null ||
+      normalizedOptions.passwordFile != null;
+    const conversionRequired = await firstValueFrom(
+      this.keyConnectorService.convertAccountRequired$,
+    );
+
+    if (
+      !passwordWasProvided &&
+      !conversionRequired &&
+      process.env.BW_NOINTERACTION !== "true" &&
+      (await this.tryBiometricUnlock(userId))
+    ) {
+      return this.successResponse();
+    }
+
     const passwordResult = await CliUtils.getPassword(password, normalizedOptions, this.logService);
 
     if (passwordResult instanceof Response) {
@@ -44,11 +71,6 @@ export class UnlockCommand {
     }
 
     await this.setNewSessionKey();
-    const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
-    if (activeAccount == null) {
-      return Response.error("No active account found");
-    }
-    const userId = activeAccount.id;
 
     try {
       await this.unlockService.unlockWithMasterPassword(userId, password);
@@ -56,7 +78,7 @@ export class UnlockCommand {
       return Response.error(e.message);
     }
 
-    if (await firstValueFrom(this.keyConnectorService.convertAccountRequired$)) {
+    if (conversionRequired) {
       const convertToKeyConnectorCommand = new ConvertToKeyConnectorCommand(
         userId,
         this.keyConnectorService,
@@ -74,6 +96,35 @@ export class UnlockCommand {
     await this.encryptedMigrator.runMigrations(userId, password);
 
     return this.successResponse();
+  }
+
+  private async tryBiometricUnlock(userId: UserId): Promise<boolean> {
+    try {
+      if (
+        (await this.biometricsService.getBiometricsStatusForUser(userId)) !==
+        BiometricsStatus.Available
+      ) {
+        return false;
+      }
+
+      if (process.env.BW_QUIET !== "true" && process.env.BW_RESPONSE !== "true") {
+        CliUtils.writeLn("Unlocking with biometrics...", false, true);
+      }
+
+      const userKey = await this.biometricsService.unlockWithBiometricsForUser(userId);
+      if (userKey == null) {
+        return false;
+      }
+
+      await this.setNewSessionKey();
+      await this.unlockService.unlockWithDecryptedUserKey(userId, userKey);
+      return true;
+    } catch (error) {
+      this.logService.info("CLI biometric unlock failed; falling back to master password", error);
+      return false;
+    } finally {
+      this.biometricsService.disconnect();
+    }
   }
 
   private async setNewSessionKey() {

--- a/apps/cli/src/key-management/commands/unlock.command.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.ts
@@ -57,7 +57,7 @@ export class UnlockCommand {
       !passwordWasProvided &&
       !conversionRequired &&
       process.env.BW_NOINTERACTION !== "true" &&
-      (await this.tryBiometricUnlock(userId))
+      (await this.tryUnlockWithDesktop(userId))
     ) {
       return this.successResponse();
     }
@@ -98,7 +98,7 @@ export class UnlockCommand {
     return this.successResponse();
   }
 
-  private async tryBiometricUnlock(userId: UserId): Promise<boolean> {
+  private async tryUnlockWithDesktop(userId: UserId): Promise<boolean> {
     try {
       if (
         (await this.biometricsService.getBiometricsStatusForUser(userId)) !==
@@ -122,8 +122,6 @@ export class UnlockCommand {
     } catch (error) {
       this.logService.info("CLI biometric unlock failed; falling back to master password", error);
       return false;
-    } finally {
-      this.biometricsService.disconnect();
     }
   }
 

--- a/apps/cli/src/oss-serve-configurator.ts
+++ b/apps/cli/src/oss-serve-configurator.ts
@@ -177,6 +177,7 @@ export class OssServeConfigurator {
       this.serviceContainer.i18nService,
       this.serviceContainer.encryptedMigrator,
       this.serviceContainer.unlockService,
+      this.serviceContainer.biometricsService,
     );
 
     this.sendCreateCommand = new SendCreateCommand(

--- a/apps/cli/src/platform/services/cli-desktop-ipc.transport.spec.ts
+++ b/apps/cli/src/platform/services/cli-desktop-ipc.transport.spec.ts
@@ -1,0 +1,154 @@
+import * as crypto from "crypto";
+import * as os from "os";
+import * as path from "path";
+
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { IncomingMessage } from "@bitwarden/sdk-internal";
+
+import {
+  CliDesktopIpcTransport,
+  encodeDesktopIpcFrame,
+  getDesktopSocketPaths,
+} from "./cli-desktop-ipc.transport";
+
+describe("getDesktopSocketPaths", () => {
+  it("uses the desktop cache socket on Linux", () => {
+    const paths = getDesktopSocketPaths("linux", "/home/alice", "/tmp/alice-cache");
+
+    expect(paths[0]).toBe(path.join("/tmp/alice-cache", "com.bitwarden.desktop", "s.bw"));
+    expect(paths).toContain(
+      path.join(
+        "/home/alice",
+        ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts/.app.bw.socket",
+      ),
+    );
+    expect(paths).toContain(
+      path.join("/home/alice", ".config/chromium/NativeMessagingHosts/.app.bw.socket"),
+    );
+  });
+
+  it("returns both sandboxed and unsandboxed macOS sockets", () => {
+    expect(getDesktopSocketPaths("darwin", "/Users/alice")).toEqual([
+      path.join(
+        "/Users/alice",
+        "Library",
+        "Group Containers",
+        "LTZ2PFU5D6.com.bitwarden.desktop",
+        "s.bw",
+      ),
+      path.join("/Users/alice", "Library", "Caches", "com.bitwarden.desktop", "s.bw"),
+    ]);
+  });
+
+  it("matches the desktop per-user Windows named pipe", () => {
+    const home = "C:\\Users\\alice";
+    const hash = crypto.createHash("sha256").update(home).digest("base64url");
+
+    expect(getDesktopSocketPaths("win32", home)).toEqual([`\\\\.\\pipe\\${hash}.s.bw`]);
+  });
+});
+
+describe("encodeDesktopIpcFrame", () => {
+  it("writes the JSON IPC envelope with the desktop length prefix", () => {
+    const frame = encodeDesktopIpcFrame({
+      type: "bitwarden-ipc-message",
+      message: {
+        destination: "DesktopRenderer",
+        payload: [1, 2, 3],
+        topic: "test-topic",
+      },
+    });
+    const payloadLength = os.endianness() === "LE" ? frame.readUInt32LE(0) : frame.readUInt32BE(0);
+
+    expect(payloadLength).toBe(frame.length - 4);
+    expect(JSON.parse(frame.subarray(4).toString("utf8"))).toEqual({
+      type: "bitwarden-ipc-message",
+      message: {
+        destination: "DesktopRenderer",
+        payload: [1, 2, 3],
+        topic: "test-topic",
+      },
+    });
+  });
+
+  it("rejects messages larger than the desktop native messaging limit", () => {
+    expect(() =>
+      encodeDesktopIpcFrame({
+        type: "bitwarden-ipc-message",
+        message: {
+          destination: "DesktopRenderer",
+          payload: new Array(1024 * 1024).fill(1),
+          topic: undefined,
+        },
+      }),
+    ).toThrow("Desktop IPC message exceeds 1048576 bytes");
+  });
+});
+
+describe("CliDesktopIpcTransport incoming frames", () => {
+  const logService = mock<LogService>();
+  const receive = jest.fn<void, [IncomingMessage]>();
+  const transport = new CliDesktopIpcTransport(logService, receive, []);
+  const processIncomingData = (
+    transport as unknown as { processIncomingData(data: Buffer): void }
+  ).processIncomingData.bind(transport);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    transport.disconnect();
+  });
+
+  it("buffers a fragmented frame before delivering it", () => {
+    const frame = encodeDesktopIpcFrame({
+      type: "bitwarden-ipc-message",
+      message: {
+        destination: "DesktopRenderer",
+        payload: [1, 2, 3],
+        topic: "fragmented",
+      },
+    });
+
+    processIncomingData(frame.subarray(0, 2));
+    expect(receive).not.toHaveBeenCalled();
+
+    processIncomingData(frame.subarray(2));
+    expect(receive).toHaveBeenCalledTimes(1);
+    expect(receive.mock.calls[0][0].payload).toEqual(new Uint8Array([1, 2, 3]));
+    expect(receive.mock.calls[0][0].source).toBe("DesktopMain");
+    expect(receive.mock.calls[0][0].topic).toBe("fragmented");
+  });
+
+  it("delivers multiple frames received in one chunk", () => {
+    const first = encodeDesktopIpcFrame({
+      type: "bitwarden-ipc-message",
+      message: { destination: "DesktopRenderer", payload: [1], topic: undefined },
+    });
+    const second = encodeDesktopIpcFrame({
+      type: "bitwarden-ipc-message",
+      message: { destination: "DesktopRenderer", payload: [2], topic: undefined },
+    });
+
+    processIncomingData(Buffer.concat([first, second]));
+
+    expect(receive).toHaveBeenCalledTimes(2);
+    expect(receive.mock.calls[0][0].payload).toEqual(new Uint8Array([1]));
+    expect(receive.mock.calls[1][0].payload).toEqual(new Uint8Array([2]));
+  });
+
+  it("disconnects when a frame exceeds the maximum size", () => {
+    const header = Buffer.alloc(4);
+    if (os.endianness() === "LE") {
+      header.writeUInt32LE(1024 * 1024 + 1);
+    } else {
+      header.writeUInt32BE(1024 * 1024 + 1);
+    }
+    const disconnect = jest.spyOn(transport, "disconnect");
+
+    processIncomingData(header);
+
+    expect(logService.error).toHaveBeenCalledWith("[IPC] Desktop message exceeds 1048576 bytes");
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/platform/services/cli-desktop-ipc.transport.spec.ts
+++ b/apps/cli/src/platform/services/cli-desktop-ipc.transport.spec.ts
@@ -113,6 +113,7 @@ describe("CliDesktopIpcTransport", () => {
 
     transport.disconnect();
 
+    expect(proxy.stdin.writableEnded).toBe(true);
     expect(proxy.process.kill).toHaveBeenCalledTimes(1);
     expect(onDisconnect).toHaveBeenCalledTimes(1);
   });

--- a/apps/cli/src/platform/services/cli-desktop-ipc.transport.spec.ts
+++ b/apps/cli/src/platform/services/cli-desktop-ipc.transport.spec.ts
@@ -1,143 +1,150 @@
-import * as crypto from "crypto";
+import { ChildProcessWithoutNullStreams } from "child_process";
+import { EventEmitter } from "events";
 import * as os from "os";
-import * as path from "path";
+import { PassThrough } from "stream";
 
 import { mock } from "jest-mock-extended";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { IncomingMessage } from "@bitwarden/sdk-internal";
+import { IncomingMessage, OutgoingMessage } from "@bitwarden/sdk-internal";
 
-import {
-  CliDesktopIpcTransport,
-  encodeDesktopIpcFrame,
-  getDesktopSocketPaths,
-} from "./cli-desktop-ipc.transport";
+import { CliDesktopIpcTransport, encodeNativeMessagingFrame } from "./cli-desktop-ipc.transport";
 
-describe("getDesktopSocketPaths", () => {
-  it("uses the desktop cache socket on Linux", () => {
-    const paths = getDesktopSocketPaths("linux", "/home/alice", "/tmp/alice-cache");
-
-    expect(paths[0]).toBe(path.join("/tmp/alice-cache", "com.bitwarden.desktop", "s.bw"));
-    expect(paths).toContain(
-      path.join(
-        "/home/alice",
-        ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts/.app.bw.socket",
-      ),
-    );
-    expect(paths).toContain(
-      path.join("/home/alice", ".config/chromium/NativeMessagingHosts/.app.bw.socket"),
-    );
-  });
-
-  it("returns both sandboxed and unsandboxed macOS sockets", () => {
-    expect(getDesktopSocketPaths("darwin", "/Users/alice")).toEqual([
-      path.join(
-        "/Users/alice",
-        "Library",
-        "Group Containers",
-        "LTZ2PFU5D6.com.bitwarden.desktop",
-        "s.bw",
-      ),
-      path.join("/Users/alice", "Library", "Caches", "com.bitwarden.desktop", "s.bw"),
-    ]);
-  });
-
-  it("matches the desktop per-user Windows named pipe", () => {
-    const home = "C:\\Users\\alice";
-    const hash = crypto.createHash("sha256").update(home).digest("base64url");
-
-    expect(getDesktopSocketPaths("win32", home)).toEqual([`\\\\.\\pipe\\${hash}.s.bw`]);
-  });
-});
-
-describe("encodeDesktopIpcFrame", () => {
-  it("writes the JSON IPC envelope with the desktop length prefix", () => {
-    const frame = encodeDesktopIpcFrame({
-      type: "bitwarden-ipc-message",
-      message: {
-        destination: "DesktopRenderer",
-        payload: [1, 2, 3],
-        topic: "test-topic",
-      },
-    });
+describe("encodeNativeMessagingFrame", () => {
+  it("writes the JSON envelope with a native-endian length prefix", () => {
+    const frame = encodeNativeMessagingFrame({ command: "connected" });
     const payloadLength = os.endianness() === "LE" ? frame.readUInt32LE(0) : frame.readUInt32BE(0);
 
     expect(payloadLength).toBe(frame.length - 4);
-    expect(JSON.parse(frame.subarray(4).toString("utf8"))).toEqual({
-      type: "bitwarden-ipc-message",
-      message: {
-        destination: "DesktopRenderer",
-        payload: [1, 2, 3],
-        topic: "test-topic",
-      },
-    });
+    expect(JSON.parse(frame.subarray(4).toString("utf8"))).toEqual({ command: "connected" });
   });
 
-  it("rejects messages larger than the desktop native messaging limit", () => {
+  it("rejects messages larger than the native-messaging limit", () => {
     expect(() =>
-      encodeDesktopIpcFrame({
-        type: "bitwarden-ipc-message",
+      encodeNativeMessagingFrame({
         message: {
-          destination: "DesktopRenderer",
           payload: new Array(1024 * 1024).fill(1),
-          topic: undefined,
         },
       }),
     ).toThrow("Desktop IPC message exceeds 1048576 bytes");
   });
 });
 
-describe("CliDesktopIpcTransport incoming frames", () => {
+describe("CliDesktopIpcTransport", () => {
   const logService = mock<LogService>();
   const receive = jest.fn<void, [IncomingMessage]>();
-  const transport = new CliDesktopIpcTransport(logService, receive, []);
-  const processIncomingData = (
-    transport as unknown as { processIncomingData(data: Buffer): void }
-  ).processIncomingData.bind(transport);
 
   beforeEach(() => {
     jest.clearAllMocks();
-    transport.disconnect();
   });
 
-  it("buffers a fragmented frame before delivering it", () => {
-    const frame = encodeDesktopIpcFrame({
+  it("starts the proxy and waits for its connected message before sending", async () => {
+    const proxy = createProxyProcess();
+    const proxySpawner = jest.fn(() => proxy.process);
+    const transport = new CliDesktopIpcTransport(
+      logService,
+      receive,
+      undefined,
+      () => "/installed/desktop_proxy",
+      proxySpawner,
+    );
+    const outgoing = {
+      destination: "DesktopRenderer",
+      payload: new Uint8Array([1, 2, 3]),
+      topic: "test-topic",
+    } as OutgoingMessage;
+    const written: Buffer[] = [];
+    proxy.stdin.on("data", (data: Buffer) => written.push(data));
+
+    const send = transport.send(outgoing);
+    expect(proxySpawner).toHaveBeenCalledWith("/installed/desktop_proxy");
+    expect(written).toHaveLength(0);
+
+    proxy.stdout.write(encodeNativeMessagingFrame({ command: "connected" }));
+    await send;
+
+    expect(written).toHaveLength(1);
+    expect(JSON.parse(written[0].subarray(4).toString("utf8"))).toEqual({
       type: "bitwarden-ipc-message",
       message: {
         destination: "DesktopRenderer",
         payload: [1, 2, 3],
-        topic: "fragmented",
+        topic: "test-topic",
       },
     });
-
-    processIncomingData(frame.subarray(0, 2));
-    expect(receive).not.toHaveBeenCalled();
-
-    processIncomingData(frame.subarray(2));
-    expect(receive).toHaveBeenCalledTimes(1);
-    expect(receive.mock.calls[0][0].payload).toEqual(new Uint8Array([1, 2, 3]));
-    expect(receive.mock.calls[0][0].source).toBe("DesktopMain");
-    expect(receive.mock.calls[0][0].topic).toBe("fragmented");
+    transport.disconnect();
   });
 
-  it("delivers multiple frames received in one chunk", () => {
-    const first = encodeDesktopIpcFrame({
+  it("rejects the connection when the proxy exits before connecting", async () => {
+    const proxy = createProxyProcess();
+    const transport = new CliDesktopIpcTransport(
+      logService,
+      receive,
+      undefined,
+      () => "/installed/desktop_proxy",
+      () => proxy.process,
+    );
+
+    const send = transport.send({
+      destination: "DesktopRenderer",
+      payload: new Uint8Array(),
+    } as OutgoingMessage);
+    proxy.process.emit("exit", 1, null);
+
+    await expect(send).rejects.toThrow("Bitwarden Desktop proxy exited with code 1");
+  });
+
+  it("terminates the proxy and reports an explicit disconnect", async () => {
+    const proxy = createProxyProcess();
+    const onDisconnect = jest.fn();
+    const transport = new CliDesktopIpcTransport(
+      logService,
+      receive,
+      onDisconnect,
+      () => "/installed/desktop_proxy",
+      () => proxy.process,
+    );
+    const send = transport.send({
+      destination: "DesktopRenderer",
+      payload: new Uint8Array(),
+    } as OutgoingMessage);
+    proxy.stdout.write(encodeNativeMessagingFrame({ command: "connected" }));
+    await send;
+
+    transport.disconnect();
+
+    expect(proxy.process.kill).toHaveBeenCalledTimes(1);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("buffers fragmented frames and delivers multiple SDK messages", () => {
+    const transport = new CliDesktopIpcTransport(logService, receive);
+    const processIncomingData = (
+      transport as unknown as { processIncomingData(data: Buffer): void }
+    ).processIncomingData.bind(transport);
+    const first = encodeNativeMessagingFrame({
       type: "bitwarden-ipc-message",
-      message: { destination: "DesktopRenderer", payload: [1], topic: undefined },
+      message: { destination: "DesktopRenderer", payload: [1], topic: "first" },
     });
-    const second = encodeDesktopIpcFrame({
+    const second = encodeNativeMessagingFrame({
       type: "bitwarden-ipc-message",
-      message: { destination: "DesktopRenderer", payload: [2], topic: undefined },
+      message: { destination: "DesktopRenderer", payload: [2], topic: "second" },
     });
 
-    processIncomingData(Buffer.concat([first, second]));
+    processIncomingData(first.subarray(0, 2));
+    expect(receive).not.toHaveBeenCalled();
 
+    processIncomingData(Buffer.concat([first.subarray(2), second]));
     expect(receive).toHaveBeenCalledTimes(2);
     expect(receive.mock.calls[0][0].payload).toEqual(new Uint8Array([1]));
     expect(receive.mock.calls[1][0].payload).toEqual(new Uint8Array([2]));
   });
 
   it("disconnects when a frame exceeds the maximum size", () => {
+    const transport = new CliDesktopIpcTransport(logService, receive);
+    const processIncomingData = (
+      transport as unknown as { processIncomingData(data: Buffer): void }
+    ).processIncomingData.bind(transport);
     const header = Buffer.alloc(4);
     if (os.endianness() === "LE") {
       header.writeUInt32LE(1024 * 1024 + 1);
@@ -152,3 +159,17 @@ describe("CliDesktopIpcTransport incoming frames", () => {
     expect(disconnect).toHaveBeenCalled();
   });
 });
+
+function createProxyProcess() {
+  const process = new EventEmitter() as ChildProcessWithoutNullStreams;
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  Object.assign(process, {
+    stdin,
+    stdout,
+    stderr,
+    kill: jest.fn(() => true),
+  });
+  return { process, stdin, stdout, stderr };
+}

--- a/apps/cli/src/platform/services/cli-desktop-ipc.transport.ts
+++ b/apps/cli/src/platform/services/cli-desktop-ipc.transport.ts
@@ -1,0 +1,226 @@
+import * as crypto from "crypto";
+import * as net from "net";
+import * as os from "os";
+import * as path from "path";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { IpcMessage, isForwardedIpcMessage, isIpcMessage } from "@bitwarden/common/platform/ipc";
+import { IncomingMessage, OutgoingMessage } from "@bitwarden/sdk-internal";
+
+const MAX_MESSAGE_SIZE = 1024 * 1024;
+const CONNECTION_TIMEOUT_MS = 5_000;
+const LINUX_FLATPAK_NATIVE_MESSAGING_PATHS = [
+  "org.mozilla.firefox/.mozilla/native-messaging-hosts",
+  "com.google.Chrome/config/google-chrome/NativeMessagingHosts",
+  "org.chromium.Chromium/config/chromium/NativeMessagingHosts",
+  "com.microsoft.Edge/config/microsoft-edge/NativeMessagingHosts",
+];
+const LINUX_NATIVE_MESSAGING_PATHS = [
+  ".config/chromium/NativeMessagingHosts",
+  ".config/google-chrome/NativeMessagingHosts",
+  ".config/microsoft-edge/NativeMessagingHosts",
+  ".mozilla/native-messaging-hosts",
+];
+
+/**
+ * Returns the desktop IPC endpoints used by desktop_native/core/src/ipc/mod.rs.
+ *
+ * macOS has separate endpoints for the sandboxed App Store build and the
+ * unsandboxed build, so both are attempted.
+ */
+export function getDesktopSocketPaths(
+  platform = os.platform(),
+  homeDir = os.homedir(),
+  xdgCacheHome = process.env.XDG_CACHE_HOME,
+): string[] {
+  if (platform === "win32") {
+    const hash = crypto.createHash("sha256").update(homeDir).digest("base64url");
+    return [`\\\\.\\pipe\\${hash}.s.bw`];
+  }
+
+  if (platform === "darwin") {
+    return [
+      path.join(homeDir, "Library", "Group Containers", "LTZ2PFU5D6.com.bitwarden.desktop", "s.bw"),
+      path.join(homeDir, "Library", "Caches", "com.bitwarden.desktop", "s.bw"),
+    ];
+  }
+
+  const socketName = ".app.bw.socket";
+  return [
+    path.join(xdgCacheHome ?? path.join(homeDir, ".cache"), "com.bitwarden.desktop", "s.bw"),
+    ...LINUX_FLATPAK_NATIVE_MESSAGING_PATHS.map((nativePath) =>
+      path.join(homeDir, ".var", "app", nativePath, socketName),
+    ),
+    ...LINUX_NATIVE_MESSAGING_PATHS.map((nativePath) => path.join(homeDir, nativePath, socketName)),
+  ];
+}
+
+export function encodeDesktopIpcFrame(message: IpcMessage): Buffer {
+  const payload = Buffer.from(JSON.stringify(message), "utf8");
+  if (payload.length > MAX_MESSAGE_SIZE) {
+    throw new Error(`Desktop IPC message exceeds ${MAX_MESSAGE_SIZE} bytes`);
+  }
+
+  const frame = Buffer.allocUnsafe(4 + payload.length);
+  if (os.endianness() === "LE") {
+    frame.writeUInt32LE(payload.length, 0);
+  } else {
+    frame.writeUInt32BE(payload.length, 0);
+  }
+  payload.copy(frame, 4);
+  return frame;
+}
+
+/** Direct socket transport for the SDK IPC client used by the CLI. */
+export class CliDesktopIpcTransport {
+  private socket?: net.Socket;
+  private connection?: Promise<net.Socket>;
+  private messageBuffer = Buffer.alloc(0);
+
+  constructor(
+    private logService: LogService,
+    private receive: (message: IncomingMessage) => void,
+    private socketPaths = getDesktopSocketPaths(),
+    private onDisconnect?: () => void,
+  ) {}
+
+  async send(message: OutgoingMessage): Promise<void> {
+    const frame = encodeDesktopIpcFrame({
+      type: "bitwarden-ipc-message",
+      message: {
+        destination: message.destination,
+        payload: [...message.payload],
+        topic: message.topic,
+      },
+    });
+    const socket = await this.connect();
+
+    await new Promise<void>((resolve, reject) => {
+      socket.write(frame, (error) => (error ? reject(error) : resolve()));
+    });
+  }
+
+  disconnect(): void {
+    this.socket?.destroy();
+    this.socket = undefined;
+    this.connection = undefined;
+    this.messageBuffer = Buffer.alloc(0);
+    this.onDisconnect?.();
+  }
+
+  private async connect(): Promise<net.Socket> {
+    if (this.socket != null && !this.socket.destroyed) {
+      return this.socket;
+    }
+
+    this.connection ??= this.connectToFirstAvailablePath();
+    try {
+      return await this.connection;
+    } catch (error) {
+      this.connection = undefined;
+      throw error;
+    }
+  }
+
+  private async connectToFirstAvailablePath(): Promise<net.Socket> {
+    let lastError: Error | undefined;
+
+    for (const socketPath of this.socketPaths) {
+      try {
+        const socket = await this.connectToPath(socketPath);
+        this.socket = socket;
+        this.logService.info(`[IPC] Connected to Bitwarden Desktop at ${socketPath}`);
+        return socket;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
+    }
+
+    throw new Error(
+      `Could not connect to the Bitwarden Desktop app${lastError ? `: ${lastError.message}` : ""}`,
+    );
+  }
+
+  private connectToPath(socketPath: string): Promise<net.Socket> {
+    return new Promise((resolve, reject) => {
+      const socket = net.createConnection(socketPath);
+      let settled = false;
+
+      const timeout = setTimeout(() => {
+        settled = true;
+        socket.destroy();
+        reject(new Error(`Connection to ${socketPath} timed out`));
+      }, CONNECTION_TIMEOUT_MS);
+
+      socket.once("connect", () => {
+        settled = true;
+        clearTimeout(timeout);
+        socket.on("data", (data) => this.processIncomingData(data));
+        socket.on("close", () => this.handleDisconnect(socket));
+        socket.on("error", (error) =>
+          this.logService.info("[IPC] Bitwarden Desktop socket error", error),
+        );
+        resolve(socket);
+      });
+
+      socket.once("error", (error) => {
+        if (!settled) {
+          clearTimeout(timeout);
+          socket.destroy();
+          reject(error);
+        }
+      });
+    });
+  }
+
+  private handleDisconnect(socket: net.Socket): void {
+    if (this.socket === socket) {
+      this.socket = undefined;
+      this.connection = undefined;
+      this.messageBuffer = Buffer.alloc(0);
+      this.onDisconnect?.();
+    }
+  }
+
+  private processIncomingData(data: Buffer): void {
+    this.messageBuffer = Buffer.concat([this.messageBuffer, data]);
+
+    while (this.messageBuffer.length >= 4) {
+      const messageLength = this.readFrameLength(this.messageBuffer);
+      if (messageLength > MAX_MESSAGE_SIZE) {
+        this.logService.error(`[IPC] Desktop message exceeds ${MAX_MESSAGE_SIZE} bytes`);
+        this.disconnect();
+        return;
+      }
+
+      if (this.messageBuffer.length < 4 + messageLength) {
+        return;
+      }
+
+      const payload = this.messageBuffer.subarray(4, 4 + messageLength);
+      this.messageBuffer = this.messageBuffer.subarray(4 + messageLength);
+
+      try {
+        const message: unknown = JSON.parse(payload.toString("utf8"));
+        if (!isIpcMessage(message) && !isForwardedIpcMessage(message)) {
+          continue;
+        }
+
+        this.receive(
+          new IncomingMessage(
+            new Uint8Array(message.message.payload),
+            message.message.destination,
+            isForwardedIpcMessage(message) ? message.originalSource : "DesktopMain",
+            message.message.topic,
+          ),
+        );
+      } catch (error) {
+        this.logService.info("[IPC] Ignoring malformed Bitwarden Desktop message", error);
+      }
+    }
+  }
+
+  private readFrameLength(buffer: Buffer): number {
+    return os.endianness() === "LE" ? buffer.readUInt32LE(0) : buffer.readUInt32BE(0);
+  }
+}

--- a/apps/cli/src/platform/services/cli-desktop-ipc.transport.ts
+++ b/apps/cli/src/platform/services/cli-desktop-ipc.transport.ts
@@ -1,61 +1,29 @@
-import * as crypto from "crypto";
-import * as net from "net";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import * as os from "os";
-import * as path from "path";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { IpcMessage, isForwardedIpcMessage, isIpcMessage } from "@bitwarden/common/platform/ipc";
+import {
+  IpcMessage,
+  isForwardedIpcMessage,
+  isIpcMessage,
+  isProxyConnectedMessage,
+} from "@bitwarden/common/platform/ipc";
 import { IncomingMessage, OutgoingMessage } from "@bitwarden/sdk-internal";
+
+import { resolveDesktopProxyPath } from "./cli-desktop-proxy-path";
 
 const MAX_MESSAGE_SIZE = 1024 * 1024;
 const CONNECTION_TIMEOUT_MS = 5_000;
-const LINUX_FLATPAK_NATIVE_MESSAGING_PATHS = [
-  "org.mozilla.firefox/.mozilla/native-messaging-hosts",
-  "com.google.Chrome/config/google-chrome/NativeMessagingHosts",
-  "org.chromium.Chromium/config/chromium/NativeMessagingHosts",
-  "com.microsoft.Edge/config/microsoft-edge/NativeMessagingHosts",
-];
-const LINUX_NATIVE_MESSAGING_PATHS = [
-  ".config/chromium/NativeMessagingHosts",
-  ".config/google-chrome/NativeMessagingHosts",
-  ".config/microsoft-edge/NativeMessagingHosts",
-  ".mozilla/native-messaging-hosts",
-];
 
-/**
- * Returns the desktop IPC endpoints used by desktop_native/core/src/ipc/mod.rs.
- *
- * macOS has separate endpoints for the sandboxed App Store build and the
- * unsandboxed build, so both are attempted.
- */
-export function getDesktopSocketPaths(
-  platform = os.platform(),
-  homeDir = os.homedir(),
-  xdgCacheHome = process.env.XDG_CACHE_HOME,
-): string[] {
-  if (platform === "win32") {
-    const hash = crypto.createHash("sha256").update(homeDir).digest("base64url");
-    return [`\\\\.\\pipe\\${hash}.s.bw`];
-  }
+type SpawnProxy = (proxyPath: string) => ChildProcessWithoutNullStreams;
 
-  if (platform === "darwin") {
-    return [
-      path.join(homeDir, "Library", "Group Containers", "LTZ2PFU5D6.com.bitwarden.desktop", "s.bw"),
-      path.join(homeDir, "Library", "Caches", "com.bitwarden.desktop", "s.bw"),
-    ];
-  }
+const spawnProxy: SpawnProxy = (proxyPath) =>
+  spawn(proxyPath, [], {
+    stdio: "pipe",
+    shell: false,
+  });
 
-  const socketName = ".app.bw.socket";
-  return [
-    path.join(xdgCacheHome ?? path.join(homeDir, ".cache"), "com.bitwarden.desktop", "s.bw"),
-    ...LINUX_FLATPAK_NATIVE_MESSAGING_PATHS.map((nativePath) =>
-      path.join(homeDir, ".var", "app", nativePath, socketName),
-    ),
-    ...LINUX_NATIVE_MESSAGING_PATHS.map((nativePath) => path.join(homeDir, nativePath, socketName)),
-  ];
-}
-
-export function encodeDesktopIpcFrame(message: IpcMessage): Buffer {
+export function encodeNativeMessagingFrame(message: IpcMessage | object): Buffer {
   const payload = Buffer.from(JSON.stringify(message), "utf8");
   if (payload.length > MAX_MESSAGE_SIZE) {
     throw new Error(`Desktop IPC message exceeds ${MAX_MESSAGE_SIZE} bytes`);
@@ -71,21 +39,30 @@ export function encodeDesktopIpcFrame(message: IpcMessage): Buffer {
   return frame;
 }
 
-/** Direct socket transport for the SDK IPC client used by the CLI. */
+/** SDK IPC transport backed by the Bitwarden Desktop native-messaging proxy. */
 export class CliDesktopIpcTransport {
-  private socket?: net.Socket;
-  private connection?: Promise<net.Socket>;
+  private proxy?: ChildProcessWithoutNullStreams;
+  private connection?: Promise<void>;
+  private connected = false;
   private messageBuffer = Buffer.alloc(0);
 
   constructor(
     private logService: LogService,
     private receive: (message: IncomingMessage) => void,
-    private socketPaths = getDesktopSocketPaths(),
     private onDisconnect?: () => void,
+    private proxyPathResolver = resolveDesktopProxyPath,
+    private proxySpawner: SpawnProxy = spawnProxy,
   ) {}
 
   async send(message: OutgoingMessage): Promise<void> {
-    const frame = encodeDesktopIpcFrame({
+    await this.connect();
+
+    const proxy = this.proxy;
+    if (proxy == null || !this.connected) {
+      throw new Error("Bitwarden Desktop proxy disconnected before the message could be sent");
+    }
+
+    const frame = encodeNativeMessagingFrame({
       type: "bitwarden-ipc-message",
       message: {
         destination: message.destination,
@@ -93,96 +70,103 @@ export class CliDesktopIpcTransport {
         topic: message.topic,
       },
     });
-    const socket = await this.connect();
 
     await new Promise<void>((resolve, reject) => {
-      socket.write(frame, (error) => (error ? reject(error) : resolve()));
+      proxy.stdin.write(frame, (error) => (error ? reject(error) : resolve()));
     });
   }
 
   disconnect(): void {
-    this.socket?.destroy();
-    this.socket = undefined;
+    const proxy = this.proxy;
+    const wasConnected = proxy != null || this.connection != null;
+
+    this.proxy = undefined;
     this.connection = undefined;
+    this.connected = false;
     this.messageBuffer = Buffer.alloc(0);
-    this.onDisconnect?.();
+    proxy?.kill();
+
+    if (wasConnected) {
+      this.onDisconnect?.();
+    }
   }
 
-  private async connect(): Promise<net.Socket> {
-    if (this.socket != null && !this.socket.destroyed) {
-      return this.socket;
+  private async connect(): Promise<void> {
+    if (this.connected) {
+      return;
     }
 
-    this.connection ??= this.connectToFirstAvailablePath();
+    this.connection ??= this.startProxy();
     try {
-      return await this.connection;
+      await this.connection;
     } catch (error) {
       this.connection = undefined;
       throw error;
     }
   }
 
-  private async connectToFirstAvailablePath(): Promise<net.Socket> {
-    let lastError: Error | undefined;
+  private startProxy(): Promise<void> {
+    const proxyPath = this.proxyPathResolver();
+    const proxy = this.proxySpawner(proxyPath);
+    this.proxy = proxy;
 
-    for (const socketPath of this.socketPaths) {
-      try {
-        const socket = await this.connectToPath(socketPath);
-        this.socket = socket;
-        this.logService.info(`[IPC] Connected to Bitwarden Desktop at ${socketPath}`);
-        return socket;
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-      }
-    }
-
-    throw new Error(
-      `Could not connect to the Bitwarden Desktop app${lastError ? `: ${lastError.message}` : ""}`,
-    );
-  }
-
-  private connectToPath(socketPath: string): Promise<net.Socket> {
-    return new Promise((resolve, reject) => {
-      const socket = net.createConnection(socketPath);
+    return new Promise<void>((resolve, reject) => {
       let settled = false;
-
       const timeout = setTimeout(() => {
-        settled = true;
-        socket.destroy();
-        reject(new Error(`Connection to ${socketPath} timed out`));
+        fail(new Error(`Connection to Bitwarden Desktop via ${proxyPath} timed out`));
+        proxy.kill();
       }, CONNECTION_TIMEOUT_MS);
 
-      socket.once("connect", () => {
+      const succeed = () => {
+        if (settled || this.proxy !== proxy) {
+          return;
+        }
         settled = true;
         clearTimeout(timeout);
-        socket.on("data", (data) => this.processIncomingData(data));
-        socket.on("close", () => this.handleDisconnect(socket));
-        socket.on("error", (error) =>
-          this.logService.info("[IPC] Bitwarden Desktop socket error", error),
-        );
-        resolve(socket);
-      });
+        this.connected = true;
+        this.logService.info(`[IPC] Connected to Bitwarden Desktop via ${proxyPath}`);
+        resolve();
+      };
 
-      socket.once("error", (error) => {
+      const fail = (error: Error) => {
         if (!settled) {
+          settled = true;
           clearTimeout(timeout);
-          socket.destroy();
           reject(error);
         }
-      });
+        this.handleProxyDisconnect(proxy);
+      };
+
+      proxy.stdout.on("data", (data: Buffer) => this.processIncomingData(data, succeed));
+      proxy.stderr.on("data", (data: Buffer) =>
+        this.logService.debug(`[IPC] Desktop proxy: ${data.toString("utf8").trimEnd()}`),
+      );
+      proxy.once("error", (error) => fail(error));
+      proxy.once("exit", (code, signal) =>
+        fail(
+          new Error(
+            `Bitwarden Desktop proxy exited${code != null ? ` with code ${code}` : ""}${
+              signal != null ? ` from signal ${signal}` : ""
+            }`,
+          ),
+        ),
+      );
     });
   }
 
-  private handleDisconnect(socket: net.Socket): void {
-    if (this.socket === socket) {
-      this.socket = undefined;
-      this.connection = undefined;
-      this.messageBuffer = Buffer.alloc(0);
-      this.onDisconnect?.();
+  private handleProxyDisconnect(proxy: ChildProcessWithoutNullStreams): void {
+    if (this.proxy !== proxy) {
+      return;
     }
+
+    this.proxy = undefined;
+    this.connection = undefined;
+    this.connected = false;
+    this.messageBuffer = Buffer.alloc(0);
+    this.onDisconnect?.();
   }
 
-  private processIncomingData(data: Buffer): void {
+  private processIncomingData(data: Buffer, onConnected: () => void = () => {}): void {
     this.messageBuffer = Buffer.concat([this.messageBuffer, data]);
 
     while (this.messageBuffer.length >= 4) {
@@ -202,6 +186,10 @@ export class CliDesktopIpcTransport {
 
       try {
         const message: unknown = JSON.parse(payload.toString("utf8"));
+        if (isProxyConnectedMessage(message)) {
+          onConnected();
+          continue;
+        }
         if (!isIpcMessage(message) && !isForwardedIpcMessage(message)) {
           continue;
         }

--- a/apps/cli/src/platform/services/cli-desktop-ipc.transport.ts
+++ b/apps/cli/src/platform/services/cli-desktop-ipc.transport.ts
@@ -84,7 +84,12 @@ export class CliDesktopIpcTransport {
     this.connection = undefined;
     this.connected = false;
     this.messageBuffer = Buffer.alloc(0);
-    proxy?.kill();
+    if (proxy != null) {
+      // Close the native-messaging stream so the proxy tears the Desktop
+      // connection down itself, then terminate it as a fallback.
+      proxy.stdin.end();
+      proxy.kill();
+    }
 
     if (wasConnected) {
       this.onDisconnect?.();

--- a/apps/cli/src/platform/services/cli-desktop-proxy-path.spec.ts
+++ b/apps/cli/src/platform/services/cli-desktop-proxy-path.spec.ts
@@ -1,5 +1,3 @@
-import * as path from "path";
-
 import {
   DESKTOP_PROXY_PATH_ENV,
   getDesktopProxyPaths,
@@ -28,24 +26,13 @@ describe("getDesktopProxyPaths", () => {
     ]);
   });
 
-  it("returns installed and native-messaging proxy paths on Linux", () => {
-    const paths = getDesktopProxyPaths("linux", "/home/alice", {});
-
-    expect(paths).toContain("/opt/Bitwarden/desktop_proxy");
-    expect(paths).toContain("/usr/lib/bitwarden/desktop_proxy");
-    expect(paths).toContain("/snap/bitwarden/current/desktop_proxy");
-    expect(paths).toContain(
-      path.posix.join(
-        "/home/alice",
-        ".config/chromium/NativeMessagingHosts/.bitwarden_desktop_proxy",
-      ),
-    );
-    expect(paths).toContain(
-      path.posix.join(
-        "/home/alice",
-        ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts/.bitwarden_desktop_proxy",
-      ),
-    );
+  it("returns standard desktop installation paths on Linux", () => {
+    expect(getDesktopProxyPaths("linux", "/home/alice", {})).toEqual([
+      "/opt/Bitwarden/desktop_proxy",
+      "/usr/lib/bitwarden/desktop_proxy",
+      "/usr/lib/bitwarden-desktop/desktop_proxy",
+      "/snap/bitwarden/current/desktop_proxy",
+    ]);
   });
 });
 

--- a/apps/cli/src/platform/services/cli-desktop-proxy-path.spec.ts
+++ b/apps/cli/src/platform/services/cli-desktop-proxy-path.spec.ts
@@ -1,0 +1,78 @@
+import * as path from "path";
+
+import {
+  DESKTOP_PROXY_PATH_ENV,
+  getDesktopProxyPaths,
+  resolveDesktopProxyPath,
+} from "./cli-desktop-proxy-path";
+
+describe("getDesktopProxyPaths", () => {
+  it("returns the standard Windows desktop installation paths", () => {
+    expect(
+      getDesktopProxyPaths("win32", "C:\\Users\\alice", {
+        LOCALAPPDATA: "C:\\Users\\alice\\AppData\\Local",
+        ProgramFiles: "C:\\Program Files",
+        "ProgramFiles(x86)": "C:\\Program Files (x86)",
+      }),
+    ).toEqual([
+      "C:\\Users\\alice\\AppData\\Local\\Programs\\Bitwarden\\desktop_proxy.exe",
+      "C:\\Program Files\\Bitwarden\\desktop_proxy.exe",
+      "C:\\Program Files (x86)\\Bitwarden\\desktop_proxy.exe",
+    ]);
+  });
+
+  it("returns system and per-user macOS application paths", () => {
+    expect(getDesktopProxyPaths("darwin", "/Users/alice", {})).toEqual([
+      "/Applications/Bitwarden.app/Contents/MacOS/desktop_proxy",
+      "/Users/alice/Applications/Bitwarden.app/Contents/MacOS/desktop_proxy",
+    ]);
+  });
+
+  it("returns installed and native-messaging proxy paths on Linux", () => {
+    const paths = getDesktopProxyPaths("linux", "/home/alice", {});
+
+    expect(paths).toContain("/opt/Bitwarden/desktop_proxy");
+    expect(paths).toContain("/usr/lib/bitwarden/desktop_proxy");
+    expect(paths).toContain("/snap/bitwarden/current/desktop_proxy");
+    expect(paths).toContain(
+      path.posix.join(
+        "/home/alice",
+        ".config/chromium/NativeMessagingHosts/.bitwarden_desktop_proxy",
+      ),
+    );
+    expect(paths).toContain(
+      path.posix.join(
+        "/home/alice",
+        ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts/.bitwarden_desktop_proxy",
+      ),
+    );
+  });
+});
+
+describe("resolveDesktopProxyPath", () => {
+  it("prefers the environment override", () => {
+    expect(resolveDesktopProxyPath(["/standard/proxy"], "/custom/proxy", () => true)).toBe(
+      "/custom/proxy",
+    );
+  });
+
+  it("rejects an invalid environment override", () => {
+    expect(() => resolveDesktopProxyPath([], "/missing/proxy", () => false)).toThrow(
+      `${DESKTOP_PROXY_PATH_ENV} points to a file that does not exist`,
+    );
+  });
+
+  it("selects the first existing well-known path", () => {
+    expect(
+      resolveDesktopProxyPath(["/missing/proxy", "/installed/proxy"], undefined, (candidate) =>
+        candidate.startsWith("/installed"),
+      ),
+    ).toBe("/installed/proxy");
+  });
+
+  it("reports how to configure a non-standard proxy path", () => {
+    expect(() => resolveDesktopProxyPath([], undefined, () => false)).toThrow(
+      `Set ${DESKTOP_PROXY_PATH_ENV} to its path`,
+    );
+  });
+});

--- a/apps/cli/src/platform/services/cli-desktop-proxy-path.spec.ts
+++ b/apps/cli/src/platform/services/cli-desktop-proxy-path.spec.ts
@@ -29,6 +29,7 @@ describe("getDesktopProxyPaths", () => {
   it("returns standard desktop installation paths on Linux", () => {
     expect(getDesktopProxyPaths("linux", "/home/alice", {})).toEqual([
       "/opt/Bitwarden/desktop_proxy",
+      "/app/Bitwarden/desktop_proxy",
       "/usr/lib/bitwarden/desktop_proxy",
       "/usr/lib/bitwarden-desktop/desktop_proxy",
       "/snap/bitwarden/current/desktop_proxy",

--- a/apps/cli/src/platform/services/cli-desktop-proxy-path.ts
+++ b/apps/cli/src/platform/services/cli-desktop-proxy-path.ts
@@ -30,6 +30,7 @@ export function getDesktopProxyPaths(
 
   return [
     "/opt/Bitwarden/desktop_proxy",
+    "/app/Bitwarden/desktop_proxy",
     "/usr/lib/bitwarden/desktop_proxy",
     "/usr/lib/bitwarden-desktop/desktop_proxy",
     "/snap/bitwarden/current/desktop_proxy",

--- a/apps/cli/src/platform/services/cli-desktop-proxy-path.ts
+++ b/apps/cli/src/platform/services/cli-desktop-proxy-path.ts
@@ -4,22 +4,6 @@ import * as path from "path";
 
 export const DESKTOP_PROXY_PATH_ENV = "BITWARDEN_DESKTOP_PROXY_PATH";
 
-const LINUX_FLATPAK_NATIVE_MESSAGING_PATHS = [
-  "org.mozilla.firefox/.mozilla/native-messaging-hosts",
-  "com.google.Chrome/config/google-chrome/NativeMessagingHosts",
-  "org.chromium.Chromium/config/chromium/NativeMessagingHosts",
-  "com.microsoft.Edge/config/microsoft-edge/NativeMessagingHosts",
-];
-const LINUX_NATIVE_MESSAGING_PATHS = [
-  ".mozilla/native-messaging-hosts",
-  ".config/google-chrome/NativeMessagingHosts",
-  ".config/chromium/NativeMessagingHosts",
-  ".config/microsoft-edge/NativeMessagingHosts",
-  ".config/vivaldi/NativeMessagingHosts",
-  ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
-  ".config/net.imput.helium/NativeMessagingHosts",
-];
-
 /** Returns well-known locations for the desktop native-messaging proxy. */
 export function getDesktopProxyPaths(
   platform = os.platform(),
@@ -44,21 +28,11 @@ export function getDesktopProxyPaths(
     ];
   }
 
-  const nativeMessagingProxy = ".bitwarden_desktop_proxy";
   return [
-    // Prefer stable Desktop installation paths. Desktop also hard-links or copies
-    // its proxy into browser native-messaging directories on Linux; those
-    // host-visible copies are useful fallbacks for sandboxed or portable installs.
     "/opt/Bitwarden/desktop_proxy",
     "/usr/lib/bitwarden/desktop_proxy",
     "/usr/lib/bitwarden-desktop/desktop_proxy",
     "/snap/bitwarden/current/desktop_proxy",
-    ...LINUX_NATIVE_MESSAGING_PATHS.map((nativePath) =>
-      path.posix.join(homeDir, nativePath, nativeMessagingProxy),
-    ),
-    ...LINUX_FLATPAK_NATIVE_MESSAGING_PATHS.map((nativePath) =>
-      path.posix.join(homeDir, ".var/app", nativePath, nativeMessagingProxy),
-    ),
   ];
 }
 

--- a/apps/cli/src/platform/services/cli-desktop-proxy-path.ts
+++ b/apps/cli/src/platform/services/cli-desktop-proxy-path.ts
@@ -1,0 +1,87 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+export const DESKTOP_PROXY_PATH_ENV = "BITWARDEN_DESKTOP_PROXY_PATH";
+
+const LINUX_FLATPAK_NATIVE_MESSAGING_PATHS = [
+  "org.mozilla.firefox/.mozilla/native-messaging-hosts",
+  "com.google.Chrome/config/google-chrome/NativeMessagingHosts",
+  "org.chromium.Chromium/config/chromium/NativeMessagingHosts",
+  "com.microsoft.Edge/config/microsoft-edge/NativeMessagingHosts",
+];
+const LINUX_NATIVE_MESSAGING_PATHS = [
+  ".mozilla/native-messaging-hosts",
+  ".config/google-chrome/NativeMessagingHosts",
+  ".config/chromium/NativeMessagingHosts",
+  ".config/microsoft-edge/NativeMessagingHosts",
+  ".config/vivaldi/NativeMessagingHosts",
+  ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
+  ".config/net.imput.helium/NativeMessagingHosts",
+];
+
+/** Returns well-known locations for the desktop native-messaging proxy. */
+export function getDesktopProxyPaths(
+  platform = os.platform(),
+  homeDir = os.homedir(),
+  environment: NodeJS.ProcessEnv = process.env,
+): string[] {
+  if (platform === "win32") {
+    return [
+      environment.LOCALAPPDATA &&
+        path.win32.join(environment.LOCALAPPDATA, "Programs", "Bitwarden", "desktop_proxy.exe"),
+      environment.ProgramFiles &&
+        path.win32.join(environment.ProgramFiles, "Bitwarden", "desktop_proxy.exe"),
+      environment["ProgramFiles(x86)"] &&
+        path.win32.join(environment["ProgramFiles(x86)"], "Bitwarden", "desktop_proxy.exe"),
+    ].filter((candidate): candidate is string => candidate != null);
+  }
+
+  if (platform === "darwin") {
+    return [
+      "/Applications/Bitwarden.app/Contents/MacOS/desktop_proxy",
+      path.posix.join(homeDir, "Applications/Bitwarden.app/Contents/MacOS/desktop_proxy"),
+    ];
+  }
+
+  const nativeMessagingProxy = ".bitwarden_desktop_proxy";
+  return [
+    // Prefer stable Desktop installation paths. Desktop also hard-links or copies
+    // its proxy into browser native-messaging directories on Linux; those
+    // host-visible copies are useful fallbacks for sandboxed or portable installs.
+    "/opt/Bitwarden/desktop_proxy",
+    "/usr/lib/bitwarden/desktop_proxy",
+    "/usr/lib/bitwarden-desktop/desktop_proxy",
+    "/snap/bitwarden/current/desktop_proxy",
+    ...LINUX_NATIVE_MESSAGING_PATHS.map((nativePath) =>
+      path.posix.join(homeDir, nativePath, nativeMessagingProxy),
+    ),
+    ...LINUX_FLATPAK_NATIVE_MESSAGING_PATHS.map((nativePath) =>
+      path.posix.join(homeDir, ".var/app", nativePath, nativeMessagingProxy),
+    ),
+  ];
+}
+
+/** Resolves an explicit override or the first installed desktop proxy. */
+export function resolveDesktopProxyPath(
+  proxyPaths = getDesktopProxyPaths(),
+  override = process.env[DESKTOP_PROXY_PATH_ENV],
+  exists: (candidate: string) => boolean = fs.existsSync,
+): string {
+  if (override != null && override !== "") {
+    if (!exists(override)) {
+      throw new Error(
+        `${DESKTOP_PROXY_PATH_ENV} points to a file that does not exist: ${override}`,
+      );
+    }
+    return override;
+  }
+
+  const proxyPath = proxyPaths.find(exists);
+  if (proxyPath == null) {
+    throw new Error(
+      `Could not find the Bitwarden Desktop proxy. Set ${DESKTOP_PROXY_PATH_ENV} to its path.`,
+    );
+  }
+  return proxyPath;
+}

--- a/apps/cli/src/platform/services/cli-ipc.service.spec.ts
+++ b/apps/cli/src/platform/services/cli-ipc.service.spec.ts
@@ -1,0 +1,53 @@
+import { mock } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { IpcClient, ipcRequestDiscover } from "@bitwarden/sdk-internal";
+
+import { CliDesktopIpcTransport } from "./cli-desktop-ipc.transport";
+import { CliIpcService, MINIMUM_BIOMETRIC_DESKTOP_VERSION } from "./cli-ipc.service";
+
+jest.mock("@bitwarden/sdk-internal", () => ({
+  ...jest.requireActual("@bitwarden/sdk-internal"),
+  ipcRequestDiscover: jest.fn(),
+}));
+
+describe("CliIpcService", () => {
+  const logService = mock<LogService>();
+  const client = mock<IpcClient>();
+  const transport = mock<CliDesktopIpcTransport>();
+
+  let service: CliIpcService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new CliIpcService(logService);
+    Object.defineProperty(service, "_client", { configurable: true, value: client });
+    Object.assign(service as object, {
+      initialization: Promise.resolve(),
+      transport,
+    });
+  });
+
+  it("discovers the connected desktop version", async () => {
+    jest.mocked(ipcRequestDiscover).mockResolvedValue({ version: "2026.7.0" });
+
+    await expect(service.verifyDesktopConnection()).resolves.toBe("2026.7.0");
+    expect(ipcRequestDiscover).toHaveBeenCalledWith(
+      client,
+      "DesktopRenderer",
+      expect.any(AbortSignal),
+    );
+
+    await expect(service.verifyDesktopConnection()).resolves.toBe("2026.7.0");
+    expect(ipcRequestDiscover).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnects and reports the minimum version when discovery fails", async () => {
+    jest.mocked(ipcRequestDiscover).mockRejectedValue(new Error("request timed out"));
+
+    await expect(service.verifyDesktopConnection()).rejects.toThrow(
+      `Biometric unlock requires Bitwarden Desktop ${MINIMUM_BIOMETRIC_DESKTOP_VERSION} or newer`,
+    );
+    expect(transport.disconnect).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/platform/services/cli-ipc.service.spec.ts
+++ b/apps/cli/src/platform/services/cli-ipc.service.spec.ts
@@ -29,21 +29,30 @@ describe("CliIpcService", () => {
   });
 
   it("discovers the connected desktop version", async () => {
-    jest.mocked(ipcRequestDiscover).mockResolvedValue({ version: "2026.7.0" });
+    jest.mocked(ipcRequestDiscover).mockResolvedValue({ version: "2026.9.0" });
 
-    await expect(service.verifyDesktopConnection()).resolves.toBe("2026.7.0");
+    await expect(service.verifyDesktopConnection()).resolves.toBe("2026.9.0");
     expect(ipcRequestDiscover).toHaveBeenCalledWith(
       client,
       "DesktopRenderer",
       expect.any(AbortSignal),
     );
 
-    await expect(service.verifyDesktopConnection()).resolves.toBe("2026.7.0");
+    await expect(service.verifyDesktopConnection()).resolves.toBe("2026.9.0");
     expect(ipcRequestDiscover).toHaveBeenCalledTimes(1);
   });
 
   it("disconnects and reports the minimum version when discovery fails", async () => {
     jest.mocked(ipcRequestDiscover).mockRejectedValue(new Error("request timed out"));
+
+    await expect(service.verifyDesktopConnection()).rejects.toThrow(
+      `Biometric unlock requires Bitwarden Desktop ${MINIMUM_BIOMETRIC_DESKTOP_VERSION} or newer`,
+    );
+    expect(transport.disconnect).toHaveBeenCalled();
+  });
+
+  it("disconnects when the discovered desktop version is too old", async () => {
+    jest.mocked(ipcRequestDiscover).mockResolvedValue({ version: "2026.8.0" });
 
     await expect(service.verifyDesktopConnection()).rejects.toThrow(
       `Biometric unlock requires Bitwarden Desktop ${MINIMUM_BIOMETRIC_DESKTOP_VERSION} or newer`,

--- a/apps/cli/src/platform/services/cli-ipc.service.ts
+++ b/apps/cli/src/platform/services/cli-ipc.service.ts
@@ -1,0 +1,91 @@
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
+import { IpcService } from "@bitwarden/common/platform/ipc";
+import {
+  IncomingMessage,
+  IpcClient,
+  IpcCommunicationBackend,
+  OutgoingMessage,
+  ipcRequestDiscover,
+} from "@bitwarden/sdk-internal";
+
+import { CliDesktopIpcTransport } from "./cli-desktop-ipc.transport";
+
+const DESKTOP_DISCOVER_TIMEOUT_MS = 5_000;
+export const MINIMUM_BIOMETRIC_DESKTOP_VERSION = "2026.7.0";
+
+/** SDK IPC service backed by the desktop app's local socket. */
+export class CliIpcService extends IpcService {
+  private communicationBackend?: IpcCommunicationBackend;
+  private transport?: CliDesktopIpcTransport;
+  private initialization?: Promise<void>;
+  private desktopVerification?: Promise<string>;
+
+  constructor(private logService: LogService) {
+    super();
+  }
+
+  override init(): Promise<void> {
+    this.initialization ??= this.initialize();
+    return this.initialization;
+  }
+
+  disconnect(): void {
+    this.desktopVerification = undefined;
+    this.transport?.disconnect();
+  }
+
+  /**
+   * Verifies that the connected desktop understands the SDK IPC protocol before
+   * sending a biometric request. Older desktop versions expose the same socket,
+   * but do not respond to SDK IPC messages.
+   */
+  async verifyDesktopConnection(): Promise<string> {
+    await this.init();
+
+    this.desktopVerification ??= this.discoverDesktop();
+    return await this.desktopVerification;
+  }
+
+  private async discoverDesktop(): Promise<string> {
+    try {
+      const response = await ipcRequestDiscover(
+        this.client,
+        "DesktopRenderer",
+        AbortSignal.timeout(DESKTOP_DISCOVER_TIMEOUT_MS),
+      );
+      return response.version;
+    } catch (error) {
+      this.disconnect();
+      const details = error instanceof Error ? ` ${error.message}` : "";
+      throw new Error(
+        `Could not establish SDK IPC with Bitwarden Desktop. Biometric unlock requires Bitwarden Desktop ${MINIMUM_BIOMETRIC_DESKTOP_VERSION} or newer.${details}`,
+      );
+    }
+  }
+
+  private async initialize(): Promise<void> {
+    await SdkLoadService.Ready;
+
+    const receive = (message: IncomingMessage) => this.communicationBackend?.receive(message);
+    this.transport = new CliDesktopIpcTransport(
+      this.logService,
+      receive,
+      undefined,
+      () => (this.desktopVerification = undefined),
+    );
+    this.communicationBackend = new IpcCommunicationBackend({
+      send: async (message: OutgoingMessage): Promise<void> => {
+        if (message.destination !== "DesktopMain" && message.destination !== "DesktopRenderer") {
+          throw new Error("CLI IPC only supports Bitwarden Desktop destinations");
+        }
+        await this.transport!.send(message);
+      },
+    });
+
+    // The desktop native IPC server currently assigns direct socket clients a
+    // BrowserBackground client ID. A first-class CLI endpoint will require a
+    // corresponding Desktop change.
+    await super.initWithClient(IpcClient.newWithSdkInMemorySessions(this.communicationBackend));
+  }
+}

--- a/apps/cli/src/platform/services/cli-ipc.service.ts
+++ b/apps/cli/src/platform/services/cli-ipc.service.ts
@@ -1,3 +1,5 @@
+import { lt } from "semver";
+
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
@@ -12,9 +14,9 @@ import {
 import { CliDesktopIpcTransport } from "./cli-desktop-ipc.transport";
 
 const DESKTOP_DISCOVER_TIMEOUT_MS = 5_000;
-export const MINIMUM_BIOMETRIC_DESKTOP_VERSION = "2026.7.0";
+export const MINIMUM_BIOMETRIC_DESKTOP_VERSION = "2026.9.0";
 
-/** SDK IPC service backed by the desktop app's local socket. */
+/** SDK IPC service backed by the Bitwarden Desktop native-messaging proxy. */
 export class CliIpcService extends IpcService {
   private communicationBackend?: IpcCommunicationBackend;
   private transport?: CliDesktopIpcTransport;
@@ -54,6 +56,9 @@ export class CliIpcService extends IpcService {
         "DesktopRenderer",
         AbortSignal.timeout(DESKTOP_DISCOVER_TIMEOUT_MS),
       );
+      if (lt(response.version, MINIMUM_BIOMETRIC_DESKTOP_VERSION)) {
+        throw new Error(`Bitwarden Desktop ${response.version} is unsupported.`);
+      }
       return response.version;
     } catch (error) {
       this.disconnect();
@@ -71,7 +76,6 @@ export class CliIpcService extends IpcService {
     this.transport = new CliDesktopIpcTransport(
       this.logService,
       receive,
-      undefined,
       () => (this.desktopVerification = undefined),
     );
     this.communicationBackend = new IpcCommunicationBackend({

--- a/apps/cli/src/program.ts
+++ b/apps/cli/src/program.ts
@@ -303,6 +303,7 @@ export class Program extends BaseProgram {
             this.serviceContainer.i18nService,
             this.serviceContainer.encryptedMigrator,
             this.serviceContainer.unlockService,
+            this.serviceContainer.biometricsService,
           );
           const response = await command.run(password, cmd);
           this.processResponse(response);

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -257,6 +257,7 @@ import { CliProcessReloadService } from "../key-management/cli-process-reload.se
 import { CliUserKeyRotationService } from "../key-management/cli-user-key-rotation-service";
 import { CliSessionTimeoutTypeService } from "../key-management/session-timeout/services/cli-session-timeout-type.service";
 import { devFlagEnabled, devFlagValue, flagEnabled } from "../platform/flags";
+import { CliIpcService } from "../platform/services/cli-ipc.service";
 import { CliPlatformUtilsService } from "../platform/services/cli-platform-utils.service";
 import { CliSdkLoadService } from "../platform/services/cli-sdk-load.service";
 import { CliSystemService } from "../platform/services/cli-system.service";
@@ -389,6 +390,8 @@ export class ServiceContainer {
   lockService: LockService;
   unlockService: UnlockService;
   autoUnlockService: AutoUnlockService;
+  biometricsService: CliBiometricsService;
+  ipcService: CliIpcService;
   private accountCryptographicStateService: DefaultAccountCryptographicStateService;
   private v2UpgradeTokenStateService: V2UpgradeTokenStateService;
 
@@ -541,6 +544,14 @@ export class ServiceContainer {
       this.accountService,
     );
 
+    this.ipcService = new CliIpcService(this.logService);
+    this.biometricsService = new CliBiometricsService(
+      this.accountService,
+      () => this.keyService,
+      this.logService,
+      this.ipcService,
+    );
+
     this.keyService = new KeyService(
       this.cryptoFunctionService,
       this.encryptService,
@@ -549,7 +560,7 @@ export class ServiceContainer {
       this.stateService,
       this.stateProvider,
       this.accountCryptographicStateService,
-      new CliBiometricsService(),
+      this.biometricsService,
     );
 
     this.autoUnlockService = new DefaultAutoUnlockService(
@@ -804,7 +815,7 @@ export class ServiceContainer {
       this.masterPasswordService,
       this.stateProvider,
       this.logService,
-      new CliBiometricsService(),
+      this.biometricsService,
       this.biometricStateService,
       this.v2UpgradeTokenStateService,
       this.autoUnlockService,
@@ -1026,17 +1037,16 @@ export class ServiceContainer {
       this.userDecryptionOptionsService,
       this.pinService,
       this.kdfConfigService,
-      new CliBiometricsService(),
+      this.biometricsService,
       this.masterPasswordUnlockService,
     );
 
-    const biometricService = new CliBiometricsService();
     const logoutService = new DefaultLogoutService(this.messagingService);
     const processReloadService = new CliProcessReloadService();
     const systemService = new CliSystemService();
     this.lockService = new DefaultLockService(
       this.accountService,
-      biometricService,
+      this.biometricsService,
       this.vaultTimeoutSettingsService,
       logoutService,
       this.messagingService,
@@ -1203,7 +1213,7 @@ export class ServiceContainer {
       this.masterPasswordService,
       this.syncService,
       this.keyService,
-      new CliBiometricsService(),
+      this.biometricsService,
       this.biometricStateService,
       this.platformUtilsService,
       new CliUserKeyRotationService(),

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -1251,6 +1251,16 @@ export class ServiceContainer {
     }
 
     await this.sdkLoadService.loadAndInit();
+
+    // Desktop IPC is optional. Commands that do not use Desktop integration must
+    // continue to work when Desktop is unavailable or incompatible.
+    try {
+      const desktopVersion = await this.ipcService.verifyDesktopConnection();
+      this.logService.info(`[IPC] Connected to Bitwarden Desktop ${desktopVersion}`);
+    } catch (error) {
+      this.logService.info("[IPC] Could not connect to Bitwarden Desktop", error);
+    }
+
     await this.storageService.init();
 
     await this.migrationRunner.run();
@@ -1276,5 +1286,9 @@ export class ServiceContainer {
     }
 
     this.inited = true;
+  }
+
+  dispose(): void {
+    this.ipcService.disconnect();
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

Discussion: https://github.com/orgs/bitwarden/discussions/17934

Follow-up to https://github.com/bitwarden/clients/pull/18273. The previous implementation was closed pending SDK-based IPC support.

## 📔 Objective

Add biometric unlock to the CLI by communicating with the running Bitwarden Desktop application through the SDK IPC framework.

When `bw unlock` is run interactively without a supplied password, the CLI:

- discovers a compatible Desktop instance;
- checks biometric availability for the active account;
- requests biometric unlock through the existing Desktop RPC handler;
- validates the returned user key before passing it to the existing unlock service; and
- falls back to the master-password prompt when Desktop biometrics are unavailable or cancelled.

Password arguments, `--passwordenv`, `--passwordfile`, and `BW_NOINTERACTION=true` retain their existing behavior and skip the biometric attempt.

The implementation uses `IpcClient.newWithSdkInMemorySessions` and adds a Node socket/named-pipe transport for Desktop's native IPC framing and platform-specific endpoints. It does not reimplement the legacy biometric encryption protocol.

The Desktop IPC bridge currently identifies direct socket connections as `BrowserBackground` clients. The CLI receives its own connection ID and SDK session, but Desktop cannot identify it as a separate CLI client type for routing or policy. This implementation therefore uses the existing browser-client routing and requires no Desktop changes. A dedicated CLI endpoint can be introduced separately if desired.

Biometric unlock requires Bitwarden Desktop 2026.7.0 or newer.

### Validation

- End-to-end biometric unlock verified on Arch Linux with Desktop 2026.7.0.
- CLI Jest suite passes: 26 suites and 287 tests.
- Production and test TypeScript checks pass.
- ESLint and Prettier checks pass.
- OSS and commercial CLI webpack builds succeed.
- Windows and macOS endpoint derivation is covered by unit tests; end-to-end runtime testing has currently only been performed on Linux.

## 📸 Screenshots

Not applicable; this is CLI-only behavior.
