### PR TITLE
fix(pam):  add missing delete action to the access rule edit page

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16955,6 +16955,9 @@
   "pamAccessRuleUpdated": {
     "message": "Access rule updated."
   },
+  "pamAccessRuleDeleted": {
+    "message": "Access rule deleted."
+  },
   "pamAccessRuleDeleteConfirmTitle": {
     "message": "Delete access rule?"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -175,7 +175,7 @@
         </bit-card>
       </bit-section>
 
-      <div class="tw-flex tw-gap-2">
+      <div class="tw-flex tw-items-center tw-gap-2">
         <button
           type="submit"
           bitButton
@@ -195,6 +195,19 @@
         >
           {{ "cancel" | i18n }}
         </button>
+
+        @if (existing() != null) {
+          <button
+            type="button"
+            bitButton
+            buttonType="danger"
+            [bitAction]="remove"
+            class="tw-ms-auto"
+            id="access-rule-edit_button_delete"
+          >
+            {{ "delete" | i18n }}
+          </button>
+        }
       </div>
     </form>
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -6,7 +6,7 @@ import { of, throwError } from "rxjs";
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { SelectItemView, ToastService } from "@bitwarden/components";
+import { DialogService, SelectItemView, ToastService } from "@bitwarden/components";
 
 import { AccessRuleSdkService, AccessRuleView } from "../..";
 
@@ -22,6 +22,9 @@ const i18nFake: Pick<I18nService, "t" | "translate"> = {
 // Stand-in for the SDK-backed CIDR check; these specs don't assert CIDR-format validity, so
 // treating every non-empty row as valid keeps seeded IP-allowlist forms submittable.
 const cidrValidationStub: CidrValidationService = { isValid: () => true };
+
+// Only the delete flow opens a dialog; specs that exercise it provide their own answer.
+const declinedDialogStub = { openSimpleDialog: () => Promise.resolve(false) };
 
 // Preset durations offered by the pickers, in seconds.
 const THIRTY_MIN = 30 * 60;
@@ -58,6 +61,7 @@ describe("AccessRuleEditComponent — default/max duration coupling", () => {
         { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
         { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: DialogService, useValue: declinedDialogStub },
       ],
     });
 
@@ -113,7 +117,10 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     getAccessRule: jest.Mock;
     createAccessRule: jest.Mock;
     updateAccessRule: jest.Mock;
+    deleteAccessRule: jest.Mock;
   };
+  let showToast: jest.Mock;
+  let dialog: { openSimpleDialog: jest.Mock };
 
   // The org's collections, as returned by the admin-console service.
   const ORG_COLLECTIONS = [
@@ -127,7 +134,10 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
       getAccessRule: jest.fn().mockResolvedValue(existing),
       createAccessRule: jest.fn().mockResolvedValue(undefined),
       updateAccessRule: jest.fn().mockResolvedValue(undefined),
+      deleteAccessRule: jest.fn().mockResolvedValue(undefined),
     };
+    showToast = jest.fn();
+    dialog = { openSimpleDialog: jest.fn().mockResolvedValue(true) };
 
     TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
     TestBed.configureTestingModule({
@@ -136,7 +146,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
         provideRouter([]),
         { provide: ActivatedRoute, useValue: routeStub(state) },
         { provide: AccessRuleSdkService, useValue: pamApi },
-        { provide: ToastService, useValue: { showToast: jest.fn() } },
+        { provide: ToastService, useValue: { showToast } },
         { provide: I18nService, useValue: i18nFake },
         { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
         {
@@ -144,6 +154,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
           useValue: { collectionAdminViews$: () => of(ORG_COLLECTIONS) },
         },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: DialogService, useValue: dialog },
       ],
     });
 
@@ -286,12 +297,59 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     expect(controls().maxExtensionDurationSeconds.value).toBe(ONE_HOUR);
   });
 
+  it("deletes the rule under edit and returns to the list once confirmed", async () => {
+    await setup({ params: { accessRuleId: "rule-1" } }, {
+      id: "rule-1",
+      name: "Existing rule",
+      collections: [],
+      conditions: [],
+    } as unknown as AccessRuleView);
+
+    await component["remove"]();
+
+    expect(dialog.openSimpleDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: { key: "pamAccessRuleDeleteConfirmContent", placeholders: ["Existing rule"] },
+      }),
+    );
+    expect(pamApi.deleteAccessRule).toHaveBeenCalledWith("org-1", "rule-1");
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "success", message: "pamAccessRuleDeleted" }),
+    );
+    expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
+  });
+
+  it("leaves the rule alone when the confirm dialog is declined", async () => {
+    await setup({ params: { accessRuleId: "rule-1" } }, {
+      id: "rule-1",
+      name: "Existing rule",
+      collections: [],
+      conditions: [],
+    } as unknown as AccessRuleView);
+    dialog.openSimpleDialog.mockResolvedValue(false);
+
+    await component["remove"]();
+
+    expect(pamApi.deleteAccessRule).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not offer a delete for a rule that doesn't exist yet (create mode)", async () => {
+    await setup({});
+
+    await component["remove"]();
+
+    expect(dialog.openSimpleDialog).not.toHaveBeenCalled();
+    expect(pamApi.deleteAccessRule).not.toHaveBeenCalled();
+  });
+
   it("toasts when the org collections fail to load", async () => {
-    const showToast = jest.fn();
+    showToast = jest.fn();
     pamApi = {
       getAccessRule: jest.fn(),
       createAccessRule: jest.fn(),
       updateAccessRule: jest.fn(),
+      deleteAccessRule: jest.fn(),
     };
 
     TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
@@ -309,6 +367,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
           useValue: { collectionAdminViews$: () => throwError(() => new Error("boom")) },
         },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: DialogService, useValue: declinedDialogStub },
       ],
     });
 
@@ -332,8 +391,9 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
       getAccessRule: jest.fn().mockRejectedValue(new Error("404")),
       createAccessRule: jest.fn(),
       updateAccessRule: jest.fn(),
+      deleteAccessRule: jest.fn(),
     };
-    const showToast = jest.fn();
+    showToast = jest.fn();
 
     TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
     TestBed.configureTestingModule({
@@ -347,6 +407,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
         { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
         { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: DialogService, useValue: declinedDialogStub },
       ],
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
@@ -11,7 +11,7 @@ import { of } from "rxjs";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { ToastService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AccessRuleSdkService, AccessRuleView } from "../..";
@@ -80,6 +80,7 @@ export default {
           useValue: { collectionAdminViews$: () => of(ORG_COLLECTIONS) },
         },
         { provide: CidrValidationService, useValue: { isValid: () => true } },
+        { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
         // Default to create mode; the Edit/Template stories override this.
         { provide: ActivatedRoute, useValue: routeStub() },
       ],

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -17,6 +17,7 @@ import {
   ButtonModule,
   CardComponent,
   CheckboxModule,
+  DialogService,
   FormFieldModule,
   HeaderComponent,
   MultiSelectModule,
@@ -104,6 +105,7 @@ export class AccessRuleEditComponent {
   private readonly accountService = inject(AccountService);
   private readonly collectionAdminService = inject(CollectionAdminService);
   private readonly cidrValidation = inject(CidrValidationService);
+  private readonly dialogService = inject(DialogService);
 
   private readonly organizationId = this.route.snapshot.params.organizationId as OrganizationId;
   private readonly accessRuleId = this.route.snapshot.params.accessRuleId as
@@ -358,6 +360,40 @@ export class AccessRuleEditComponent {
   };
 
   protected readonly cancel = (): Promise<boolean> => this.navigateToList();
+
+  /**
+   * Delete the rule under edit, after confirmation. Edit mode only — there is nothing
+   * to delete before the rule exists on the server.
+   */
+  protected readonly remove = async (): Promise<void> => {
+    const existing = this.existing();
+    if (existing == null) {
+      return;
+    }
+
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "pamAccessRuleDeleteConfirmTitle" },
+      content: { key: "pamAccessRuleDeleteConfirmContent", placeholders: [existing.name] },
+      acceptButtonText: { key: "delete" },
+      cancelButtonText: { key: "cancel" },
+      type: "warning",
+    });
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await this.pamApi.deleteAccessRule(this.organizationId, existing.id);
+      this.toastService.showToast({
+        variant: "success",
+        message: this.i18nService.t("pamAccessRuleDeleted"),
+      });
+      await this.navigateToList();
+    } catch (e) {
+      const message = accessRuleErrorMessage(e) ?? this.i18nService.t("unexpectedError");
+      this.toastService.showToast({ variant: "error", message });
+    }
+  };
 
   /** Return to the access-rules list (the parent of both the `new` and `:id` routes). */
   private navigateToList(): Promise<boolean> {


### PR DESCRIPTION
## 📔 Objective

The access rule edit page was missing the Delete action specified in the designs, deleting a rule
was only possible from the row menu on the access-rules list

<img width="988" height="369" alt="image" src="https://github.com/user-attachments/assets/a634ee5f-3f2f-4510-b78d-a992968da290" />
