### PR TITLE
[PM-38906] Decrypt Admin Console collections in a single SDK call, preserving decryption failures

### DIFF
--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -6,6 +6,7 @@ import { Router } from "@angular/router";
 
 import {
   CollectionAdminService,
+  CollectionEncryptionService,
   CollectionService,
   DefaultCollectionAdminService,
   DefaultOrganizationUserService,
@@ -418,6 +419,9 @@ const safeProviders: SafeProvider[] = [
       EncryptService,
       CollectionService,
       OrganizationService,
+      CollectionEncryptionService,
+      ConfigService,
+      LogService,
     ],
   }),
   safeProvider({

--- a/libs/admin-console/src/common/collections/abstractions/collection-encryption.service.ts
+++ b/libs/admin-console/src/common/collections/abstractions/collection-encryption.service.ts
@@ -5,9 +5,8 @@ import { CollectionView } from "@bitwarden/common/admin-console/models/collectio
 import { UserId } from "@bitwarden/common/types/guid";
 
 /**
- * The result of decrypting a batch of collections where individual failures do not abort the
- * rest of the batch. A collection that fails to decrypt is returned in `failure` instead of
- * being silently dropped.
+ * Result of decrypting a batch of collections. Collections that fail to decrypt are returned
+ * in `failure` instead of aborting the batch.
  */
 export type CollectionDecryptionResult = {
   success: CollectionView[];
@@ -39,13 +38,7 @@ export abstract class CollectionEncryptionService {
   abstract decryptMany(collections: Collection[], userId: UserId): Observable<CollectionView[]>;
 
   /**
-   * Decrypts many collections using the SDK for the given userId, returning successes and
-   * failures separately. Unlike `decryptMany`, a single collection that fails to decrypt does
-   * not silently drop — it is returned in `failure` instead.
-   *
-   * Implementations may use `FeatureFlag.CollectionBulkDecryptWithFailures` to choose between a
-   * batched SDK call and decrypting collections one at a time, but both paths must uphold this
-   * success/failure contract.
+   * Like `decryptMany`, but returns failures separately instead of dropping them.
    *
    * @param collections The encrypted collection objects
    * @param userId The user ID whose keys will be used for decryption

--- a/libs/admin-console/src/common/collections/abstractions/collection-encryption.service.ts
+++ b/libs/admin-console/src/common/collections/abstractions/collection-encryption.service.ts
@@ -5,6 +5,16 @@ import { CollectionView } from "@bitwarden/common/admin-console/models/collectio
 import { UserId } from "@bitwarden/common/types/guid";
 
 /**
+ * The result of decrypting a batch of collections where individual failures do not abort the
+ * rest of the batch. A collection that fails to decrypt is returned in `failure` instead of
+ * being silently dropped.
+ */
+export type CollectionDecryptionResult = {
+  success: CollectionView[];
+  failure: Collection[];
+};
+
+/**
  * Service responsible for encrypting and decrypting collections using the Rust SDK.
  */
 export abstract class CollectionEncryptionService {
@@ -21,13 +31,29 @@ export abstract class CollectionEncryptionService {
   /**
    * Decrypts many collections using the SDK for the given userId.
    *
-   * Collections that fail to decrypt are logged and dropped from the result rather than
-   * aborting the rest of the batch.
-   *
    * @param collections The encrypted collection objects
    * @param userId The user ID whose keys will be used for decryption
    *
    * @returns An observable that emits an array of decrypted collection views
    */
   abstract decryptMany(collections: Collection[], userId: UserId): Observable<CollectionView[]>;
+
+  /**
+   * Decrypts many collections using the SDK for the given userId, returning successes and
+   * failures separately. Unlike `decryptMany`, a single collection that fails to decrypt does
+   * not silently drop — it is returned in `failure` instead.
+   *
+   * Implementations may use `FeatureFlag.CollectionBulkDecryptWithFailures` to choose between a
+   * batched SDK call and decrypting collections one at a time, but both paths must uphold this
+   * success/failure contract.
+   *
+   * @param collections The encrypted collection objects
+   * @param userId The user ID whose keys will be used for decryption
+   *
+   * @returns An observable that emits a {@link CollectionDecryptionResult}
+   */
+  abstract decryptManyWithFailures(
+    collections: Collection[],
+    userId: UserId,
+  ): Observable<CollectionDecryptionResult>;
 }

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.spec.ts
@@ -200,10 +200,7 @@ describe("DefaultCollectionAdminService", () => {
       });
 
       it("still decrypts responses that carry no groups/users", async () => {
-        // `ApiService` builds every element as a `CollectionAccessDetailsResponse`, whose
-        // `groups`/`users` default to `[]`, so this shape does not occur on the current call
-        // path. The cast below forces the plain `CollectionResponse` class to cover the
-        // defensive `isCollectionAccessDetailsResponse` branch in `decryptManyV1`.
+        // Forces the plain CollectionResponse shape, which doesn't occur in practice today.
         apiService.getManyCollectionsWithAccessDetails.mockResolvedValue(
           new ListResponse(
             {
@@ -226,8 +223,6 @@ describe("DefaultCollectionAdminService", () => {
 
         const result = await firstValueFrom(service.collectionAdminViews$(orgId, userId));
 
-        // Both constructors yield the same name and an empty `groups`, so assert the branch
-        // taken rather than the resulting shape.
         expect(fromResponse).toHaveBeenCalledTimes(1);
         expect(fromAccessDetails).not.toHaveBeenCalled();
         expect(collectionEncryptionService.decryptManyWithFailures).not.toHaveBeenCalled();

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.spec.ts
@@ -13,12 +13,13 @@ import {
 } from "@bitwarden/common/admin-console/models/collections/collection.response";
 import { CollectionView } from "@bitwarden/common/admin-console/models/collections/collection.view";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
-import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
 import { ListResponse } from "@bitwarden/common/models/response/list.response";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { EncryptService } from "@bitwarden/legacy-crypto";
 
 import { CollectionService } from "../abstractions";
 import {

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.spec.ts
@@ -1,0 +1,233 @@
+import { mock, MockProxy } from "jest-mock-extended";
+import { firstValueFrom, of } from "rxjs";
+
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import {
+  Collection,
+  CollectionTypes,
+} from "@bitwarden/common/admin-console/models/collections/collection";
+import {
+  CollectionAccessDetailsResponse,
+  CollectionResponse,
+} from "@bitwarden/common/admin-console/models/collections/collection.response";
+import { CollectionView } from "@bitwarden/common/admin-console/models/collections/collection.view";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { EncryptService } from "@bitwarden/common/key-management/crypto/abstractions/encrypt.service";
+import { ListResponse } from "@bitwarden/common/models/response/list.response";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { KeyService } from "@bitwarden/key-management";
+
+import { CollectionService } from "../abstractions";
+import {
+  CollectionDecryptionResult,
+  CollectionEncryptionService,
+} from "../abstractions/collection-encryption.service";
+
+import { DefaultCollectionAdminService } from "./default-collection-admin.service";
+
+const userId = "59fbbb44-8cc8-4279-ab40-afc5f68704f4" as UserId;
+const orgId = "c5e9654f-6cc5-44c4-8e09-3d323522668c" as OrganizationId;
+const collectionId1 = "bdc4ef23-1116-477e-ae73-247854af58cb";
+const collectionId2 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+function makeAccessDetailsResponse(
+  overrides: Partial<{
+    id: string;
+    name: string;
+    externalId: string;
+    assigned: boolean;
+    unmanaged: boolean;
+  }> = {},
+): CollectionAccessDetailsResponse {
+  return new CollectionAccessDetailsResponse({
+    object: "collectionAccessDetails",
+    id: overrides.id ?? collectionId1,
+    organizationId: orgId,
+    name: overrides.name ?? "2.abc123|def456==|ghi789==",
+    externalId: overrides.externalId,
+    readOnly: false,
+    manage: true,
+    hidePasswords: false,
+    assigned: overrides.assigned ?? true,
+    unmanaged: overrides.unmanaged ?? false,
+    type: CollectionTypes.SharedCollection,
+    groups: [],
+    users: [],
+  });
+}
+
+function makeCollectionView(id: string, overrides: Partial<CollectionView> = {}): CollectionView {
+  const view = new CollectionView({
+    id: id as any,
+    organizationId: orgId,
+    name: "Decrypted Name",
+  });
+  return Object.assign(view, overrides);
+}
+
+function makeResult(
+  success: CollectionView[],
+  failure: Collection[] = [],
+): CollectionDecryptionResult {
+  return { success, failure };
+}
+
+describe("DefaultCollectionAdminService", () => {
+  let service: DefaultCollectionAdminService;
+
+  let apiService: MockProxy<ApiService>;
+  let keyService: MockProxy<KeyService>;
+  let encryptService: MockProxy<EncryptService>;
+  let collectionService: MockProxy<CollectionService>;
+  let organizationService: MockProxy<OrganizationService>;
+  let collectionEncryptionService: MockProxy<CollectionEncryptionService>;
+  let configService: MockProxy<ConfigService>;
+  let logService: MockProxy<LogService>;
+
+  beforeEach(() => {
+    apiService = mock();
+    keyService = mock();
+    encryptService = mock();
+    collectionService = mock();
+    organizationService = mock();
+    collectionEncryptionService = mock();
+    configService = mock();
+    logService = mock();
+
+    keyService.orgKeys$.mockReturnValue(of({ [orgId]: {} as any }));
+
+    service = new DefaultCollectionAdminService(
+      apiService,
+      keyService,
+      encryptService,
+      collectionService,
+      organizationService,
+      collectionEncryptionService,
+      configService,
+      logService,
+    );
+  });
+
+  function mockApiResponse(collections: CollectionAccessDetailsResponse[]) {
+    apiService.getManyCollectionsWithAccessDetails.mockResolvedValue(
+      new ListResponse({ data: collections }, CollectionAccessDetailsResponse),
+    );
+  }
+
+  describe("collectionAdminViews$", () => {
+    it("checks the CollectionAdminBulkDecrypt feature flag", async () => {
+      configService.getFeatureFlag$.mockReturnValue(of(false));
+      encryptService.decryptString.mockResolvedValue("Decrypted Name");
+      mockApiResponse([makeAccessDetailsResponse()]);
+
+      await firstValueFrom(service.collectionAdminViews$(orgId, userId));
+
+      expect(configService.getFeatureFlag$).toHaveBeenCalledWith(
+        FeatureFlag.CollectionAdminBulkDecrypt,
+      );
+    });
+
+    describe("when CollectionAdminBulkDecrypt is enabled", () => {
+      beforeEach(() => {
+        configService.getFeatureFlag$.mockReturnValue(of(true));
+      });
+
+      it("decrypts collections via CollectionEncryptionService", async () => {
+        mockApiResponse([makeAccessDetailsResponse()]);
+        collectionEncryptionService.decryptManyWithFailures.mockReturnValue(
+          of(makeResult([makeCollectionView(collectionId1, { name: "Decrypted Name" })])),
+        );
+
+        const result = await firstValueFrom(service.collectionAdminViews$(orgId, userId));
+
+        expect(collectionEncryptionService.decryptManyWithFailures).toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ id: collectionId1 })]),
+          userId,
+        );
+        expect(encryptService.decryptString).not.toHaveBeenCalled();
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("Decrypted Name");
+      });
+
+      it("shows a placeholder view for a collection that fails to decrypt, without dropping it", async () => {
+        const failing = makeAccessDetailsResponse({ id: collectionId1 });
+        const succeeding = makeAccessDetailsResponse({ id: collectionId2 });
+        mockApiResponse([failing, succeeding]);
+
+        const failedCollection = new Collection({
+          id: collectionId1 as any,
+          organizationId: orgId,
+          name: failing.name as any,
+        });
+
+        collectionEncryptionService.decryptManyWithFailures.mockReturnValue(
+          of(
+            makeResult(
+              [makeCollectionView(collectionId2, { name: "Collection 2" })],
+              [failedCollection],
+            ),
+          ),
+        );
+
+        const result = await firstValueFrom(service.collectionAdminViews$(orgId, userId));
+
+        expect(result).toHaveLength(2);
+        const failedView = result.find((v) => v.id === collectionId1);
+        expect(failedView?.name).toBe("[error: cannot decrypt]");
+      });
+
+      it("falls back to the original path when responses are not access-details responses", async () => {
+        // The API method is typed to always return `CollectionAccessDetailsResponse`, but at
+        // runtime a caller without manage permissions on any collection gets back the narrower
+        // `CollectionResponse` shape (no `groups`/`users`), which is exactly what
+        // `isCollectionAccessDetailsResponse` distinguishes at runtime. The cast below simulates
+        // that real mismatch; the v1 path (via EncryptService) must be used even though the flag
+        // is enabled.
+        apiService.getManyCollectionsWithAccessDetails.mockResolvedValue(
+          new ListResponse(
+            {
+              data: [
+                {
+                  object: "collection",
+                  id: collectionId1,
+                  organizationId: orgId,
+                  name: "2.abc123|def456==|ghi789==",
+                },
+              ],
+            },
+            CollectionResponse,
+          ) as unknown as ListResponse<CollectionAccessDetailsResponse>,
+        );
+        encryptService.decryptString.mockResolvedValue("Decrypted Name");
+
+        const result = await firstValueFrom(service.collectionAdminViews$(orgId, userId));
+
+        expect(collectionEncryptionService.decryptManyWithFailures).not.toHaveBeenCalled();
+        expect(encryptService.decryptString).toHaveBeenCalled();
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("Decrypted Name");
+      });
+    });
+
+    describe("when CollectionAdminBulkDecrypt is disabled", () => {
+      beforeEach(() => {
+        configService.getFeatureFlag$.mockReturnValue(of(false));
+      });
+
+      it("decrypts collections one at a time via EncryptService", async () => {
+        mockApiResponse([makeAccessDetailsResponse()]);
+        encryptService.decryptString.mockResolvedValue("Decrypted Name");
+
+        const result = await firstValueFrom(service.collectionAdminViews$(orgId, userId));
+
+        expect(collectionEncryptionService.decryptManyWithFailures).not.toHaveBeenCalled();
+        expect(encryptService.decryptString).toHaveBeenCalled();
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("Decrypted Name");
+      });
+    });
+  });
+});

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.spec.ts
@@ -7,6 +7,7 @@ import {
   Collection,
   CollectionTypes,
 } from "@bitwarden/common/admin-console/models/collections/collection";
+import { CollectionAdminView } from "@bitwarden/common/admin-console/models/collections/collection-admin.view";
 import {
   CollectionAccessDetailsResponse,
   CollectionResponse,
@@ -179,14 +180,30 @@ describe("DefaultCollectionAdminService", () => {
         const failedView = result.find((v) => v.id === collectionId1);
         expect(failedView?.name).toBe("[error: cannot decrypt]");
       });
+    });
 
-      it("falls back to the original path when responses are not access-details responses", async () => {
-        // The API method is typed to always return `CollectionAccessDetailsResponse`, but at
-        // runtime a caller without manage permissions on any collection gets back the narrower
-        // `CollectionResponse` shape (no `groups`/`users`), which is exactly what
-        // `isCollectionAccessDetailsResponse` distinguishes at runtime. The cast below simulates
-        // that real mismatch; the v1 path (via EncryptService) must be used even though the flag
-        // is enabled.
+    describe("when CollectionAdminBulkDecrypt is disabled", () => {
+      beforeEach(() => {
+        configService.getFeatureFlag$.mockReturnValue(of(false));
+      });
+
+      it("decrypts collections one at a time via EncryptService", async () => {
+        mockApiResponse([makeAccessDetailsResponse()]);
+        encryptService.decryptString.mockResolvedValue("Decrypted Name");
+
+        const result = await firstValueFrom(service.collectionAdminViews$(orgId, userId));
+
+        expect(collectionEncryptionService.decryptManyWithFailures).not.toHaveBeenCalled();
+        expect(encryptService.decryptString).toHaveBeenCalled();
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("Decrypted Name");
+      });
+
+      it("still decrypts responses that carry no groups/users", async () => {
+        // `ApiService` builds every element as a `CollectionAccessDetailsResponse`, whose
+        // `groups`/`users` default to `[]`, so this shape does not occur on the current call
+        // path. The cast below forces the plain `CollectionResponse` class to cover the
+        // defensive `isCollectionAccessDetailsResponse` branch in `decryptManyV1`.
         apiService.getManyCollectionsWithAccessDetails.mockResolvedValue(
           new ListResponse(
             {
@@ -204,28 +221,16 @@ describe("DefaultCollectionAdminService", () => {
         );
         encryptService.decryptString.mockResolvedValue("Decrypted Name");
 
-        const result = await firstValueFrom(service.collectionAdminViews$(orgId, userId));
-
-        expect(collectionEncryptionService.decryptManyWithFailures).not.toHaveBeenCalled();
-        expect(encryptService.decryptString).toHaveBeenCalled();
-        expect(result).toHaveLength(1);
-        expect(result[0].name).toBe("Decrypted Name");
-      });
-    });
-
-    describe("when CollectionAdminBulkDecrypt is disabled", () => {
-      beforeEach(() => {
-        configService.getFeatureFlag$.mockReturnValue(of(false));
-      });
-
-      it("decrypts collections one at a time via EncryptService", async () => {
-        mockApiResponse([makeAccessDetailsResponse()]);
-        encryptService.decryptString.mockResolvedValue("Decrypted Name");
+        const fromResponse = jest.spyOn(CollectionAdminView, "fromCollectionResponse");
+        const fromAccessDetails = jest.spyOn(CollectionAdminView, "fromCollectionAccessDetails");
 
         const result = await firstValueFrom(service.collectionAdminViews$(orgId, userId));
 
+        // Both constructors yield the same name and an empty `groups`, so assert the branch
+        // taken rather than the resulting shape.
+        expect(fromResponse).toHaveBeenCalledTimes(1);
+        expect(fromAccessDetails).not.toHaveBeenCalled();
         expect(collectionEncryptionService.decryptManyWithFailures).not.toHaveBeenCalled();
-        expect(encryptService.decryptString).toHaveBeenCalled();
         expect(result).toHaveLength(1);
         expect(result[0].name).toBe("Decrypted Name");
       });

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
@@ -145,11 +145,6 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     );
   }
 
-  /**
-   * Routes decryption through the SDK-backed batch path or the original per-item path based on
-   * {@link FeatureFlag.CollectionAdminBulkDecrypt}. The empty case is handled by the caller, so
-   * this is a straight two-way mapping: flag on -> SDK, flag off -> non-SDK.
-   */
   private decryptMany(
     organizationId: string,
     userId: UserId,
@@ -166,14 +161,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     );
   }
 
-  /**
-   * V1 implementation: decrypts each collection individually via `EncryptService`.
-   *
-   * Accepts the wider `CollectionResponse` shape and narrows per item. Every caller today passes
-   * `CollectionAccessDetailsResponse`s, so the `fromCollectionResponse` branch is defensive only —
-   * it keeps this path correct if a caller ever supplies responses built from the plain
-   * `CollectionResponse` class, which carries no `groups`/`users`.
-   */
+  /** Decrypts each collection individually via `EncryptService`. */
   private async decryptManyV1(
     organizationId: string,
     collections: CollectionResponse[] | CollectionAccessDetailsResponse[],
@@ -181,9 +169,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
   ): Promise<CollectionAdminView[]> {
     const orgKey = orgKeys[organizationId as OrganizationId];
 
-    // Sequential rather than `Promise.all`: decryption is compute-bound, so there is no
-    // concurrency to win, and the extra promise scheduling makes the parallel form slower
-    // on both V8 and SpiderMonkey.
+    // Sequential, not Promise.all: decryption is CPU-bound, so parallelizing only adds overhead.
     const views: CollectionAdminView[] = [];
     for (const c of collections) {
       views.push(
@@ -196,13 +182,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     return views;
   }
 
-  /**
-   * V2 implementation: delegates to `CollectionEncryptionService` and wraps results into
-   * `CollectionAdminView`s. Gated behind {@link FeatureFlag.CollectionAdminBulkDecrypt}.
-   *
-   * Both per-collection and batch-level failures are caught and rendered as placeholder views
-   * so admins can still see and manage collections that failed to decrypt.
-   */
+  /** Decrypts via `CollectionEncryptionService`, rendering failures as placeholder views. */
   private decryptManyV2(
     collections: CollectionAccessDetailsResponse[],
     userId: UserId,
@@ -321,13 +301,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
   }
 }
 
-/**
- * Duck-types a response as a `CollectionAccessDetailsResponse` by the presence of `groups` and
- * `users`. Note this is true for every instance the API layer builds today: `ApiService`
- * constructs `ListResponse(r, CollectionAccessDetailsResponse)`, and that class defaults both
- * fields to `[]` regardless of the payload. The check is retained as a guard against a caller
- * supplying responses built from the plain `CollectionResponse` class.
- */
+/** Duck-types a response as a `CollectionAccessDetailsResponse` by its `groups`/`users` fields. */
 function isCollectionAccessDetailsResponse(
   response: CollectionResponse | CollectionAccessDetailsResponse,
 ): response is CollectionAccessDetailsResponse {

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
@@ -1,4 +1,14 @@
-import { combineLatest, firstValueFrom, from, map, Observable, of, switchMap } from "rxjs";
+import {
+  catchError,
+  combineLatest,
+  distinctUntilChanged,
+  firstValueFrom,
+  from,
+  map,
+  Observable,
+  of,
+  switchMap,
+} from "rxjs";
 
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import {
@@ -12,8 +22,13 @@ import {
   CollectionDetailsResponse,
   CollectionResponse,
   CollectionData,
+  CollectionView,
 } from "@bitwarden/common/admin-console/models/collections";
+import { Collection } from "@bitwarden/common/admin-console/models/collections/collection";
 import { SelectionReadOnlyRequest } from "@bitwarden/common/admin-console/models/request/selection-read-only.request";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
 import { OrgKey } from "@bitwarden/common/types/key";
 import { KeyService } from "@bitwarden/key-management";
@@ -21,6 +36,7 @@ import { KeyService } from "@bitwarden/key-management";
 import { EncryptService } from "@bitwarden/legacy-crypto";
 
 import { CollectionAdminService, CollectionService } from "../abstractions";
+import { CollectionEncryptionService } from "../abstractions/collection-encryption.service";
 import {
   BulkCollectionAccessRequest,
   BaseCollectionRequest,
@@ -35,6 +51,9 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     private encryptService: EncryptService,
     private collectionService: CollectionService,
     private organizationService: OrganizationService,
+    private collectionEncryptionService: CollectionEncryptionService,
+    private configService: ConfigService,
+    private logService: LogService,
   ) {}
 
   collectionAdminViews$(organizationId: string, userId: UserId): Observable<CollectionAdminView[]> {
@@ -50,7 +69,7 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
           throw new Error("No org keys found.");
         }
 
-        return this.decryptMany(organizationId, res.data, orgKeys);
+        return this.decryptMany(organizationId, userId, res.data, orgKeys);
       }),
     );
   }
@@ -126,29 +145,106 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     );
   }
 
-  private async decryptMany(
+  private decryptMany(
+    organizationId: string,
+    userId: UserId,
+    collections: CollectionResponse[] | CollectionAccessDetailsResponse[],
+    orgKeys: Record<OrganizationId, OrgKey>,
+  ): Observable<CollectionAdminView[]> {
+    if (collections.length > 0 && collections.every(isCollectionAccessDetailsResponse)) {
+      return this.configService.getFeatureFlag$(FeatureFlag.CollectionAdminBulkDecrypt).pipe(
+        distinctUntilChanged(),
+        switchMap((bulkDecryptEnabled) =>
+          bulkDecryptEnabled
+            ? this.decryptManyV2(collections as CollectionAccessDetailsResponse[], userId)
+            : from(this.decryptManyV1(organizationId, collections, orgKeys)),
+        ),
+      );
+    }
+
+    return from(this.decryptManyV1(organizationId, collections, orgKeys));
+  }
+
+  private async decryptManyV1(
     organizationId: string,
     collections: CollectionResponse[] | CollectionAccessDetailsResponse[],
     orgKeys: Record<OrganizationId, OrgKey>,
   ): Promise<CollectionAdminView[]> {
-    const promises = collections.map(async (c) => {
-      if (isCollectionAccessDetailsResponse(c)) {
-        return CollectionAdminView.fromCollectionAccessDetails(
-          c,
-          this.encryptService,
-          orgKeys[organizationId as OrganizationId],
-        );
-      }
+    return Promise.all(
+      collections.map((c) =>
+        isCollectionAccessDetailsResponse(c)
+          ? CollectionAdminView.fromCollectionAccessDetails(
+              c,
+              this.encryptService,
+              orgKeys[organizationId as OrganizationId],
+            )
+          : CollectionAdminView.fromCollectionResponse(
+              c,
+              this.encryptService,
+              orgKeys[organizationId as OrganizationId],
+            ),
+      ),
+    );
+  }
 
-      return await CollectionAdminView.fromCollectionResponse(
-        c,
-        this.encryptService,
-        orgKeys[organizationId as OrganizationId],
+  /**
+   * V2 implementation: delegates to `CollectionEncryptionService` and wraps results into
+   * `CollectionAdminView`s. Gated behind {@link FeatureFlag.CollectionAdminBulkDecrypt}.
+   *
+   * Both per-collection and batch-level failures are caught and rendered as placeholder views
+   * so admins can still see and manage collections that failed to decrypt.
+   */
+  private decryptManyV2(
+    collections: CollectionAccessDetailsResponse[],
+    userId: UserId,
+  ): Observable<CollectionAdminView[]> {
+    const responseMap = new Map(collections.map((c) => [c.id, c]));
+    const collectionsToDecrypt = collections.map((c) =>
+      Collection.fromCollectionAccessDetailsResponse(c),
+    );
+
+    return this.collectionEncryptionService
+      .decryptManyWithFailures(collectionsToDecrypt, userId)
+      .pipe(
+        map((result) => [
+          ...this.mapDecryptedSuccesses(result.success, responseMap),
+          ...this.mapDecryptedFailures(result.failure, responseMap),
+        ]),
+        catchError((e: unknown) => {
+          this.logService.error("[DefaultCollectionAdminService] Batch decryption failed", e);
+          return of(
+            collections.map((c) =>
+              CollectionAdminView.fromCollectionAccessDetailsDecryptionFailure(c),
+            ),
+          );
+        }),
       );
-    });
+  }
 
-    const r = await Promise.all(promises);
-    return r;
+  private mapDecryptedSuccesses(
+    views: CollectionView[],
+    responseMap: Map<string, CollectionAccessDetailsResponse>,
+  ): CollectionAdminView[] {
+    return views
+      .map((view) => {
+        const source = responseMap.get(view.id);
+        return source ? CollectionAdminView.fromCollectionView(view, source) : undefined;
+      })
+      .filter((v): v is CollectionAdminView => v !== undefined);
+  }
+
+  private mapDecryptedFailures(
+    failures: Collection[],
+    responseMap: Map<string, CollectionAccessDetailsResponse>,
+  ): CollectionAdminView[] {
+    return failures
+      .map((failure) => {
+        const source = responseMap.get(failure.id);
+        return source
+          ? CollectionAdminView.fromCollectionAccessDetailsDecryptionFailure(source)
+          : undefined;
+      })
+      .filter((v): v is CollectionAdminView => v !== undefined);
   }
 
   private async encrypt(

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
@@ -170,21 +170,21 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     collections: CollectionResponse[] | CollectionAccessDetailsResponse[],
     orgKeys: Record<OrganizationId, OrgKey>,
   ): Promise<CollectionAdminView[]> {
-    return Promise.all(
-      collections.map((c) =>
+    const orgKey = orgKeys[organizationId as OrganizationId];
+
+    // Sequential rather than `Promise.all`: decryption is compute-bound, so there is no
+    // concurrency to win, and the extra promise scheduling makes the parallel form slower
+    // on both V8 and SpiderMonkey.
+    const views: CollectionAdminView[] = [];
+    for (const c of collections) {
+      views.push(
         isCollectionAccessDetailsResponse(c)
-          ? CollectionAdminView.fromCollectionAccessDetails(
-              c,
-              this.encryptService,
-              orgKeys[organizationId as OrganizationId],
-            )
-          : CollectionAdminView.fromCollectionResponse(
-              c,
-              this.encryptService,
-              orgKeys[organizationId as OrganizationId],
-            ),
-      ),
-    );
+          ? await CollectionAdminView.fromCollectionAccessDetails(c, this.encryptService, orgKey)
+          : await CollectionAdminView.fromCollectionResponse(c, this.encryptService, orgKey),
+      );
+    }
+
+    return views;
   }
 
   /**

--- a/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-admin.service.ts
@@ -145,26 +145,35 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
     );
   }
 
+  /**
+   * Routes decryption through the SDK-backed batch path or the original per-item path based on
+   * {@link FeatureFlag.CollectionAdminBulkDecrypt}. The empty case is handled by the caller, so
+   * this is a straight two-way mapping: flag on -> SDK, flag off -> non-SDK.
+   */
   private decryptMany(
     organizationId: string,
     userId: UserId,
-    collections: CollectionResponse[] | CollectionAccessDetailsResponse[],
+    collections: CollectionAccessDetailsResponse[],
     orgKeys: Record<OrganizationId, OrgKey>,
   ): Observable<CollectionAdminView[]> {
-    if (collections.length > 0 && collections.every(isCollectionAccessDetailsResponse)) {
-      return this.configService.getFeatureFlag$(FeatureFlag.CollectionAdminBulkDecrypt).pipe(
-        distinctUntilChanged(),
-        switchMap((bulkDecryptEnabled) =>
-          bulkDecryptEnabled
-            ? this.decryptManyV2(collections as CollectionAccessDetailsResponse[], userId)
-            : from(this.decryptManyV1(organizationId, collections, orgKeys)),
-        ),
-      );
-    }
-
-    return from(this.decryptManyV1(organizationId, collections, orgKeys));
+    return this.configService.getFeatureFlag$(FeatureFlag.CollectionAdminBulkDecrypt).pipe(
+      distinctUntilChanged(),
+      switchMap((bulkDecryptEnabled) =>
+        bulkDecryptEnabled
+          ? this.decryptManyV2(collections, userId)
+          : from(this.decryptManyV1(organizationId, collections, orgKeys)),
+      ),
+    );
   }
 
+  /**
+   * V1 implementation: decrypts each collection individually via `EncryptService`.
+   *
+   * Accepts the wider `CollectionResponse` shape and narrows per item. Every caller today passes
+   * `CollectionAccessDetailsResponse`s, so the `fromCollectionResponse` branch is defensive only —
+   * it keeps this path correct if a caller ever supplies responses built from the plain
+   * `CollectionResponse` class, which carries no `groups`/`users`.
+   */
   private async decryptManyV1(
     organizationId: string,
     collections: CollectionResponse[] | CollectionAccessDetailsResponse[],
@@ -312,6 +321,13 @@ export class DefaultCollectionAdminService implements CollectionAdminService {
   }
 }
 
+/**
+ * Duck-types a response as a `CollectionAccessDetailsResponse` by the presence of `groups` and
+ * `users`. Note this is true for every instance the API layer builds today: `ApiService`
+ * constructs `ListResponse(r, CollectionAccessDetailsResponse)`, and that class defaults both
+ * fields to `[]` regardless of the payload. The check is retained as a guard against a caller
+ * supplying responses built from the plain `CollectionResponse` class.
+ */
 function isCollectionAccessDetailsResponse(
   response: CollectionResponse | CollectionAccessDetailsResponse,
 ): response is CollectionAccessDetailsResponse {

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom, of } from "rxjs";
+import { firstValueFrom, lastValueFrom, of, toArray } from "rxjs";
 
 import {
   Collection,
@@ -87,6 +87,7 @@ describe("DefaultCollectionEncryptionService", () => {
 
   let mockDecrypt: jest.Mock;
   let mockDecryptListWithFailures: jest.Mock;
+  let mockSdk: { take: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -109,7 +110,7 @@ describe("DefaultCollectionEncryptionService", () => {
       },
       [Symbol.dispose]: jest.fn(),
     };
-    const mockSdk = { take: jest.fn().mockReturnValue(mockRef) };
+    mockSdk = { take: jest.fn().mockReturnValue(mockRef) };
 
     (sdkService.userClient$ as jest.Mock).mockReturnValue(of(mockSdk));
     service = new DefaultCollectionEncryptionService(sdkService, logService, configService);
@@ -284,6 +285,23 @@ describe("DefaultCollectionEncryptionService", () => {
           expect.stringContaining("Failed to decrypt collections in batch"),
         );
       });
+
+      it("times each emission of userClient$ separately", async () => {
+        // userClient$ is long-lived and re-emits on unlock and key re-emission. A startTime
+        // captured when the pipeline was built would be reused for every later emission, so
+        // measure would report elapsed session time rather than decrypt duration.
+        jest.spyOn(performance, "now").mockReturnValueOnce(1000).mockReturnValueOnce(2000);
+        (sdkService.userClient$ as jest.Mock).mockReturnValue(of(mockSdk, mockSdk));
+
+        const collection = makeCollection();
+        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
+        mockDecryptListWithFailures.mockReturnValue(makeResult([makeSdkCollectionView()]));
+
+        await lastValueFrom(service.decryptManyWithFailures([collection], userId).pipe(toArray()));
+
+        const startTimes = (logService.measure as jest.Mock).mock.calls.map(([start]) => start);
+        expect(startTimes).toEqual([1000, 2000]);
+      });
     });
   });
 
@@ -395,6 +413,22 @@ describe("DefaultCollectionEncryptionService", () => {
         expect(logService.error).toHaveBeenCalledWith(
           expect.stringContaining("Failed to decrypt collections in batch"),
         );
+      });
+
+      it("times each emission of userClient$ separately", async () => {
+        // See the equivalent test on the enabled path - both variants capture startTime inside
+        // concatMap so that a re-emitting userClient$ does not inflate later measurements.
+        jest.spyOn(performance, "now").mockReturnValueOnce(1000).mockReturnValueOnce(2000);
+        (sdkService.userClient$ as jest.Mock).mockReturnValue(of(mockSdk, mockSdk));
+
+        const collection = makeCollection();
+        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
+        mockDecrypt.mockReturnValue(makeSdkCollectionView());
+
+        await lastValueFrom(service.decryptManyWithFailures([collection], userId).pipe(toArray()));
+
+        const startTimes = (logService.measure as jest.Mock).mock.calls.map(([start]) => start);
+        expect(startTimes).toEqual([1000, 2000]);
       });
     });
   });

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
@@ -15,6 +15,7 @@ import { EncString } from "@bitwarden/legacy-crypto";
 import {
   Collection as SdkCollection,
   CollectionView as SdkCollectionView,
+  DecryptCollectionListResult,
 } from "@bitwarden/sdk-internal";
 
 import { DefaultCollectionEncryptionService } from "./default-collection-encryption.service";
@@ -59,6 +60,13 @@ function makeSdkCollectionView(overrides: Partial<SdkCollectionView> = {}): SdkC
   };
 }
 
+function makeResult(
+  successes: SdkCollectionView[],
+  failures: SdkCollection[] = [],
+): DecryptCollectionListResult {
+  return { successes, failures };
+}
+
 describe("DefaultCollectionEncryptionService", () => {
   let service: DefaultCollectionEncryptionService;
 
@@ -88,7 +96,6 @@ describe("DefaultCollectionEncryptionService", () => {
 
     const mockCollectionsClient = {
       decrypt: mockDecrypt,
-      decrypt_list: jest.fn(),
       decrypt_list_with_failures: mockDecryptListWithFailures,
       encrypt: jest.fn(),
       encrypt_list: jest.fn(),
@@ -108,87 +115,122 @@ describe("DefaultCollectionEncryptionService", () => {
     service = new DefaultCollectionEncryptionService(sdkService, logService, configService);
   });
 
+  describe("decryptManyWithFailures", () => {
+    it("checks the CollectionBulkDecryptWithFailures feature flag", async () => {
+      (configService.getFeatureFlag$ as jest.Mock).mockReturnValue(of(false));
+      mockDecrypt.mockReturnValue(makeSdkCollectionView());
+
+      await firstValueFrom(service.decryptManyWithFailures([makeCollection()], userId));
+
+      expect(configService.getFeatureFlag$).toHaveBeenCalledWith(
+        FeatureFlag.CollectionBulkDecryptWithFailures,
+      );
+    });
+  });
+
   describe("when CollectionBulkDecryptWithFailures is enabled", () => {
     beforeEach(() => {
       (configService.getFeatureFlag$ as jest.Mock).mockReturnValue(of(true));
     });
 
-    describe("decryptMany", () => {
-      it("checks the CollectionBulkDecryptWithFailures feature flag", async () => {
-        mockDecryptListWithFailures.mockReturnValue({
-          successes: [makeSdkCollectionView()],
-          failures: [],
+    describe("decrypt", () => {
+      it("decrypts a single collection and maps the result", async () => {
+        const collection = makeCollection();
+        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
+
+        const sdkView = makeSdkCollectionView({ name: "Decrypted Name" });
+        mockDecryptListWithFailures.mockReturnValue(makeResult([sdkView]));
+
+        const result = await firstValueFrom(service.decrypt(collection, userId));
+
+        expect(mockDecryptListWithFailures).toHaveBeenCalledWith([stubSdkCollection]);
+        expect(mockDecrypt).not.toHaveBeenCalled();
+        expect(result).toBeInstanceOf(CollectionView);
+        expect(result.name).toBe("Decrypted Name");
+      });
+
+      it("logs the error and rejects when the SDK throws", async () => {
+        const collection = makeCollection();
+        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
+        mockDecryptListWithFailures.mockImplementation(() => {
+          throw new Error("crypto failure");
         });
 
-        await firstValueFrom(service.decryptMany([makeCollection()], userId));
-
-        expect(configService.getFeatureFlag$).toHaveBeenCalledWith(
-          FeatureFlag.CollectionBulkDecryptWithFailures,
+        await expect(firstValueFrom(service.decrypt(collection, userId))).rejects.toThrow();
+        expect(logService.error).toHaveBeenCalledWith(
+          expect.stringContaining("Failed to decrypt collections in batch"),
         );
       });
 
+      it("logs the error and rejects when the SDK client is unavailable", async () => {
+        (sdkService.userClient$ as jest.Mock).mockReturnValue(of(null));
+        const collection = makeCollection();
+        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
+
+        await expect(firstValueFrom(service.decrypt(collection, userId))).rejects.toThrow();
+        expect(logService.error).toHaveBeenCalledWith(
+          expect.stringContaining("Failed to decrypt collections in batch"),
+        );
+      });
+    });
+
+    describe("decryptMany", () => {
       it("returns an empty array without calling the SDK for empty input", async () => {
         const result = await firstValueFrom(service.decryptMany([], userId));
         expect(result).toEqual([]);
         expect(mockDecryptListWithFailures).not.toHaveBeenCalled();
       });
 
-      it("decrypts all collections via a single batch call and returns views", async () => {
+      it("decrypts all collections and returns views", async () => {
         const collection1 = makeCollection();
         const collection2 = makeCollection({ id: collectionId2 });
         jest.spyOn(collection1, "toSdkCollection").mockReturnValue(stubSdkCollection);
         jest.spyOn(collection2, "toSdkCollection").mockReturnValue(stubSdkCollection);
 
-        mockDecryptListWithFailures.mockReturnValue({
-          successes: [
-            makeSdkCollectionView({ id: collectionId as any, name: "Collection 1" }),
+        mockDecryptListWithFailures.mockReturnValue(
+          makeResult([
             makeSdkCollectionView({ id: collectionId2 as any, name: "Collection 2" }),
-          ],
-          failures: [],
-        });
+            makeSdkCollectionView({ id: collectionId as any, name: "Collection 1" }),
+          ]),
+        );
 
         const result = await firstValueFrom(
           service.decryptMany([collection1, collection2], userId),
         );
 
         expect(result).toHaveLength(2);
-        expect(result[0].name).toBe("Collection 1");
-        expect(result[1].name).toBe("Collection 2");
+        expect(result.map((v) => v.name)).toEqual(
+          expect.arrayContaining(["Collection 1", "Collection 2"]),
+        );
       });
 
-      it("logs and drops any collection the SDK returns as a failure", async () => {
+      it("returns failures separately without dropping successes", async () => {
         const collection1 = makeCollection();
         const collection2 = makeCollection({ id: collectionId2 });
         jest.spyOn(collection1, "toSdkCollection").mockReturnValue(stubSdkCollection);
         jest.spyOn(collection2, "toSdkCollection").mockReturnValue(stubSdkCollection);
 
-        // SDK reports collection1 as a failure and returns only collection2.
-        mockDecryptListWithFailures.mockReturnValue({
-          successes: [makeSdkCollectionView({ id: collectionId2 as any, name: "Collection 2" })],
-          failures: [{ id: collectionId as any }],
-        });
-
-        const result = await firstValueFrom(
-          service.decryptMany([collection1, collection2], userId),
+        const failedSdkCollection: SdkCollection = {
+          ...stubSdkCollection,
+          id: collectionId as any,
+        };
+        mockDecryptListWithFailures.mockReturnValue(
+          makeResult(
+            [makeSdkCollectionView({ id: collectionId2 as any, name: "Collection 2" })],
+            [failedSdkCollection],
+          ),
         );
 
-        expect(result).toHaveLength(1);
-        expect(result[0].name).toBe("Collection 2");
-        expect(logService.error).toHaveBeenCalledWith(
-          expect.stringContaining(`Failed to decrypt collection ${collection1.id}`),
+        const { success, failure } = await firstValueFrom(
+          service.decryptManyWithFailures([collection1, collection2], userId),
         );
-      });
 
-      it("rejects when the batch SDK call throws", async () => {
-        const collection = makeCollection();
-        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
-        mockDecryptListWithFailures.mockImplementation(() => {
-          throw new Error("batch failure");
-        });
-
-        await expect(firstValueFrom(service.decryptMany([collection], userId))).rejects.toThrow();
+        expect(success).toHaveLength(1);
+        expect(success[0].name).toBe("Collection 2");
+        expect(failure).toHaveLength(1);
+        expect(failure[0].id).toBe(collectionId);
         expect(logService.error).toHaveBeenCalledWith(
-          expect.stringContaining("Failed to decrypt collections in batch"),
+          expect.stringContaining(`Failed to decrypt 1 collection(s): ${collectionId}`),
         );
       });
 
@@ -199,52 +241,37 @@ describe("DefaultCollectionEncryptionService", () => {
           type: CollectionTypes.DefaultUserCollection,
         });
         jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
-        mockDecryptListWithFailures.mockReturnValue({
-          successes: [makeSdkCollectionView({ type: CollectionTypes.DefaultUserCollection })],
-          failures: [],
-        });
+        mockDecryptListWithFailures.mockReturnValue(
+          makeResult([makeSdkCollectionView({ type: CollectionTypes.DefaultUserCollection })]),
+        );
 
         const [result] = await firstValueFrom(service.decryptMany([collection], userId));
 
         expect(result.defaultUserCollectionEmail).toBe(email);
       });
 
-      it("matches each decrypted view to its source collection by ID", async () => {
-        const email = "offboarded@example.com";
+      it("resolves duplicate input ids by letting the last entry win", async () => {
+        // A duplicate id indicates a duplicate collection - the map collapses to the last entry,
+        // which is used to re-associate the decrypted view with its source (needed to preserve
+        // `defaultUserCollectionEmail`, which gates the security restriction in
+        // `CollectionView.canEditName()`).
         const collection1 = makeCollection({
-          defaultUserCollectionEmail: email,
+          defaultUserCollectionEmail: "offboarded@example.com",
           type: CollectionTypes.DefaultUserCollection,
         });
         const collection2 = makeCollection({
-          id: collectionId2,
+          // same id as collection1, but no defaultUserCollectionEmail
           type: CollectionTypes.SharedCollection,
         });
         jest.spyOn(collection1, "toSdkCollection").mockReturnValue(stubSdkCollection);
         jest.spyOn(collection2, "toSdkCollection").mockReturnValue(stubSdkCollection);
+        mockDecryptListWithFailures.mockReturnValue(makeResult([makeSdkCollectionView()]));
 
-        // Return views in reverse order to confirm ID-based matching, not index-based.
-        mockDecryptListWithFailures.mockReturnValue({
-          successes: [
-            makeSdkCollectionView({
-              id: collectionId2 as any,
-              type: CollectionTypes.SharedCollection,
-            }),
-            makeSdkCollectionView({
-              id: collectionId as any,
-              type: CollectionTypes.DefaultUserCollection,
-            }),
-          ],
-          failures: [],
-        });
-
-        const results = await firstValueFrom(
+        const [result] = await firstValueFrom(
           service.decryptMany([collection1, collection2], userId),
         );
 
-        const view1 = results.find((v) => v.id === collectionId);
-        const view2 = results.find((v) => v.id === collectionId2);
-        expect(view1?.defaultUserCollectionEmail).toBe(email);
-        expect(view2?.defaultUserCollectionEmail).toBeUndefined();
+        expect(result.defaultUserCollectionEmail).toBeUndefined();
       });
 
       it("logs the error and rejects when the SDK client is unavailable", async () => {
@@ -258,34 +285,25 @@ describe("DefaultCollectionEncryptionService", () => {
         );
       });
     });
+  });
+
+  describe("when CollectionBulkDecryptWithFailures is disabled", () => {
+    beforeEach(() => {
+      (configService.getFeatureFlag$ as jest.Mock).mockReturnValue(of(false));
+    });
 
     describe("decrypt", () => {
-      it("decrypts a single collection via the batch SDK call and maps the result", async () => {
+      it("decrypts a single collection using the original per-item SDK call", async () => {
         const collection = makeCollection();
         jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
-
-        const sdkView = makeSdkCollectionView({ name: "Decrypted Name" });
-        mockDecryptListWithFailures.mockReturnValue({ successes: [sdkView], failures: [] });
+        mockDecrypt.mockReturnValue(makeSdkCollectionView({ name: "Decrypted Name" }));
 
         const result = await firstValueFrom(service.decrypt(collection, userId));
 
-        expect(mockDecryptListWithFailures).toHaveBeenCalledWith([stubSdkCollection]);
-        expect(mockDecrypt).not.toHaveBeenCalled();
+        expect(mockDecrypt).toHaveBeenCalledWith(stubSdkCollection);
+        expect(mockDecryptListWithFailures).not.toHaveBeenCalled();
         expect(result).toBeInstanceOf(CollectionView);
         expect(result.name).toBe("Decrypted Name");
-      });
-
-      it("rejects when the batch call throws", async () => {
-        const collection = makeCollection();
-        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
-        mockDecryptListWithFailures.mockImplementation(() => {
-          throw new Error("batch failure");
-        });
-
-        await expect(firstValueFrom(service.decrypt(collection, userId))).rejects.toThrow();
-        expect(logService.error).toHaveBeenCalledWith(
-          expect.stringContaining("Failed to decrypt collections in batch"),
-        );
       });
 
       it("logs the error and rejects when the SDK client is unavailable", async () => {
@@ -298,12 +316,6 @@ describe("DefaultCollectionEncryptionService", () => {
           expect.stringContaining("Failed to decrypt collections in batch"),
         );
       });
-    });
-  });
-
-  describe("when CollectionBulkDecryptWithFailures is disabled", () => {
-    beforeEach(() => {
-      (configService.getFeatureFlag$ as jest.Mock).mockReturnValue(of(false));
     });
 
     describe("decryptMany", () => {
@@ -333,7 +345,7 @@ describe("DefaultCollectionEncryptionService", () => {
         expect(result[1].name).toBe("Collection 2");
       });
 
-      it("logs and drops items that fail to decrypt without aborting the rest", async () => {
+      it("logs and returns a failure for an item that fails to decrypt, without dropping the rest", async () => {
         const collection1 = makeCollection();
         const collection2 = makeCollection({ id: collectionId2 });
         jest.spyOn(collection1, "toSdkCollection").mockReturnValue(stubSdkCollection);
@@ -345,15 +357,17 @@ describe("DefaultCollectionEncryptionService", () => {
           })
           .mockReturnValueOnce(makeSdkCollectionView({ name: "Collection 2" }));
 
-        const result = await firstValueFrom(
-          service.decryptMany([collection1, collection2], userId),
+        const { success, failure } = await firstValueFrom(
+          service.decryptManyWithFailures([collection1, collection2], userId),
         );
 
         expect(logService.error).toHaveBeenCalledWith(
           expect.stringContaining(`Failed to decrypt collection ${collection1.id}`),
         );
-        expect(result).toHaveLength(1);
-        expect(result[0].name).toBe("Collection 2");
+        expect(success).toHaveLength(1);
+        expect(success[0].name).toBe("Collection 2");
+        expect(failure).toHaveLength(1);
+        expect(failure[0]).toBe(collection1);
       });
 
       it("preserves defaultUserCollectionEmail from the source collection", async () => {
@@ -378,32 +392,6 @@ describe("DefaultCollectionEncryptionService", () => {
         jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
 
         await expect(firstValueFrom(service.decryptMany([collection], userId))).rejects.toThrow();
-        expect(logService.error).toHaveBeenCalledWith(
-          expect.stringContaining("Failed to decrypt collections in batch"),
-        );
-      });
-    });
-
-    describe("decrypt", () => {
-      it("decrypts a single collection using the original per-item SDK call", async () => {
-        const collection = makeCollection();
-        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
-        mockDecrypt.mockReturnValue(makeSdkCollectionView({ name: "Decrypted Name" }));
-
-        const result = await firstValueFrom(service.decrypt(collection, userId));
-
-        expect(mockDecrypt).toHaveBeenCalledWith(stubSdkCollection);
-        expect(mockDecryptListWithFailures).not.toHaveBeenCalled();
-        expect(result).toBeInstanceOf(CollectionView);
-        expect(result.name).toBe("Decrypted Name");
-      });
-
-      it("logs the error and rejects when the SDK client is unavailable", async () => {
-        (sdkService.userClient$ as jest.Mock).mockReturnValue(of(null));
-        const collection = makeCollection();
-        jest.spyOn(collection, "toSdkCollection").mockReturnValue(stubSdkCollection);
-
-        await expect(firstValueFrom(service.decrypt(collection, userId))).rejects.toThrow();
         expect(logService.error).toHaveBeenCalledWith(
           expect.stringContaining("Failed to decrypt collections in batch"),
         );

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
@@ -252,10 +252,6 @@ describe("DefaultCollectionEncryptionService", () => {
       });
 
       it("resolves duplicate input ids by letting the last entry win", async () => {
-        // A duplicate id indicates a duplicate collection - the map collapses to the last entry,
-        // which is used to re-associate the decrypted view with its source (needed to preserve
-        // `defaultUserCollectionEmail`, which gates the security restriction in
-        // `CollectionView.canEditName()`).
         const collection1 = makeCollection({
           defaultUserCollectionEmail: "offboarded@example.com",
           type: CollectionTypes.DefaultUserCollection,
@@ -287,9 +283,7 @@ describe("DefaultCollectionEncryptionService", () => {
       });
 
       it("times each emission of userClient$ separately", async () => {
-        // userClient$ is long-lived and re-emits on unlock and key re-emission. A startTime
-        // captured when the pipeline was built would be reused for every later emission, so
-        // measure would report elapsed session time rather than decrypt duration.
+        // userClient$ can re-emit; startTime should be captured per emission, not once.
         jest.spyOn(performance, "now").mockReturnValueOnce(1000).mockReturnValueOnce(2000);
         (sdkService.userClient$ as jest.Mock).mockReturnValue(of(mockSdk, mockSdk));
 
@@ -416,8 +410,6 @@ describe("DefaultCollectionEncryptionService", () => {
       });
 
       it("times each emission of userClient$ separately", async () => {
-        // See the equivalent test on the enabled path - both variants capture startTime inside
-        // concatMap so that a re-emitting userClient$ does not inflate later measurements.
         jest.spyOn(performance, "now").mockReturnValueOnce(1000).mockReturnValueOnce(2000);
         (sdkService.userClient$ as jest.Mock).mockReturnValue(of(mockSdk, mockSdk));
 

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.spec.ts
@@ -271,6 +271,43 @@ describe("DefaultCollectionEncryptionService", () => {
         expect(result.defaultUserCollectionEmail).toBeUndefined();
       });
 
+      it("matches each decrypted view to its source collection by ID", async () => {
+        const email = "offboarded@example.com";
+        const collection1 = makeCollection({
+          defaultUserCollectionEmail: email,
+          type: CollectionTypes.DefaultUserCollection,
+        });
+        const collection2 = makeCollection({
+          id: collectionId2,
+          type: CollectionTypes.SharedCollection,
+        });
+        jest.spyOn(collection1, "toSdkCollection").mockReturnValue(stubSdkCollection);
+        jest.spyOn(collection2, "toSdkCollection").mockReturnValue(stubSdkCollection);
+
+        // Return views in reverse order to confirm ID-based matching, not index-based.
+        mockDecryptListWithFailures.mockReturnValue(
+          makeResult([
+            makeSdkCollectionView({
+              id: collectionId2 as any,
+              type: CollectionTypes.SharedCollection,
+            }),
+            makeSdkCollectionView({
+              id: collectionId as any,
+              type: CollectionTypes.DefaultUserCollection,
+            }),
+          ]),
+        );
+
+        const results = await firstValueFrom(
+          service.decryptMany([collection1, collection2], userId),
+        );
+
+        const view1 = results.find((v) => v.id === collectionId);
+        const view2 = results.find((v) => v.id === collectionId2);
+        expect(view1?.defaultUserCollectionEmail).toBe(email);
+        expect(view2?.defaultUserCollectionEmail).toBeUndefined();
+      });
+
       it("logs the error and rejects when the SDK client is unavailable", async () => {
         (sdkService.userClient$ as jest.Mock).mockReturnValue(of(null));
         const collection = makeCollection();

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
@@ -16,10 +16,13 @@ import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SdkService, uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
-import { CollectionId, UserId } from "@bitwarden/common/types/guid";
+import { UserId } from "@bitwarden/common/types/guid";
 import { DecryptCollectionListResult } from "@bitwarden/sdk-internal";
 
-import { CollectionEncryptionService } from "../abstractions/collection-encryption.service";
+import {
+  CollectionDecryptionResult,
+  CollectionEncryptionService,
+} from "../abstractions/collection-encryption.service";
 
 export class DefaultCollectionEncryptionService implements CollectionEncryptionService {
   constructor(
@@ -42,26 +45,36 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
   }
 
   decryptMany(collections: Collection[], userId: UserId): Observable<CollectionView[]> {
+    return this.decryptManyWithFailures(collections, userId).pipe(map((result) => result.success));
+  }
+
+  decryptManyWithFailures(
+    collections: Collection[],
+    userId: UserId,
+  ): Observable<CollectionDecryptionResult> {
     if (!collections || collections.length === 0) {
-      return of([]);
+      return of({ success: [], failure: [] });
     }
 
     return this.configService.getFeatureFlag$(FeatureFlag.CollectionBulkDecryptWithFailures).pipe(
       distinctUntilChanged(),
       switchMap((bulkDecryptEnabled) =>
         bulkDecryptEnabled
-          ? this.decryptManyV2(collections, userId)
-          : this.decryptManyV1(collections, userId),
+          ? this.decryptManyWithFailuresV2(collections, userId)
+          : this.decryptManyWithFailuresV1(collections, userId),
       ),
     );
   }
 
   /**
    * V1 implementation: decrypts each collection individually via the SDK, one at a time.
-   * A collection that fails to decrypt is logged and dropped rather than aborting the rest
-   * of the batch.
+   * A collection that fails to decrypt is logged and returned in `failure` instead of aborting
+   * the rest of the batch.
    */
-  private decryptManyV1(collections: Collection[], userId: UserId): Observable<CollectionView[]> {
+  private decryptManyWithFailuresV1(
+    collections: Collection[],
+    userId: UserId,
+  ): Observable<CollectionDecryptionResult> {
     const startTime = performance.now();
 
     return this.sdkService.userClient$(userId).pipe(
@@ -69,16 +82,18 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
         using ref = sdk.take();
 
         const success: CollectionView[] = [];
+        const failure: Collection[] = [];
         for (const collection of collections) {
           try {
             const sdkView = ref.value.vault().collections().decrypt(collection.toSdkCollection());
             success.push(CollectionView.fromSdkCollectionView(sdkView, collection));
           } catch (error: unknown) {
             this.logService.error(`Failed to decrypt collection ${collection.id}: ${error}`);
+            failure.push(collection);
           }
         }
 
-        return success;
+        return { success, failure };
       }),
       catchError((error: unknown) => {
         this.logService.error(`Failed to decrypt collections in batch: ${error}`);
@@ -89,10 +104,11 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
           startTime,
           "Admin Console",
           "DefaultCollectionEncryptionService",
-          "decryptMany (v1, one at a time)",
+          "decryptManyWithFailures (v1, one at a time)",
           [
             ["Items", collections.length],
-            ["Successes", result.length],
+            ["Successes", result.success.length],
+            ["Failures", result.failure.length],
           ],
         );
       }),
@@ -100,44 +116,32 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
   }
 
   /**
-   * V2 implementation using the SDK's `decrypt_list_with_failures` for batch performance with
-   * per-item failure tolerance. The SDK natively separates successes from failures, so collections
-   * that fail to decrypt are logged and dropped without aborting the rest of the batch. Gated
-   * behind {@link FeatureFlag.CollectionBulkDecryptWithFailures} until the SDK bindings have
-   * rolled out everywhere this service is used.
+   * V2 implementation using the SDK's `decrypt_list_with_failures`, which parallelizes
+   * decryption of the whole list for better performance on large lists. Gated behind
+   * {@link FeatureFlag.CollectionBulkDecryptWithFailures} until the SDK bindings that expose
+   * this method have rolled out everywhere this service is used.
    */
-  private decryptManyV2(collections: Collection[], userId: UserId): Observable<CollectionView[]> {
+  private decryptManyWithFailuresV2(
+    collections: Collection[],
+    userId: UserId,
+  ): Observable<CollectionDecryptionResult> {
     const startTime = performance.now();
 
     return this.sdkService.userClient$(userId).pipe(
       concatMap(async (sdk) => {
         using ref = sdk.take();
 
-        const collectionsById = new Map<CollectionId, Collection>(
-          collections.map((c) => [c.id, c]),
-        );
-        const sdkCollections = collections.map((c) => c.toSdkCollection());
+        const collectionMap = this.buildCollectionMap(collections);
+
         const result: DecryptCollectionListResult = ref.value
           .vault()
           .collections()
-          .decrypt_list_with_failures(sdkCollections);
+          .decrypt_list_with_failures(collections.map((c) => c.toSdkCollection()));
 
-        const success: CollectionView[] = [];
-        for (const sdkView of result.successes) {
-          const collection = sdkView.id
-            ? collectionsById.get(uuidAsString(sdkView.id) as CollectionId)
-            : undefined;
-          if (collection) {
-            success.push(CollectionView.fromSdkCollectionView(sdkView, collection));
-          }
-        }
-
-        for (const failed of result.failures) {
-          const id = failed.id ? uuidAsString(failed.id) : "(unknown id)";
-          this.logService.error(`Failed to decrypt collection ${id}: not returned by SDK`);
-        }
-
-        return success;
+        return {
+          success: this.mapDecryptedSuccesses(result.successes, collectionMap),
+          failure: this.mapDecryptedFailures(result.failures),
+        };
       }),
       catchError((error: unknown) => {
         this.logService.error(`Failed to decrypt collections in batch: ${error}`);
@@ -148,13 +152,52 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
           startTime,
           "Admin Console",
           "DefaultCollectionEncryptionService",
-          "decryptMany (v2, decrypt_list_with_failures)",
+          "decryptManyWithFailures (v2, decrypt_list_with_failures)",
           [
             ["Items", collections.length],
-            ["Successes", result.length],
+            ["Successes", result.success.length],
+            ["Failures", result.failure.length],
           ],
         );
       }),
     );
+  }
+
+  /**
+   * Builds a lookup of source `Collection`s by id, used to re-associate decrypted SDK views with
+   * their source (needed to preserve `defaultUserCollectionEmail`, which gates the security
+   * restriction in `CollectionView.canEditName()`). Duplicate ids collapse to the last entry,
+   * which is the same collection either way.
+   */
+  private buildCollectionMap(collections: Collection[]): Map<string, Collection> {
+    return new Map(collections.map((c) => [c.id, c]));
+  }
+
+  private mapDecryptedSuccesses(
+    sdkViews: DecryptCollectionListResult["successes"],
+    collectionMap: Map<string, Collection>,
+  ): CollectionView[] {
+    return sdkViews
+      .map((sdkView) => {
+        const original = sdkView.id ? collectionMap.get(uuidAsString(sdkView.id)) : undefined;
+        return original ? CollectionView.fromSdkCollectionView(sdkView, original) : undefined;
+      })
+      .filter((v): v is CollectionView => v !== undefined);
+  }
+
+  private mapDecryptedFailures(
+    sdkCollections: DecryptCollectionListResult["failures"],
+  ): Collection[] {
+    const failures = sdkCollections.map((sdkCollection) =>
+      Collection.fromSdkCollection(sdkCollection),
+    );
+
+    if (failures.length > 0) {
+      this.logService.error(
+        `Failed to decrypt ${failures.length} collection(s): ${failures.map((f) => f.id).join(", ")}`,
+      );
+    }
+
+    return failures;
   }
 }

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
@@ -6,7 +6,6 @@ import {
   map,
   of,
   switchMap,
-  tap,
   throwError,
 } from "rxjs";
 
@@ -75,10 +74,9 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
     collections: Collection[],
     userId: UserId,
   ): Observable<CollectionDecryptionResult> {
-    const startTime = performance.now();
-
     return this.sdkService.userClient$(userId).pipe(
       concatMap(async (sdk) => {
+        const startTime = performance.now();
         using ref = sdk.take();
 
         const success: CollectionView[] = [];
@@ -93,24 +91,13 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
           }
         }
 
-        return { success, failure };
+        const result = { success, failure };
+        this.measureDecrypt(startTime, "v1, one at a time", collections.length, result);
+        return result;
       }),
       catchError((error: unknown) => {
         this.logService.error(`Failed to decrypt collections in batch: ${error}`);
         return throwError(() => (error instanceof Error ? error : new Error(String(error))));
-      }),
-      tap((result) => {
-        this.logService.measure(
-          startTime,
-          "Admin Console",
-          "DefaultCollectionEncryptionService",
-          "decryptManyWithFailures (v1, one at a time)",
-          [
-            ["Items", collections.length],
-            ["Successes", result.success.length],
-            ["Failures", result.failure.length],
-          ],
-        );
       }),
     );
   }
@@ -125,41 +112,59 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
     collections: Collection[],
     userId: UserId,
   ): Observable<CollectionDecryptionResult> {
-    const startTime = performance.now();
-
     return this.sdkService.userClient$(userId).pipe(
       concatMap(async (sdk) => {
+        const startTime = performance.now();
         using ref = sdk.take();
 
         const collectionMap = this.buildCollectionMap(collections);
 
-        const result: DecryptCollectionListResult = ref.value
+        const sdkResult: DecryptCollectionListResult = ref.value
           .vault()
           .collections()
           .decrypt_list_with_failures(collections.map((c) => c.toSdkCollection()));
 
-        return {
-          success: this.mapDecryptedSuccesses(result.successes, collectionMap),
-          failure: this.mapDecryptedFailures(result.failures),
+        const result = {
+          success: this.mapDecryptedSuccesses(sdkResult.successes, collectionMap),
+          failure: this.mapDecryptedFailures(sdkResult.failures),
         };
+        this.measureDecrypt(
+          startTime,
+          "v2, decrypt_list_with_failures",
+          collections.length,
+          result,
+        );
+        return result;
       }),
       catchError((error: unknown) => {
         this.logService.error(`Failed to decrypt collections in batch: ${error}`);
         return throwError(() => (error instanceof Error ? error : new Error(String(error))));
       }),
-      tap((result) => {
-        this.logService.measure(
-          startTime,
-          "Admin Console",
-          "DefaultCollectionEncryptionService",
-          "decryptManyWithFailures (v2, decrypt_list_with_failures)",
-          [
-            ["Items", collections.length],
-            ["Successes", result.success.length],
-            ["Failures", result.failure.length],
-          ],
-        );
-      }),
+    );
+  }
+
+  /**
+   * Records how long a single decrypt took. `startTime` must be captured inside the
+   * `concatMap` rather than when the pipeline is built: `userClient$` re-emits on unlock and on
+   * key re-emission, so a `startTime` closed over at build time would make every emission after
+   * the first report elapsed session time instead of decrypt duration.
+   */
+  private measureDecrypt(
+    startTime: DOMHighResTimeStamp,
+    variant: string,
+    itemCount: number,
+    result: CollectionDecryptionResult,
+  ): void {
+    this.logService.measure(
+      startTime,
+      "Admin Console",
+      "DefaultCollectionEncryptionService",
+      `decryptManyWithFailures (${variant})`,
+      [
+        ["Items", itemCount],
+        ["Successes", result.success.length],
+        ["Failures", result.failure.length],
+      ],
     );
   }
 

--- a/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
+++ b/libs/admin-console/src/common/collections/services/default-collection-encryption.service.ts
@@ -65,11 +65,7 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
     );
   }
 
-  /**
-   * V1 implementation: decrypts each collection individually via the SDK, one at a time.
-   * A collection that fails to decrypt is logged and returned in `failure` instead of aborting
-   * the rest of the batch.
-   */
+  /** Decrypts each collection individually via the SDK, one at a time. */
   private decryptManyWithFailuresV1(
     collections: Collection[],
     userId: UserId,
@@ -102,12 +98,7 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
     );
   }
 
-  /**
-   * V2 implementation using the SDK's `decrypt_list_with_failures`, which parallelizes
-   * decryption of the whole list for better performance on large lists. Gated behind
-   * {@link FeatureFlag.CollectionBulkDecryptWithFailures} until the SDK bindings that expose
-   * this method have rolled out everywhere this service is used.
-   */
+  /** Decrypts the whole list in one SDK call via `decrypt_list_with_failures`. */
   private decryptManyWithFailuresV2(
     collections: Collection[],
     userId: UserId,
@@ -143,12 +134,7 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
     );
   }
 
-  /**
-   * Records how long a single decrypt took. `startTime` must be captured inside the
-   * `concatMap` rather than when the pipeline is built: `userClient$` re-emits on unlock and on
-   * key re-emission, so a `startTime` closed over at build time would make every emission after
-   * the first report elapsed session time instead of decrypt duration.
-   */
+  /** startTime must be captured inside concatMap since userClient$ can re-emit. */
   private measureDecrypt(
     startTime: DOMHighResTimeStamp,
     variant: string,
@@ -168,12 +154,6 @@ export class DefaultCollectionEncryptionService implements CollectionEncryptionS
     );
   }
 
-  /**
-   * Builds a lookup of source `Collection`s by id, used to re-associate decrypted SDK views with
-   * their source (needed to preserve `defaultUserCollectionEmail`, which gates the security
-   * restriction in `CollectionView.canEditName()`). Duplicate ids collapse to the last entry,
-   * which is the same collection either way.
-   */
   private buildCollectionMap(collections: Collection[]): Map<string, Collection> {
     return new Map(collections.map((c) => [c.id, c]));
   }

--- a/libs/common/src/admin-console/models/collections/collection-admin.view.ts
+++ b/libs/common/src/admin-console/models/collections/collection-admin.view.ts
@@ -151,12 +151,7 @@ export class CollectionAdminView extends CollectionView {
     return view;
   }
 
-  /**
-   * Wraps an already-decrypted `CollectionView` (produced by
-   * {@link CollectionEncryptionService.decryptManyWithFailures}) with the admin-only fields
-   * (`groups`, `users`, `unmanaged`, `assigned`) carried by the access-details response. This is a
-   * data transform only - decryption itself is the responsibility of `CollectionEncryptionService`.
-   */
+  /** Combines an already-decrypted `CollectionView` with the admin-only fields from the source response. */
   static fromCollectionView(
     view: CollectionView,
     source: CollectionAccessDetailsResponse,
@@ -186,13 +181,7 @@ export class CollectionAdminView extends CollectionView {
     return adminView;
   }
 
-  /**
-   * Creates a placeholder CollectionAdminView for a collection that failed to decrypt via the
-   * SDK bulk path (`decrypt_list_with_failures`). Unlike the personal-vault decryption path, the
-   * Admin Console must never silently drop a collection that fails to decrypt, since admins still
-   * need to see, manage, and delete it. Mirrors the fallback behavior of
-   * {@link fromCollectionAccessDetails}'s catch branch.
-   */
+  /** Placeholder view for a collection that failed to decrypt, so admins can still manage it. */
   static fromCollectionAccessDetailsDecryptionFailure(
     source: CollectionAccessDetailsResponse,
   ): CollectionAdminView {

--- a/libs/common/src/admin-console/models/collections/collection-admin.view.ts
+++ b/libs/common/src/admin-console/models/collections/collection-admin.view.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { EncryptService, EncString } from "@bitwarden/legacy-crypto";
+import { DECRYPT_ERROR, EncryptService, EncString } from "@bitwarden/legacy-crypto";
 
 import { OrgKey } from "../../../types/key";
 import { Organization } from "../domain/organization";
@@ -123,7 +123,7 @@ export class CollectionAdminView extends CollectionView {
     try {
       view.name = await encryptService.decryptString(new EncString(view.name), orgKey);
     } catch (e) {
-      view.name = "[error: cannot decrypt]";
+      view.name = DECRYPT_ERROR;
       // Note: This should be replaced by the owning team with appropriate, domain-specific behavior.
       // eslint-disable-next-line no-console
       console.error(
@@ -147,6 +147,70 @@ export class CollectionAdminView extends CollectionView {
     view.users = collection.users
       ? collection.users.map((g) => new CollectionAccessSelectionView(g))
       : [];
+
+    return view;
+  }
+
+  /**
+   * Wraps an already-decrypted `CollectionView` (produced by
+   * {@link CollectionEncryptionService.decryptManyWithFailures}) with the admin-only fields
+   * (`groups`, `users`, `unmanaged`, `assigned`) carried by the access-details response. This is a
+   * data transform only - decryption itself is the responsibility of `CollectionEncryptionService`.
+   */
+  static fromCollectionView(
+    view: CollectionView,
+    source: CollectionAccessDetailsResponse,
+  ): CollectionAdminView {
+    const adminView = new CollectionAdminView({
+      id: view.id,
+      organizationId: view.organizationId,
+      name: view.name,
+    });
+
+    adminView.externalId = view.externalId;
+    adminView.hidePasswords = view.hidePasswords;
+    adminView.readOnly = view.readOnly;
+    adminView.manage = view.manage;
+    adminView.type = view.type;
+    adminView.defaultUserCollectionEmail = view.defaultUserCollectionEmail;
+
+    adminView.assigned = source.assigned;
+    adminView.unmanaged = source.unmanaged;
+    adminView.groups = source.groups
+      ? source.groups.map((g) => new CollectionAccessSelectionView(g))
+      : [];
+    adminView.users = source.users
+      ? source.users.map((g) => new CollectionAccessSelectionView(g))
+      : [];
+
+    return adminView;
+  }
+
+  /**
+   * Creates a placeholder CollectionAdminView for a collection that failed to decrypt via the
+   * SDK bulk path (`decrypt_list_with_failures`). Unlike the personal-vault decryption path, the
+   * Admin Console must never silently drop a collection that fails to decrypt, since admins still
+   * need to see, manage, and delete it. Mirrors the fallback behavior of
+   * {@link fromCollectionAccessDetails}'s catch branch.
+   */
+  static fromCollectionAccessDetailsDecryptionFailure(
+    source: CollectionAccessDetailsResponse,
+  ): CollectionAdminView {
+    const view = new CollectionAdminView({ ...source, name: DECRYPT_ERROR });
+
+    view.assigned = source.assigned;
+    view.readOnly = source.readOnly;
+    view.hidePasswords = source.hidePasswords;
+    view.manage = source.manage;
+    view.unmanaged = source.unmanaged;
+    view.type = source.type;
+    view.externalId = source.externalId;
+    view.defaultUserCollectionEmail = source.defaultUserCollectionEmail;
+
+    view.groups = source.groups
+      ? source.groups.map((g) => new CollectionAccessSelectionView(g))
+      : [];
+    view.users = source.users ? source.users.map((g) => new CollectionAccessSelectionView(g)) : [];
 
     return view;
   }

--- a/libs/common/src/admin-console/models/collections/collection.ts
+++ b/libs/common/src/admin-console/models/collections/collection.ts
@@ -8,6 +8,7 @@ import { CollectionId, OrganizationId } from "../../../types/guid";
 import { OrgKey } from "../../../types/key";
 
 import { CollectionData } from "./collection.data";
+import { CollectionAccessDetailsResponse } from "./collection.response";
 
 import { CollectionView } from ".";
 
@@ -52,6 +53,31 @@ export class Collection extends Domain {
     collection.manage = obj.manage;
     collection.type = obj.type;
     collection.defaultUserCollectionEmail = obj.defaultUserCollectionEmail;
+
+    return collection;
+  }
+
+  /**
+   * Creates a Collection domain model from a `CollectionAccessDetailsResponse`, for use with SDK
+   * crypto operations (see {@link CollectionEncryptionService}). Admin-only fields (`groups`,
+   * `users`, `unmanaged`, `assigned`) are not carried by `Collection` and must be re-attached by
+   * the caller when transforming a decrypted result back to a `CollectionAdminView`.
+   */
+  static fromCollectionAccessDetailsResponse(
+    response: CollectionAccessDetailsResponse,
+  ): Collection {
+    const collection = new Collection({
+      id: response.id,
+      name: new EncString(response.name),
+      organizationId: response.organizationId,
+    });
+
+    collection.externalId = response.externalId;
+    collection.readOnly = response.readOnly;
+    collection.hidePasswords = response.hidePasswords;
+    collection.manage = response.manage;
+    collection.type = response.type;
+    collection.defaultUserCollectionEmail = response.defaultUserCollectionEmail;
 
     return collection;
   }

--- a/libs/common/src/admin-console/models/collections/collection.ts
+++ b/libs/common/src/admin-console/models/collections/collection.ts
@@ -57,12 +57,7 @@ export class Collection extends Domain {
     return collection;
   }
 
-  /**
-   * Creates a Collection domain model from a `CollectionAccessDetailsResponse`, for use with SDK
-   * crypto operations (see {@link CollectionEncryptionService}). Admin-only fields (`groups`,
-   * `users`, `unmanaged`, `assigned`) are not carried by `Collection` and must be re-attached by
-   * the caller when transforming a decrypted result back to a `CollectionAdminView`.
-   */
+  /** Note: admin-only fields (`groups`, `users`, etc.) are not carried by `Collection`. */
   static fromCollectionAccessDetailsResponse(
     response: CollectionAccessDetailsResponse,
   ): Collection {

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -13,6 +13,7 @@ export enum FeatureFlag {
   /* Admin Console Team */
   GenerateInviteLink = "pm-32497-generate-invite-link",
   CollectionBulkDecryptWithFailures = "collection-bulk-decrypt-with-failures",
+  CollectionAdminBulkDecrypt = "collection-admin-bulk-decrypt",
   StagedStatus = "pm-34423-staged-status",
   PM28365_ChangeMemberEmail = "pm-28365-change-member-email-no-mp",
 
@@ -147,6 +148,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.GenerateInviteLink]: FALSE,
   [FeatureFlag.StagedStatus]: FALSE,
   [FeatureFlag.CollectionBulkDecryptWithFailures]: FALSE,
+  [FeatureFlag.CollectionAdminBulkDecrypt]: FALSE,
   [FeatureFlag.PM28365_ChangeMemberEmail]: FALSE,
 
   /* Autofill */


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38906

## 📔 Objective

Utilize SDK for decryption and utilize decryptMany methods so only 1 SDK call is used

## Performane Improvements
<img width="466" height="260" alt="image" src="https://github.com/user-attachments/assets/07e6c234-cb3c-4205-83ec-fa84164bf6b4" />