### PR TITLE
fix(pam): align the access rule form copy with the design

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16868,6 +16868,9 @@
   "pamAccessRuleCollectionsHint": {
     "message": "This access rule will apply to all selected collections."
   },
+  "pamAccessRuleEventLogNoticeStart": {
+    "message": "All requests and decisions are logged to"
+  },
   "pamAccessRuleCollectionsLoadError": {
     "message": "Couldn't load collections. Refresh the page to try again."
   },
@@ -16877,17 +16880,17 @@
   "pamAccessRuleDescription": {
     "message": "Description"
   },
-  "pamAccessRuleDefaultDuration": {
-    "message": "Default access duration"
+  "pamAccessRuleDefaultDurationLabel": {
+    "message": "Default duration"
   },
-  "pamAccessRuleMaxDuration": {
-    "message": "Maximum access duration"
+  "pamAccessRuleMaxDurationLabel": {
+    "message": "Maximum duration"
   },
   "pamAccessRuleMaxDurationNoCap": {
     "message": "No cap"
   },
-  "pamAccessRuleMaxDurationHint": {
-    "message": "Any single lease is clamped to at most this long, whatever the requester asks for."
+  "pamAccessRuleMaxDurationRequestHint": {
+    "message": "This is the longest duration a requester can ask for."
   },
   "pamAccessRuleDuration15m": {
     "message": "15 minutes"
@@ -16913,11 +16916,11 @@
   "pamAccessRuleDuration7d": {
     "message": "7 days"
   },
-  "pamAccessRuleSingleActiveLease": {
-    "message": "Only one user can hold an active lease at a time"
+  "pamAccessRuleSingleActiveUser": {
+    "message": "Only 1 user can have active access at a time"
   },
-  "pamAccessRuleSingleActiveLeaseHint": {
-    "message": "New requests are queued until the current lease ends or is revoked."
+  "pamAccessRuleSingleActiveUserHint": {
+    "message": "Others with approval can attempt to start access once the current session ends or is revoked."
   },
   "pamAccessRuleAllowExtensions": {
     "message": "Allow lease extensions"
@@ -17690,6 +17693,9 @@
   },
   "accessRuleIpAllowlistCidrPlaceholder": {
     "message": "e.g. 10.0.0.0/8"
+  },
+  "accessRuleIpAllowlistCidrHint": {
+    "message": "Enter one IP range per line in CIDR notation."
   },
   "accessRuleIpAllowlistAddRow": {
     "message": "Add CIDR range"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16868,14 +16868,14 @@
   "pamAccessRuleCollectionsHint": {
     "message": "This access rule will apply to all selected collections."
   },
-  "pamAccessRuleEventLogNoticeStart": {
-    "message": "All requests and decisions are logged to"
+  "pamAccessRuleEventLogNotice": {
+    "message": "All requests and decisions are logged."
+  },
+  "pamAccessRuleViewEventLogs": {
+    "message": "View event logs"
   },
   "pamAccessRuleCollectionsLoadError": {
     "message": "Couldn't load collections. Refresh the page to try again."
-  },
-  "pamAccessRuleDefaultDurationHint": {
-    "message": "This duration will be pre-filled in access requests."
   },
   "pamAccessRuleDescription": {
     "message": "Description"
@@ -16889,8 +16889,8 @@
   "pamAccessRuleMaxDurationNoCap": {
     "message": "No cap"
   },
-  "pamAccessRuleMaxDurationRequestHint": {
-    "message": "This is the longest duration a requester can ask for."
+  "pamAccessRuleMaxDurationCapHint": {
+    "message": "Access is limited to this length, whatever duration is requested."
   },
   "pamAccessRuleDuration15m": {
     "message": "15 minutes"
@@ -17693,9 +17693,6 @@
   },
   "accessRuleIpAllowlistCidrPlaceholder": {
     "message": "e.g. 10.0.0.0/8"
-  },
-  "accessRuleIpAllowlistCidrHint": {
-    "message": "Enter one IP range per line in CIDR notation."
   },
   "accessRuleIpAllowlistAddRow": {
     "message": "Add CIDR range"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16883,6 +16883,9 @@
   "pamAccessRuleDefaultDurationLabel": {
     "message": "Default duration"
   },
+  "pamAccessRuleDefaultDurationHint": {
+    "message": "This duration will be pre-filled in access requests."
+  },
   "pamAccessRuleMaxDurationLabel": {
     "message": "Maximum duration"
   },
@@ -17693,6 +17696,9 @@
   },
   "accessRuleIpAllowlistCidrPlaceholder": {
     "message": "e.g. 10.0.0.0/8"
+  },
+  "accessRuleIpAllowlistCidrHint": {
+    "message": "Enter one IP range per line in CIDR notation."
   },
   "accessRuleIpAllowlistAddRow": {
     "message": "Add CIDR range"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16877,22 +16877,22 @@
   "pamAccessRuleCollectionsLoadError": {
     "message": "Couldn't load collections. Refresh the page to try again."
   },
-  "pamAccessRuleDescription": {
-    "message": "Description"
-  },
-  "pamAccessRuleDefaultDurationLabel": {
-    "message": "Default duration"
-  },
   "pamAccessRuleDefaultDurationHint": {
     "message": "This duration will be pre-filled in access requests."
   },
-  "pamAccessRuleMaxDurationLabel": {
+  "pamAccessRuleDescription": {
+    "message": "Description"
+  },
+  "pamAccessRuleDefaultDuration": {
+    "message": "Default duration"
+  },
+  "pamAccessRuleMaxDuration": {
     "message": "Maximum duration"
   },
   "pamAccessRuleMaxDurationNoCap": {
     "message": "No cap"
   },
-  "pamAccessRuleMaxDurationCapHint": {
+  "pamAccessRuleMaxDurationHint": {
     "message": "Access is limited to this length, whatever duration is requested."
   },
   "pamAccessRuleDuration15m": {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -77,7 +77,7 @@
         </bit-section-header>
         <bit-card>
           <bit-form-field>
-            <bit-label>{{ "pamAccessRuleDefaultDurationLabel" | i18n }}</bit-label>
+            <bit-label>{{ "pamAccessRuleDefaultDuration" | i18n }}</bit-label>
             <bit-select
               id="access-rule-edit_select_default-duration"
               formControlName="defaultLeaseDurationSeconds"
@@ -90,7 +90,7 @@
           </bit-form-field>
 
           <bit-form-field>
-            <bit-label>{{ "pamAccessRuleMaxDurationLabel" | i18n }}</bit-label>
+            <bit-label>{{ "pamAccessRuleMaxDuration" | i18n }}</bit-label>
             <bit-select
               id="access-rule-edit_select_max-duration"
               formControlName="maxLeaseDurationSeconds"
@@ -103,7 +103,7 @@
                 <bit-option [value]="opt.seconds" [label]="opt.labelKey | i18n" />
               }
             </bit-select>
-            <bit-hint>{{ "pamAccessRuleMaxDurationCapHint" | i18n }}</bit-hint>
+            <bit-hint>{{ "pamAccessRuleMaxDurationHint" | i18n }}</bit-hint>
           </bit-form-field>
 
           <bit-form-control [disableMargin]="!formGroup.controls.allowsExtensions.value">

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -83,6 +83,7 @@
                 <bit-option [value]="opt.seconds" [label]="opt.labelKey | i18n" />
               }
             </bit-select>
+            <bit-hint>{{ "pamAccessRuleDefaultDurationHint" | i18n }}</bit-hint>
           </bit-form-field>
 
           <bit-form-field>

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -1,13 +1,16 @@
 <bit-header [title]="titleText()">
-  <div slot="breadcrumbs" class="tw-flex tw-items-center">
+  <div slot="breadcrumbs" class="tw-flex tw-items-baseline">
     <bit-breadcrumbs showTrailingArrow>
       <bit-breadcrumb [route]="['..']">{{ "pamAccessRules" | i18n }}</bit-breadcrumb>
     </bit-breadcrumbs>
     <!-- A route-less bit-breadcrumb falls back to a focusable button that does nothing and never
          gets aria-current; a static span carries the current-page semantics without that trap. -->
-    <span bitTypography="h3" aria-current="page" class="tw-inline-block tw-text-fg-heading">{{
-      pageTypeKey | i18n
-    }}</span>
+    <span
+      bitTypography="h3"
+      aria-current="page"
+      class="tw-inline-block !tw-m-0 !tw-text-fg-heading"
+      >{{ pageTypeKey | i18n }}</span
+    >
   </div>
 </bit-header>
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -1,7 +1,14 @@
 <bit-header [title]="titleText()">
-  <bit-breadcrumbs slot="breadcrumbs" showTrailingArrow>
-    <bit-breadcrumb [route]="['..']">{{ "pamAccessRules" | i18n }}</bit-breadcrumb>
-  </bit-breadcrumbs>
+  <div slot="breadcrumbs" class="tw-flex tw-items-center">
+    <bit-breadcrumbs showTrailingArrow>
+      <bit-breadcrumb [route]="['..']">{{ "pamAccessRules" | i18n }}</bit-breadcrumb>
+    </bit-breadcrumbs>
+    <!-- A route-less bit-breadcrumb falls back to a focusable button that does nothing and never
+         gets aria-current; a static span carries the current-page semantics without that trap. -->
+    <span bitTypography="h3" aria-current="page" class="tw-inline-block tw-text-fg-heading">{{
+      pageTypeKey | i18n
+    }}</span>
+  </div>
 </bit-header>
 
 <bit-container>

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -1,7 +1,6 @@
 <bit-header [title]="titleText()">
-  <bit-breadcrumbs slot="breadcrumbs">
+  <bit-breadcrumbs slot="breadcrumbs" showTrailingArrow>
     <bit-breadcrumb [route]="['..']">{{ "pamAccessRules" | i18n }}</bit-breadcrumb>
-    <bit-breadcrumb>{{ pageTypeKey | i18n }}</bit-breadcrumb>
   </bit-breadcrumbs>
 </bit-header>
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -77,7 +77,6 @@
                 <bit-option [value]="opt.seconds" [label]="opt.labelKey | i18n" />
               }
             </bit-select>
-            <bit-hint>{{ "pamAccessRuleDefaultDurationHint" | i18n }}</bit-hint>
           </bit-form-field>
 
           <bit-form-field>
@@ -94,7 +93,7 @@
                 <bit-option [value]="opt.seconds" [label]="opt.labelKey | i18n" />
               }
             </bit-select>
-            <bit-hint>{{ "pamAccessRuleMaxDurationRequestHint" | i18n }}</bit-hint>
+            <bit-hint>{{ "pamAccessRuleMaxDurationCapHint" | i18n }}</bit-hint>
           </bit-form-field>
 
           <bit-form-control [disableMargin]="!formGroup.controls.allowsExtensions.value">
@@ -176,12 +175,14 @@
         </bit-card>
       </bit-section>
 
-      <p bitTypography="body2" class="tw-text-muted">
-        {{ "pamAccessRuleEventLogNoticeStart" | i18n }}
-        <a bitLink [routerLink]="eventLogRoute" id="access-rule-edit_anchor_event-logs">{{
-          "eventLogs" | i18n
-        }}</a>
-      </p>
+      @if (canAccessEventLogs()) {
+        <p bitTypography="body2" class="tw-text-muted">
+          {{ "pamAccessRuleEventLogNotice" | i18n }}
+          <a bitLink [routerLink]="eventLogRoute" id="access-rule-edit_anchor_event-logs">{{
+            "pamAccessRuleViewEventLogs" | i18n
+          }}</a>
+        </p>
+      }
 
       <div class="tw-flex tw-items-center tw-gap-2">
         <button

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -1,6 +1,7 @@
-<bit-header [title]="titleText()" icon="bwi-clock">
+<bit-header [title]="titleText()">
   <bit-breadcrumbs slot="breadcrumbs">
     <bit-breadcrumb [route]="['..']">{{ "pamAccessRules" | i18n }}</bit-breadcrumb>
+    <bit-breadcrumb>{{ pageTypeKey | i18n }}</bit-breadcrumb>
   </bit-breadcrumbs>
 </bit-header>
 
@@ -67,7 +68,7 @@
         </bit-section-header>
         <bit-card>
           <bit-form-field>
-            <bit-label>{{ "pamAccessRuleDefaultDuration" | i18n }}</bit-label>
+            <bit-label>{{ "pamAccessRuleDefaultDurationLabel" | i18n }}</bit-label>
             <bit-select
               id="access-rule-edit_select_default-duration"
               formControlName="defaultLeaseDurationSeconds"
@@ -80,7 +81,7 @@
           </bit-form-field>
 
           <bit-form-field>
-            <bit-label>{{ "pamAccessRuleMaxDuration" | i18n }}</bit-label>
+            <bit-label>{{ "pamAccessRuleMaxDurationLabel" | i18n }}</bit-label>
             <bit-select
               id="access-rule-edit_select_max-duration"
               formControlName="maxLeaseDurationSeconds"
@@ -93,7 +94,7 @@
                 <bit-option [value]="opt.seconds" [label]="opt.labelKey | i18n" />
               }
             </bit-select>
-            <bit-hint>{{ "pamAccessRuleMaxDurationHint" | i18n }}</bit-hint>
+            <bit-hint>{{ "pamAccessRuleMaxDurationRequestHint" | i18n }}</bit-hint>
           </bit-form-field>
 
           <bit-form-control [disableMargin]="!formGroup.controls.allowsExtensions.value">
@@ -169,11 +170,18 @@
               id="access-rule-edit_checkbox_single-active-lease"
               formControlName="singleActiveLease"
             />
-            <bit-label>{{ "pamAccessRuleSingleActiveLease" | i18n }}</bit-label>
-            <bit-hint>{{ "pamAccessRuleSingleActiveLeaseHint" | i18n }}</bit-hint>
+            <bit-label>{{ "pamAccessRuleSingleActiveUser" | i18n }}</bit-label>
+            <bit-hint>{{ "pamAccessRuleSingleActiveUserHint" | i18n }}</bit-hint>
           </bit-form-control>
         </bit-card>
       </bit-section>
+
+      <p bitTypography="body2" class="tw-text-muted">
+        {{ "pamAccessRuleEventLogNoticeStart" | i18n }}
+        <a bitLink [routerLink]="eventLogRoute" id="access-rule-edit_anchor_event-logs">{{
+          "eventLogs" | i18n
+        }}</a>
+      </p>
 
       <div class="tw-flex tw-items-center tw-gap-2">
         <button

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -1,3 +1,4 @@
+import { Provider } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, provideRouter, Router } from "@angular/router";
@@ -48,6 +49,24 @@ function routeStub(state: RouteState): Partial<ActivatedRoute> {
   } as unknown as ActivatedRoute;
 }
 
+/**
+ * The providers every block needs, with `overrides` appended so a block's own stub
+ * wins (Angular resolves the last provider for a token).
+ */
+const providersWith = (...overrides: Provider[]): Provider[] => [
+  provideRouter([]),
+  { provide: ActivatedRoute, useValue: routeStub({}) },
+  { provide: AccessRuleSdkService, useValue: {} },
+  { provide: ToastService, useValue: { showToast: jest.fn() } },
+  { provide: I18nService, useValue: i18nFake },
+  { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+  { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
+  { provide: CidrValidationService, useValue: cidrValidationStub },
+  { provide: OrganizationService, useValue: organizationServiceStub() },
+  { provide: DialogService, useValue: declinedDialogStub },
+  ...overrides,
+];
+
 describe("AccessRuleEditComponent — default/max duration coupling", () => {
   let fixture: ComponentFixture<AccessRuleEditComponent>;
   let component: AccessRuleEditComponent;
@@ -57,18 +76,7 @@ describe("AccessRuleEditComponent — default/max duration coupling", () => {
     TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
-      providers: [
-        provideRouter([]),
-        { provide: ActivatedRoute, useValue: routeStub({}) },
-        { provide: AccessRuleSdkService, useValue: {} },
-        { provide: ToastService, useValue: { showToast: jest.fn() } },
-        { provide: I18nService, useValue: i18nFake },
-        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
-        { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
-        { provide: CidrValidationService, useValue: cidrValidationStub },
-        { provide: OrganizationService, useValue: organizationServiceStub() },
-        { provide: DialogService, useValue: declinedDialogStub },
-      ],
+      providers: providersWith(),
     });
 
     fixture = TestBed.createComponent(AccessRuleEditComponent);
@@ -124,21 +132,14 @@ describe("AccessRuleEditComponent — page furniture", () => {
   ) => {
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
-      providers: [
-        provideRouter([]),
+      providers: providersWith(
         { provide: ActivatedRoute, useValue: routeStub(state) },
         {
           provide: AccessRuleSdkService,
           useValue: { getAccessRule: jest.fn().mockResolvedValue(existing) },
         },
-        { provide: ToastService, useValue: { showToast: jest.fn() } },
-        { provide: I18nService, useValue: i18nFake },
-        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
-        { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
-        { provide: CidrValidationService, useValue: cidrValidationStub },
         { provide: OrganizationService, useValue: organizationServiceStub(canAccessEventLogs) },
-        { provide: DialogService, useValue: declinedDialogStub },
-      ],
+      ),
     });
 
     jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
@@ -237,21 +238,16 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
-      providers: [
-        provideRouter([]),
+      providers: providersWith(
         { provide: ActivatedRoute, useValue: routeStub(state) },
         { provide: AccessRuleSdkService, useValue: pamApi },
         { provide: ToastService, useValue: { showToast } },
-        { provide: I18nService, useValue: i18nFake },
-        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
         {
           provide: CollectionAdminService,
           useValue: { collectionAdminViews$: () => of(ORG_COLLECTIONS) },
         },
-        { provide: CidrValidationService, useValue: cidrValidationStub },
-        { provide: OrganizationService, useValue: organizationServiceStub() },
         { provide: DialogService, useValue: dialog },
-      ],
+      ),
     });
 
     navigate = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
@@ -459,31 +455,6 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     expect(controls().maxExtensionDurationSeconds.value).toBe(ONE_HOUR);
   });
 
-  it("heads the page with the rule's own name in edit mode", async () => {
-    await setup({ params: { accessRuleId: "rule-1" } }, {
-      id: "rule-1",
-      name: "Production database access",
-      collections: [],
-      conditions: [],
-    } as unknown as AccessRuleView);
-
-    expect(component["titleText"]()).toBe("Production database access");
-    expect(component["pageTypeKey"]).toBe("pamAccessRuleEditTitle");
-  });
-
-  it("keeps the page-type label as the heading in create mode, where there is no name yet", async () => {
-    await setup({});
-
-    expect(component["titleText"]()).toBe("pamAccessRuleCreateTitle");
-    expect(component["pageTypeKey"]).toBe("pamAccessRuleCreateTitle");
-  });
-
-  it("links the footer notice at the organization's event logs", async () => {
-    await setup({});
-
-    expect(component["eventLogRoute"]).toEqual(["/organizations", "org-1", "reporting", "events"]);
-  });
-
   it("deletes the rule under edit and returns to the list once confirmed", async () => {
     await setup({ params: { accessRuleId: "rule-1" } }, {
       id: "rule-1",
@@ -542,21 +513,14 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
-      providers: [
-        provideRouter([]),
-        { provide: ActivatedRoute, useValue: routeStub({}) },
+      providers: providersWith(
         { provide: AccessRuleSdkService, useValue: pamApi },
         { provide: ToastService, useValue: { showToast } },
-        { provide: I18nService, useValue: i18nFake },
-        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
         {
           provide: CollectionAdminService,
           useValue: { collectionAdminViews$: () => throwError(() => new Error("boom")) },
         },
-        { provide: CidrValidationService, useValue: cidrValidationStub },
-        { provide: OrganizationService, useValue: organizationServiceStub() },
-        { provide: DialogService, useValue: declinedDialogStub },
-      ],
+      ),
     });
 
     jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
@@ -586,18 +550,11 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
-      providers: [
-        provideRouter([]),
+      providers: providersWith(
         { provide: ActivatedRoute, useValue: routeStub({ params: { accessRuleId: "missing" } }) },
         { provide: AccessRuleSdkService, useValue: pamApi },
         { provide: ToastService, useValue: { showToast } },
-        { provide: I18nService, useValue: i18nFake },
-        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
-        { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
-        { provide: CidrValidationService, useValue: cidrValidationStub },
-        { provide: OrganizationService, useValue: organizationServiceStub() },
-        { provide: DialogService, useValue: declinedDialogStub },
-      ],
+      ),
     });
 
     navigate = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -148,7 +148,7 @@ describe("AccessRuleEditComponent — page furniture", () => {
     return fixture;
   };
 
-  it("shows the rule's name as the heading and the page type in the breadcrumb", async () => {
+  it("shows the rule's name as the heading, with the list as the only breadcrumb", async () => {
     const fixture = await render({ params: { accessRuleId: "rule-1" } }, {
       id: "rule-1",
       name: "Production database access",
@@ -159,7 +159,9 @@ describe("AccessRuleEditComponent — page furniture", () => {
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain("Production database access");
     expect(text).toContain("pamAccessRules");
-    expect(text).toContain("pamAccessRuleEditTitle");
+
+    const crumbs = fixture.nativeElement.querySelectorAll("bit-breadcrumbs button");
+    expect(crumbs).toHaveLength(0);
   });
 
   it("links the event logs at the organization's reporting route", async () => {
@@ -437,7 +439,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     expect(controls().maxExtensionDurationSeconds.value).toBe(ONE_HOUR);
   });
 
-  it("heads the page with the rule's own name in edit mode, and names the page type in the breadcrumb", async () => {
+  it("heads the page with the rule's own name in edit mode", async () => {
     await setup({ params: { accessRuleId: "rule-1" } }, {
       id: "rule-1",
       name: "Production database access",

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -111,8 +111,6 @@ describe("AccessRuleEditComponent — default/max duration coupling", () => {
 });
 
 describe("AccessRuleEditComponent — page furniture", () => {
-  // Unlike the other suites, this one renders the real template: the heading, the breadcrumb
-  // trail and the event-log footer are exactly what's under test here.
   const render = async (state: RouteState, existing?: AccessRuleView) => {
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -148,7 +148,7 @@ describe("AccessRuleEditComponent — page furniture", () => {
     return fixture;
   };
 
-  it("shows the rule's name as the heading, with the list as the only breadcrumb", async () => {
+  it("shows the rule's name as the heading, with the list and edit-page crumbs", async () => {
     const fixture = await render({ params: { accessRuleId: "rule-1" } }, {
       id: "rule-1",
       name: "Production database access",
@@ -162,6 +162,26 @@ describe("AccessRuleEditComponent — page furniture", () => {
 
     const crumbs = fixture.nativeElement.querySelectorAll("bit-breadcrumbs button");
     expect(crumbs).toHaveLength(0);
+
+    const pageTypeCrumb = fixture.nativeElement.querySelector(
+      '[slot="breadcrumbs"] [aria-current="page"]',
+    );
+    expect(pageTypeCrumb.textContent.trim()).toBe("pamAccessRuleEditTitle");
+  });
+
+  it("shows the create-page crumb and heading in create mode", async () => {
+    const fixture = await render({});
+
+    const crumbs = fixture.nativeElement.querySelectorAll("bit-breadcrumbs button");
+    expect(crumbs).toHaveLength(0);
+
+    const pageTypeCrumb = fixture.nativeElement.querySelector(
+      '[slot="breadcrumbs"] [aria-current="page"]',
+    );
+    expect(pageTypeCrumb.textContent.trim()).toBe("pamAccessRuleCreateTitle");
+
+    const heading = fixture.nativeElement.querySelector("h1");
+    expect(heading.textContent).toContain("pamAccessRuleCreateTitle");
   });
 
   it("links the event logs at the organization's reporting route", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -1,4 +1,4 @@
-import { Provider } from "@angular/core";
+import { EnvironmentProviders, Provider } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, provideRouter, Router } from "@angular/router";
@@ -53,7 +53,7 @@ function routeStub(state: RouteState): Partial<ActivatedRoute> {
  * The providers every block needs, with `overrides` appended so a block's own stub
  * wins (Angular resolves the last provider for a token).
  */
-const providersWith = (...overrides: Provider[]): Provider[] => [
+const providersWith = (...overrides: Provider[]): (Provider | EnvironmentProviders)[] => [
   provideRouter([]),
   { provide: ActivatedRoute, useValue: routeStub({}) },
   { provide: AccessRuleSdkService, useValue: {} },

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute, provideRouter, Router } from "@angular/router";
 import { of, throwError } from "rxjs";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService, SelectItemView, ToastService } from "@bitwarden/components";
@@ -25,6 +26,10 @@ const cidrValidationStub: CidrValidationService = { isValid: () => true };
 
 // Only the delete flow opens a dialog; specs that exercise it provide their own answer.
 const declinedDialogStub = { openSimpleDialog: () => Promise.resolve(false) };
+
+const organizationServiceStub = (canAccessEventLogs = true) => ({
+  organizations$: () => of([{ id: "org-1", canAccessEventLogs }]),
+});
 
 // Preset durations offered by the pickers, in seconds.
 const THIRTY_MIN = 30 * 60;
@@ -61,6 +66,7 @@ describe("AccessRuleEditComponent — default/max duration coupling", () => {
         { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
         { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: OrganizationService, useValue: organizationServiceStub() },
         { provide: DialogService, useValue: declinedDialogStub },
       ],
     });
@@ -111,7 +117,11 @@ describe("AccessRuleEditComponent — default/max duration coupling", () => {
 });
 
 describe("AccessRuleEditComponent — page furniture", () => {
-  const render = async (state: RouteState, existing?: AccessRuleView) => {
+  const render = async (
+    state: RouteState,
+    existing?: AccessRuleView,
+    canAccessEventLogs = true,
+  ) => {
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
       providers: [
@@ -126,6 +136,7 @@ describe("AccessRuleEditComponent — page furniture", () => {
         { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
         { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: OrganizationService, useValue: organizationServiceStub(canAccessEventLogs) },
         { provide: DialogService, useValue: declinedDialogStub },
       ],
     });
@@ -151,7 +162,7 @@ describe("AccessRuleEditComponent — page furniture", () => {
     expect(text).toContain("pamAccessRuleEditTitle");
   });
 
-  it("links 'Event logs' at the organization's reporting route", async () => {
+  it("links the event logs at the organization's reporting route", async () => {
     const fixture = await render({});
 
     const link = fixture.nativeElement.querySelector(
@@ -159,6 +170,13 @@ describe("AccessRuleEditComponent — page furniture", () => {
     ) as HTMLAnchorElement | null;
     expect(link).not.toBeNull();
     expect(link!.getAttribute("href")).toBe("/organizations/org-1/reporting/events");
+  });
+
+  it("drops the event log notice for an organization without event log access", async () => {
+    const fixture = await render({}, undefined, false);
+
+    expect(fixture.nativeElement.querySelector("#access-rule-edit_anchor_event-logs")).toBeNull();
+    expect(fixture.nativeElement.textContent).not.toContain("pamAccessRuleEventLogNotice");
   });
 });
 
@@ -209,6 +227,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
           useValue: { collectionAdminViews$: () => of(ORG_COLLECTIONS) },
         },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: OrganizationService, useValue: organizationServiceStub() },
         { provide: DialogService, useValue: dialog },
       ],
     });
@@ -513,6 +532,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
           useValue: { collectionAdminViews$: () => throwError(() => new Error("boom")) },
         },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: OrganizationService, useValue: organizationServiceStub() },
         { provide: DialogService, useValue: declinedDialogStub },
       ],
     });
@@ -553,6 +573,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
         { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
         { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
         { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: OrganizationService, useValue: organizationServiceStub() },
         { provide: DialogService, useValue: declinedDialogStub },
       ],
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -110,6 +110,60 @@ describe("AccessRuleEditComponent — default/max duration coupling", () => {
   });
 });
 
+describe("AccessRuleEditComponent — page furniture", () => {
+  // Unlike the other suites, this one renders the real template: the heading, the breadcrumb
+  // trail and the event-log footer are exactly what's under test here.
+  const render = async (state: RouteState, existing?: AccessRuleView) => {
+    TestBed.configureTestingModule({
+      imports: [AccessRuleEditComponent, ReactiveFormsModule],
+      providers: [
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: routeStub(state) },
+        {
+          provide: AccessRuleSdkService,
+          useValue: { getAccessRule: jest.fn().mockResolvedValue(existing) },
+        },
+        { provide: ToastService, useValue: { showToast: jest.fn() } },
+        { provide: I18nService, useValue: i18nFake },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+        { provide: CollectionAdminService, useValue: { collectionAdminViews$: () => of([]) } },
+        { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: DialogService, useValue: declinedDialogStub },
+      ],
+    });
+
+    jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
+    const fixture = TestBed.createComponent(AccessRuleEditComponent);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  };
+
+  it("shows the rule's name as the heading and the page type in the breadcrumb", async () => {
+    const fixture = await render({ params: { accessRuleId: "rule-1" } }, {
+      id: "rule-1",
+      name: "Production database access",
+      collections: [],
+      conditions: [],
+    } as unknown as AccessRuleView);
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("Production database access");
+    expect(text).toContain("pamAccessRules");
+    expect(text).toContain("pamAccessRuleEditTitle");
+  });
+
+  it("links 'Event logs' at the organization's reporting route", async () => {
+    const fixture = await render({});
+
+    const link = fixture.nativeElement.querySelector(
+      "#access-rule-edit_anchor_event-logs",
+    ) as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe("/organizations/org-1/reporting/events");
+  });
+});
+
 describe("AccessRuleEditComponent — load, collections, and submit", () => {
   let component: AccessRuleEditComponent;
   let navigate: jest.SpyInstance;
@@ -364,6 +418,31 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
 
     expect(controls().maxLeaseDurationSeconds.value).toBe(ONE_HOUR);
     expect(controls().maxExtensionDurationSeconds.value).toBe(ONE_HOUR);
+  });
+
+  it("heads the page with the rule's own name in edit mode, and names the page type in the breadcrumb", async () => {
+    await setup({ params: { accessRuleId: "rule-1" } }, {
+      id: "rule-1",
+      name: "Production database access",
+      collections: [],
+      conditions: [],
+    } as unknown as AccessRuleView);
+
+    expect(component["titleText"]()).toBe("Production database access");
+    expect(component["pageTypeKey"]).toBe("pamAccessRuleEditTitle");
+  });
+
+  it("keeps the page-type label as the heading in create mode, where there is no name yet", async () => {
+    await setup({});
+
+    expect(component["titleText"]()).toBe("pamAccessRuleCreateTitle");
+    expect(component["pageTypeKey"]).toBe("pamAccessRuleCreateTitle");
+  });
+
+  it("links the footer notice at the organization's event logs", async () => {
+    await setup({});
+
+    expect(component["eventLogRoute"]).toEqual(["/organizations", "org-1", "reporting", "events"]);
   });
 
   it("deletes the rule under edit and returns to the list once confirmed", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
@@ -10,6 +10,7 @@ import {
 import { of } from "rxjs";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
@@ -80,6 +81,10 @@ export default {
           useValue: { collectionAdminViews$: () => of(ORG_COLLECTIONS) },
         },
         { provide: CidrValidationService, useValue: { isValid: () => true } },
+        {
+          provide: OrganizationService,
+          useValue: { organizations$: () => of([{ id: "org-1", canAccessEventLogs: true }]) },
+        },
         { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
         // Default to create mode; the Edit/Template stories override this.
         { provide: ActivatedRoute, useValue: routeStub() },

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
@@ -20,6 +20,7 @@ import {
   DialogService,
   FormFieldModule,
   HeaderComponent,
+  LinkModule,
   MultiSelectModule,
   SectionComponent,
   SectionHeaderComponent,
@@ -87,7 +88,9 @@ const NAME_MAX_LENGTH = 256;
     FormFieldModule,
     HeaderComponent,
     IpAllowlistEditorComponent,
+    LinkModule,
     MultiSelectModule,
+    RouterLink,
     SectionComponent,
     SectionHeaderComponent,
     SelectModule,
@@ -124,9 +127,26 @@ export class AccessRuleEditComponent {
   /** The rule being edited, loaded in edit mode; null while loading or in create mode. */
   protected readonly existing = signal<AccessRuleView | null>(null);
   protected readonly loading = signal(true);
-  protected readonly titleText = computed(() =>
-    this.i18nService.t(this.editing ? "pamAccessRuleEditTitle" : "pamAccessRuleCreateTitle"),
+
+  /**
+   * The breadcrumb's trailing (non-link) crumb, naming the page type — the design moves
+   * "Edit access rule" / "New access rule" off the heading and into the trail.
+   */
+  protected readonly pageTypeKey = this.editing
+    ? "pamAccessRuleEditTitle"
+    : "pamAccessRuleCreateTitle";
+
+  /**
+   * The page heading. Edit mode shows the rule's own name, per the design; it falls back to
+   * the page-type label until the rule has loaded. Create mode keeps the page-type label,
+   * since there is no name yet and a blank heading would be worse.
+   */
+  protected readonly titleText = computed(
+    () => this.existing()?.name ?? this.i18nService.t(this.pageTypeKey),
   );
+
+  /** Absolute route to the organization's event logs, linked from the footer notice. */
+  protected readonly eventLogRoute = ["/organizations", this.organizationId, "reporting", "events"];
 
   protected readonly formGroup = this.formBuilder.nonNullable.group({
     name: ["", [Validators.required, Validators.maxLength(NAME_MAX_LENGTH)]],

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, map, switchMap } from "rxjs";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -109,6 +110,7 @@ export class AccessRuleEditComponent {
   private readonly i18nService = inject(I18nService);
   private readonly accountService = inject(AccountService);
   private readonly collectionAdminService = inject(CollectionAdminService);
+  private readonly organizationService = inject(OrganizationService);
   private readonly cidrValidation = inject(CidrValidationService);
   private readonly dialogService = inject(DialogService);
 
@@ -145,8 +147,26 @@ export class AccessRuleEditComponent {
     () => this.existing()?.name ?? this.i18nService.t(this.pageTypeKey),
   );
 
-  /** Absolute route to the organization's event logs, linked from the footer notice. */
   protected readonly eventLogRoute = ["/organizations", this.organizationId, "reporting", "events"];
+
+  /**
+   * Gates the footer notice. `canManageAccessRules` (this page's guard) does not imply access to
+   * event logs: `canAccessEventLogs` also requires the organization's `useEvents` entitlement, and
+   * without it the reporting route bounces the admin straight back out.
+   */
+  protected readonly canAccessEventLogs = toSignal(
+    this.accountService.activeAccount$.pipe(
+      getUserId,
+      switchMap((userId) => this.organizationService.organizations$(userId)),
+      map((organizations) =>
+        organizations.some(
+          (organization) =>
+            organization.id === this.organizationId && organization.canAccessEventLogs,
+        ),
+      ),
+    ),
+    { initialValue: false },
+  );
 
   protected readonly formGroup = this.formBuilder.nonNullable.group({
     name: ["", [Validators.required, Validators.maxLength(NAME_MAX_LENGTH)]],

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -11,6 +11,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { getById } from "@bitwarden/common/platform/misc/rxjs-operators";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   AsyncActionsModule,
@@ -114,6 +115,8 @@ export class AccessRuleEditComponent {
   private readonly cidrValidation = inject(CidrValidationService);
   private readonly dialogService = inject(DialogService);
 
+  private readonly activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
+
   private readonly organizationId = this.route.snapshot.params.organizationId as OrganizationId;
   private readonly accessRuleId = this.route.snapshot.params.accessRuleId as
     AccessRuleId | undefined;
@@ -151,15 +154,10 @@ export class AccessRuleEditComponent {
    * without it the reporting route bounces the admin straight back out.
    */
   protected readonly canAccessEventLogs = toSignal(
-    this.accountService.activeAccount$.pipe(
-      getUserId,
+    this.activeUserId$.pipe(
       switchMap((userId) => this.organizationService.organizations$(userId)),
-      map((organizations) =>
-        organizations.some(
-          (organization) =>
-            organization.id === this.organizationId && organization.canAccessEventLogs,
-        ),
-      ),
+      getById(this.organizationId),
+      map((organization) => organization?.canAccessEventLogs ?? false),
     ),
     { initialValue: false },
   );
@@ -311,7 +309,7 @@ export class AccessRuleEditComponent {
 
   private async loadCollections(rule: AccessRuleView | null): Promise<void> {
     try {
-      const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+      const userId = await firstValueFrom(this.activeUserId$);
       const collections = await firstValueFrom(
         this.collectionAdminService.collectionAdminViews$(this.organizationId, userId),
       );

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -130,10 +130,6 @@ export class AccessRuleEditComponent {
   protected readonly existing = signal<AccessRuleView | null>(null);
   protected readonly loading = signal(true);
 
-  /**
-   * The breadcrumb's trailing (non-link) crumb, naming the page type — the design moves
-   * "Edit access rule" / "New access rule" off the heading and into the trail.
-   */
   protected readonly pageTypeKey = this.editing
     ? "pamAccessRuleEditTitle"
     : "pamAccessRuleCreateTitle";

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.html
@@ -28,6 +28,10 @@
   }
 </div>
 
+<p bitTypography="helper" class="tw-text-muted">
+  {{ "accessRuleIpAllowlistCidrHint" | i18n }}
+</p>
+
 @if (cidrArray().touched && cidrArray().hasError("duplicateCidrs")) {
   <p class="tw-text-danger" bitTypography="helper">
     {{ "accessRuleIpAllowlistDuplicateCidr" | i18n }}

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.html
@@ -24,7 +24,6 @@
           (click)="removeRow($index)"
         ></button>
       }
-      <bit-hint>{{ "accessRuleIpAllowlistCidrHint" | i18n }}</bit-hint>
     </bit-form-field>
   }
 </div>

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.html
@@ -24,6 +24,7 @@
           (click)="removeRow($index)"
         ></button>
       }
+      <bit-hint>{{ "accessRuleIpAllowlistCidrHint" | i18n }}</bit-hint>
     </bit-form-field>
   }
 </div>

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
@@ -139,7 +139,6 @@ describe("AccessRulesComponent — activation toasts", () => {
     rules: AccessRuleView[],
   ): Promise<ComponentFixture<AccessRulesComponent>> => {
     showToast = jest.fn();
-    // Echo the request back as the updated rule; only the toast is under test here.
     const updateAccessRule = jest
       .fn()
       .mockImplementation((_orgId, id) => Promise.resolve(rule(id)));

--- a/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.spec.ts
@@ -37,7 +37,7 @@ describe("accessRuleSummaryKeys", () => {
   it("adds the single-active-lease restriction", () => {
     expect(accessRuleSummaryKeys(rule({ singleActiveLease: true }))).toEqual([
       "pamAccessRuleConditionAutoApproved",
-      "pamAccessRuleSingleActiveLease",
+      "pamAccessRuleSingleActiveUser",
     ]);
   });
 
@@ -50,7 +50,7 @@ describe("accessRuleSummaryKeys", () => {
     expect(accessRuleSummaryKeys(rule({ conditions, singleActiveLease: true }))).toEqual([
       "pamAccessRuleConditionRequiresApproval",
       "pamAccessRuleConditionIpRestricted",
-      "pamAccessRuleSingleActiveLease",
+      "pamAccessRuleSingleActiveUser",
     ]);
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.ts
+++ b/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.ts
@@ -21,7 +21,7 @@ export function accessRuleSummaryKeys(rule: SummarizableRule): string[] {
     keys.push("pamAccessRuleConditionIpRestricted");
   }
   if (rule.singleActiveLease) {
-    keys.push("pamAccessRuleSingleActiveLease");
+    keys.push("pamAccessRuleSingleActiveUser");
   }
   return keys;
 }

--- a/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/collection-access-rule-callout.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/collection-access-rule-callout.component.spec.ts
@@ -115,7 +115,7 @@ describe("CollectionAccessRuleCalloutComponent", () => {
 
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain("pamAccessRuleConditionRequiresApproval");
-    expect(text).toContain("pamAccessRuleSingleActiveLease");
+    expect(text).toContain("pamAccessRuleSingleActiveUser");
   });
 
   it("names every governing rule, not just the first", async () => {


### PR DESCRIPTION
Aligns the access rule form's copy and chrome with the design. See the before/after screenshots; the numbered markers match the list below.

1. Breadcrumb: now reads "Access rules > New access rule" / "Access rules > Edit access rule", matching the design. The page-type crumb is a static `<span aria-current="page">` rather than a second `<bit-breadcrumb>`, because a route-less `bit-breadcrumb` falls through to the library's button template and renders a focusable control that does nothing and never receives `aria-current`. A test asserts the breadcrumbs contain zero `<button>` elements.
2. Header: clock icon dropped, title becomes the rule's own name in edit mode.
3, 5. Duration labels shortened to "Default duration" and "Maximum duration".
7. Single-active-lease label and hint reworded.
8. New footer notice linking to Event logs, gated on the organization's event-log entitlement. This page's `canManageAccessRules` guard does not imply `canAccessEventLogs`, so an ungated link would route PAM-only orgs to a page that bounces them out.

<img width="2850" height="3584" alt="22507-after-edit-form" src="https://github.com/user-attachments/assets/9e882a96-619a-4634-a2f4-8f10141285ab" />
<img width="2850" height="3546" alt="22507-before-edit-form" src="https://github.com/user-attachments/assets/a82b3493-cbae-4814-ba3f-7c4e81cdee7c" />
<img width="2880" height="1814" alt="22507-breadcrumb-create" src="https://github.com/user-attachments/assets/df888092-9721-477b-ae59-68c736a09e8c" />


