### PR TITLE
feat(pam): add discard, save-error, and validation summary states

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16985,6 +16985,21 @@
       }
     }
   },
+  "pamAccessRuleSaveErrorTitle": {
+    "message": "Rule not saved"
+  },
+  "pamAccessRuleSaveErrorBody": {
+    "message": "Something went wrong. Your rule wasn't saved, but your information is still here. Try again."
+  },
+  "pamAccessRuleDiscardConfirmTitle": {
+    "message": "Discard rule"
+  },
+  "pamAccessRuleDiscardConfirmContent": {
+    "message": "The details you entered won't be saved."
+  },
+  "pamAccessRuleDiscard": {
+    "message": "Discard"
+  },
   "pamNoAccessRulesYetTitle": {
     "message": "No access rules yet"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16973,6 +16973,15 @@
   "pamAccessRuleDeleted": {
     "message": "Access rule deleted."
   },
+  "pamAccessRuleDiscardTitle": {
+    "message": "Discard rule"
+  },
+  "pamAccessRuleDiscardContent": {
+    "message": "The details you entered won't be saved."
+  },
+  "pamAccessRuleDiscardConfirm": {
+    "message": "Discard"
+  },
   "pamAccessRuleDeleteConfirmTitle": {
     "message": "Delete access rule?"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16991,15 +16991,6 @@
   "pamAccessRuleSaveErrorBody": {
     "message": "Something went wrong. Your rule wasn't saved, but your information is still here. Try again."
   },
-  "pamAccessRuleDiscardConfirmTitle": {
-    "message": "Discard rule"
-  },
-  "pamAccessRuleDiscardConfirmContent": {
-    "message": "The details you entered won't be saved."
-  },
-  "pamAccessRuleDiscard": {
-    "message": "Discard"
-  },
   "pamNoAccessRulesYetTitle": {
     "message": "No access rules yet"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -115,7 +115,9 @@
                 <bit-option [value]="opt.seconds" [label]="opt.labelKey | i18n" />
               }
             </bit-select>
-            <bit-hint>{{ "pamAccessRuleMaxDurationHint" | i18n }}</bit-hint>
+            @if (formGroup.controls.maxLeaseDurationSeconds.value !== noDurationCap) {
+              <bit-hint>{{ "pamAccessRuleMaxDurationHint" | i18n }}</bit-hint>
+            }
           </bit-form-field>
 
           <bit-form-control [disableMargin]="!formGroup.controls.allowsExtensions.value">

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -19,6 +19,12 @@
     <bit-spinner />
   } @else {
     <form [formGroup]="formGroup" [bitSubmit]="submit">
+      @if (saveError(); as saveErrorMessage) {
+        <bit-callout type="danger" [title]="'pamAccessRuleSaveErrorTitle' | i18n">
+          {{ saveErrorMessage }}
+        </bit-callout>
+      }
+
       <bit-section>
         <bit-section-header>
           <h2 bitTypography="h5">{{ "pamAccessRuleGeneralInfoHeading" | i18n }}</h2>
@@ -193,6 +199,8 @@
           }}</a>
         </p>
       }
+
+      <bit-error-summary [formGroup]="formGroup" />
 
       <div class="tw-flex tw-items-center tw-gap-2">
         <button

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -20,7 +20,13 @@
   } @else {
     <form [formGroup]="formGroup" [bitSubmit]="submit">
       @if (saveError(); as saveErrorMessage) {
-        <bit-callout type="danger" [title]="'pamAccessRuleSaveErrorTitle' | i18n">
+        <bit-callout
+          #saveErrorCallout
+          role="alert"
+          tabindex="-1"
+          type="danger"
+          [title]="'pamAccessRuleSaveErrorTitle' | i18n"
+        >
           {{ saveErrorMessage }}
         </bit-callout>
       }
@@ -216,8 +222,7 @@
           type="button"
           bitButton
           buttonType="secondary"
-          bitFormButton
-          (click)="cancel()"
+          [bitAction]="cancel"
           id="access-rule-edit_button_cancel"
         >
           {{ "cancel" | i18n }}

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -25,7 +25,6 @@ const i18nFake: Pick<I18nService, "t" | "translate"> = {
 // treating every non-empty row as valid keeps seeded IP-allowlist forms submittable.
 const cidrValidationStub: CidrValidationService = { isValid: () => true };
 
-// Only the delete flow opens a dialog; specs that exercise it provide their own answer.
 const declinedDialogStub = { openSimpleDialog: () => Promise.resolve(false) };
 
 const organizationServiceStub = (canAccessEventLogs = true) => ({
@@ -655,6 +654,17 @@ describe("AccessRuleEditComponent — form states", () => {
       expect(navigate).not.toHaveBeenCalled();
     });
 
+    it("moves focus to the callout, which renders far above the Save button", async () => {
+      await render();
+      fillRequiredFields();
+      pamApi.createAccessRule.mockRejectedValue(new Error("boom"));
+
+      await submitAndRender();
+      await fixture.whenStable();
+
+      expect(document.activeElement).toBe(callout());
+    });
+
     it("keeps everything the user entered when the save fails", async () => {
       await render();
       fillRequiredFields();
@@ -734,10 +744,10 @@ describe("AccessRuleEditComponent — form states", () => {
 
       expect(dialog.openSimpleDialog).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: { key: "pamAccessRuleDiscardConfirmTitle" },
-          content: { key: "pamAccessRuleDiscardConfirmContent" },
-          acceptButtonText: { key: "pamAccessRuleDiscard" },
-          cancelButtonText: { key: "cancel" },
+          title: { key: "discardEditsTitle" },
+          content: { key: "discardEditsConfirmation" },
+          acceptButtonText: { key: "discardEdits" },
+          cancelButtonText: { key: "keepEditing" },
           type: "warning",
         }),
       );
@@ -754,6 +764,30 @@ describe("AccessRuleEditComponent — form states", () => {
 
       expect(navigate).not.toHaveBeenCalled();
       expect(controls().name.value).toBe("Half-finished rule");
+    });
+
+    it("asks again when the route is left by any other means", async () => {
+      await render();
+      controls().name.setValue("Half-finished rule");
+      controls().name.markAsDirty();
+      dialog.openSimpleDialog.mockResolvedValue(false);
+
+      await expect(component.confirmDiscard()).resolves.toBe(false);
+      expect(dialog.openSimpleDialog).toHaveBeenCalled();
+    });
+
+    it("does not ask a second time for the navigation Cancel already confirmed", async () => {
+      await render();
+      controls().name.setValue("Half-finished rule");
+      controls().name.markAsDirty();
+      navigate.mockImplementation(async () => {
+        expect(await component.confirmDiscard()).toBe(true);
+        return true;
+      });
+
+      await component["cancel"]();
+
+      expect(dialog.openSimpleDialog).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -425,9 +425,8 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     ] satisfies SelectItemView[]);
     await component["submit"]();
 
-    expect(TestBed.inject(ToastService).showToast).toHaveBeenCalledWith(
-      expect.objectContaining({ variant: "error", message: "pamAccessRuleCollectionConflict" }),
-    );
+    expect(component["saveError"]()).toBe("pamAccessRuleCollectionConflict");
+    expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
     expect(navigate).not.toHaveBeenCalled();
   });
 
@@ -670,6 +669,25 @@ describe("AccessRuleEditComponent — form states", () => {
       expect(document.activeElement).toBe(callout());
     });
 
+    it("moves focus back to the callout when a second save fails in a row", async () => {
+      await render();
+      fillRequiredFields();
+      pamApi.createAccessRule.mockRejectedValue(new Error("boom"));
+      await submitAndRender();
+      await fixture.whenStable();
+
+      const nameInput = fixture.nativeElement.querySelector(
+        "#access-rule-edit_input_name",
+      ) as HTMLInputElement;
+      nameInput.focus();
+      expect(document.activeElement).toBe(nameInput);
+
+      await submitAndRender();
+      await fixture.whenStable();
+
+      expect(document.activeElement).toBe(callout());
+    });
+
     it("keeps everything the user entered when the save fails", async () => {
       await render();
       fillRequiredFields();
@@ -795,6 +813,31 @@ describe("AccessRuleEditComponent — form states", () => {
 
       await expect(component.confirmDiscard()).resolves.toBe(false);
       expect(dialog.openSimpleDialog).toHaveBeenCalled();
+    });
+
+    it("does not ask once a successful save has left the page", async () => {
+      await render();
+      fillRequiredFields();
+      controls().name.markAsDirty();
+
+      await component["submit"]();
+
+      expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
+      await expect(component.confirmDiscard()).resolves.toBe(true);
+      expect(dialog.openSimpleDialog).not.toHaveBeenCalled();
+    });
+
+    it("does not ask once the rule has been deleted", async () => {
+      await render({ params: { accessRuleId: "rule-1" } });
+      controls().name.setValue("Renamed rule");
+      controls().name.markAsDirty();
+
+      await component["remove"]();
+
+      expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
+      await expect(component.confirmDiscard()).resolves.toBe(true);
+      // Only the delete confirmation itself; no discard prompt on the way out.
+      expect(dialog.openSimpleDialog).toHaveBeenCalledTimes(1);
     });
 
     it("does not ask a second time for the navigation Cancel already confirmed", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -567,3 +567,193 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
   });
 });
+
+describe("AccessRuleEditComponent — form states", () => {
+  let fixture: ComponentFixture<AccessRuleEditComponent>;
+  let component: AccessRuleEditComponent;
+  let navigate: jest.SpyInstance;
+  let showToast: jest.Mock;
+  let dialog: { openSimpleDialog: jest.Mock };
+  let pamApi: {
+    getAccessRule: jest.Mock;
+    createAccessRule: jest.Mock;
+    updateAccessRule: jest.Mock;
+    deleteAccessRule: jest.Mock;
+  };
+
+  const ORG_COLLECTIONS = [{ id: "col-1", name: "Engineering" }];
+
+  const render = async () => {
+    pamApi = {
+      getAccessRule: jest.fn(),
+      createAccessRule: jest.fn().mockResolvedValue(undefined),
+      updateAccessRule: jest.fn().mockResolvedValue(undefined),
+      deleteAccessRule: jest.fn().mockResolvedValue(undefined),
+    };
+    showToast = jest.fn();
+    dialog = { openSimpleDialog: jest.fn().mockResolvedValue(true) };
+
+    TestBed.configureTestingModule({
+      imports: [AccessRuleEditComponent, ReactiveFormsModule],
+      providers: [
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: routeStub({}) },
+        { provide: AccessRuleSdkService, useValue: pamApi },
+        { provide: ToastService, useValue: { showToast } },
+        { provide: I18nService, useValue: i18nFake },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+        {
+          provide: CollectionAdminService,
+          useValue: { collectionAdminViews$: () => of(ORG_COLLECTIONS) },
+        },
+        { provide: CidrValidationService, useValue: cidrValidationStub },
+        { provide: OrganizationService, useValue: organizationServiceStub() },
+        { provide: DialogService, useValue: dialog },
+      ],
+    });
+
+    navigate = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
+    fixture = TestBed.createComponent(AccessRuleEditComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+    fixture.detectChanges();
+  };
+
+  const controls = () => component["formGroup"].controls;
+
+  const fillRequiredFields = () => {
+    controls().name.setValue("Production access");
+    controls().collections.setValue([
+      {
+        id: "col-1",
+        listName: "Engineering",
+        labelName: "Engineering",
+        icon: "bwi-collection-shared",
+      },
+    ] satisfies SelectItemView[]);
+  };
+
+  const submitAndRender = async () => {
+    await component["submit"]();
+    fixture.detectChanges();
+  };
+
+  const callout = () => fixture.nativeElement.querySelector("bit-callout") as HTMLElement | null;
+
+  describe("save error", () => {
+    it("renders an inline callout instead of a toast when the save fails", async () => {
+      await render();
+      fillRequiredFields();
+      pamApi.createAccessRule.mockRejectedValue(new Error("boom"));
+
+      await submitAndRender();
+
+      expect(callout()).not.toBeNull();
+      expect(callout()!.textContent).toContain("pamAccessRuleSaveErrorTitle");
+      expect(callout()!.textContent).toContain("pamAccessRuleSaveErrorBody");
+      expect(showToast).not.toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("keeps everything the user entered when the save fails", async () => {
+      await render();
+      fillRequiredFields();
+      pamApi.createAccessRule.mockRejectedValue(new Error("boom"));
+
+      await submitAndRender();
+
+      expect(controls().name.value).toBe("Production access");
+      expect(controls().collections.value.map((c) => c.id)).toEqual(["col-1"]);
+    });
+
+    it("prefers the server's own message over the generic sentence", async () => {
+      await render();
+      fillRequiredFields();
+      const serverError = Object.assign(new Error("Rule name already in use."), {
+        name: "AccessRuleError",
+        variant: "Conflict",
+      });
+      pamApi.createAccessRule.mockRejectedValue(serverError);
+
+      await submitAndRender();
+
+      expect(callout()!.textContent).toContain("Rule name already in use.");
+      expect(callout()!.textContent).not.toContain("pamAccessRuleSaveErrorBody");
+    });
+
+    it("clears the callout when the user resubmits", async () => {
+      await render();
+      fillRequiredFields();
+      pamApi.createAccessRule.mockRejectedValue(new Error("boom"));
+      await submitAndRender();
+      expect(callout()).not.toBeNull();
+
+      pamApi.createAccessRule.mockResolvedValue(undefined);
+      await submitAndRender();
+
+      expect(callout()).toBeNull();
+      expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
+    });
+  });
+
+  describe("validation summary", () => {
+    it("summarises the invalid fields when an incomplete form is submitted", async () => {
+      await render();
+
+      await submitAndRender();
+
+      const summary = fixture.nativeElement.querySelector("bit-error-summary") as HTMLElement;
+      expect(summary.textContent).toContain("fieldsNeedAttention");
+      expect(pamApi.createAccessRule).not.toHaveBeenCalled();
+    });
+
+    it("shows no summary before the form has been submitted", async () => {
+      await render();
+
+      const summary = fixture.nativeElement.querySelector("bit-error-summary") as HTMLElement;
+      expect(summary.textContent!.trim()).toBe("");
+    });
+  });
+
+  describe("discard confirmation", () => {
+    it("leaves a pristine form without asking", async () => {
+      await render();
+
+      await component["cancel"]();
+
+      expect(dialog.openSimpleDialog).not.toHaveBeenCalled();
+      expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
+    });
+
+    it("confirms before discarding a form the user has typed into", async () => {
+      await render();
+      controls().name.setValue("Half-finished rule");
+      controls().name.markAsDirty();
+
+      await component["cancel"]();
+
+      expect(dialog.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: { key: "pamAccessRuleDiscardConfirmTitle" },
+          content: { key: "pamAccessRuleDiscardConfirmContent" },
+          acceptButtonText: { key: "pamAccessRuleDiscard" },
+          cancelButtonText: { key: "cancel" },
+          type: "warning",
+        }),
+      );
+      expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
+    });
+
+    it("stays on the form with its values intact when the dialog is dismissed", async () => {
+      await render();
+      controls().name.setValue("Half-finished rule");
+      controls().name.markAsDirty();
+      dialog.openSimpleDialog.mockResolvedValue(false);
+
+      await component["cancel"]();
+
+      expect(navigate).not.toHaveBeenCalled();
+      expect(controls().name.value).toBe("Half-finished rule");
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -582,9 +582,14 @@ describe("AccessRuleEditComponent — form states", () => {
 
   const ORG_COLLECTIONS = [{ id: "col-1", name: "Engineering" }];
 
-  const render = async () => {
+  const render = async (state: RouteState = {}) => {
     pamApi = {
-      getAccessRule: jest.fn(),
+      getAccessRule: jest.fn().mockResolvedValue({
+        id: "rule-1",
+        name: "Existing rule",
+        collections: [],
+        conditions: [],
+      } as unknown as AccessRuleView),
       createAccessRule: jest.fn().mockResolvedValue(undefined),
       updateAccessRule: jest.fn().mockResolvedValue(undefined),
       deleteAccessRule: jest.fn().mockResolvedValue(undefined),
@@ -596,7 +601,7 @@ describe("AccessRuleEditComponent — form states", () => {
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
       providers: [
         provideRouter([]),
-        { provide: ActivatedRoute, useValue: routeStub({}) },
+        { provide: ActivatedRoute, useValue: routeStub(state) },
         { provide: AccessRuleSdkService, useValue: pamApi },
         { provide: ToastService, useValue: { showToast } },
         { provide: I18nService, useValue: i18nFake },
@@ -744,14 +749,30 @@ describe("AccessRuleEditComponent — form states", () => {
 
       expect(dialog.openSimpleDialog).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: { key: "discardEditsTitle" },
-          content: { key: "discardEditsConfirmation" },
-          acceptButtonText: { key: "discardEdits" },
-          cancelButtonText: { key: "keepEditing" },
+          title: { key: "pamAccessRuleDiscardTitle" },
+          content: { key: "pamAccessRuleDiscardContent" },
+          acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
+          cancelButtonText: { key: "cancel" },
           type: "warning",
         }),
       );
       expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
+    });
+
+    it("names the edits, not the rule, when an existing rule is being edited", async () => {
+      await render({ params: { accessRuleId: "rule-1" } });
+      controls().name.setValue("Renamed rule");
+      controls().name.markAsDirty();
+
+      await component["cancel"]();
+
+      expect(dialog.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: { key: "discardEditsTitle" },
+          acceptButtonText: { key: "discardEdits" },
+          cancelButtonText: { key: "keepEditing" },
+        }),
+      );
     });
 
     it("stays on the form with its values intact when the dialog is dismissed", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
@@ -8,6 +8,7 @@ import {
   StoryObj,
 } from "@storybook/angular";
 import { of } from "rxjs";
+import { getByText, userEvent } from "storybook/test";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -116,4 +117,53 @@ export const Edit: Story = {
       providers: [{ provide: ActivatedRoute, useValue: routeStub({ accessRuleId: "rule-1" }) }],
     }),
   ],
+};
+
+/**
+ * The save-failure callout. Edit mode, with the update rejected: the form arrives valid and
+ * populated, so pressing Save goes straight to the failure rather than to validation.
+ */
+export const SaveError: Story = {
+  decorators: [
+    moduleMetadata({
+      providers: [
+        { provide: ActivatedRoute, useValue: routeStub({ accessRuleId: "rule-1" }) },
+        {
+          provide: AccessRuleSdkService,
+          useValue: {
+            ...pamApi,
+            updateAccessRule: () =>
+              Promise.reject(new Error("The access rule service is unavailable.")),
+          } satisfies Partial<AccessRuleSdkService>,
+        },
+      ],
+    }),
+  ],
+  play: async (context) => {
+    await userEvent.click(getByText(context.canvasElement, "Save"));
+  },
+};
+
+/**
+ * The validation summary above the action row: submitting the empty create form, where
+ * name and collections are both required.
+ */
+export const ValidationSummary: Story = {
+  play: async (context) => {
+    await userEvent.click(getByText(context.canvasElement, "Save"));
+  },
+};
+
+/**
+ * The discard confirmation. Typing into the name dirties the form, so Cancel asks before
+ * leaving; the dialog stub declines, which is the "stay on the form" branch.
+ */
+export const DiscardConfirmation: Story = {
+  play: async (context) => {
+    const canvas = context.canvasElement;
+    const name = canvas.querySelector("#access-rule-edit_input_name") as HTMLInputElement;
+
+    await userEvent.type(name, "Half-finished rule");
+    await userEvent.click(getByText(canvas, "Cancel"));
+  },
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
@@ -1,4 +1,5 @@
 import { importProvidersFrom } from "@angular/core";
+import { provideAnimations } from "@angular/platform-browser/animations";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import {
   applicationConfig,
@@ -13,7 +14,7 @@ import { getByText, userEvent } from "storybook/test";
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { DialogModule, DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AccessRuleSdkService, AccessRuleView } from "../..";
@@ -156,9 +157,14 @@ export const ValidationSummary: Story = {
 
 /**
  * The discard confirmation. Typing into the name dirties the form, so Cancel asks before
- * leaving; the dialog stub declines, which is the "stay on the form" branch.
+ * leaving. `DialogModule` supplies the real {@link DialogService} in place of the default
+ * stub, so the dialog itself renders — it is what this story is for.
  */
 export const DiscardConfirmation: Story = {
+  decorators: [
+    applicationConfig({ providers: [provideAnimations()] }),
+    moduleMetadata({ imports: [DialogModule] }),
+  ],
   play: async (context) => {
     const canvas = context.canvasElement;
     const name = canvas.querySelector("#access-rule-edit_input_name") as HTMLInputElement;

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -478,13 +478,23 @@ export class AccessRuleEditComponent {
       return true;
     }
 
-    return await this.dialogService.openSimpleDialog({
-      title: { key: "discardEditsTitle" },
-      content: { key: "discardEditsConfirmation" },
-      acceptButtonText: { key: "discardEdits" },
-      cancelButtonText: { key: "keepEditing" },
-      type: "warning",
-    });
+    // Creating: the design names the thing being abandoned, the rule itself. Editing: the rule
+    // already exists and only the edits are lost, so the repo's shared wording is the true one.
+    return this.editing
+      ? await this.dialogService.openSimpleDialog({
+          title: { key: "discardEditsTitle" },
+          content: { key: "discardEditsConfirmation" },
+          acceptButtonText: { key: "discardEdits" },
+          cancelButtonText: { key: "keepEditing" },
+          type: "warning",
+        })
+      : await this.dialogService.openSimpleDialog({
+          title: { key: "pamAccessRuleDiscardTitle" },
+          content: { key: "pamAccessRuleDiscardContent" },
+          acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
+          cancelButtonText: { key: "cancel" },
+          type: "warning",
+        });
   }
 
   protected readonly cancel = async (): Promise<void> => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -1,8 +1,17 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  effect,
+  inject,
+  signal,
+  viewChild,
+} from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
-import { ActivatedRoute, Router, RouterLink } from "@angular/router";
+import { ActivatedRoute, CanDeactivateFn, Router, RouterLink } from "@angular/router";
 import { firstValueFrom, map, switchMap } from "rxjs";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
@@ -142,6 +151,16 @@ export class AccessRuleEditComponent {
    */
   protected readonly saveError = signal<string | null>(null);
 
+  private readonly saveErrorCallout = viewChild("saveErrorCallout", {
+    read: ElementRef<HTMLElement>,
+  });
+
+  /**
+   * True while a deliberate exit is under way (saved, deleted, or a confirmed discard), so
+   * {@link confirmDiscard} doesn't ask a second time for a navigation the admin already agreed to.
+   */
+  private readonly leaving = signal(false);
+
   protected readonly pageTypeKey = this.editing
     ? "pamAccessRuleEditTitle"
     : "pamAccessRuleCreateTitle";
@@ -223,6 +242,12 @@ export class AccessRuleEditComponent {
   );
 
   constructor() {
+    // `bit-callout` is not a live region and the callout renders above three sections of form
+    // while Save sits below them, so without moving focus a failed save is silent for a screen
+    // reader and off-screen for everyone else.
+    effect(() => {
+      this.saveErrorCallout()?.nativeElement.focus();
+    });
     this.coupleDurationBounds();
     this.coupleIpAllowlistEnabled();
     void this.initialize();
@@ -444,21 +469,27 @@ export class AccessRuleEditComponent {
   };
 
   /**
-   * Leave the form, confirming first if anything has been entered. A pristine form has
-   * nothing to lose, so it skips the dialog rather than asking about an empty page.
+   * Confirm before unsaved edits are thrown away. Called both by Cancel and by the route's
+   * CanDeactivate guard, which covers the breadcrumb and browser back/forward. A pristine form
+   * has nothing to lose, so it skips the dialog rather than asking about an empty page.
    */
+  async confirmDiscard(): Promise<boolean> {
+    if (this.leaving() || !this.formGroup.dirty) {
+      return true;
+    }
+
+    return await this.dialogService.openSimpleDialog({
+      title: { key: "discardEditsTitle" },
+      content: { key: "discardEditsConfirmation" },
+      acceptButtonText: { key: "discardEdits" },
+      cancelButtonText: { key: "keepEditing" },
+      type: "warning",
+    });
+  }
+
   protected readonly cancel = async (): Promise<void> => {
-    if (this.formGroup.dirty) {
-      const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "pamAccessRuleDiscardConfirmTitle" },
-        content: { key: "pamAccessRuleDiscardConfirmContent" },
-        acceptButtonText: { key: "pamAccessRuleDiscard" },
-        cancelButtonText: { key: "cancel" },
-        type: "warning",
-      });
-      if (!confirmed) {
-        return;
-      }
+    if (!(await this.confirmDiscard())) {
+      return;
     }
 
     await this.navigateToList();
@@ -495,7 +526,15 @@ export class AccessRuleEditComponent {
   };
 
   /** Return to the access-rules list (the parent of both the `new` and `:id` routes). */
-  private navigateToList(): Promise<boolean> {
-    return this.router.navigate([".."], { relativeTo: this.route });
+  private async navigateToList(): Promise<boolean> {
+    this.leaving.set(true);
+    try {
+      return await this.router.navigate([".."], { relativeTo: this.route });
+    } finally {
+      this.leaving.set(false);
+    }
   }
 }
+
+export const accessRuleEditDiscardGuard: CanDeactivateFn<AccessRuleEditComponent> = (component) =>
+  component.confirmDiscard();

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -155,12 +155,6 @@ export class AccessRuleEditComponent {
     read: ElementRef<HTMLElement>,
   });
 
-  /**
-   * True while a deliberate exit is under way (saved, deleted, or a confirmed discard), so
-   * {@link confirmDiscard} doesn't ask a second time for a navigation the admin already agreed to.
-   */
-  private readonly leaving = signal(false);
-
   protected readonly pageTypeKey = this.editing
     ? "pamAccessRuleEditTitle"
     : "pamAccessRuleCreateTitle";
@@ -246,6 +240,9 @@ export class AccessRuleEditComponent {
     // while Save sits below them, so without moving focus a failed save is silent for a screen
     // reader and off-screen for everyone else.
     effect(() => {
+      if (this.saveError() == null) {
+        return;
+      }
       this.saveErrorCallout()?.nativeElement.focus();
     });
     this.coupleDurationBounds();
@@ -474,27 +471,27 @@ export class AccessRuleEditComponent {
    * has nothing to lose, so it skips the dialog rather than asking about an empty page.
    */
   async confirmDiscard(): Promise<boolean> {
-    if (this.leaving() || !this.formGroup.dirty) {
+    if (!this.formGroup.dirty) {
       return true;
     }
 
     // Creating: the design names the thing being abandoned, the rule itself. Editing: the rule
     // already exists and only the edits are lost, so the repo's shared wording is the true one.
-    return this.editing
-      ? await this.dialogService.openSimpleDialog({
+    const copy = this.editing
+      ? {
           title: { key: "discardEditsTitle" },
           content: { key: "discardEditsConfirmation" },
           acceptButtonText: { key: "discardEdits" },
           cancelButtonText: { key: "keepEditing" },
-          type: "warning",
-        })
-      : await this.dialogService.openSimpleDialog({
+        }
+      : {
           title: { key: "pamAccessRuleDiscardTitle" },
           content: { key: "pamAccessRuleDiscardContent" },
           acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
           cancelButtonText: { key: "cancel" },
-          type: "warning",
-        });
+        };
+
+    return await this.dialogService.openSimpleDialog({ ...copy, type: "warning" });
   }
 
   protected readonly cancel = async (): Promise<void> => {
@@ -536,13 +533,11 @@ export class AccessRuleEditComponent {
   };
 
   /** Return to the access-rules list (the parent of both the `new` and `:id` routes). */
-  private async navigateToList(): Promise<boolean> {
-    this.leaving.set(true);
-    try {
-      return await this.router.navigate([".."], { relativeTo: this.route });
-    } finally {
-      this.leaving.set(false);
-    }
+  private navigateToList(): Promise<boolean> {
+    // A save, delete, or confirmed discard is an exit the admin has already agreed to, so the
+    // form has nothing left to lose and the CanDeactivate guard must not ask a second time.
+    this.formGroup.markAsPristine();
+    return this.router.navigate([".."], { relativeTo: this.route });
   }
 }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -17,6 +17,7 @@ import {
   AsyncActionsModule,
   BreadcrumbsModule,
   ButtonModule,
+  CalloutModule,
   CardComponent,
   CheckboxModule,
   DialogService,
@@ -85,6 +86,7 @@ const NAME_MAX_LENGTH = 256;
     AsyncActionsModule,
     BreadcrumbsModule,
     ButtonModule,
+    CalloutModule,
     CardComponent,
     CheckboxModule,
     FormFieldModule,
@@ -132,6 +134,13 @@ export class AccessRuleEditComponent {
   /** The rule being edited, loaded in edit mode; null while loading or in create mode. */
   protected readonly existing = signal<AccessRuleView | null>(null);
   protected readonly loading = signal(true);
+
+  /**
+   * Message for the inline save-failure callout; null while there is nothing to report.
+   * A failed save must not toast — the notice has to persist alongside the entered values
+   * so the admin can retry without re-keying the form.
+   */
+  protected readonly saveError = signal<string | null>(null);
 
   protected readonly pageTypeKey = this.editing
     ? "pamAccessRuleEditTitle"
@@ -399,6 +408,7 @@ export class AccessRuleEditComponent {
   }
 
   protected readonly submit = async (): Promise<void> => {
+    this.saveError.set(null);
     this.formGroup.markAllAsTouched();
     if (this.formGroup.invalid) {
       return;
@@ -425,14 +435,34 @@ export class AccessRuleEditComponent {
     } catch (e) {
       // The collection-conflict rejection gets friendlier copy than the server's line
       // ("One or more collections are already governed by…"), which UAT found hard to parse.
-      const message = isAccessRuleCollectionConflict(e)
-        ? this.i18nService.t("pamAccessRuleCollectionConflict")
-        : (accessRuleErrorMessage(e) ?? this.i18nService.t("unexpectedError"));
-      this.toastService.showToast({ variant: "error", message });
+      this.saveError.set(
+        isAccessRuleCollectionConflict(e)
+          ? this.i18nService.t("pamAccessRuleCollectionConflict")
+          : (accessRuleErrorMessage(e) ?? this.i18nService.t("pamAccessRuleSaveErrorBody")),
+      );
     }
   };
 
-  protected readonly cancel = (): Promise<boolean> => this.navigateToList();
+  /**
+   * Leave the form, confirming first if anything has been entered. A pristine form has
+   * nothing to lose, so it skips the dialog rather than asking about an empty page.
+   */
+  protected readonly cancel = async (): Promise<void> => {
+    if (this.formGroup.dirty) {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamAccessRuleDiscardConfirmTitle" },
+        content: { key: "pamAccessRuleDiscardConfirmContent" },
+        acceptButtonText: { key: "pamAccessRuleDiscard" },
+        cancelButtonText: { key: "cancel" },
+        type: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    await this.navigateToList();
+  };
 
   /**
    * Delete the rule under edit, after confirmation. Edit mode only — there is nothing

--- a/bitwarden_license/bit-web/src/app/pam/pam-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/pam/pam-routing.module.ts
@@ -7,7 +7,10 @@ import { organizationPermissionsGuard } from "@bitwarden/web-vault/app/admin-con
 
 import { AccessAuditComponent } from "./access-audit/access-audit.component";
 import { AccessNameResolverService } from "./access-requests/access-name-resolver.service";
-import { AccessRuleEditComponent } from "./access-rules/access-rule-edit/access-rule-edit.component";
+import {
+  AccessRuleEditComponent,
+  accessRuleEditDiscardGuard,
+} from "./access-rules/access-rule-edit/access-rule-edit.component";
 import { AccessRulesComponent } from "./access-rules/access-rules.component";
 
 const routes: Routes = [
@@ -42,11 +45,13 @@ const routes: Routes = [
           {
             path: "new",
             component: AccessRuleEditComponent,
+            canDeactivate: [accessRuleEditDiscardGuard],
             data: { titleId: "pamAccessRuleCreateTitle" },
           },
           {
             path: ":accessRuleId",
             component: AccessRuleEditComponent,
+            canDeactivate: [accessRuleEditDiscardGuard],
             data: { titleId: "pamAccessRuleEditTitle" },
           },
         ],


### PR DESCRIPTION
Adds three states the form lacked. 

**Save error.** A failed save showed a toast that vanished on its own. It now shows a persistent inline callout above the form, and the entered values are left intact. PM-40037 rules out a toast explicitly.

**Validation summary.** Submitting an incomplete form relied on field-level errors alone. A summary above the buttons now reports how many fields need attention.

**Discard confirmation.** Cancel navigated away and lost typed input silently. It now confirms, but only when the form is dirty.

<img width="2880" height="1814" alt="22508-after-save-error" src="https://github.com/user-attachments/assets/ee4adf8b-c513-4dc2-ba43-334b50049856" />
<img width="2850" height="2974" alt="22508-after-validation-summary" src="https://github.com/user-attachments/assets/651f7fbd-ad23-4fd0-b3f7-7aa0fe5d6ca4" />

<img width="2850" height="2974" alt="callout-validation-summary-in-page" src="https://github.com/user-attachments/assets/538e62a0-3a71-4f5e-831d-edb27292cafd" />
<img width="2880" height="1814" alt="callout-discard-dialog-in-page" src="https://github.com/user-attachments/assets/f00e7437-4d48-461d-934c-2eef7ccb81f3" />
