### PR TITLE
[PM-42166] Update member access report terminology

### DIFF
--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/view/member-access-export.view.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/view/member-access-export.view.ts
@@ -15,7 +15,7 @@ export const userReportItemHeaders: { [key in keyof MemberAccessExportItem]: str
   twoStepLogin: "Two-Step Login",
   accountRecovery: "Account Recovery",
   group: "Group",
-  collection: "Collection",
-  collectionPermission: "Collection Permission",
+  collection: "Shared Folder",
+  collectionPermission: "Shared Folder Permission",
   totalItems: "Total Items",
 };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42166

## 📔 Objective

Updates Member Access Report terminology to Shared Folder which was missed by Design's pass initially.

## 📸 Screenshots

<img width="1298" height="592" alt="image" src="https://github.com/user-attachments/assets/e5487e64-bd06-44b3-91bd-e441a6dfcd3a" />

