### PR TITLE
[PM-42185] Reset Login URI host caches when URI changes

### DIFF
--- a/libs/common/src/vault/models/view/login-uri-view.spec.ts
+++ b/libs/common/src/vault/models/view/login-uri-view.spec.ts
@@ -101,6 +101,21 @@ const idnTestDomains = [
 ];
 
 describe("LoginUriView", () => {
+  it("invalidates cached URI components when the URI changes", () => {
+    const uri = new LoginUriView();
+    uri.uri = "https://old.example.com:8443/login";
+
+    expect(uri.domain).toBe("example.com");
+    expect(uri.hostname).toBe("old.example.com");
+    expect(uri.host).toBe("old.example.com:8443");
+
+    uri.uri = "https://new.example.net:9443/login";
+
+    expect(uri.domain).toBe("example.net");
+    expect(uri.hostname).toBe("new.example.net");
+    expect(uri.host).toBe("new.example.net:9443");
+  });
+
   it("isWebsite() given an invalid domain should return false", async () => {
     const uri = new LoginUriView();
     Object.assign(uri, { match: UriMatchStrategy.Host, uri: "bit!:_&ward.com" });

--- a/libs/common/src/vault/models/view/login-uri.view.ts
+++ b/libs/common/src/vault/models/view/login-uri.view.ts
@@ -32,6 +32,8 @@ export class LoginUriView implements View {
   set uri(value: string | undefined) {
     this._uri = value;
     this._domain = undefined;
+    this._hostname = undefined;
+    this._host = undefined;
     this._canLaunch = undefined;
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #22524

## 📔 Objective

`LoginUriView` caches its domain, hostname, host, and launch result. When the URI changes, the hostname and host caches are not cleared, so they can continue returning values from the previous URI.

This change clears both caches in the URI setter and adds a regression test covering updates to the domain, hostname, and host.

Verification performed:

- `npx jest src/vault/models/view/login-uri-view.spec.ts --runInBand`
- `npx nx run @bitwarden/common:build`
- `npx nx run @bitwarden/common:lint`
- `npm run lint`
