### PR TITLE
[PM-42196] Update Native Passkey Ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -184,22 +184,22 @@ apps/desktop/src/autofill/models/ssh-agent-setting.ts          @bitwarden/team-d
 apps/desktop/src/autofill/components/approve-ssh-request.html  @bitwarden/team-desktop-native-dev  @bitwarden/wg-ssh-keys
 apps/desktop/src/autofill/components/approve-ssh-request.ts    @bitwarden/team-desktop-native-dev  @bitwarden/wg-ssh-keys
 
-## Desktop Native + Skunkworks co-owned files
-apps/desktop/desktop_native/autofill_provider                   @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/desktop_native/core/src/autofill                   @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/desktop_native/napi/src/autofill.rs                @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/desktop_native/objc/src/native/autofill            @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/desktop_native/win_webauthn                        @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/desktop_native/windows_plugin_authenticator        @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/macos                                              @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/desktop-autofill.preload.ts           @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/main/main-desktop-autofill*           @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/modal/credentials                     @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/models/autofill-*                     @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/models/ipc-handler.type.ts            @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/services/desktop-autofill.service.ts  @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/services/desktop-autofill.service.spec.ts  @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
-apps/desktop/src/autofill/services/desktop-fido2*               @bitwarden/team-desktop-native-dev  @bitwarden/team-skunkworks
+## Desktop Native Passkey files
+apps/desktop/desktop_native/autofill_provider                   @bitwarden/team-skunkworks
+apps/desktop/desktop_native/core/src/autofill                   @bitwarden/team-skunkworks
+apps/desktop/desktop_native/napi/src/autofill.rs                @bitwarden/team-skunkworks
+apps/desktop/desktop_native/objc/src/native/autofill            @bitwarden/team-skunkworks
+apps/desktop/desktop_native/win_webauthn                        @bitwarden/team-skunkworks
+apps/desktop/desktop_native/windows_plugin_authenticator        @bitwarden/team-skunkworks
+apps/desktop/macos                                              @bitwarden/team-skunkworks
+apps/desktop/src/autofill/desktop-autofill.preload.ts           @bitwarden/team-skunkworks
+apps/desktop/src/autofill/main/main-desktop-autofill*           @bitwarden/team-skunkworks
+apps/desktop/src/autofill/modal/credentials                     @bitwarden/team-skunkworks
+apps/desktop/src/autofill/models/autofill-*                     @bitwarden/team-skunkworks
+apps/desktop/src/autofill/models/ipc-handler.type.ts            @bitwarden/team-skunkworks
+apps/desktop/src/autofill/services/desktop-autofill.service.ts  @bitwarden/team-skunkworks
+apps/desktop/src/autofill/services/desktop-autofill.service.spec.ts  @bitwarden/team-skunkworks
+apps/desktop/src/autofill/services/desktop-fido2*               @bitwarden/team-skunkworks
 
 # DuckDuckGo integration
 apps/desktop/native-messaging-test-runner                        @bitwarden/team-desktop-native-dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -184,7 +184,7 @@ apps/desktop/src/autofill/models/ssh-agent-setting.ts          @bitwarden/team-d
 apps/desktop/src/autofill/components/approve-ssh-request.html  @bitwarden/team-desktop-native-dev  @bitwarden/wg-ssh-keys
 apps/desktop/src/autofill/components/approve-ssh-request.ts    @bitwarden/team-desktop-native-dev  @bitwarden/wg-ssh-keys
 
-## Desktop Native Passkey files
+## Native Passkey files
 apps/desktop/desktop_native/autofill_provider                   @bitwarden/team-skunkworks
 apps/desktop/desktop_native/core/src/autofill                   @bitwarden/team-skunkworks
 apps/desktop/desktop_native/napi/src/autofill.rs                @bitwarden/team-skunkworks


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42196

## 📔 Objective

Update the native passkey ownership to be fully owned by Skunkworks, as the Desktop Native plan for intaking native passkeys has changed.
