### PR TITLE
[PM-42209] Browser: Persist browser auto fill override state

### DIFF
--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -984,6 +984,35 @@ describe("BrowserApi", () => {
       expect(chrome.privacy.services.passwordSavingEnabled.get).not.toHaveBeenCalled();
     });
 
+    it("uses the privacy API when no persisted state exists", async () => {
+      const privacyGet = jest.fn((_details, callback) =>
+        callback({ value: false, levelOfControl: "controlled_by_this_extension" }),
+      );
+      chrome.privacy.services.autofillAddressEnabled.get = privacyGet;
+      chrome.privacy.services.autofillCreditCardEnabled.get = privacyGet;
+      chrome.privacy.services.passwordSavingEnabled.get = privacyGet;
+
+      await expect(BrowserApi.browserAutofillSettingsOverridden()).resolves.toBe(true);
+      expect(chrome.storage.local.get).toHaveBeenCalledWith(
+        "bitwardenDefaultPasswordManagerEnabled",
+        expect.any(Function),
+      );
+    });
+
+    it("uses the privacy API when the persisted state is null", async () => {
+      chrome.storage.local.get.mockImplementation((_keys, callback) =>
+        callback({ bitwardenDefaultPasswordManagerEnabled: null }),
+      );
+      const privacyGet = jest.fn((_details, callback) =>
+        callback({ value: false, levelOfControl: "controlled_by_this_extension" }),
+      );
+      chrome.privacy.services.autofillAddressEnabled.get = privacyGet;
+      chrome.privacy.services.autofillCreditCardEnabled.get = privacyGet;
+      chrome.privacy.services.passwordSavingEnabled.get = privacyGet;
+
+      await expect(BrowserApi.browserAutofillSettingsOverridden()).resolves.toBe(true);
+    });
+
     it("returns true if the browser autofill settings are overridden", async () => {
       const mockFn = jest.fn<
         void,

--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -956,6 +956,34 @@ describe("BrowserApi", () => {
   });
 
   describe("browserAutofillSettingsOverridden", () => {
+    beforeEach(() => {
+      chrome.storage.local.get.mockImplementation((_keys, callback) => callback({}));
+    });
+
+    it("uses the persisted state when the privacy API reports a different value", async () => {
+      chrome.storage.local.get.mockImplementation((_keys, callback) =>
+        callback({ bitwardenDefaultPasswordManagerEnabled: true }),
+      );
+      const privacyGet = jest.fn((_details, callback) =>
+        callback({ value: true, levelOfControl: "controlled_by_this_extension" }),
+      );
+      chrome.privacy.services.autofillAddressEnabled.get = privacyGet;
+      chrome.privacy.services.autofillCreditCardEnabled.get = privacyGet;
+      chrome.privacy.services.passwordSavingEnabled.get = privacyGet;
+
+      await expect(BrowserApi.browserAutofillSettingsOverridden()).resolves.toBe(true);
+      expect(privacyGet).not.toHaveBeenCalled();
+    });
+
+    it("treats an explicitly persisted false state as authoritative", async () => {
+      chrome.storage.local.get.mockImplementation((_keys, callback) =>
+        callback({ bitwardenDefaultPasswordManagerEnabled: false }),
+      );
+
+      await expect(BrowserApi.browserAutofillSettingsOverridden()).resolves.toBe(false);
+      expect(chrome.privacy.services.passwordSavingEnabled.get).not.toHaveBeenCalled();
+    });
+
     it("returns true if the browser autofill settings are overridden", async () => {
       const mockFn = jest.fn<
         void,
@@ -1062,6 +1090,10 @@ describe("BrowserApi", () => {
   });
 
   describe("updateDefaultBrowserAutofillSettings", () => {
+    beforeEach(() => {
+      chrome.storage.local.set.mockImplementation((_value, callback) => callback());
+    });
+
     it("updates the default browser autofill settings", async () => {
       await BrowserApi.updateDefaultBrowserAutofillSettings(false);
 
@@ -1074,6 +1106,23 @@ describe("BrowserApi", () => {
       expect(chrome.privacy.services.passwordSavingEnabled.set).toHaveBeenCalledWith({
         value: false,
       });
+      expect(chrome.storage.local.set).toHaveBeenCalledWith(
+        { bitwardenDefaultPasswordManagerEnabled: true },
+        expect.any(Function),
+      );
+    });
+
+    it("persists the requested state when a privacy setting cannot be applied", async () => {
+      chrome.privacy.services.autofillAddressEnabled.set.mockRejectedValue(
+        new Error("unsupported by browser"),
+      );
+
+      await expect(BrowserApi.updateDefaultBrowserAutofillSettings(false)).resolves.toBeUndefined();
+
+      expect(chrome.storage.local.set).toHaveBeenCalledWith(
+        { bitwardenDefaultPasswordManagerEnabled: true },
+        expect.any(Function),
+      );
     });
 
     it("only sets passwordSavingEnabled on Firefox", async () => {

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -14,6 +14,8 @@ import { BrowserPlatformUtilsService } from "../services/platform-utils/browser-
 import { registerContentScriptsPolyfill } from "./browser-api.register-content-scripts-polyfill";
 import { ExtensionInstallType } from "./extension-install-type";
 
+const DefaultPasswordManagerStorageKey = "bitwardenDefaultPasswordManagerEnabled";
+
 export class BrowserApi {
   static isWebExtensionsApi: boolean = typeof browser !== "undefined";
   static isSafariApi: boolean = isBrowserSafariApi();
@@ -946,6 +948,12 @@ export class BrowserApi {
    * Identifies if the browser autofill settings are overridden by the extension.
    */
   static async browserAutofillSettingsOverridden(): Promise<boolean> {
+    const localState = await BrowserApi.getDefaultPasswordManagerLocalState();
+
+    if (localState !== null) {
+      return localState;
+    }
+
     if (!(await BrowserApi.permissionsGranted(["privacy"]))) {
       return false;
     }
@@ -984,19 +992,28 @@ export class BrowserApi {
    * @param value - Determines whether to enable or disable the autofill settings.
    */
   static async updateDefaultBrowserAutofillSettings(value: boolean) {
-    if (BrowserApi.isFirefox) {
-      if (BrowserApi.isWebExtensionsApi) {
-        await browser.privacy?.services?.passwordSavingEnabled?.set({ value });
-      } else {
-        await chrome.privacy.services.passwordSavingEnabled.set({ value });
-      }
+    await BrowserApi.setDefaultPasswordManagerLocalState(!value);
 
+    if (BrowserApi.isFirefox) {
+      try {
+        if (BrowserApi.isWebExtensionsApi) {
+          await browser.privacy?.services?.passwordSavingEnabled?.set({ value });
+        } else {
+          await chrome.privacy.services.passwordSavingEnabled.set({ value });
+        }
+      } catch {
+        return;
+      }
       return;
     }
 
-    await chrome.privacy.services.autofillAddressEnabled.set({ value });
-    await chrome.privacy.services.autofillCreditCardEnabled.set({ value });
-    await chrome.privacy.services.passwordSavingEnabled.set({ value });
+    try {
+      await chrome.privacy.services.autofillAddressEnabled.set({ value });
+      await chrome.privacy.services.autofillCreditCardEnabled.set({ value });
+      await chrome.privacy.services.passwordSavingEnabled.set({ value });
+    } catch {
+      return;
+    }
   }
 
   /**
@@ -1034,5 +1051,35 @@ export class BrowserApi {
     filter?: chrome.scripting.ContentScriptFilter,
   ): Promise<void> {
     await chrome.scripting.unregisterContentScripts(filter);
+  }
+
+  private static async getDefaultPasswordManagerLocalState(): Promise<boolean | null> {
+    try {
+      const result = BrowserApi.isWebExtensionsApi
+        ? await browser.storage.local.get({ [DefaultPasswordManagerStorageKey]: null })
+        : await new Promise<Record<string, unknown>>((resolve) =>
+            chrome.storage.local.get({ [DefaultPasswordManagerStorageKey]: null }, resolve),
+          );
+      if (DefaultPasswordManagerStorageKey in result) {
+        return Boolean(result[DefaultPasswordManagerStorageKey]);
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private static async setDefaultPasswordManagerLocalState(value: boolean): Promise<void> {
+    try {
+      if (BrowserApi.isWebExtensionsApi) {
+        await browser.storage.local.set({ [DefaultPasswordManagerStorageKey]: value });
+      } else {
+        await new Promise<void>((resolve) =>
+          chrome.storage.local.set({ [DefaultPasswordManagerStorageKey]: value }, resolve),
+        );
+      }
+    } catch {
+      return;
+    }
   }
 }

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -1056,12 +1056,13 @@ export class BrowserApi {
   private static async getDefaultPasswordManagerLocalState(): Promise<boolean | null> {
     try {
       const result = BrowserApi.isWebExtensionsApi
-        ? await browser.storage.local.get({ [DefaultPasswordManagerStorageKey]: null })
+        ? await browser.storage.local.get(DefaultPasswordManagerStorageKey)
         : await new Promise<Record<string, unknown>>((resolve) =>
-            chrome.storage.local.get({ [DefaultPasswordManagerStorageKey]: null }, resolve),
+            chrome.storage.local.get(DefaultPasswordManagerStorageKey, resolve),
           );
-      if (DefaultPasswordManagerStorageKey in result) {
-        return Boolean(result[DefaultPasswordManagerStorageKey]);
+      const value = result[DefaultPasswordManagerStorageKey];
+      if (typeof value === "boolean") {
+        return value;
       }
       return null;
     } catch {

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -1055,11 +1055,17 @@ export class BrowserApi {
 
   private static async getDefaultPasswordManagerLocalState(): Promise<boolean | null> {
     try {
-      const result = BrowserApi.isWebExtensionsApi
-        ? await browser.storage.local.get(DefaultPasswordManagerStorageKey)
-        : await new Promise<Record<string, unknown>>((resolve) =>
-            chrome.storage.local.get(DefaultPasswordManagerStorageKey, resolve),
-          );
+    const result = BrowserApi.isWebExtensionsApi
+      ? await browser.storage.local.get(DefaultPasswordManagerStorageKey)
+      : await new Promise<Record<string, unknown>>((resolve, reject) => {
+          chrome.storage.local.get(DefaultPasswordManagerStorageKey, (items) => {
+            if (chrome.runtime.lastError) {
+              reject(chrome.runtime.lastError);
+            } else {
+              resolve(items as Record<string, unknown>);
+            }
+          });
+        });
       const value = result[DefaultPasswordManagerStorageKey];
       if (typeof value === "boolean") {
         return value;


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. --> No existing Jira or GitHub issue. This change addresses incorrect browser autofill override state in Chromium-based browser forks.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->Persist the browser autofill override state in extension storage so the Autofill settings checkbox remains correct after navigating away and returning. Missing or `null` storage values continue to fall back to the browser privacy API.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Not applicable. There are no visual UI changes.
