### PR TITLE
chore(lock): Move LockService into libs/unlock and add lock/unlock source tracking

### DIFF
--- a/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
+++ b/apps/browser/src/auth/popup/account-switching/account-switcher.component.ts
@@ -4,7 +4,7 @@ import { Router } from "@angular/router";
 import { Observable, Subject, firstValueFrom, map, of, startWith, switchMap } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
@@ -24,6 +24,7 @@ import {
   SectionHeaderComponent,
   TypographyModule,
 } from "@bitwarden/components";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
@@ -127,13 +128,13 @@ export class AccountSwitcherComponent implements OnInit, OnDestroy {
 
   async lock(userId: string) {
     this.loading = true;
-    await this.lockService.lock(userId as UserId);
+    await this.lockService.lock(userId as UserId, LockSource.Manual);
     await this.router.navigate(["lock"]);
   }
 
   async lockAll() {
     this.loading = true;
-    await this.lockService.lockAll();
+    await this.lockService.lockAll(LockSource.Manual);
     await this.router.navigate(["lock"]);
   }
 

--- a/apps/browser/src/auth/popup/accounts/foreground-lock.service.ts
+++ b/apps/browser/src/auth/popup/accounts/foreground-lock.service.ts
@@ -1,18 +1,22 @@
 import { filter, firstValueFrom } from "rxjs";
 
-import { LockService } from "@bitwarden/auth/common";
 import {
   CommandDefinition,
   MessageListener,
   MessageSender,
 } from "@bitwarden/common/platform/messaging";
 import { newGuid } from "@bitwarden/guid";
+import { LockService, LockSource } from "@bitwarden/unlock";
 import { UserId } from "@bitwarden/user-core";
 
 const LOCK_ALL_FINISHED = new CommandDefinition<{ requestId: string }>("lockAllFinished");
-const LOCK_ALL = new CommandDefinition<{ requestId: string }>("lockAll");
+const LOCK_ALL = new CommandDefinition<{ requestId: string; source: LockSource }>("lockAll");
 const LOCK_USER_FINISHED = new CommandDefinition<{ requestId: string }>("lockUserFinished");
-const LOCK_USER = new CommandDefinition<{ requestId: string; userId: UserId }>("lockUser");
+const LOCK_USER = new CommandDefinition<{
+  requestId: string;
+  userId: UserId;
+  source: LockSource;
+}>("lockUser");
 
 export class ForegroundLockService implements LockService {
   constructor(
@@ -20,7 +24,7 @@ export class ForegroundLockService implements LockService {
     private readonly messageListener: MessageListener,
   ) {}
 
-  async lockAll(): Promise<void> {
+  async lockAll(source: LockSource): Promise<void> {
     const requestId = newGuid();
     const finishMessage = firstValueFrom(
       this.messageListener
@@ -28,12 +32,12 @@ export class ForegroundLockService implements LockService {
         .pipe(filter((m) => m.requestId === requestId)),
     );
 
-    this.messageSender.send(LOCK_ALL, { requestId });
+    this.messageSender.send(LOCK_ALL, { requestId, source });
 
     await finishMessage;
   }
 
-  async lock(userId: UserId): Promise<void> {
+  async lock(userId: UserId, source: LockSource): Promise<void> {
     const requestId = newGuid();
     const finishMessage = firstValueFrom(
       this.messageListener
@@ -41,12 +45,14 @@ export class ForegroundLockService implements LockService {
         .pipe(filter((m) => m.requestId === requestId)),
     );
 
-    this.messageSender.send(LOCK_USER, { requestId, userId });
+    this.messageSender.send(LOCK_USER, { requestId, userId, source });
 
     await finishMessage;
   }
 
-  async runPlatformOnLockActions(userId: UserId): Promise<void> {}
+  async runPlatformOnLockActions(userId: UserId, source: LockSource): Promise<void> {}
 
-  async registerOnLockAction(action: (userId: UserId) => Promise<void>): Promise<void> {}
+  async registerOnLockAction(
+    action: (userId: UserId, source: LockSource) => Promise<void>,
+  ): Promise<void> {}
 }

--- a/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.spec.ts
@@ -7,7 +7,6 @@ import { firstValueFrom, of, BehaviorSubject } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { NudgesService } from "@bitwarden/angular/vault";
-import { LockService } from "@bitwarden/auth/common";
 import { AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -38,6 +37,7 @@ import { BiometricStateService, KeyService } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 // eslint-disable-next-line no-restricted-imports
 import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { LockService } from "@bitwarden/unlock";
 
 import { NativeMessagingPermissionDialogComponent } from "../../../key-management/shared-unlock/popup/native-messaging-permission-dialog.component";
 import { BrowserApi } from "../../../platform/browser/browser-api";

--- a/apps/browser/src/auth/popup/settings/account-security.component.ts
+++ b/apps/browser/src/auth/popup/settings/account-security.component.ts
@@ -20,7 +20,6 @@ import {
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { NudgesService, NudgeType } from "@bitwarden/angular/vault";
 import { FingerprintDialogComponent } from "@bitwarden/auth/angular";
-import { LockService } from "@bitwarden/auth/common";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "@bitwarden/common/admin-console/enums";
 import { getFirstPolicy } from "@bitwarden/common/admin-console/services/policy/default-policy.service";
@@ -60,6 +59,7 @@ import { KeyService, BiometricStateService } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 // eslint-disable-next-line no-restricted-imports
 import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 import {
   NativeMessagingPermissionDialogComponent,
@@ -556,7 +556,7 @@ export class AccountSecurityComponent implements OnInit, OnDestroy {
 
   async lock() {
     const activeUserId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
-    await this.lockService.lock(activeUserId);
+    await this.lockService.lock(activeUserId, LockSource.Manual);
   }
 
   async logOut() {

--- a/apps/browser/src/auth/services/extension-lock.service.ts
+++ b/apps/browser/src/auth/services/extension-lock.service.ts
@@ -1,18 +1,17 @@
-import { DefaultLockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import MainBackground from "@bitwarden/browser/background/main.background";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
-import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/key-management/vault-timeout";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { SystemService } from "@bitwarden/common/platform/abstractions/system.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
-import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { BiometricsService, KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
 import { StateEventRunnerService } from "@bitwarden/state";
+import { DefaultLockService, LockSource } from "@bitwarden/unlock";
 import { UserId } from "@bitwarden/user-core";
 
 export class ExtensionLockService extends DefaultLockService {
@@ -22,9 +21,7 @@ export class ExtensionLockService extends DefaultLockService {
     vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     logoutService: LogoutService,
     messagingService: MessagingService,
-    searchService: SearchService,
     folderService: FolderService,
-    masterPasswordService: InternalMasterPasswordServiceAbstraction,
     stateEventRunnerService: StateEventRunnerService,
     cipherService: CipherService,
     authService: AuthService,
@@ -40,9 +37,7 @@ export class ExtensionLockService extends DefaultLockService {
       vaultTimeoutSettingsService,
       logoutService,
       messagingService,
-      searchService,
       folderService,
-      masterPasswordService,
       stateEventRunnerService,
       cipherService,
       authService,
@@ -53,8 +48,8 @@ export class ExtensionLockService extends DefaultLockService {
     );
   }
 
-  async runPlatformOnLockActions(userId: UserId): Promise<void> {
-    await super.runPlatformOnLockActions(userId);
+  async runPlatformOnLockActions(userId: UserId, source: LockSource): Promise<void> {
+    await super.runPlatformOnLockActions(userId, source);
     await this.main.refreshMenu(true);
   }
 }

--- a/apps/browser/src/background/commands.background.ts
+++ b/apps/browser/src/background/commands.background.ts
@@ -2,13 +2,13 @@
 // @ts-strict-ignore
 import { firstValueFrom, Observable } from "rxjs";
 
-import { LockService } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { ExtensionCommand, ExtensionCommandType } from "@bitwarden/common/autofill/constants";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 // FIXME (PM-22628): Popup imports are forbidden in background
 // eslint-disable-next-line no-restricted-imports
@@ -78,7 +78,7 @@ export default class CommandsBackground {
         break;
       case ExtensionCommand.LockVault: {
         const activeUserId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
-        await this.lockService.lock(activeUserId);
+        await this.lockService.lock(activeUserId, LockSource.Manual);
         break;
       }
       default:

--- a/apps/browser/src/background/idle.background.ts
+++ b/apps/browser/src/background/idle.background.ts
@@ -1,6 +1,6 @@
 import { firstValueFrom } from "rxjs";
 
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import {
   VaultTimeoutAction,
@@ -9,6 +9,7 @@ import {
   VaultTimeoutStringType,
 } from "@bitwarden/common/key-management/vault-timeout";
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
+import { LockService, LockSource } from "@bitwarden/unlock";
 import { UserId } from "@bitwarden/user-core";
 
 const IdleInterval = 60 * 5; // 5 minutes
@@ -74,7 +75,7 @@ export default class IdleBackground {
                 if (action === VaultTimeoutAction.LogOut) {
                   await this.logoutService.logout(userId as UserId, "vaultTimeout");
                 } else {
-                  await this.lockService.lock(userId as UserId);
+                  await this.lockService.lock(userId as UserId, LockSource.VaultTimeout);
                 }
               }
             }

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -36,7 +36,6 @@ import {
   DefaultAuthRequestApiService,
   DefaultLogoutService,
   InternalUserDecryptionOptionsServiceAbstraction,
-  LockService,
   LoginEmailServiceAbstraction,
   DefaultLoginStrategyCacheService,
   DefaultLoginStrategySessionTimeoutService,
@@ -320,7 +319,7 @@ import {
   DefaultStateService,
   InlineDerivedStateProvider,
 } from "@bitwarden/state-internal";
-import { DefaultUnlockService, UnlockService } from "@bitwarden/unlock";
+import { DefaultUnlockService, LockService, UnlockService } from "@bitwarden/unlock";
 import {
   IndividualVaultExportService,
   IndividualVaultExportServiceAbstraction,
@@ -1523,9 +1522,7 @@ export default class MainBackground {
       this.vaultTimeoutSettingsService,
       logoutService,
       this.messagingService,
-      this.searchService,
       this.folderService,
-      this.masterPasswordService,
       this.stateEventRunnerService,
       this.cipherService,
       this.authService,

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -2,7 +2,6 @@
 // @ts-strict-ignore
 import { firstValueFrom, map, mergeMap } from "rxjs";
 
-import { LockService } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AutofillOverlayVisibility, ExtensionCommand } from "@bitwarden/common/autofill/constants";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
@@ -16,6 +15,7 @@ import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { VaultMessages } from "@bitwarden/common/vault/enums/vault-messages.enum";
 import { BiometricsCommands } from "@bitwarden/key-management";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 // FIXME (PM-22628): Popup imports are forbidden in background
 // eslint-disable-next-line no-restricted-imports
@@ -321,17 +321,17 @@ export default class RuntimeBackground {
         this.lockedVaultPendingNotifications = [];
         break;
       case "lockVault":
-        await this.lockService.lock(msg.userId);
+        await this.lockService.lock(msg.userId, LockSource.Manual);
         break;
       case "lockAll":
         {
-          await this.lockService.lockAll();
+          await this.lockService.lockAll(msg.source);
           this.messagingService.send("lockAllFinished", { requestId: msg.requestId });
         }
         break;
       case "lockUser":
         {
-          await this.lockService.lock(msg.userId);
+          await this.lockService.lock(msg.userId, msg.source);
           this.messagingService.send("lockUserFinished", {
             requestId: msg.requestId,
           });

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -39,7 +39,6 @@ import {
   NewDeviceVerificationComponentService,
 } from "@bitwarden/auth/angular";
 import {
-  LockService,
   LoginEmailService,
   SsoUrlService,
   LogoutService,
@@ -184,6 +183,7 @@ import {
 } from "@bitwarden/legacy-crypto";
 import { DerivedStateProvider, GlobalStateProvider, StateProvider } from "@bitwarden/state";
 import { InlineDerivedStateProvider } from "@bitwarden/state-internal";
+import { LockService } from "@bitwarden/unlock";
 import {
   DefaultSshImportPromptService,
   PasswordRepromptService,

--- a/apps/browser/src/popup/services/services.module.ts
+++ b/apps/browser/src/popup/services/services.module.ts
@@ -183,7 +183,7 @@ import {
 } from "@bitwarden/legacy-crypto";
 import { DerivedStateProvider, GlobalStateProvider, StateProvider } from "@bitwarden/state";
 import { InlineDerivedStateProvider } from "@bitwarden/state-internal";
-import { LockService } from "@bitwarden/unlock";
+import { ForegroundLockService, LockService } from "@bitwarden/unlock";
 import {
   DefaultSshImportPromptService,
   PasswordRepromptService,
@@ -191,7 +191,6 @@ import {
 } from "@bitwarden/vault";
 
 import { AccountSwitcherService } from "../../auth/popup/account-switching/services/account-switcher.service";
-import { ForegroundLockService } from "../../auth/popup/accounts/foreground-lock.service";
 import { ExtensionChangePasswordService } from "../../auth/popup/change-password/extension-change-password.service";
 import { ExtensionLoginComponentService } from "../../auth/popup/login/extension-login-component.service";
 import { ExtensionLoginViaWebAuthnComponentService } from "../../auth/popup/login/extension-login-via-webauthn-component.service";

--- a/apps/cli/src/auth/commands/lock.command.ts
+++ b/apps/cli/src/auth/commands/lock.command.ts
@@ -1,8 +1,8 @@
 import { firstValueFrom } from "rxjs";
 
-import { LockService } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 import { Response } from "../../models/response";
 import { MessageResponse } from "../../models/response/message.response";
@@ -15,7 +15,7 @@ export class LockCommand {
 
   async run() {
     const activeUserId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
-    await this.lockService.lock(activeUserId);
+    await this.lockService.lock(activeUserId, LockSource.Manual);
     process.env.BW_SESSION = undefined;
     const res = new MessageResponse("Your vault is locked.", null);
     return Response.success(res);

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -23,9 +23,7 @@ import {
   SsoUrlService,
   AuthRequestApiServiceAbstraction,
   DefaultAuthRequestApiService,
-  DefaultLockService,
   DefaultLogoutService,
-  LockService,
 } from "@bitwarden/auth/common";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
 import { InternalNewPolicyService } from "@bitwarden/common/admin-console/abstractions/policy/new-policy.service";
@@ -229,7 +227,12 @@ import {
   DefaultStateService,
 } from "@bitwarden/state-internal";
 import { SerializedMemoryStorageService } from "@bitwarden/storage-core";
-import { DefaultUnlockService, UnlockService } from "@bitwarden/unlock";
+import {
+  DefaultLockService,
+  LockService,
+  DefaultUnlockService,
+  UnlockService,
+} from "@bitwarden/unlock";
 import {
   IndividualVaultExportService,
   IndividualVaultExportServiceAbstraction,
@@ -995,9 +998,7 @@ export class ServiceContainer {
       this.vaultTimeoutSettingsService,
       logoutService,
       this.messagingService,
-      this.searchService,
       this.folderService,
-      this.masterPasswordService,
       this.stateEventRunnerService,
       this.cipherService,
       this.authService,

--- a/apps/desktop/src/app/app.component.spec.ts
+++ b/apps/desktop/src/app/app.component.spec.ts
@@ -10,7 +10,6 @@ import { DocumentLangSetter } from "@bitwarden/angular/platform/i18n";
 import { ModalService } from "@bitwarden/angular/services/modal.service";
 import {
   AuthRequestServiceAbstraction,
-  LockService,
   UserDecryptionOptionsServiceAbstraction,
 } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -46,6 +45,7 @@ import { DialogService, ToastService } from "@bitwarden/components";
 import { KeyService, BiometricStateService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
+import { LockService } from "@bitwarden/unlock";
 
 import { AppComponent } from "./app.component";
 

--- a/apps/desktop/src/app/app.component.ts
+++ b/apps/desktop/src/app/app.component.ts
@@ -24,7 +24,6 @@ import { FingerprintDialogComponent } from "@bitwarden/auth/angular";
 import {
   AuthRequestServiceAbstraction,
   DESKTOP_SSO_CALLBACK,
-  LockService,
   LogoutReason,
   UserDecryptionOptionsServiceAbstraction,
 } from "@bitwarden/auth/common";
@@ -72,6 +71,7 @@ import { KeyService, BiometricStateService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { LegacyCompatKeyService } from "@bitwarden/legacy-crypto";
 import { TroubleshootingDialogComponent } from "@bitwarden/logging-angular";
+import { LockService, LockSource } from "@bitwarden/unlock";
 import { AddEditFolderDialogComponent, AddEditFolderDialogResult } from "@bitwarden/vault";
 
 import { DeviceManagementDialogComponent } from "../auth/device-management/device-management-dialog.component";
@@ -244,10 +244,10 @@ export class AppComponent implements OnInit, OnDestroy {
             this.loading = false;
             break;
           case "lockVault":
-            await this.lockService.lock(message.userId ?? this.activeUserId);
+            await this.lockService.lock(message.userId ?? this.activeUserId, LockSource.Manual);
             break;
           case "lockAllVaults": {
-            await this.lockService.lockAll();
+            await this.lockService.lockAll(LockSource.Manual);
             break;
           }
           case "locked":
@@ -874,7 +874,7 @@ export class AppComponent implements OnInit, OnDestroy {
       if (options[0] === timeout) {
         options[1] === "logOut"
           ? await this.logOut("vaultTimeout", userId as UserId)
-          : await this.lockService.lock(userId as UserId);
+          : await this.lockService.lock(userId as UserId, LockSource.VaultTimeout);
       }
     }
   }

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -32,7 +32,6 @@ import {
 } from "@bitwarden/auth/angular";
 import {
   InternalUserDecryptionOptionsServiceAbstraction,
-  LockService,
   LoginEmailService,
   SsoUrlService,
 } from "@bitwarden/auth/common";
@@ -142,7 +141,7 @@ import {
   WebCryptoFunctionService,
 } from "@bitwarden/legacy-crypto";
 import { SerializedMemoryStorageService } from "@bitwarden/storage-core";
-import { UnlockService } from "@bitwarden/unlock";
+import { LockService, UnlockService } from "@bitwarden/unlock";
 import {
   CipherFormGenerationService,
   DefaultSshImportPromptService,

--- a/apps/web/src/app/admin-console/organizations/collections/vault-header/vault-header.component.stories.ts
+++ b/apps/web/src/app/admin-console/organizations/collections/vault-header/vault-header.component.stories.ts
@@ -4,7 +4,7 @@ import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/an
 import { of } from "rxjs";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { ProviderService } from "@bitwarden/common/admin-console/abstractions/provider.service";
@@ -23,6 +23,7 @@ import { TreeNode } from "@bitwarden/common/vault/models/domain/tree-node";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { DialogService } from "@bitwarden/components";
 import { enabledFlags } from "@bitwarden/storybook";
+import { LockService } from "@bitwarden/unlock";
 import { RoutedVaultFilterModel } from "@bitwarden/vault";
 
 import { PreloadedEnglishI18nModule } from "../../../../core/tests";

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -7,7 +7,6 @@ import { Subject, filter, firstValueFrom, map, timeout } from "rxjs";
 
 import { DeviceTrustToastService } from "@bitwarden/angular/auth/services/device-trust-toast.service.abstraction";
 import { DocumentLangSetter } from "@bitwarden/angular/platform/i18n";
-import { LockService } from "@bitwarden/auth/common";
 import { InternalOrganizationServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
@@ -26,6 +25,7 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { InternalFolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { DialogService, RouterFocusManagerService, ToastService } from "@bitwarden/components";
 import { KeyService, BiometricStateService } from "@bitwarden/key-management";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 const BroadcasterSubscriptionId = "AppComponent";
 const IdleTimeout = 60000 * 10; // 10 minutes
@@ -115,7 +115,7 @@ export class AppComponent implements OnDestroy, OnInit {
             break;
           case "lockVault": {
             const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-            await this.lockService.lock(userId);
+            await this.lockService.lock(userId, LockSource.Manual);
             break;
           }
           case "locked":

--- a/apps/web/src/app/billing/members/free-bitwarden-families.component.stories.ts
+++ b/apps/web/src/app/billing/members/free-bitwarden-families.component.stories.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, convertToParamMap, Router } from "@angular/router";
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
 import { of } from "rxjs";
 
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
@@ -22,6 +22,7 @@ import { DialogService, ToastService } from "@bitwarden/components";
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { EncryptService } from "@bitwarden/legacy-crypto";
+import { LockService } from "@bitwarden/unlock";
 import { Vfo1TerminologyService } from "@bitwarden/vault";
 
 import { PreloadedEnglishI18nModule } from "../../core/tests";

--- a/apps/web/src/app/billing/settings/sponsored-families.component.stories.ts
+++ b/apps/web/src/app/billing/settings/sponsored-families.component.stories.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, convertToParamMap, Router } from "@angular/router";
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
 import { of } from "rxjs";
 
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
@@ -16,6 +16,7 @@ import { ConfigService } from "@bitwarden/common/platform/abstractions/config/co
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SyncService } from "@bitwarden/common/platform/sync";
 import { ToastService } from "@bitwarden/components";
+import { LockService } from "@bitwarden/unlock";
 import { Vfo1TerminologyService } from "@bitwarden/vault";
 
 import { PreloadedEnglishI18nModule } from "../../core/tests";

--- a/apps/web/src/app/core/core.module.ts
+++ b/apps/web/src/app/core/core.module.ts
@@ -42,7 +42,6 @@ import {
 } from "@bitwarden/auth/angular";
 import {
   InternalUserDecryptionOptionsServiceAbstraction,
-  LockService,
   LoginEmailService,
 } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
@@ -146,7 +145,7 @@ import {
   LegacyCompatKeyService,
 } from "@bitwarden/legacy-crypto";
 import { SerializedMemoryStorageService } from "@bitwarden/storage-core";
-import { UnlockService } from "@bitwarden/unlock";
+import { LockService, UnlockService } from "@bitwarden/unlock";
 import {
   CipherFormGenerationService,
   DefaultSshImportPromptService,

--- a/apps/web/src/app/layouts/header/account-menu.component.ts
+++ b/apps/web/src/app/layouts/header/account-menu.component.ts
@@ -2,13 +2,14 @@ import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { map, Observable } from "rxjs";
 
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import {
   VaultTimeoutAction,
   VaultTimeoutSettingsService,
 } from "@bitwarden/common/key-management/vault-timeout";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 import { DynamicAvatarComponent } from "../../components/dynamic-avatar.component";
 import { SharedModule } from "../../shared";
@@ -37,7 +38,7 @@ export class AccountMenuComponent {
   protected async lock() {
     const userId = this.account()?.id;
     if (userId) {
-      await this.lockService.lock(userId);
+      await this.lockService.lock(userId, LockSource.Manual);
     }
   }
 

--- a/apps/web/src/app/vault/individual-vault/vault.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault.component.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "@bitwarden/admin-console/common";
 import { SearchPipe } from "@bitwarden/angular/pipes/search.pipe";
 import { VaultProfileService } from "@bitwarden/angular/vault/services/vault-profile.service";
-import { AuthRequestServiceAbstraction, LockService, LogoutService } from "@bitwarden/auth/common";
+import { AuthRequestServiceAbstraction, LogoutService } from "@bitwarden/auth/common";
 import { AutomaticUserConfirmationService } from "@bitwarden/auto-confirm";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { OrganizationApiServiceAbstraction } from "@bitwarden/common/admin-console/abstractions/organization/organization-api.service.abstraction";
@@ -51,6 +51,7 @@ import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/res
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { DialogRef, DialogService, ScrollLayoutService, ToastService } from "@bitwarden/components";
 import { MessageListener } from "@bitwarden/messaging";
+import { LockService } from "@bitwarden/unlock";
 import {
   ASSIGN_COLLECTIONS_DIALOG,
   AssignCollectionsDialogRef,

--- a/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/member-access-report.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/dirt/reports/member-access-report/member-access-report.component.stories.ts
@@ -14,7 +14,7 @@ import {
   OrganizationUserApiService,
 } from "@bitwarden/admin-console/common";
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { ProviderService } from "@bitwarden/common/admin-console/abstractions/provider.service";
@@ -44,6 +44,7 @@ import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { EncryptService } from "@bitwarden/legacy-crypto";
 import { featureFlagModes } from "@bitwarden/storybook";
+import { LockService } from "@bitwarden/unlock";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { MemberAccessReportComponent } from "./member-access-report.component";

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -39,11 +39,9 @@ import {
   AuthRequestService,
   AuthRequestServiceAbstraction,
   DefaultAuthRequestApiService,
-  DefaultLockService,
   DefaultLoginSuccessHandlerService,
   DefaultLogoutService,
   InternalUserDecryptionOptionsServiceAbstraction,
-  LockService,
   LoginEmailService,
   LoginEmailServiceAbstraction,
   LoginStrategyCacheService,
@@ -417,7 +415,12 @@ import {
   DefaultStateService,
 } from "@bitwarden/state-internal";
 import { SafeInjectionToken } from "@bitwarden/ui-common";
-import { DefaultUnlockService, UnlockService } from "@bitwarden/unlock";
+import {
+  DefaultLockService,
+  LockService,
+  DefaultUnlockService,
+  UnlockService,
+} from "@bitwarden/unlock";
 import {
   UserCryptoDialogService,
   UserKeyRotationService,
@@ -2038,9 +2041,7 @@ const safeProviders: SafeProvider[] = [
       VaultTimeoutSettingsService,
       LogoutService,
       MessagingServiceAbstraction,
-      SearchServiceAbstraction,
       FolderServiceAbstraction,
-      InternalMasterPasswordServiceAbstraction,
       StateEventRunnerService,
       CipherServiceAbstraction,
       AuthServiceAbstraction,

--- a/libs/auth/src/common/services/index.ts
+++ b/libs/auth/src/common/services/index.ts
@@ -5,7 +5,6 @@ export * from "./login-strategies/default-login-strategy-session-timeout.service
 export * from "./user-decryption-options/user-decryption-options.service";
 export * from "./auth-request/auth-request.service";
 export * from "./auth-request/auth-request-api.service";
-export * from "./accounts/lock.service";
 export * from "./login-success-handler/default-login-success-handler.service";
 export * from "./sso-redirect/sso-url.service";
 export * from "./logout/default-logout.service";

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-follower.service.ts
@@ -1,14 +1,12 @@
 import { firstValueFrom, Observable, Subject } from "rxjs";
 
-// eslint-disable-next-line no-restricted-imports
-import { LockService } from "@bitwarden/auth/common";
 import { ClientType } from "@bitwarden/client-type";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { SharedUnlockFollower } from "@bitwarden/sdk-internal";
-import { UnlockService } from "@bitwarden/unlock";
+import { LockService, UnlockService } from "@bitwarden/unlock";
 
 import { AccountService } from "../../auth/abstractions/account.service";
 import { EnvironmentService } from "../../platform/abstractions/environment.service";

--- a/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
+++ b/libs/common/src/key-management/shared-unlock/default-shared-unlock-leader.service.ts
@@ -1,14 +1,12 @@
 import { firstValueFrom, Observable, Subject } from "rxjs";
 
-// eslint-disable-next-line no-restricted-imports
-import { LockService } from "@bitwarden/auth/common";
 import { ClientType } from "@bitwarden/client-type";
 // eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { SharedUnlockLeader } from "@bitwarden/sdk-internal";
-import { UnlockService } from "@bitwarden/unlock";
+import { LockService, UnlockService } from "@bitwarden/unlock";
 
 import { AccountService } from "../../auth/abstractions/account.service";
 import { EnvironmentService } from "../../platform/abstractions/environment.service";

--- a/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
+++ b/libs/common/src/key-management/shared-unlock/shared-unlock-driver.ts
@@ -1,13 +1,11 @@
 import { firstValueFrom } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
-import { LockService } from "@bitwarden/auth/common";
-// eslint-disable-next-line no-restricted-imports
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { UserId, SharedUnlockDriver, SymmetricKey } from "@bitwarden/sdk-internal";
-import { UnlockService } from "@bitwarden/unlock";
+import { LockService, LockSource, UnlockService } from "@bitwarden/unlock";
 import { UserId as TSUserId } from "@bitwarden/user-core";
 
 import { AccountService } from "../../auth/abstractions/account.service";
@@ -43,7 +41,7 @@ export class JsSharedUnlockDriver implements SharedUnlockDriver {
       return;
     }
 
-    await this.lockService.lock(fromSdkUserId(user_id));
+    await this.lockService.lock(fromSdkUserId(user_id), LockSource.SharedUnlock);
   }
 
   async unlock_user(user_id: UserId, user_key: SymmetricKey): Promise<void> {

--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout.service.spec.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout.service.spec.ts
@@ -5,7 +5,8 @@ import { BehaviorSubject, from, of } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 import { FakeAccountService, mockAccountServiceWith, mockAccountInfoWith } from "../../../../spec";
 import { AccountInfo } from "../../../auth/abstractions/account.service";
@@ -158,7 +159,7 @@ describe("VaultTimeoutService", () => {
   };
 
   const expectUserToHaveLocked = (userId: string) => {
-    expect(lockService.lock).toHaveBeenCalledWith(userId);
+    expect(lockService.lock).toHaveBeenCalledWith(userId, LockSource.VaultTimeout);
   };
 
   const expectUserToHaveLoggedOut = (userId: string) => {
@@ -166,7 +167,7 @@ describe("VaultTimeoutService", () => {
   };
 
   const expectNoAction = (userId: string) => {
-    expect(lockService.lock).not.toHaveBeenCalledWith(userId);
+    expect(lockService.lock).not.toHaveBeenCalledWith(userId, LockSource.VaultTimeout);
     expect(logoutService.logout).not.toHaveBeenCalledWith(userId, "vaultTimeout");
   };
 

--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout.service.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout.service.ts
@@ -4,7 +4,8 @@ import { combineLatest, concatMap, firstValueFrom } from "rxjs";
 
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
+import { LockService, LockSource } from "@bitwarden/unlock";
 
 import { AccountService } from "../../../auth/abstractions/account.service";
 import { AuthService } from "../../../auth/abstractions/auth.service";
@@ -129,6 +130,6 @@ export class VaultTimeoutService implements VaultTimeoutServiceAbstraction {
     );
     timeoutAction === VaultTimeoutAction.LogOut
       ? await this.logoutService.logout(userId, "vaultTimeout")
-      : await this.lockService.lock(userId);
+      : await this.lockService.lock(userId, LockSource.VaultTimeout);
   }
 }

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -41,6 +41,7 @@ import {
 import { StateProvider, StateService } from "@bitwarden/state";
 import { UserId } from "@bitwarden/user-core";
 
+import { UnlockSource } from "./unlock-source.enum";
 import { UnlockService } from "./unlock.service";
 
 export type KeyConnectorUnlockData = {
@@ -55,8 +56,9 @@ export type KeyConnectorUnlockData = {
 };
 
 export class DefaultUnlockService implements UnlockService {
-  private onUnlockActions: Array<(userId: UserId, userKey: SymmetricCryptoKey) => Promise<void>> =
-    [];
+  private onUnlockActions: Array<
+    (userId: UserId, userKey: SymmetricCryptoKey, source: UnlockSource) => Promise<void>
+  > = [];
 
   constructor(
     private registerSdkService: RegisterSdkService,
@@ -75,29 +77,37 @@ export class DefaultUnlockService implements UnlockService {
   ) {}
 
   registerOnUnlockAction(
-    action: (userId: UserId, userKey: SymmetricCryptoKey) => Promise<void>,
+    action: (userId: UserId, userKey: SymmetricCryptoKey, source: UnlockSource) => Promise<void>,
   ): void {
     this.onUnlockActions.push(action);
   }
 
   async unlockWithPin(userId: UserId, pin: string): Promise<void> {
     const startTime = performance.now();
-    await this.unlockWithMethod(userId, {
-      pinState: {
-        pin,
+    await this.unlockWithMethod(
+      userId,
+      {
+        pinState: {
+          pin,
+        },
       },
-    });
+      UnlockSource.Manual,
+    );
     this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithPin");
   }
 
   async unlockWithMasterPassword(userId: UserId, masterPassword: string): Promise<void> {
     const startTime = performance.now();
-    await this.unlockWithMethod(userId, {
-      masterPasswordUnlock: {
-        password: masterPassword,
-        master_password_unlock: await this.getMasterPasswordUnlockData(userId),
+    await this.unlockWithMethod(
+      userId,
+      {
+        masterPasswordUnlock: {
+          password: masterPassword,
+          master_password_unlock: await this.getMasterPasswordUnlockData(userId),
+        },
       },
-    });
+      UnlockSource.Manual,
+    );
     await this.setLegacyMasterKeyFromUnlockData(
       masterPassword,
       await this.getMasterPasswordUnlockData(userId),
@@ -120,11 +130,15 @@ export class DefaultUnlockService implements UnlockService {
 
     // Now that we have the biometrics-protected user key, we can initialize the SDK with it to complete the unlock process.
     const startTime = performance.now();
-    await this.unlockWithMethod(userId, {
-      decryptedKey: {
-        decrypted_user_key: userKey.toSdk(),
+    await this.unlockWithMethod(
+      userId,
+      {
+        decryptedKey: {
+          decrypted_user_key: userKey.toSdk(),
+        },
       },
-    });
+      UnlockSource.Manual,
+    );
     this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithBiometrics");
   }
 
@@ -136,22 +150,30 @@ export class DefaultUnlockService implements UnlockService {
     // key-connector-unlock-data. It will unwrap the provided key and set it to state, unlocking
     // the vault.
     const startTime = performance.now();
-    await this.unlockWithMethod(userId, {
-      keyConnectorUrl: {
-        url: keyConnectorUnlockData.url,
-        key_connector_key_wrapped_user_key: keyConnectorUnlockData.keyConnectorKeyWrappedUserKey,
+    await this.unlockWithMethod(
+      userId,
+      {
+        keyConnectorUrl: {
+          url: keyConnectorUnlockData.url,
+          key_connector_key_wrapped_user_key: keyConnectorUnlockData.keyConnectorKeyWrappedUserKey,
+        },
       },
-    });
+      UnlockSource.Manual,
+    );
     this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithKeyConnector");
   }
 
   async unlockWithDecryptedUserKey(userId: UserId, userKey: SymmetricCryptoKey): Promise<void> {
     const startTime = performance.now();
-    await this.unlockWithMethod(userId, {
-      decryptedKey: {
-        decrypted_user_key: userKey.toSdk(),
+    await this.unlockWithMethod(
+      userId,
+      {
+        decryptedKey: {
+          decrypted_user_key: userKey.toSdk(),
+        },
       },
-    });
+      UnlockSource.Manual,
+    );
     this.logService.measure(
       startTime,
       "Unlock",
@@ -171,12 +193,24 @@ export class DefaultUnlockService implements UnlockService {
     }
 
     const startTime = performance.now();
-    await this.unlockWithDecryptedUserKey(userId, userKey);
+    await this.unlockWithMethod(
+      userId,
+      {
+        decryptedKey: {
+          decrypted_user_key: userKey.toSdk(),
+        },
+      },
+      UnlockSource.Auto,
+    );
     this.logService.measure(startTime, "Unlock", "DefaultUnlockService", "unlockWithAutoUnlockKey");
     return true;
   }
 
-  private async unlockWithMethod(userId: UserId, method: InitUserCryptoMethod): Promise<void> {
+  private async unlockWithMethod(
+    userId: UserId,
+    method: InitUserCryptoMethod,
+    source: UnlockSource,
+  ): Promise<void> {
     await firstValueFrom(
       this.registerSdkService.registerClient$(userId).pipe(
         map(async (sdk) => {
@@ -195,7 +229,7 @@ export class DefaultUnlockService implements UnlockService {
             upgradeToken: await this.getV2UpgradeToken(userId),
           });
 
-          await this.runOnUnlockSideEffects(userId, ref);
+          await this.runOnUnlockSideEffects(userId, ref, source);
         }),
       ),
     );
@@ -275,6 +309,7 @@ export class DefaultUnlockService implements UnlockService {
   private async runOnUnlockSideEffects(
     userId: UserId,
     client: Ref<PasswordManagerClient>,
+    source: UnlockSource,
   ): Promise<void> {
     const userKey = SymmetricCryptoKey.fromString(
       await client.value.crypto().get_user_encryption_key(),
@@ -288,7 +323,7 @@ export class DefaultUnlockService implements UnlockService {
     await this.stateProvider.setUserState(USER_EVER_HAD_USER_KEY, true, userId);
 
     for (const action of this.onUnlockActions) {
-      await action(userId, userKey);
+      await action(userId, userKey, source);
     }
   }
 

--- a/libs/unlock/src/foreground-lock.service.ts
+++ b/libs/unlock/src/foreground-lock.service.ts
@@ -6,8 +6,10 @@ import {
   MessageSender,
 } from "@bitwarden/common/platform/messaging";
 import { newGuid } from "@bitwarden/guid";
-import { LockService, LockSource } from "@bitwarden/unlock";
 import { UserId } from "@bitwarden/user-core";
+
+import { LockSource } from "./lock-source.enum";
+import { LockService } from "./lock.service";
 
 const LOCK_ALL_FINISHED = new CommandDefinition<{ requestId: string }>("lockAllFinished");
 const LOCK_ALL = new CommandDefinition<{ requestId: string; source: LockSource }>("lockAll");

--- a/libs/unlock/src/index.ts
+++ b/libs/unlock/src/index.ts
@@ -1,2 +1,5 @@
+export { LockService, DefaultLockService } from "./lock.service";
+export { LockSource } from "./lock-source.enum";
 export { UnlockService } from "./unlock.service";
+export { UnlockSource } from "./unlock-source.enum";
 export { DefaultUnlockService, KeyConnectorUnlockData } from "./default-unlock.service";

--- a/libs/unlock/src/index.ts
+++ b/libs/unlock/src/index.ts
@@ -1,4 +1,5 @@
 export { LockService, DefaultLockService } from "./lock.service";
+export { ForegroundLockService } from "./foreground-lock.service";
 export { LockSource } from "./lock-source.enum";
 export { UnlockService } from "./unlock.service";
 export { UnlockSource } from "./unlock-source.enum";

--- a/libs/unlock/src/lock-source.enum.ts
+++ b/libs/unlock/src/lock-source.enum.ts
@@ -1,0 +1,14 @@
+/**
+ * What caused a lock. Handed to every callback registered through
+ * {@link LockService.registerOnLockAction} so a listener can tell the locks it caused itself apart
+ * from the ones it should react to.
+ */
+export const LockSource = Object.freeze({
+  /** The vault timeout elapsed, the system locked, or the client idled out. */
+  VaultTimeout: "vaultTimeout",
+  /** The user locked this device themselves. */
+  Manual: "manual",
+  /** Another device locked this one over the shared unlock protocol. */
+  SharedUnlock: "sharedUnlock",
+} as const);
+export type LockSource = (typeof LockSource)[keyof typeof LockSource];

--- a/libs/unlock/src/lock.service.spec.ts
+++ b/libs/unlock/src/lock.service.spec.ts
@@ -1,10 +1,10 @@
 import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
 
+import { LogoutService } from "@bitwarden/auth/common";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
-import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/key-management/vault-timeout";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { SystemService } from "@bitwarden/common/platform/abstractions/system.service";
@@ -12,13 +12,11 @@ import { mockAccountServiceWith, mockAccountInfoWith } from "@bitwarden/common/s
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
-import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { BiometricsService, KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
 import { StateEventRunnerService } from "@bitwarden/state";
 
-import { LogoutService } from "../../abstractions";
-
+import { LockSource } from "./lock-source.enum";
 import { DefaultLockService } from "./lock.service";
 
 describe("DefaultLockService", () => {
@@ -31,9 +29,7 @@ describe("DefaultLockService", () => {
   const vaultTimeoutSettingsService = mock<VaultTimeoutSettingsService>();
   const logoutService = mock<LogoutService>();
   const messagingService = mock<MessagingService>();
-  const searchService = mock<SearchService>();
   const folderService = mock<FolderService>();
-  const masterPasswordService = mock<InternalMasterPasswordServiceAbstraction>();
   const stateEventRunnerService = mock<StateEventRunnerService>();
   const cipherService = mock<CipherService>();
   const authService = mock<AuthService>();
@@ -47,9 +43,7 @@ describe("DefaultLockService", () => {
     vaultTimeoutSettingsService,
     logoutService,
     messagingService,
-    searchService,
     folderService,
-    masterPasswordService,
     stateEventRunnerService,
     cipherService,
     authService,
@@ -66,9 +60,7 @@ describe("DefaultLockService", () => {
       vaultTimeoutSettingsService,
       logoutService,
       messagingService,
-      searchService,
       folderService,
-      masterPasswordService,
       stateEventRunnerService,
       cipherService,
       authService,
@@ -97,14 +89,14 @@ describe("DefaultLockService", () => {
 
       const lockSpy = jest.spyOn(sut, "lock").mockResolvedValue(undefined);
 
-      await sut.lockAll();
+      await sut.lockAll(LockSource.Manual);
 
       // Non-Active users should be called first
-      expect(lockSpy).toHaveBeenNthCalledWith(1, mockUser2);
-      expect(lockSpy).toHaveBeenNthCalledWith(2, mockUser3);
+      expect(lockSpy).toHaveBeenNthCalledWith(1, mockUser2, LockSource.Manual);
+      expect(lockSpy).toHaveBeenNthCalledWith(2, mockUser3, LockSource.Manual);
 
       // Active user should be called last
-      expect(lockSpy).toHaveBeenNthCalledWith(3, mockUser1);
+      expect(lockSpy).toHaveBeenNthCalledWith(3, mockUser1, LockSource.Manual);
     });
   });
 
@@ -113,7 +105,7 @@ describe("DefaultLockService", () => {
 
     it("returns early if user is already logged out", async () => {
       authService.authStatusFor$.mockReturnValue(of(AuthenticationStatus.LoggedOut));
-      await sut.lock(userId);
+      await sut.lock(userId, LockSource.Manual);
       // Should return early, not call logoutService.logout
       expect(logoutService.logout).not.toHaveBeenCalled();
       expect(stateEventRunnerService.handleEvent).not.toHaveBeenCalled();
@@ -122,7 +114,7 @@ describe("DefaultLockService", () => {
     it("logs out if user cannot lock", async () => {
       authService.authStatusFor$.mockReturnValue(of(AuthenticationStatus.Unlocked));
       vaultTimeoutSettingsService.canLock.mockResolvedValue(false);
-      await sut.lock(userId);
+      await sut.lock(userId, LockSource.Manual);
       expect(logoutService.logout).toHaveBeenCalledWith(userId, "vaultTimeout");
       expect(stateEventRunnerService.handleEvent).not.toHaveBeenCalled();
     });
@@ -131,7 +123,7 @@ describe("DefaultLockService", () => {
       authService.authStatusFor$.mockReturnValue(of(AuthenticationStatus.Locked));
       logoutService.logout.mockClear();
       vaultTimeoutSettingsService.canLock.mockResolvedValue(true);
-      await sut.lock(userId);
+      await sut.lock(userId, LockSource.Manual);
       expect(logoutService.logout).not.toHaveBeenCalled();
       expect(stateEventRunnerService.handleEvent).toHaveBeenCalledWith("lock", userId);
     });

--- a/libs/unlock/src/lock.service.ts
+++ b/libs/unlock/src/lock.service.ts
@@ -1,41 +1,49 @@
 import { combineLatest, filter, firstValueFrom, map, timeout } from "rxjs";
 
+import { LogoutService } from "@bitwarden/auth/common";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { assertNonNullish } from "@bitwarden/common/auth/utils";
 import { ProcessReloadServiceAbstraction } from "@bitwarden/common/key-management/abstractions/process-reload.service";
-import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/key-management/vault-timeout";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { SystemService } from "@bitwarden/common/platform/abstractions/system.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
-import { SearchService } from "@bitwarden/common/vault/abstractions/search.service";
 import { BiometricsService, KeyService } from "@bitwarden/key-management";
 import { LogService } from "@bitwarden/logging";
 import { StateEventRunnerService } from "@bitwarden/state";
 
-import { LogoutService } from "../../abstractions";
+import { LockSource } from "./lock-source.enum";
 
 export abstract class LockService {
   /**
    * Locks all accounts.
+   * @param source What caused the lock
    */
-  abstract lockAll(): Promise<void>;
+  abstract lockAll(source: LockSource): Promise<void>;
   /**
    * Performs lock for a user.
    * @param userId The user id to lock
+   * @param source What caused the lock
    */
-  abstract lock(userId: UserId): Promise<void>;
+  abstract lock(userId: UserId, source: LockSource): Promise<void>;
 
-  abstract runPlatformOnLockActions(userId: UserId): Promise<void>;
-  abstract registerOnLockAction(action: (userId: UserId) => Promise<void>): void;
+  abstract runPlatformOnLockActions(userId: UserId, source: LockSource): Promise<void>;
+  /**
+   * Registers an action to be run when a user is locked through this service.
+   *
+   * @param action Callback invoked after a lock with the user id and what caused the lock.
+   */
+  abstract registerOnLockAction(
+    action: (userId: UserId, source: LockSource) => Promise<void>,
+  ): void;
 }
 
 export class DefaultLockService implements LockService {
-  private onLockActions: Array<(userId: UserId) => Promise<void>> = [];
+  private onLockActions: Array<(userId: UserId, source: LockSource) => Promise<void>> = [];
 
   constructor(
     private readonly accountService: AccountService,
@@ -43,9 +51,7 @@ export class DefaultLockService implements LockService {
     private readonly vaultTimeoutSettingsService: VaultTimeoutSettingsService,
     private readonly logoutService: LogoutService,
     private readonly messagingService: MessagingService,
-    private readonly searchService: SearchService,
     private readonly folderService: FolderService,
-    private readonly masterPasswordService: InternalMasterPasswordServiceAbstraction,
     private readonly stateEventRunnerService: StateEventRunnerService,
     private readonly cipherService: CipherService,
     private readonly authService: AuthService,
@@ -55,11 +61,11 @@ export class DefaultLockService implements LockService {
     private readonly keyService: KeyService,
   ) {}
 
-  registerOnLockAction(action: (userId: UserId) => Promise<void>): void {
+  registerOnLockAction(action: (userId: UserId, source: LockSource) => Promise<void>): void {
     this.onLockActions.push(action);
   }
 
-  async lockAll() {
+  async lockAll(source: LockSource) {
     const accounts = await firstValueFrom(
       combineLatest([this.accountService.activeAccount$, this.accountService.accounts$]).pipe(
         map(([activeAccount, accounts]) => {
@@ -78,18 +84,18 @@ export class DefaultLockService implements LockService {
     );
 
     for (const otherAccount of accounts.otherAccounts) {
-      await this.lock(otherAccount);
+      await this.lock(otherAccount, source);
     }
 
     // Do the active account last in case we ever try to route the user on lock
     // that way this whole operation will be complete before that routing
     // could take place.
     if (accounts.activeAccount != null) {
-      await this.lock(accounts.activeAccount);
+      await this.lock(accounts.activeAccount, source);
     }
   }
 
-  async lock(userId: UserId): Promise<void> {
+  async lock(userId: UserId, source: LockSource): Promise<void> {
     assertNonNullish(userId, "userId", "LockService");
 
     this.logService.info(`[LockService] Locking user ${userId}`);
@@ -113,7 +119,7 @@ export class DefaultLockService implements LockService {
     await this.wipeDecryptedState(userId);
     await this.waitForLockedStatus(userId);
     await this.systemService.clearPendingClipboard();
-    await this.runPlatformOnLockActions(userId);
+    await this.runPlatformOnLockActions(userId, source);
 
     this.logService.info(`[LockService] Locked user ${userId}`);
 
@@ -156,9 +162,9 @@ export class DefaultLockService implements LockService {
     );
   }
 
-  async runPlatformOnLockActions(userId: UserId): Promise<void> {
+  async runPlatformOnLockActions(userId: UserId, source: LockSource): Promise<void> {
     for (const action of this.onLockActions) {
-      await action(userId);
+      await action(userId, source);
     }
     // No platform specific actions to run for this platform.
     return;

--- a/libs/unlock/src/unlock-source.enum.ts
+++ b/libs/unlock/src/unlock-source.enum.ts
@@ -1,0 +1,22 @@
+/**
+ * What caused an unlock. Handed to every callback registered through
+ * {@link UnlockService.registerOnUnlockAction} so a listener can tell the unlocks it caused itself
+ * apart from the ones it should react to.
+ */
+export const UnlockSource = Object.freeze({
+  /**
+   * The user unlocked this device themselves — master password, PIN, biometrics, key connector,
+   * PRF, or logging in with another device.
+   */
+  Manual: "manual",
+  /**
+   * The vault was restored from the never-lock key rather than unlocked by anyone.
+   *
+   * Nothing reports this yet: the never-lock restore in `UserAutoUnlockKeyService` sets the user key
+   * directly instead of going through `UnlockService`.
+   */
+  Auto: "auto",
+  /** Another device unlocked this one over the shared unlock protocol. */
+  SharedUnlock: "sharedUnlock",
+} as const);
+export type UnlockSource = (typeof UnlockSource)[keyof typeof UnlockSource];

--- a/libs/unlock/src/unlock.service.ts
+++ b/libs/unlock/src/unlock.service.ts
@@ -3,6 +3,7 @@ import { UserId } from "@bitwarden/common/types/guid";
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 
 import { KeyConnectorUnlockData } from "./default-unlock.service";
+import { UnlockSource } from "./unlock-source.enum";
 
 /**
  * Service for unlocking a user's account with various methods.
@@ -74,10 +75,10 @@ export abstract class UnlockService {
   /**
    * Registers an action to be run when a user is unlocked through this service.
    *
-   * @param action Callback invoked after a successful unlock with the user id and the
-   *   freshly-decrypted user key.
+   * @param action Callback invoked after a successful unlock with the user id, the
+   *   freshly-decrypted user key, and what caused the unlock.
    */
   abstract registerOnUnlockAction(
-    action: (userId: UserId, userKey: SymmetricCryptoKey) => Promise<void>,
+    action: (userId: UserId, userKey: SymmetricCryptoKey, source: UnlockSource) => Promise<void>,
   ): void;
 }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-41447

## 📔 Objective
We need unlock and lock source tracking to prevent an instant re-lock caused by shared unlock. To do so, the callers of lock / unlock need to provide a lock source. In the case of unlock, this is done in the unlock service. In the case of lock, this is provided by the callers (vault timeout, manual UI lock, shared unlock).

This also in the same step moves the lock service to KM ownership, because auth does not own lock / unlock, and it was only owned by auth for historical reasons.

Note that the move of the service, and the addition of the lock source are combined into one PR to have fewer review round-trips, since these often touch the same files.

## 📸 Screenshots

N/A — no UI changes.
