### PR TITLE
Badge privileged collections from the collection, not the rules list

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
+++ b/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
@@ -61,7 +61,8 @@ import {
  * side so an unprovided token stays inert: `CIPHER_VIEW_BANNER` (the requester's
  * leasing entry point on an open cipher) and `VAULT_ROW_LEASE_BADGE` (the per-row
  * access-state pill, on cipher AND collection rows — collection rows show the
- * "Privileged" pill backed by the shared `GovernedCollectionsService` lookup),
+ * "Privileged" pill straight off the collection's server-derived
+ * `hasEnabledAccessRule`),
  * both component classes, plus `GATED_CIPHER_RELOADER` (the
  * observable that reveals a gated cipher in place once a lease covers it),
  * `COLLECTION_ACCESS_RULE_CALLOUT` (the governing-rule notice in the collection
@@ -116,8 +117,9 @@ export function providePam(): SafeProvider[] {
       provide: VAULT_ROW_LEASE_BADGE,
       useValue: VaultRowLeaseBadgeComponent,
     }),
-    // Root-level (not per-badge) so every collection-row badge AND the collection-dialog
-    // callout share one cached per-org rules read.
+    // Root-level so repeated opens of the collection dialog share one cached per-org rules read.
+    // The vault-row badge no longer reads it — the collection carries `hasEnabledAccessRule` — but
+    // the callout still does, because it names the governing rules rather than just counting them.
     safeProvider({
       provide: GovernedCollectionsService,
       useClass: GovernedCollectionsService,

--- a/bitwarden_license/bit-web/src/app/pam/services/governed-collections.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/governed-collections.service.ts
@@ -8,24 +8,28 @@ import type { AccessRuleView } from "../abstractions/access-rule";
 import { AccessRuleSdkService } from "../abstractions/access-rule-sdk.service";
 
 /**
- * How long a cached per-org read is served before a new consumer triggers a fresh one.
- * Collection rows live under a virtual scroller with no template cache, so badge subscriptions
- * churn on every scroll pass — the TTL absorbs that churn with one read, while still bounding
- * how stale the badge and callout can be after rules change. Expiry is checked lazily on
- * access (no timers), so already-mounted rows keep their value and the next mount re-reads.
+ * How long a cached per-org read is served before a new consumer triggers a fresh one. Bounds how
+ * stale the callout can be after rules change, while collapsing repeated opens of the collection
+ * dialog into one read. Expiry is checked lazily on access (no timers), so an already-open callout
+ * keeps its value and the next open re-reads.
  */
 const CACHE_TTL_MS = 30_000;
 
 type CacheEntry = { fetchedAt: number; rules$: Observable<readonly AccessRuleView[]> };
 
 /**
- * One shared, cached `listAccessRules` read per organization — the source both the
- * collection-row badge and the collection-dialog callout derive from (via
- * `rulesGoverningCollection`), so a vault list of N collections issues one read, not N,
- * and "governed" cannot mean two different things on two surfaces.
+ * One shared, cached `listAccessRules` read per organization, backing the collection-dialog
+ * callout via `rulesGoverningCollection`.
  *
- * Informational consumers only, so a failed read resolves to no rules (badge and callout
- * simply don't render) rather than erroring the host surfaces.
+ * The vault-row "Privileged" badge used to derive from this too, but now reads the collection's
+ * own server-derived `hasEnabledAccessRule`. The callout still needs the rules themselves because
+ * it *names* the governing rules and summarises what they enforce — a boolean cannot say that.
+ * Both surfaces nonetheless agree on what "governed" means: the server computes the flag as
+ * "associated with a rule that is enabled", which is exactly what `rulesGoverningCollection`
+ * filters for.
+ *
+ * An informational consumer only, so a failed read resolves to no rules (the callout simply
+ * doesn't render) rather than erroring the host surface.
  */
 @Injectable()
 export class GovernedCollectionsService {

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject, of } from "rxjs";
+import { BehaviorSubject } from "rxjs";
 
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -8,14 +7,8 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import type { CipherAccessStateView } from "@bitwarden/sdk-internal";
 
 import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
-import type { AccessRuleView } from "../abstractions/access-rule";
-import { GovernedCollectionsService } from "../services/governed-collections.service";
 
 import { VaultRowLeaseBadgeComponent } from "./vault-row-lease-badge.component";
-
-function accessRule(enabled: boolean, collections: string[]): AccessRuleView {
-  return { enabled, collections } as unknown as AccessRuleView;
-}
 
 describe("VaultRowLeaseBadgeComponent", () => {
   let fixture: ComponentFixture<VaultRowLeaseBadgeComponent>;
@@ -24,7 +17,6 @@ describe("VaultRowLeaseBadgeComponent", () => {
   let accessRequestSdkService: {
     getCipherAccessState: jest.Mock<Promise<CipherAccessStateView>, [string]>;
   };
-  let governedCollections: MockProxy<GovernedCollectionsService>;
 
   function create(cipher: CipherView): void {
     fixture = TestBed.createComponent(VaultRowLeaseBadgeComponent);
@@ -33,7 +25,7 @@ describe("VaultRowLeaseBadgeComponent", () => {
     fixture.detectChanges();
   }
 
-  function createForCollection(collection: { id?: string; organizationId?: string }): void {
+  function createForCollection(collection: { hasEnabledAccessRule?: boolean }): void {
     fixture = TestBed.createComponent(VaultRowLeaseBadgeComponent);
     fixture.componentRef.setInput("collection", collection);
     component = fixture.componentInstance;
@@ -50,15 +42,12 @@ describe("VaultRowLeaseBadgeComponent", () => {
   beforeEach(() => {
     enabled$ = new BehaviorSubject<boolean>(true);
     accessRequestSdkService = { getCipherAccessState: jest.fn() };
-    governedCollections = mock<GovernedCollectionsService>();
-    governedCollections.rules$.mockReturnValue(of([]));
 
     TestBed.configureTestingModule({
       imports: [VaultRowLeaseBadgeComponent],
       providers: [
         { provide: ConfigService, useValue: { getFeatureFlag$: () => enabled$ } },
         { provide: AccessRequestSdkService, useValue: accessRequestSdkService },
-        { provide: GovernedCollectionsService, useValue: governedCollections },
         {
           provide: I18nService,
           useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
@@ -147,44 +136,30 @@ describe("VaultRowLeaseBadgeComponent", () => {
   });
 
   describe("on a collection row", () => {
-    it("resolves the privileged pill for a collection governed by an enabled rule", () => {
-      governedCollections.rules$.mockReturnValue(of([accessRule(true, ["col-1"])]));
-
-      createForCollection({ id: "col-1", organizationId: "org-1" });
+    it("resolves the privileged pill when the collection has an enabled access rule", () => {
+      createForCollection({ hasEnabledAccessRule: true });
 
       expect(component["badge"]()).toEqual({ kind: "privileged" });
     });
 
-    it("renders nothing when only a disabled rule names the collection", () => {
-      governedCollections.rules$.mockReturnValue(of([accessRule(false, ["col-1"])]));
-
-      createForCollection({ id: "col-1", organizationId: "org-1" });
-
-      expect(component["badge"]()).toBeNull();
-    });
-
     it("renders nothing for an ungoverned collection", () => {
-      governedCollections.rules$.mockReturnValue(of([accessRule(true, ["col-other"])]));
-
-      createForCollection({ id: "col-1", organizationId: "org-1" });
+      createForCollection({ hasEnabledAccessRule: false });
 
       expect(component["badge"]()).toBeNull();
     });
 
-    it("renders nothing while the PAM flag is off, without reading rules", () => {
+    it("renders nothing while the PAM flag is off", () => {
       enabled$.next(false);
 
-      createForCollection({ id: "col-1", organizationId: "org-1" });
+      createForCollection({ hasEnabledAccessRule: true });
 
       expect(component["badge"]()).toBeNull();
-      expect(governedCollections.rules$).not.toHaveBeenCalled();
     });
 
-    it("renders nothing for pseudo-collections with no id or organization (e.g. Unassigned)", () => {
-      createForCollection({ id: undefined, organizationId: undefined });
+    it("renders nothing for pseudo-collections carrying no server state (e.g. Unassigned)", () => {
+      createForCollection({});
 
       expect(component["badge"]()).toBeNull();
-      expect(governedCollections.rules$).not.toHaveBeenCalled();
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
@@ -4,7 +4,6 @@ import { catchError, combineLatest, from, map, Observable, of, switchMap } from 
 
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   CipherViewLike,
   CipherViewLikeUtils,
@@ -13,16 +12,14 @@ import {
 import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
 import { AccessBadgeState, cipherAccessBadgeState } from "../access-state-badge/access-badge-state";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
-import { rulesGoverningCollection } from "../collection-access-rule-callout/access-rule-summary";
-import { GovernedCollectionsService } from "../services/governed-collections.service";
 
 /**
- * The collection fields the badge reads, structurally — the host passes its own
+ * The collection field the badge reads, structurally — the host passes its own
  * `CollectionView`/`CollectionAdminView`, which this component must not import to stay
- * decoupled from the admin-console models. Both are optional because the vault list also
- * renders pseudo-collections ("Unassigned") with no id or organization.
+ * decoupled from the admin-console models. Optional because the vault list also renders
+ * pseudo-collections ("Unassigned"), which carry no server state at all.
  */
-type BadgeCollection = { id?: string; organizationId?: OrganizationId };
+type BadgeCollection = { hasEnabledAccessRule?: boolean };
 
 /**
  * Binds `VAULT_ROW_LEASE_BADGE` for one row in the vault list — cipher or collection.
@@ -37,10 +34,12 @@ type BadgeCollection = { id?: string; organizationId?: OrganizationId };
  * behavior that needs live polling lives in the cipher-view banner / gated-cipher reloader,
  * not here). The active-lease countdown ticks locally inside the shared badge once fetched.
  *
- * A collection row shows the resting "Privileged" pill when the collection is governed by
- * an enabled access rule — the same claim the collection-dialog callout makes, derived from
- * the same cached per-org `listAccessRules` read ({@link GovernedCollectionsService},
- * readable by any org member) through the same {@link rulesGoverningCollection} predicate.
+ * A collection row shows the resting "Privileged" pill straight off the collection's
+ * `hasEnabledAccessRule`, which the server derives on the collection read paths. No fetch: the
+ * flag arrives with the collection itself, so the badge costs nothing per row, cannot go stale
+ * against the list it is rendered beside, and works for viewers who cannot read the
+ * organization's access rules — notably provider users, whom `MemberRequirement` excludes from
+ * the access-rules endpoint by design.
  */
 @Component({
   selector: "app-pam-vault-row-lease-badge",
@@ -54,7 +53,6 @@ export class VaultRowLeaseBadgeComponent {
 
   private readonly configService = inject(ConfigService);
   private readonly accessRequestSdkService = inject(AccessRequestSdkService);
-  private readonly governedCollections = inject(GovernedCollectionsService);
 
   private readonly state$: Observable<AccessBadgeState | null> = combineLatest([
     toObservable(this.cipher),
@@ -89,16 +87,9 @@ export class VaultRowLeaseBadgeComponent {
     );
   }
 
-  private collectionState$({ id, organizationId }: BadgeCollection) {
-    if (id == null || organizationId == null) {
-      return of(null);
-    }
-    return this.governedCollections
-      .rules$(organizationId)
-      .pipe(
-        map((rules): AccessBadgeState | null =>
-          rulesGoverningCollection(rules, id).length > 0 ? { kind: "privileged" } : null,
-        ),
-      );
+  private collectionState$({
+    hasEnabledAccessRule,
+  }: BadgeCollection): Observable<AccessBadgeState | null> {
+    return of(hasEnabledAccessRule === true ? { kind: "privileged" } : null);
   }
 }

--- a/libs/admin-console/src/common/collections/models/collection.spec.ts
+++ b/libs/admin-console/src/common/collections/models/collection.spec.ts
@@ -65,6 +65,7 @@ describe("Collection", () => {
       hidePasswords: true,
       type: CollectionTypes.DefaultUserCollection,
       defaultUserCollectionEmail: "defaultCollectionEmail",
+      hasEnabledAccessRule: false,
     });
   });
 
@@ -96,6 +97,25 @@ describe("Collection", () => {
       assigned: true,
       type: CollectionTypes.DefaultUserCollection,
       defaultUserCollectionEmail: "defaultCollectionEmail",
+      hasEnabledAccessRule: false,
     });
+  });
+
+  it("carries hasEnabledAccessRule from the response through to the decrypted view", async () => {
+    const governed = new CollectionData(
+      new CollectionDetailsResponse({
+        id: "id" as CollectionId,
+        organizationId: "orgId" as OrganizationId,
+        name: "encName",
+        hasEnabledAccessRule: true,
+      }),
+    );
+    expect(governed.hasEnabledAccessRule).toBe(true);
+
+    const collection = Collection.fromCollectionData(governed);
+    expect(collection.hasEnabledAccessRule).toBe(true);
+
+    const view = await collection.decrypt(makeSymmetricCryptoKey<OrgKey>(), encService);
+    expect(view.hasEnabledAccessRule).toBe(true);
   });
 });

--- a/libs/common/src/admin-console/models/collections/collection-admin.view.ts
+++ b/libs/common/src/admin-console/models/collections/collection-admin.view.ts
@@ -139,6 +139,7 @@ export class CollectionAdminView extends CollectionView {
     view.type = collection.type;
     view.externalId = collection.externalId;
     view.defaultUserCollectionEmail = collection.defaultUserCollectionEmail;
+    view.hasEnabledAccessRule = collection.hasEnabledAccessRule;
 
     view.groups = collection.groups
       ? collection.groups.map((g) => new CollectionAccessSelectionView(g))

--- a/libs/common/src/admin-console/models/collections/collection-sdk-mapping.spec.ts
+++ b/libs/common/src/admin-console/models/collections/collection-sdk-mapping.spec.ts
@@ -185,6 +185,39 @@ describe("CollectionView SDK mapping", () => {
       expect(result.assigned).toBe(true);
     });
 
+    describe("hasEnabledAccessRule preservation (privileged-access badge)", () => {
+      it("copies hasEnabledAccessRule from the source collection", () => {
+        const result = CollectionView.fromSdkCollectionView(
+          makeSdkCollectionView(),
+          makeCollection({ hasEnabledAccessRule: true }),
+        );
+
+        expect(result.hasEnabledAccessRule).toBe(true);
+      });
+
+      it("leaves hasEnabledAccessRule false for an ungoverned collection", () => {
+        const result = CollectionView.fromSdkCollectionView(
+          makeSdkCollectionView(),
+          makeCollection(),
+        );
+
+        expect(result.hasEnabledAccessRule).toBe(false);
+      });
+
+      /**
+       * The SDK's `Collection` and `CollectionView` are `#[serde(deny_unknown_fields)]`, so an extra
+       * key on either object thrown across the wasm boundary fails at runtime, not compile time.
+       * These pin that the flag rides alongside the SDK rather than through it.
+       */
+      it("does not send hasEnabledAccessRule across the wasm boundary", () => {
+        const collection = makeCollection({ hasEnabledAccessRule: true });
+        const view = CollectionView.fromSdkCollectionView(makeSdkCollectionView(), collection);
+
+        expect(collection.toSdkCollection()).not.toHaveProperty("hasEnabledAccessRule");
+        expect(view.toSdkCollectionView()).not.toHaveProperty("hasEnabledAccessRule");
+      });
+    });
+
     describe("defaultUserCollectionEmail preservation (canEditName security invariant)", () => {
       it("copies defaultUserCollectionEmail from the source collection, not the SDK view", () => {
         const email = "offboarded-user@example.com";

--- a/libs/common/src/admin-console/models/collections/collection.data.ts
+++ b/libs/common/src/admin-console/models/collections/collection.data.ts
@@ -14,6 +14,12 @@ export class CollectionData {
   manage: boolean = false;
   hidePasswords: boolean = false;
   type: CollectionType = CollectionTypes.SharedCollection;
+  /**
+   * True when the collection is governed by an access rule that is currently enabled, meaning its
+   * items are gated behind PAM leasing. Server-derived: the association alone is not enough,
+   * because a disabled rule gates nothing.
+   */
+  hasEnabledAccessRule: boolean = false;
 
   constructor(response: CollectionDetailsResponse) {
     this.id = response.id;
@@ -25,6 +31,7 @@ export class CollectionData {
     this.hidePasswords = response.hidePasswords;
     this.type = response.type;
     this.defaultUserCollectionEmail = response.defaultUserCollectionEmail;
+    this.hasEnabledAccessRule = response.hasEnabledAccessRule;
   }
 
   static fromJSON(obj: Jsonify<CollectionData | null>): CollectionData | null {

--- a/libs/common/src/admin-console/models/collections/collection.response.ts
+++ b/libs/common/src/admin-console/models/collections/collection.response.ts
@@ -27,6 +27,12 @@ export class CollectionDetailsResponse extends CollectionResponse {
   readOnly: boolean;
   manage: boolean;
   hidePasswords: boolean;
+  /**
+   * True when the collection is governed by an access rule that is currently enabled, meaning its
+   * items are gated behind PAM leasing. Server-derived: the association alone is not enough,
+   * because a disabled rule gates nothing.
+   */
+  hasEnabledAccessRule: boolean;
 
   /**
    * Flag indicating the user has been explicitly assigned to this Collection
@@ -38,6 +44,7 @@ export class CollectionDetailsResponse extends CollectionResponse {
     this.readOnly = this.getResponseProperty("ReadOnly") || false;
     this.manage = this.getResponseProperty("Manage") || false;
     this.hidePasswords = this.getResponseProperty("HidePasswords") || false;
+    this.hasEnabledAccessRule = this.getResponseProperty("HasEnabledAccessRule") || false;
 
     // Temporary until the API is updated to return this property in AC-2084
     // For now, we can assume that if the object is 'collectionDetails' then the user is assigned

--- a/libs/common/src/admin-console/models/collections/collection.ts
+++ b/libs/common/src/admin-console/models/collections/collection.ts
@@ -28,6 +28,12 @@ export class Collection extends Domain {
   manage: boolean = false;
   type: CollectionType = CollectionTypes.SharedCollection;
   defaultUserCollectionEmail: string | undefined;
+  /**
+   * True when the collection is governed by an access rule that is currently enabled, meaning its
+   * items are gated behind PAM leasing. Server-derived: the association alone is not enough,
+   * because a disabled rule gates nothing.
+   */
+  hasEnabledAccessRule: boolean = false;
 
   constructor(c: { id: CollectionId; name: EncString; organizationId: OrganizationId }) {
     super();
@@ -52,6 +58,7 @@ export class Collection extends Domain {
     collection.manage = obj.manage;
     collection.type = obj.type;
     collection.defaultUserCollectionEmail = obj.defaultUserCollectionEmail;
+    collection.hasEnabledAccessRule = obj.hasEnabledAccessRule;
 
     return collection;
   }
@@ -72,6 +79,7 @@ export class Collection extends Domain {
     collection.hidePasswords = view.hidePasswords;
     collection.manage = view.manage;
     collection.type = view.type;
+    collection.hasEnabledAccessRule = view.hasEnabledAccessRule;
 
     return collection;
   }
@@ -97,11 +105,18 @@ export class Collection extends Domain {
     collection.manage = sdkCollection.manage;
     collection.defaultUserCollectionEmail = sdkCollection.defaultUserCollectionEmail;
     collection.type = sdkCollection.type;
+    // hasEnabledAccessRule is deliberately absent from SdkCollection — see toSdkCollection below.
     return collection;
   }
 
   /**
    * Maps Collection to SDK format for use with the SDK crypto operations.
+   *
+   * WARNING: the SDK's `Collection` is `#[serde(deny_unknown_fields)]`, so this object must contain
+   * exactly the fields the Rust type declares. `hasEnabledAccessRule` is NOT one of them — adding it
+   * here throws at runtime rather than failing to compile. It rides alongside the SDK instead, the
+   * same way `defaultUserCollectionEmail` does on the way back (see
+   * {@link CollectionView.fromSdkCollectionView}).
    */
   toSdkCollection(): SdkCollection {
     return {

--- a/libs/common/src/admin-console/models/collections/collection.view.ts
+++ b/libs/common/src/admin-console/models/collections/collection.view.ts
@@ -27,6 +27,12 @@ export class CollectionView implements View, ITreeNodeObject {
   assigned: boolean = false;
   type: CollectionType = CollectionTypes.SharedCollection;
   defaultUserCollectionEmail: string | undefined;
+  /**
+   * True when the collection is governed by an access rule that is currently enabled, meaning its
+   * items are gated behind PAM leasing. Server-derived: the association alone is not enough,
+   * because a disabled rule gates nothing.
+   */
+  hasEnabledAccessRule: boolean = false;
 
   private _name: string;
 
@@ -144,6 +150,7 @@ export class CollectionView implements View, ITreeNodeObject {
     view.manage = collection.manage;
     view.type = collection.type;
     view.defaultUserCollectionEmail = collection.defaultUserCollectionEmail;
+    view.hasEnabledAccessRule = collection.hasEnabledAccessRule;
     return view;
   }
 
@@ -167,6 +174,7 @@ export class CollectionView implements View, ITreeNodeObject {
     view.type = collection.type;
     view.assigned = collection.assigned;
     view.defaultUserCollectionEmail = collection.defaultUserCollectionEmail;
+    view.hasEnabledAccessRule = collection.hasEnabledAccessRule;
     return view;
   }
 
@@ -177,11 +185,15 @@ export class CollectionView implements View, ITreeNodeObject {
   /**
    * Creates a CollectionView from the SDK CollectionView returned by SDK decrypt operations.
    *
-   * The `sourceCollection` parameter is required to preserve `defaultUserCollectionEmail`, which
-   * the SDK's CollectionView type does not carry. That field is consumed by `canEditName()` to
-   * enforce the security restriction that prevents editing names on offboarded default-user
-   * collections (see WARNING on `canEditName`). Without it the restriction would be silently
-   * bypassed on the SDK decrypt path.
+   * The `sourceCollection` parameter is required to preserve fields the SDK's CollectionView type
+   * does not carry:
+   *
+   * - `defaultUserCollectionEmail`, consumed by `canEditName()` to enforce the security restriction
+   *   that prevents editing names on offboarded default-user collections (see WARNING on
+   *   `canEditName`). Without it the restriction would be silently bypassed on the SDK decrypt path.
+   * - `hasEnabledAccessRule`, which drives the privileged-access badge in the vault list. It is
+   *   plaintext server-derived state with nothing to decrypt, so it rides alongside the SDK rather
+   *   than through it — the SDK's `Collection` is `deny_unknown_fields` and does not declare it.
    */
   static fromSdkCollectionView(
     sdkView: SdkCollectionView,
@@ -200,6 +212,7 @@ export class CollectionView implements View, ITreeNodeObject {
     view.assigned = true;
     view.defaultUserCollectionEmail = sourceCollection.defaultUserCollectionEmail;
     view.type = sdkView.type;
+    view.hasEnabledAccessRule = sourceCollection.hasEnabledAccessRule;
 
     return view;
   }


### PR DESCRIPTION
Part of [PM-42246](https://bitwarden.atlassian.net/browse/PM-42246).

> [!IMPORTANT]
> Depends on **bitwarden/server#8236**. Without it the field is absent, the badge reads `false`, and collection rows go back to being empty. Merge the server side first.

## The problem

The vault list's **Controlled access** column decided whether a collection row is privileged by fetching the organization's access rules and matching collection ids. That works for a member, but `GET organizations/{orgId}/access-rules` requires organization membership by design — so a provider browsing a client organization's Admin Console gets a 403, `GovernedCollectionsService` swallows it to `[]`, and every collection cell renders empty. The column is there; the rows never fill in.

## The change

The server now derives the answer per collection ([#8236](https://github.com/bitwarden/server/pull/8236)), so read it off the collection.

- Bridge `hasEnabledAccessRule` through `CollectionDetailsResponse` → `CollectionData` → `Collection` → `CollectionView`, plus `CollectionAdminView` for the Admin Console's local-decrypt path.
- `VaultRowLeaseBadgeComponent` renders the resting "Privileged" pill straight from the flag.

A collection row now costs no request, cannot disagree with the list it is drawn beside (the old read was cached for 30s), and is right for any viewer who can see the collection at all.

`GovernedCollectionsService` **stays** — the collection-dialog callout still needs it, because it names the governing rules and summarises what they enforce, which a boolean cannot do. Both surfaces still agree on what "governed" means: the server computes the flag as *associated with a rule that is enabled*, which is exactly what `rulesGoverningCollection` filters for.

## The wasm boundary

The flag rides *alongside* the SDK, not through it. The SDK's `Collection` and `CollectionView` are `#[serde(deny_unknown_fields)]` and declare no such field, so adding it to `toSdkCollection()` would **throw at runtime rather than fail to compile**. It is restored from `sourceCollection` in `fromSdkCollectionView` instead — the same carry-forward `defaultUserCollectionEmail` already relies on, and the reason that parameter exists.

Two tests in `collection-sdk-mapping.spec.ts` pin both halves of that, since no type can. No `sdk-internal` change is needed; if another platform ever wants this, the field moves into the Rust types instead.

## Testing

- Full jest suite: 23,967 passing. (One unrelated SIGSEGV jest-worker crash in a billing spec; passes in isolation.)
- New coverage: badge behaviour for governed / ungoverned / flag-off / pseudo-collection rows; `hasEnabledAccessRule` surviving response → data → domain → decrypted view; and the two wasm-boundary assertions above.
- **Not yet done:** nobody has seen this in a browser. Wants a UAT pass as an ordinary member *and* as a provider user in the Admin Console — the provider case is the whole point of the change.

[PM-42246]: https://bitwarden.atlassian.net/browse/PM-42246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ