### PR TITLE
fix(pam): render the active lease countdown through the shared access-state badge

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -247,7 +247,7 @@
               {{ lease.notBefore | date: "short" }} &ndash; {{ lease.notAfter | date: "short" }}
             </td>
             <td bitCell>
-              <span bitBadge variant="success">{{ lease.notAfter | remainingTime: nowMs() }}</span>
+              <app-pam-access-state-badge [state]="leaseBadgeState(lease)" />
             </td>
             <td bitCell>
               <button

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -247,7 +247,7 @@
               {{ lease.notBefore | date: "short" }} &ndash; {{ lease.notAfter | date: "short" }}
             </td>
             <td bitCell>
-              <app-pam-access-state-badge [state]="leaseBadgeState(lease)" />
+              <app-pam-access-state-badge [state]="leaseBadgeState(lease.id)" />
             </td>
             <td bitCell>
               <button

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -1,0 +1,132 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { provideRouter } from "@angular/router";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject } from "rxjs";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { DialogService, ToastService } from "@bitwarden/components";
+
+import { MyAccessLeaseRow, MyAccessRequestRow } from "./my-access-row";
+import { MyAccessService } from "./my-access.service";
+import { MyRequestsTabComponent } from "./my-requests-tab.component";
+
+const LEASE_END = "2026-08-20T12:00:00.000Z";
+
+// Overrides are loosely typed rather than `Partial<MyAccessLeaseRow>`: the row's ids are opaque
+// branded types, so tests stand in plain strings and rely on the single cast below — the same
+// convention as `history-tab.component.spec.ts`.
+function leaseRow(overrides: Record<string, unknown> = {}): MyAccessLeaseRow {
+  return {
+    id: "lease-1",
+    requestId: "req-1",
+    cipherId: "cipher-1",
+    collectionId: "col-1",
+    cipherName: "Prod database",
+    collectionName: "Production",
+    notBefore: "2026-08-20T11:00:00.000Z",
+    notAfter: LEASE_END,
+    extendedBySeconds: null,
+    extendedUntil: null,
+    ...overrides,
+  } as unknown as MyAccessLeaseRow;
+}
+
+describe("MyRequestsTabComponent", () => {
+  let fixture: ComponentFixture<MyRequestsTabComponent>;
+  let leases$: BehaviorSubject<MyAccessLeaseRow[]>;
+
+  function create(): void {
+    fixture = TestBed.createComponent(MyRequestsTabComponent);
+    fixture.detectChanges();
+  }
+
+  function query(selector: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(selector) as HTMLElement | null;
+  }
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    leases$ = new BehaviorSubject<MyAccessLeaseRow[]>([]);
+
+    await TestBed.configureTestingModule({
+      imports: [MyRequestsTabComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        {
+          provide: MyAccessService,
+          useValue: {
+            pendingRows$: new BehaviorSubject<MyAccessRequestRow[]>([]),
+            extensionRows$: new BehaviorSubject<MyAccessRequestRow[]>([]),
+            leases$,
+            cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
+          },
+        },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: LogService, useValue: mock<LogService>() },
+        {
+          provide: I18nService,
+          useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
+        },
+      ],
+    })
+      .overrideComponent(MyRequestsTabComponent, { add: { schemas: [NO_ERRORS_SCHEMA] } })
+      .compileComponents();
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    jest.useRealTimers();
+  });
+
+  describe("active lease countdown", () => {
+    it("rests on the accent 'time left' badge while the lease has plenty of time", () => {
+      jest.setSystemTime(new Date("2026-08-20T11:30:00.000Z"));
+      leases$.next([leaseRow()]);
+
+      create();
+
+      expect(query('[data-testid="access-state-badge-active"]')).not.toBeNull();
+      expect(query('[data-testid="access-state-badge-ending-soon"]')).toBeNull();
+    });
+
+    it("shows the danger 'ending soon' badge inside the last five minutes", () => {
+      jest.setSystemTime(new Date("2026-08-20T11:57:00.000Z"));
+      leases$.next([leaseRow()]);
+
+      create();
+
+      expect(query('[data-testid="access-state-badge-ending-soon"]')).not.toBeNull();
+      expect(query('[data-testid="access-state-badge-active"]')).toBeNull();
+    });
+
+    it("escalates without a reload as the clock crosses the threshold", () => {
+      jest.setSystemTime(new Date("2026-08-20T11:52:00.000Z"));
+      leases$.next([leaseRow()]);
+      create();
+      expect(query('[data-testid="access-state-badge-active"]')).not.toBeNull();
+
+      jest.advanceTimersByTime(4 * 60_000);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="access-state-badge-ending-soon"]')).not.toBeNull();
+    });
+
+    it("hands the badge the lease expiry as its active state", () => {
+      jest.setSystemTime(new Date("2026-08-20T11:30:00.000Z"));
+      const lease = leaseRow();
+      leases$.next([lease]);
+
+      create();
+
+      expect(fixture.componentInstance["leaseBadgeState"](lease)).toEqual({
+        kind: "active",
+        expiresAt: new Date(LEASE_END),
+      });
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -123,7 +123,7 @@ describe("MyRequestsTabComponent", () => {
 
       create();
 
-      expect(fixture.componentInstance["leaseBadgeState"](lease)).toEqual({
+      expect(fixture.componentInstance["leaseBadgeState"](lease.id)).toEqual({
         kind: "active",
         expiresAt: new Date(LEASE_END),
       });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -147,12 +147,13 @@ export class MyRequestsTabComponent implements OnInit {
   /**
    * Badge state is memoised per lease so the shared badge component sees a stable input across the
    * one-second `nowMs` tick. A fresh object every tick would re-run the badge's own effect and
-   * restart its countdown interval, so the label could never settle on a whole second.
+   * restart its countdown interval, so the label could never settle on a whole second. Keyed off
+   * the unfiltered rows so that typing in the search box does not churn the surviving badges.
    */
   private readonly leaseBadgeStates = computed(
     () =>
       new Map<AccessLeaseId, AccessBadgeState>(
-        this.leases().map((lease) => [
+        this.allLeases().map((lease) => [
           lease.id,
           { kind: "active", expiresAt: new Date(lease.notAfter) },
         ]),
@@ -212,8 +213,8 @@ export class MyRequestsTabComponent implements OnInit {
     return this.cipherById().get(cipherId);
   }
 
-  protected leaseBadgeState(lease: MyAccessLeaseRow): AccessBadgeState | null {
-    return this.leaseBadgeStates().get(lease.id) ?? null;
+  protected leaseBadgeState(id: AccessLeaseId): AccessBadgeState | null {
+    return this.leaseBadgeStates().get(id) ?? null;
   }
 
   protected isCancelling(id: AccessRequestId): boolean {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -36,6 +36,8 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { AccessLeaseId, AccessRequestId } from "..";
+import { AccessBadgeState } from "../access-state-badge/access-badge-state";
+import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { RemainingTimePipe } from "../date/remaining-time.pipe";
 
@@ -68,6 +70,7 @@ type FilterableRow = {
     CommonModule,
     ReactiveFormsModule,
     RouterModule,
+    AccessStateBadgeComponent,
     AccordionComponent,
     AccordionGroupComponent,
     BadgeComponent,
@@ -142,6 +145,21 @@ export class MyRequestsTabComponent implements OnInit {
   protected readonly leases = computed(() => this.applyFilters(this.allLeases()));
 
   /**
+   * Badge state is memoised per lease so the shared badge component sees a stable input across the
+   * one-second `nowMs` tick. A fresh object every tick would re-run the badge's own effect and
+   * restart its countdown interval, so the label could never settle on a whole second.
+   */
+  private readonly leaseBadgeStates = computed(
+    () =>
+      new Map<AccessLeaseId, AccessBadgeState>(
+        this.leases().map((lease) => [
+          lease.id,
+          { kind: "active", expiresAt: new Date(lease.notAfter) },
+        ]),
+      ),
+  );
+
+  /**
    * Each table renders from its own data source so `bit-table` can sort the rows independently.
    */
   protected readonly pendingDataSource = new TableDataSource<MyAccessRequestRow>();
@@ -192,6 +210,10 @@ export class MyRequestsTabComponent implements OnInit {
    */
   protected cipherFor(cipherId: string): CipherView | undefined {
     return this.cipherById().get(cipherId);
+  }
+
+  protected leaseBadgeState(lease: MyAccessLeaseRow): AccessBadgeState | null {
+    return this.leaseBadgeStates().get(lease.id) ?? null;
   }
 
   protected isCancelling(id: AccessRequestId): boolean {

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.ts
@@ -5,6 +5,7 @@ import {
   effect,
   inject,
   input,
+  NgZone,
   signal,
 } from "@angular/core";
 
@@ -46,6 +47,7 @@ export class AccessStateBadgeComponent {
   readonly state = input.required<AccessBadgeState | null>();
 
   private readonly i18nService = inject(I18nService);
+  private readonly ngZone = inject(NgZone);
 
   /** Ticks once a second while an active-lease countdown is showing so the label stays live. */
   private readonly now = signal(Date.now());
@@ -87,8 +89,14 @@ export class AccessStateBadgeComponent {
       if (this.state()?.kind !== "active") {
         return;
       }
-      const id = setInterval(() => this.now.set(Date.now()), 1000);
-      onCleanup(() => clearInterval(id));
+      // Outside the Angular zone: a table can host dozens of these at once, and a periodic in-zone
+      // timer both triggers change detection per badge per second and never lets NgZone settle,
+      // which would hang `fixture.whenStable()` for any host embedding them. The signal write
+      // still drives change detection on its own.
+      this.ngZone.runOutsideAngular(() => {
+        const id = setInterval(() => this.now.set(Date.now()), 1000);
+        onCleanup(() => clearInterval(id));
+      });
     });
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39642
https://bitwarden.atlassian.net/browse/PM-40498

## 📔 Objective

The active-lease countdown on the Requests page rendered as a raw `<span bitBadge variant="success">`,
so it stayed green to expiry and never warned a member their session was ending.

Routes that cell through the shared `AccessStateBadgeComponent` / `cipherAccessBadgeState` model, so
it escalates to the danger "Ending soon" treatment under five minutes, matching the vault row and the
cipher-view modal.

## 📸 Screenshots

<img width="2880" height="1814" alt="01-before-my-requests" src="https://github.com/user-attachments/assets/082b2a8c-668a-4002-a84a-4bab18c389ca" />
<img width="2880" height="1814" alt="02-after-my-requests" src="https://github.com/user-attachments/assets/a2d7c4fa-d33a-45b8-b5ba-c16f9167270c" />

## ⚠️ Known limitations

The shared model has no reachable `unavailable` state: the per-cipher access-state response is
caller-scoped, so nothing on it reveals that another user holds the cipher. The server already knows
(`AccessRule.SingleActiveLease`, `SingleActiveLeaseEvaluator`, and a cross-user `EXISTS` in
`AccessLease_CreateFromApprovedRequest`) but only evaluates it at activation, surfacing a 409.
Exposing it at read time is additive server- and SDK-side and needs no client change.
