### PR TITLE
fix(pam): render the requests page status badges from the shared access-state model

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17419,9 +17419,6 @@
   "pamExtendLeaseError": {
     "message": "Couldn't extend access."
   },
-  "pamStatusPending": {
-    "message": "Pending"
-  },
   "pamStatusApproved": {
     "message": "Approved"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
@@ -35,8 +35,10 @@
       <div class="tw-flex tw-gap-4">
         <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnStatus" | i18n }}</dt>
         <dd class="tw-m-0 tw-flex-1">
-          @if (badge(); as b) {
-            <span bitBadge [variant]="b.statusVariant">{{ b.statusLabelKey | i18n }}</span>
+          @if (badge()?.badgeState; as state) {
+            <app-pam-access-state-badge [state]="state" />
+          } @else if (badge()?.statusBadge; as b) {
+            <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
           }
         </dd>
       </div>
@@ -105,8 +107,8 @@
           <dd class="tw-m-0 tw-flex-1">
             @if (leaseActive()) {
               <span bitBadge variant="success">{{ "pamStatusActivated" | i18n }}</span>
-            } @else if (badge(); as b) {
-              <span bitBadge [variant]="b.statusVariant">{{ b.statusLabelKey | i18n }}</span>
+            } @else if (badge()?.statusBadge; as b) {
+              <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
             }
           </dd>
         </div>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -41,6 +41,7 @@ import {
   reasonText,
   relativeStart,
 } from "../..";
+import { AccessStateBadgeComponent } from "../../access-state-badge/access-state-badge.component";
 import { RemainingTimePipe } from "../../date/remaining-time.pipe";
 import { emptyResolvedNames } from "../access-name-resolver.service";
 import { historyDisplayStatus } from "../my-access-row";
@@ -84,6 +85,7 @@ const DECISION_LABEL_KEYS = {
     RouterModule,
     I18nPipe,
     HeaderModule,
+    AccessStateBadgeComponent,
     BadgeComponent,
     ButtonModule,
     IconModule,

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -72,13 +72,17 @@
           </div>
         </td>
         <td bitCell>
-          <span
-            bitBadge
-            [variant]="row.statusVariant"
-            [attr.data-testid]="'my-access-history-status-' + row.id"
-          >
-            {{ row.statusLabelKey | i18n }}
-          </span>
+          @if (row.badgeState; as state) {
+            <app-pam-access-state-badge [state]="state" />
+          } @else if (row.statusBadge; as badge) {
+            <span
+              bitBadge
+              [variant]="badge.variant"
+              [attr.data-testid]="'my-access-history-status-' + row.id"
+            >
+              {{ badge.labelKey | i18n }}
+            </span>
+          }
         </td>
         <td bitCell>
           @if (row.resolverLabelKey) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -27,8 +27,8 @@ function historyRow(overrides: Record<string, unknown> = {}): MyAccessRequestRow
     cipherName: "Prod database",
     collectionName: "Production",
     status: "denied",
-    statusVariant: "danger",
-    statusLabelKey: "pamStatusDenied",
+    badgeState: null,
+    statusBadge: { labelKey: "pamStatusDenied", variant: "danger" },
     submittedAt: "2026-08-17T11:00:00.000Z",
     resolvedAt: "2026-08-17T11:30:00.000Z",
     leaseNotBefore: "2026-08-17T12:00:00.000Z",
@@ -169,13 +169,14 @@ describe("HistoryTabComponent", () => {
     const activeGrant = historyRow({
       id: "managed-1",
       status: "approved",
-      statusLabelKey: "pamStatusActivated",
+      statusBadge: { labelKey: "pamStatusActivated", variant: "success" },
       producedLeaseId: "lease-1",
     });
     const unstartedApproval = historyRow({
       id: "managed-2",
       status: "approved",
-      statusLabelKey: "pamStatusApproved",
+      badgeState: { kind: "ready" },
+      statusBadge: null,
       producedLeaseId: null,
     });
 
@@ -204,7 +205,7 @@ describe("HistoryTabComponent", () => {
       const revoked = historyRow({
         id: "managed-1",
         status: "approved",
-        statusLabelKey: "pamStatusRevoked",
+        statusBadge: { labelKey: "pamStatusRevoked", variant: "subtle" },
         producedLeaseId: "lease-1",
       });
       managedRows$.next([revoked]);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -175,8 +175,8 @@ describe("HistoryTabComponent", () => {
     const unstartedApproval = historyRow({
       id: "managed-2",
       status: "approved",
-      badgeState: { kind: "ready" },
-      statusBadge: null,
+      badgeState: null,
+      statusBadge: { labelKey: "pamStatusApproved", variant: "success" },
       producedLeaseId: null,
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -28,6 +28,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import type { AccessLeaseId, AccessRequestId } from "../abstractions/access-lease";
+import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { RelativeTimePipe } from "../date/relative-time.pipe";
@@ -63,6 +64,7 @@ type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
   imports: [
     CommonModule,
     RouterModule,
+    AccessStateBadgeComponent,
     BadgeComponent,
     ButtonModule,
     IconComponent,
@@ -137,7 +139,7 @@ export class HistoryTabComponent {
 
   /**
    * A lease the caller granted and can still end: the row is one they manage, it produced a lease,
-   * and that lease is still live. `statusLabelKey` is the already-resolved display status, so this
+   * and that lease is still live. `statusBadge` is the already-resolved display status, so this
    * reads the same conclusion the badge shows rather than re-deriving it.
    */
   protected canRevoke(row: MyAccessRequestRow): boolean {
@@ -145,7 +147,7 @@ export class HistoryTabComponent {
       this.showingManaged() &&
       this.managedIds().has(String(row.id)) &&
       row.producedLeaseId != null &&
-      row.statusLabelKey === "pamStatusActivated"
+      row.statusBadge?.labelKey === "pamStatusActivated"
     );
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
@@ -159,11 +159,11 @@ describe("historyDisplayStatus", () => {
     });
   });
 
-  it("badges an approved request that has not started as ready", () => {
+  it("badges an approved request that has not started as approved, not ready to use", () => {
     const r = request("req-1", { status: "approved", producedLeaseId: undefined });
     expect(historyDisplayStatus(r)).toEqual({
-      badgeState: { kind: "ready" },
-      statusBadge: null,
+      badgeState: null,
+      statusBadge: { labelKey: "pamStatusApproved", variant: "success" },
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
@@ -10,8 +10,7 @@ import {
   extensionsByLeaseId,
   historyDisplayStatus,
   resolveResolver,
-  statusBadgeVariant,
-  statusLabelKey,
+  terminalStatusBadge,
   toLeaseRow,
   toRequestRow,
 } from "./my-access-row";
@@ -76,15 +75,14 @@ function names(overrides: Partial<ResolvedNames> = {}): ResolvedNames {
   return { ...emptyResolvedNames(), ...overrides };
 }
 
-describe("statusLabelKey / statusBadgeVariant", () => {
+describe("terminalStatusBadge", () => {
   it.each([
     ["denied", "pamStatusDenied", "danger"],
     ["canceled", "pamStatusCanceled", "subtle"],
     ["expired", "pamStatusExpired", "warning"],
     ["unknown", "pamStatusUnknown", "subtle"],
   ] as const)("maps %s to %s / %s", (status, labelKey, variant) => {
-    expect(statusLabelKey(status)).toBe(labelKey);
-    expect(statusBadgeVariant(status)).toBe(variant);
+    expect(terminalStatusBadge(status)).toEqual({ labelKey, variant });
   });
 });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
@@ -78,8 +78,6 @@ function names(overrides: Partial<ResolvedNames> = {}): ResolvedNames {
 
 describe("statusLabelKey / statusBadgeVariant", () => {
   it.each([
-    ["pending", "pamStatusPending", "primary"],
-    ["approved", "pamStatusApproved", "success"],
     ["denied", "pamStatusDenied", "danger"],
     ["canceled", "pamStatusCanceled", "subtle"],
     ["expired", "pamStatusExpired", "warning"],
@@ -98,8 +96,8 @@ describe("historyDisplayStatus", () => {
       producedLeaseStatus: "active",
     });
     expect(historyDisplayStatus(r)).toEqual({
-      statusLabelKey: "pamStatusActivated",
-      statusVariant: "success",
+      badgeState: null,
+      statusBadge: { labelKey: "pamStatusActivated", variant: "success" },
     });
   });
 
@@ -110,8 +108,8 @@ describe("historyDisplayStatus", () => {
       producedLeaseStatus: "canceled",
     });
     expect(historyDisplayStatus(r)).toEqual({
-      statusLabelKey: "pamStatusEndedByYou",
-      statusVariant: "subtle",
+      badgeState: null,
+      statusBadge: { labelKey: "pamStatusEndedByYou", variant: "subtle" },
     });
   });
 
@@ -122,8 +120,8 @@ describe("historyDisplayStatus", () => {
       producedLeaseStatus: "revoked",
     });
     expect(historyDisplayStatus(r)).toEqual({
-      statusLabelKey: "pamStatusRevoked",
-      statusVariant: "subtle",
+      badgeState: null,
+      statusBadge: { labelKey: "pamStatusRevoked", variant: "subtle" },
     });
   });
 
@@ -138,8 +136,8 @@ describe("historyDisplayStatus", () => {
       decisions: [decision({ deciderKind: "human", id: "user-1", verdict: "deny" })],
     });
     expect(historyDisplayStatus(r)).toEqual({
-      statusLabelKey: "pamStatusRevoked",
-      statusVariant: "subtle",
+      badgeState: null,
+      statusBadge: { labelKey: "pamStatusRevoked", variant: "subtle" },
     });
   });
 
@@ -150,16 +148,32 @@ describe("historyDisplayStatus", () => {
       producedLeaseStatus: "expired",
     });
     expect(historyDisplayStatus(r)).toEqual({
-      statusLabelKey: "pamStatusExpired",
-      statusVariant: "warning",
+      badgeState: null,
+      statusBadge: { labelKey: "pamStatusExpired", variant: "warning" },
+    });
+  });
+
+  it("badges a pending request from the shared access-state model", () => {
+    const r = request("req-1", { status: "pending" });
+    expect(historyDisplayStatus(r)).toEqual({
+      badgeState: { kind: "pending" },
+      statusBadge: null,
+    });
+  });
+
+  it("badges an approved request that has not started as ready", () => {
+    const r = request("req-1", { status: "approved", producedLeaseId: undefined });
+    expect(historyDisplayStatus(r)).toEqual({
+      badgeState: { kind: "ready" },
+      statusBadge: null,
     });
   });
 
   it("falls back to the base status mapping for non-activated requests", () => {
     const r = request("req-1", { status: "denied" });
     expect(historyDisplayStatus(r)).toEqual({
-      statusLabelKey: "pamStatusDenied",
-      statusVariant: "danger",
+      badgeState: null,
+      statusBadge: { labelKey: "pamStatusDenied", variant: "danger" },
     });
   });
 });
@@ -212,8 +226,8 @@ describe("toRequestRow", () => {
 
     expect(row.cipherName).toBe("Prod DB");
     expect(row.collectionName).toBe("Infra");
-    expect(row.statusLabelKey).toBe("pamStatusPending");
-    expect(row.statusVariant).toBe("primary");
+    expect(row.badgeState).toEqual({ kind: "pending" });
+    expect(row.statusBadge).toBeNull();
     expect(row.id).toBe("req-1");
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -95,33 +95,18 @@ type TerminalRequestStatus = Exclude<AccessRequestStatus, "pending" | "approved"
 /** Time an extension (or sum of extensions) added to a lease, and the resulting end (ms). */
 export type LeaseExtensionSummary = { addedSeconds: number; latestEndMs: number };
 
-/** Map a status to a badge variant. Exported for tests + storybook fidelity. */
-export function statusBadgeVariant(status: TerminalRequestStatus): BadgeVariant {
+/** Map a terminal status to its badge. Exported for tests + storybook fidelity. */
+export function terminalStatusBadge(status: TerminalRequestStatus): TerminalStatusBadge {
   switch (status) {
     case "denied":
-      return "danger";
+      return { labelKey: "pamStatusDenied", variant: "danger" };
     case "canceled":
-      return "subtle";
+      return { labelKey: "pamStatusCanceled", variant: "subtle" };
     case "expired":
-      return "warning";
+      return { labelKey: "pamStatusExpired", variant: "warning" };
     case "unknown":
     default:
-      return "subtle";
-  }
-}
-
-/** i18n key for a status label. Exported for tests. */
-export function statusLabelKey(status: TerminalRequestStatus): string {
-  switch (status) {
-    case "denied":
-      return "pamStatusDenied";
-    case "canceled":
-      return "pamStatusCanceled";
-    case "expired":
-      return "pamStatusExpired";
-    case "unknown":
-    default:
-      return "pamStatusUnknown";
+      return { labelKey: "pamStatusUnknown", variant: "subtle" };
   }
 }
 
@@ -164,7 +149,7 @@ export function historyDisplayStatus(
   if (request.status === "pending") {
     return { badgeState: { kind: "pending" }, statusBadge: null };
   }
-  return terminal(statusLabelKey(request.status), statusBadgeVariant(request.status));
+  return { badgeState: null, statusBadge: terminalStatusBadge(request.status) };
 }
 
 function terminal(

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -32,8 +32,8 @@ export type MyAccessRequestRow = {
   status: AccessRequestStatus;
   /**
    * The shared access-state badge for the status column, so this page, the vault row and the
-   * cipher-view modal show one vocabulary. Null for the terminal statuses, which the shared model
-   * has no equivalent for — {@link statusBadge} carries those. See {@link historyDisplayStatus}.
+   * cipher-view modal show one vocabulary. Null for every outcome the shared model cannot state
+   * from this row alone — {@link statusBadge} carries those. See {@link historyDisplayStatus}.
    */
   badgeState: AccessBadgeState | null;
   /** Set exactly when {@link badgeState} is null — see {@link historyDisplayStatus}. */
@@ -86,9 +86,9 @@ export type MyAccessLeaseRow = {
 export type TerminalStatusBadge = { readonly labelKey: string; readonly variant: BadgeVariant };
 
 /**
- * The statuses whose badge is NOT taken from the shared access-state model. `pending` and
- * `approved` are excluded because both map onto it — `pending` and `ready` respectively — and
- * routing them here again would fork the vocabulary the three surfaces share.
+ * The statuses whose badge is a plain function of the status. `pending` is excluded because it
+ * maps onto the shared access-state model, and `approved` because its badge also depends on the
+ * lease the request did or did not mint.
  */
 type TerminalRequestStatus = Exclude<AccessRequestStatus, "pending" | "approved">;
 
@@ -113,10 +113,9 @@ export function terminalStatusBadge(status: TerminalRequestStatus): TerminalStat
 /**
  * Display status + badge for a request.
  *
- * A pending request and an approved-but-unstarted one both have an equivalent in the shared
- * access-state model, so they return an {@link AccessBadgeState} and are rendered by
- * `AccessStateBadgeComponent` — the same recipe the vault row and the cipher-view modal use.
- * Every other outcome is terminal, has no equivalent in that model, and keeps its own label.
+ * A pending request has an equivalent in the shared access-state model, so it returns an
+ * {@link AccessBadgeState} and is rendered by `AccessStateBadgeComponent` — the same recipe the
+ * vault row and the cipher-view modal use. Every other outcome keeps its own label.
  *
  * Activation is not a status of its own: an approved request that minted a lease is recognised by
  * `producedLeaseId`, and the lease's `producedLeaseStatus` drives the label from there.
@@ -131,7 +130,12 @@ export function historyDisplayStatus(
 ): Pick<MyAccessRequestRow, "badgeState" | "statusBadge"> {
   if (request.status === "approved") {
     if (request.producedLeaseId == null) {
-      return { badgeState: { kind: "ready" }, statusBadge: null };
+      // Deliberately NOT the shared model's "Ready to use". That state is caller-scoped and this
+      // row model also feeds the approver surfaces (ApproverInboxService.historyRows$, and
+      // /pam/requests/:id reached from the approvals inbox), where the viewer holds no lease. It
+      // would also claim availability before `leaseNotBefore` and after `leaseNotAfter`, neither
+      // of which this branch can see. "Approved" is true from either side, at any time.
+      return terminal("pamStatusApproved", "success");
     }
     if (request.producedLeaseStatus === "active") {
       return terminal("pamStatusActivated", "success");

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -12,6 +12,7 @@ import {
   humanApprover,
   requestedWindowSeconds,
 } from "..";
+import { AccessBadgeState } from "../access-state-badge/access-badge-state";
 
 import { ResolvedNames } from "./access-name-resolver.service";
 
@@ -29,10 +30,14 @@ export type MyAccessRequestRow = {
   /** The collection's display name, or null when it isn't in the caller's local vault. */
   collectionName: string | null;
   status: AccessRequestStatus;
-  /** Precomputed badge variant for the status column — see {@link historyDisplayStatus}. */
-  statusVariant: BadgeVariant;
-  /** Precomputed i18n key for the status column — see {@link historyDisplayStatus}. */
-  statusLabelKey: string;
+  /**
+   * The shared access-state badge for the status column, so this page, the vault row and the
+   * cipher-view modal show one vocabulary. Null for the terminal statuses, which the shared model
+   * has no equivalent for — {@link statusBadge} carries those. See {@link historyDisplayStatus}.
+   */
+  badgeState: AccessBadgeState | null;
+  /** Set exactly when {@link badgeState} is null — see {@link historyDisplayStatus}. */
+  statusBadge: TerminalStatusBadge | null;
   submittedAt: string;
   resolvedAt: string | null;
   leaseNotBefore: string;
@@ -77,22 +82,28 @@ export type MyAccessLeaseRow = {
   extendedUntil: string | null;
 };
 
+/** Colour + copy for a terminal status, which the shared access-state model does not describe. */
+export type TerminalStatusBadge = { readonly labelKey: string; readonly variant: BadgeVariant };
+
+/**
+ * The statuses whose badge is NOT taken from the shared access-state model. `pending` and
+ * `approved` are excluded because both map onto it — `pending` and `ready` respectively — and
+ * routing them here again would fork the vocabulary the three surfaces share.
+ */
+type TerminalRequestStatus = Exclude<AccessRequestStatus, "pending" | "approved">;
+
 /** Time an extension (or sum of extensions) added to a lease, and the resulting end (ms). */
 export type LeaseExtensionSummary = { addedSeconds: number; latestEndMs: number };
 
 /** Map a status to a badge variant. Exported for tests + storybook fidelity. */
-export function statusBadgeVariant(status: AccessRequestStatus): BadgeVariant {
+export function statusBadgeVariant(status: TerminalRequestStatus): BadgeVariant {
   switch (status) {
-    case "approved":
-      return "success";
     case "denied":
       return "danger";
     case "canceled":
       return "subtle";
     case "expired":
       return "warning";
-    case "pending":
-      return "primary";
     case "unknown":
     default:
       return "subtle";
@@ -100,18 +111,14 @@ export function statusBadgeVariant(status: AccessRequestStatus): BadgeVariant {
 }
 
 /** i18n key for a status label. Exported for tests. */
-export function statusLabelKey(status: AccessRequestStatus): string {
+export function statusLabelKey(status: TerminalRequestStatus): string {
   switch (status) {
-    case "approved":
-      return "pamStatusApproved";
     case "denied":
       return "pamStatusDenied";
     case "canceled":
       return "pamStatusCanceled";
     case "expired":
       return "pamStatusExpired";
-    case "pending":
-      return "pamStatusPending";
     case "unknown":
     default:
       return "pamStatusUnknown";
@@ -121,9 +128,13 @@ export function statusLabelKey(status: AccessRequestStatus): string {
 /**
  * Display status + badge for a request.
  *
+ * A pending request and an approved-but-unstarted one both have an equivalent in the shared
+ * access-state model, so they return an {@link AccessBadgeState} and are rendered by
+ * `AccessStateBadgeComponent` — the same recipe the vault row and the cipher-view modal use.
+ * Every other outcome is terminal, has no equivalent in that model, and keeps its own label.
+ *
  * Activation is not a status of its own: an approved request that minted a lease is recognised by
- * `producedLeaseId`, and the lease's `producedLeaseStatus` drives the label from there. An approved
- * request not yet activated keeps the plain "Approved" label.
+ * `producedLeaseId`, and the lease's `producedLeaseStatus` drives the label from there.
  *
  `canceled` and `revoked` are distinct lease statuses, so the label reads straight off
  * `producedLeaseStatus`: the requester ending their own lease is "Cancelled", an operator ending it
@@ -132,25 +143,35 @@ export function statusLabelKey(status: AccessRequestStatus): string {
  */
 export function historyDisplayStatus(
   request: Pick<AccessRequestView, "status" | "producedLeaseId" | "producedLeaseStatus">,
-): Pick<MyAccessRequestRow, "statusLabelKey" | "statusVariant"> {
-  if (request.status === "approved" && request.producedLeaseId != null) {
+): Pick<MyAccessRequestRow, "badgeState" | "statusBadge"> {
+  if (request.status === "approved") {
+    if (request.producedLeaseId == null) {
+      return { badgeState: { kind: "ready" }, statusBadge: null };
+    }
     if (request.producedLeaseStatus === "active") {
-      return { statusLabelKey: "pamStatusActivated", statusVariant: "success" };
+      return terminal("pamStatusActivated", "success");
     }
     if (request.producedLeaseStatus === "canceled") {
-      return { statusLabelKey: "pamStatusEndedByYou", statusVariant: "subtle" };
+      return terminal("pamStatusEndedByYou", "subtle");
     }
     if (request.producedLeaseStatus === "revoked") {
-      return { statusLabelKey: "pamStatusRevoked", statusVariant: "subtle" };
+      return terminal("pamStatusRevoked", "subtle");
     }
     // "expired" (or the SDK's "unknown" default) — the server has no autonomous-expiry push in
     // v1, so a lapsed lease still reads as its last known status; default to Expired here.
-    return { statusLabelKey: "pamStatusExpired", statusVariant: "warning" };
+    return terminal("pamStatusExpired", "warning");
   }
-  return {
-    statusLabelKey: statusLabelKey(request.status),
-    statusVariant: statusBadgeVariant(request.status),
-  };
+  if (request.status === "pending") {
+    return { badgeState: { kind: "pending" }, statusBadge: null };
+  }
+  return terminal(statusLabelKey(request.status), statusBadgeVariant(request.status));
+}
+
+function terminal(
+  labelKey: string,
+  variant: BadgeVariant,
+): Pick<MyAccessRequestRow, "badgeState" | "statusBadge"> {
+  return { badgeState: null, statusBadge: { labelKey, variant } };
 }
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
@@ -222,7 +222,7 @@ describe("MyAccessService", () => {
       expect(leases).toEqual([]);
       const history = await firstValueFrom(service.historyRows$);
       expect(history.map((r) => r.id)).toEqual(["req-1"]);
-      expect(history[0].statusLabelKey).toBe("pamStatusEndedByYou");
+      expect(history[0].statusBadge?.labelKey).toBe("pamStatusEndedByYou");
     });
 
     it("rolls back the optimistic patch and rethrows when the SDK call fails", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
@@ -259,7 +259,7 @@ describe("ApproverInboxService", () => {
       );
 
       const history = await firstValueFrom(service.historyRows$);
-      expect(history[0].statusLabelKey).toBe("pamStatusRevoked");
+      expect(history[0].statusBadge?.labelKey).toBe("pamStatusRevoked");
     });
 
     it("restores the row and rethrows when the revoke fails", async () => {
@@ -272,7 +272,7 @@ describe("ApproverInboxService", () => {
         ),
       ).rejects.toThrow("boom");
       const history = await firstValueFrom(service.historyRows$);
-      expect(history[0].statusLabelKey).toBe("pamStatusActivated");
+      expect(history[0].statusBadge?.labelKey).toBe("pamStatusActivated");
     });
 
     it("cancels an approval via access_requests().cancel()", async () => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40498

## 📔 Objective

The Requests page built status badges from `AccessRequestStatus` via `statusBadgeVariant` /
`statusLabelKey`, a vocabulary disjoint from the vault's ("Pending" vs "Pending approval", "Approved"
vs "Ready to use", no icons).

Renders those badges from the shared access-state model so the surfaces agree. Terminal outcomes keep
their own label/variant pair via `statusBadge`.

## 📸 Screenshots

<img width="2880" height="1814" alt="01-before-request-detail" src="https://github.com/user-attachments/assets/9a88103c-c63a-4144-a024-e193617f2c7c" />
<img width="2880" height="1814" alt="02-after-request-detail" src="https://github.com/user-attachments/assets/c2433005-1d66-44c5-8497-7a69a22237ca" />


## ⚠️ Known limitations

**"Approved" is kept where the design specifies "Ready to use", deliberately.** Rationale is inline at
`my-access-row.ts:133-137`: "Ready to use" is caller-scoped, and this row model also feeds the approver
surfaces (`ApproverInboxService.historyRows$`, `/pam/requests/:id` from the approvals inbox) where the
viewer holds no lease; it would also claim availability outside the granted window. "Ready to use" does
ship on the cipher-view banner, where the viewer is by construction the caller.

The `unavailable` state is unreachable; see the first PR in this stack. Spelling is inconsistent at
this point in the chain; the next PR fixes it.
