### PR TITLE
fix(pam): spell "canceled" with one l across the requests surfaces

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17383,8 +17383,8 @@
   "pamStartLeaseError": {
     "message": "Couldn't start access."
   },
-  "pamMyRequestsCancelSuccess": {
-    "message": "Request cancelled"
+  "pamMyRequestsCanceledToast": {
+    "message": "Request canceled"
   },
   "pamMyRequestsCancelError": {
     "message": "Could not cancel request"
@@ -17436,9 +17436,6 @@
   },
   "pamStatusRevoked": {
     "message": "Revoked"
-  },
-  "pamStatusEndedByYou": {
-    "message": "Cancelled"
   },
   "pamStatusUnknown": {
     "message": "Unknown"
@@ -17536,8 +17533,8 @@
   "pamAuditKindRequestDenied": {
     "message": "Request denied"
   },
-  "pamAuditKindRequestCancelled": {
-    "message": "Request cancelled"
+  "pamAuditKindRequestCanceled": {
+    "message": "Request canceled"
   },
   "pamAuditKindRequestExpiredUnanswered": {
     "message": "Request expired without a decision"
@@ -17860,8 +17857,8 @@
   "pamInboxRevokedToast": {
     "message": "Access revoked"
   },
-  "pamInboxCancelApprovalToast": {
-    "message": "Approval cancelled"
+  "pamInboxApprovalCanceledToast": {
+    "message": "Approval canceled"
   },
   "pamInboxCancelApprovalFailed": {
     "message": "Could not cancel approval"

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -50,7 +50,7 @@ export function auditKindLabelKey(kind: AccessAuditEventKind): string {
     case AccessAuditEventKind.RequestDenied:
       return "pamAuditKindRequestDenied";
     case AccessAuditEventKind.RequestCancelled:
-      return "pamAuditKindRequestCancelled";
+      return "pamAuditKindRequestCanceled";
     case AccessAuditEventKind.RequestExpiredUnanswered:
       return "pamAuditKindRequestExpiredUnanswered";
     case AccessAuditEventKind.RequestExpiredUnactivated:

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
@@ -305,7 +305,7 @@ describe("AccessRequestRouteComponent", () => {
       expect(detail.cancel).toHaveBeenCalled();
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "success",
-        message: "pamMyRequestsCancelSuccess",
+        message: "pamMyRequestsCanceledToast",
       });
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -284,7 +284,7 @@ export class AccessRequestRouteComponent implements OnInit {
       await this.detail.cancel();
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamMyRequestsCancelSuccess"),
+        message: this.i18nService.t("pamMyRequestsCanceledToast"),
       });
     } catch (e) {
       this.logService.error(e);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -283,7 +283,7 @@ describe("HistoryTabComponent", () => {
       expect(inbox.cancelApproval).toHaveBeenCalledWith("managed-2");
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "success",
-        message: "pamInboxCancelApprovalToast",
+        message: "pamInboxApprovalCanceledToast",
       });
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -185,7 +185,7 @@ export class HistoryTabComponent {
     if (!this.canCancelApproval(row) || this.isActing(row)) {
       return;
     }
-    await this.act(row, "pamInboxCancelApprovalToast", "pamInboxCancelApprovalFailed", () =>
+    await this.act(row, "pamInboxApprovalCanceledToast", "pamInboxCancelApprovalFailed", () =>
       this.inbox.cancelApproval(row.id as AccessRequestId),
     );
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
@@ -99,7 +99,7 @@ describe("historyDisplayStatus", () => {
     });
   });
 
-  it("labels a canceled lease as Cancelled (pamStatusEndedByYou)", () => {
+  it("labels a canceled lease as Canceled (pamStatusCanceled)", () => {
     const r = request("req-1", {
       status: "approved",
       producedLeaseId: "lease-1",
@@ -107,7 +107,7 @@ describe("historyDisplayStatus", () => {
     });
     expect(historyDisplayStatus(r)).toEqual({
       badgeState: null,
-      statusBadge: { labelKey: "pamStatusEndedByYou", variant: "subtle" },
+      statusBadge: { labelKey: "pamStatusCanceled", variant: "subtle" },
     });
   });
 
@@ -125,7 +125,7 @@ describe("historyDisplayStatus", () => {
 
   it("reads Revoked off the lease status even with the requester's own deny on the log", () => {
     // The label used to be derived from the decision log; `canceled` vs `revoked` settles it now,
-    // so a self-deny recorded alongside an operator revoke must not flip it back to Cancelled.
+    // so a self-deny recorded alongside an operator revoke must not flip it back to Canceled.
     const r = request("req-1", {
       status: "approved",
       requesterId: "user-1",

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
@@ -99,7 +99,7 @@ describe("historyDisplayStatus", () => {
     });
   });
 
-  it("labels a canceled lease as Canceled (pamStatusCanceled)", () => {
+  it("labels a canceled lease as Canceled", () => {
     const r = request("req-1", {
       status: "approved",
       producedLeaseId: "lease-1",

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -121,7 +121,7 @@ export function terminalStatusBadge(status: TerminalRequestStatus): TerminalStat
  * `producedLeaseId`, and the lease's `producedLeaseStatus` drives the label from there.
  *
  `canceled` and `revoked` are distinct lease statuses, so the label reads straight off
- * `producedLeaseStatus`: the requester ending their own lease is "Cancelled", an operator ending it
+ * `producedLeaseStatus`: the requester ending their own lease is "Canceled", an operator ending it
  * out from under them is "Revoked". An `active` produced lease is labelled like a live grant — callers exclude it from History (it
  * belongs in Active leases) but the detail page's top status field can still render it correctly.
  */
@@ -141,7 +141,7 @@ export function historyDisplayStatus(
       return terminal("pamStatusActivated", "success");
     }
     if (request.producedLeaseStatus === "canceled") {
-      return terminal("pamStatusEndedByYou", "subtle");
+      return terminal("pamStatusCanceled", "subtle");
     }
     if (request.producedLeaseStatus === "revoked") {
       return terminal("pamStatusRevoked", "subtle");

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -120,7 +120,7 @@ export function terminalStatusBadge(status: TerminalRequestStatus): TerminalStat
  * Activation is not a status of its own: an approved request that minted a lease is recognised by
  * `producedLeaseId`, and the lease's `producedLeaseStatus` drives the label from there.
  *
- `canceled` and `revoked` are distinct lease statuses, so the label reads straight off
+ * `canceled` and `revoked` are distinct lease statuses, so the label reads straight off
  * `producedLeaseStatus`: the requester ending their own lease is "Canceled", an operator ending it
  * out from under them is "Revoked". An `active` produced lease is labelled like a live grant — callers exclude it from History (it
  * belongs in Active leases) but the detail page's top status field can still render it correctly.

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
@@ -222,7 +222,7 @@ describe("MyAccessService", () => {
       expect(leases).toEqual([]);
       const history = await firstValueFrom(service.historyRows$);
       expect(history.map((r) => r.id)).toEqual(["req-1"]);
-      expect(history[0].statusBadge?.labelKey).toBe("pamStatusEndedByYou");
+      expect(history[0].statusBadge?.labelKey).toBe("pamStatusCanceled");
     });
 
     it("rolls back the optimistic patch and rethrows when the SDK call fails", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
@@ -211,7 +211,7 @@ export class MyAccessService {
    * End the caller's own active lease early. Optimistically drops the lease from Active leases and
    * marks its originating request's produced lease `canceled` — the status the server records for a
    * self-service end, as against `revoked` for an operator ending it — so the grant reappears in
-   * History labelled "Cancelled" straight away; then calls the API and, on failure, restores both
+   * History labelled "Canceled" straight away; then calls the API and, on failure, restores both
    * and rethrows so the caller can toast.
    */
   async endLease(leaseId: AccessLeaseId): Promise<void> {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -275,7 +275,7 @@ export class MyRequestsTabComponent implements OnInit {
       await this.myAccess.cancel(row.id);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamMyRequestsCancelSuccess"),
+        message: this.i18nService.t("pamMyRequestsCanceledToast"),
       });
     } catch (e) {
       this.logService.error(e);

--- a/bitwarden_license/bit-web/src/app/pam/pam.allium
+++ b/bitwarden_license/bit-web/src/app/pam/pam.allium
@@ -243,7 +243,7 @@ entity AccessRequest {
     -- activation-window end, and moves the request to `activated`. An approved
     -- request left unactivated past its actionable_until bound transitions to
     -- `expired`. Single use: one approved request yields at most one lease.
-    status: pending | approved | activated | denied | cancelled | expired
+    status: pending | approved | activated | denied | canceled | expired
     -- Non-optional under its when-clause: every transition out of `pending` is
     -- structurally obliged to set it (and every resolution rule does).
     resolved_at: Timestamp when status != pending
@@ -275,13 +275,13 @@ entity AccessRequest {
     transitions status {
         pending -> approved
         pending -> denied
-        pending -> cancelled
+        pending -> canceled
         pending -> expired
         approved -> activated
         approved -> expired
         approved -> denied
-        approved -> cancelled
-        terminal: activated, denied, cancelled, expired
+        approved -> canceled
+        terminal: activated, denied, canceled, expired
     }
 }
 
@@ -612,7 +612,7 @@ rule MemberCancelsOwnRequest {
     when: MemberCancelsRequest(member, request)
     requires: request.status in {pending, approved}
     requires: request.requester = member
-    ensures: request.status = cancelled
+    ensures: request.status = canceled
     ensures: request.resolved_at = now
     -- No decision was made; approver fields are present (status != pending) but
     -- empty.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40498

## 📚 Stack

PR 3 of 10, based on `pam/requests-badge-vocabulary`.

## 📔 Objective

Spells "canceled" with one l across the Requests surfaces, matching the SDK's `canceled` and the rule
stated in `bitwarden_license/bit-web/src/app/pam/CLAUDE.md`. Renames the affected keys in
`apps/web/src/locales/en/messages.json` and their PAM call sites, and collapses the duplicate
`pamStatusEndedByYou` into the existing `pamStatusCanceled`.

Also corrects the `cancelled` spelling in the `pam.allium` domain spec, which was the last place in
the PAM tree disagreeing with the implementation. `cancellation`, the noun, correctly keeps two Ls.


## ⚠️ Known limitations

- **This PR alone still ships both spellings.** `pendingStateCancelSuccess` ("Request cancelled.")
  survives at this branch's tip and is removed one PR up by #22549, which renames it to
  `pamCancelRequestCanceledToast`. The stack as a whole is consistent.
- **A canceled request may not stay "Canceled."** The History label is applied optimistically on
  cancel while the server-backed status is `expired`, so the row reads "Expired" on the next load.
  Whether the persisted status should be `canceled` is a product question.
- **History cannot distinguish a cancellation from an expiry.** A user-initiated cancel is recorded
  with resolver "Access rule", so "I gave this up" and "it timed out" are indistinguishable in the
  audit trail. Out of scope here, but worth raising separately.
- Translated locales are managed through Crowdin and untouched; renamed keys fall back to English
  until re-translated.
