### PR TITLE
feat(pam): confirm before canceling an access request

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17641,6 +17641,18 @@
   "pendingStateCancelRequest": {
     "message": "Cancel request"
   },
+  "pamKeepRequest": {
+    "message": "Keep request"
+  },
+  "pamCancelRequestTitle": {
+    "message": "Cancel access request"
+  },
+  "pamCancelRequestPendingConfirm": {
+    "message": "This withdraws your request before an approver has decided on it. You can submit a new request at any time."
+  },
+  "pamCancelRequestApprovedConfirm": {
+    "message": "This gives up access that has already been approved. You can submit a new request, but it will need to be approved again."
+  },
   "pendingStateCancelSuccess": {
     "message": "Request cancelled."
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17653,8 +17653,8 @@
   "pamCancelRequestApprovedConfirm": {
     "message": "This gives up access that has already been approved. You can submit a new request, but it will need to be approved again."
   },
-  "pendingStateCancelSuccess": {
-    "message": "Request cancelled."
+  "pamCancelRequestCanceledToast": {
+    "message": "Request canceled"
   },
   "pendingStateCancelError": {
     "message": "Couldn't cancel the request."

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -591,7 +591,7 @@ describe("CipherViewBannerComponent", () => {
       expect(requestsApi.cancelAccessRequest).toHaveBeenCalledWith("request-3");
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "success",
-        message: "pendingStateCancelSuccess",
+        message: "pamCancelRequestCanceledToast",
       });
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -160,6 +160,7 @@ describe("CipherViewBannerComponent", () => {
           useValue: new AccessRequestCancelService(
             requestsApi,
             accessRefresh,
+            dialogService,
             toastService,
             i18nService,
             logService,
@@ -578,10 +579,11 @@ describe("CipherViewBannerComponent", () => {
       });
     });
 
-    it("cancels a pending request", async () => {
+    it("cancels a pending request once confirmed", async () => {
       requestsApi.getCipherAccessState.mockResolvedValue(
         accessState({ pendingRequest: requestView({ id: "request-3" } as never) }),
       );
+      dialogService.openSimpleDialog.mockResolvedValue(true);
       await create(gatedCipher());
 
       await component["cancelRequest"]();
@@ -597,11 +599,24 @@ describe("CipherViewBannerComponent", () => {
       requestsApi.getCipherAccessState.mockResolvedValue(
         accessState({ approvedRequest: requestView({ id: "request-4" } as never) }),
       );
+      dialogService.openSimpleDialog.mockResolvedValue(true);
       await create(gatedCipher());
 
       await component["cancelRequest"]();
 
       expect(requestsApi.cancelAccessRequest).toHaveBeenCalledWith("request-4");
+    });
+
+    it("leaves the request standing when the cancel confirmation is dismissed", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ pendingRequest: requestView({ id: "request-3" } as never) }),
+      );
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+      await create(gatedCipher());
+
+      await component["cancelRequest"]();
+
+      expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
     });
 
     it("ends an active lease once confirmed", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
+++ b/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
@@ -5,7 +5,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
-import { ToastService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 import { SafeProvider, safeProvider } from "@bitwarden/ui-common";
 import { CIPHER_VIEW_BANNER, GATED_CIPHER_RELOADER } from "@bitwarden/vault";
 import { COLLECTION_ACCESS_RULE_CALLOUT } from "@bitwarden/web-vault/app/admin-console/organizations/shared/components/collection-dialog/collection-access-rule-callout.token";
@@ -161,7 +161,14 @@ export function providePam(): SafeProvider[] {
     safeProvider({
       provide: AccessRequestCancelService,
       useClass: AccessRequestCancelService,
-      deps: [AccessRequestSdkService, AccessRefreshService, ToastService, I18nService, LogService],
+      deps: [
+        AccessRequestSdkService,
+        AccessRefreshService,
+        DialogService,
+        ToastService,
+        I18nService,
+        LogService,
+      ],
     }),
     safeProvider({
       provide: VaultRowAccessActionsService,

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
@@ -121,19 +121,12 @@ describe("AccessRequestCancelService", () => {
     expect(toastService.showToast).not.toHaveBeenCalled();
   });
 
-  it("does not ask for confirmation when no request is outstanding anymore", async () => {
-    requestsApi.getCipherAccessState.mockResolvedValue(state());
-
-    await service.cancelOutstandingRequest(CIPHER_ID);
-
-    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
-  });
-
   it("does nothing when no request is outstanding anymore", async () => {
     requestsApi.getCipherAccessState.mockResolvedValue(state());
 
     await service.cancelOutstandingRequest(CIPHER_ID);
 
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
     expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
     expect(toastService.showToast).not.toHaveBeenCalled();
   });

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
@@ -3,7 +3,7 @@ import { NEVER } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { ToastService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import type { AccessRequestId, CipherAccessStateView } from "../abstractions/access-lease";
 import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
@@ -26,6 +26,7 @@ function state(overrides: Partial<CipherAccessStateView> = {}): CipherAccessStat
 
 describe("AccessRequestCancelService", () => {
   let requestsApi: MockProxy<AccessRequestSdkService>;
+  let dialogService: MockProxy<DialogService>;
   let toastService: MockProxy<ToastService>;
   let i18nService: MockProxy<I18nService>;
   let logService: MockProxy<LogService>;
@@ -34,6 +35,8 @@ describe("AccessRequestCancelService", () => {
 
   beforeEach(() => {
     requestsApi = mock<AccessRequestSdkService>();
+    dialogService = mock<DialogService>();
+    dialogService.openSimpleDialog.mockResolvedValue(true);
     toastService = mock<ToastService>();
     i18nService = mock<I18nService>();
     logService = mock<LogService>();
@@ -46,6 +49,7 @@ describe("AccessRequestCancelService", () => {
     service = new AccessRequestCancelService(
       requestsApi,
       accessRefresh,
+      dialogService,
       toastService,
       i18nService,
       logService,
@@ -75,6 +79,54 @@ describe("AccessRequestCancelService", () => {
     await service.cancelOutstandingRequest(CIPHER_ID);
 
     expect(requestsApi.cancelAccessRequest).toHaveBeenCalledWith(REQUEST_ID);
+  });
+
+  it("describes the pending case in the confirmation", async () => {
+    requestsApi.getCipherAccessState.mockResolvedValue(
+      state({ pendingRequest: { id: REQUEST_ID } as never }),
+    );
+
+    await service.cancelOutstandingRequest(CIPHER_ID);
+
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: { key: "pamCancelRequestTitle" },
+        content: { key: "pamCancelRequestPendingConfirm" },
+        cancelButtonText: { key: "pamKeepRequest" },
+      }),
+    );
+  });
+
+  it("describes the approved case in the confirmation", async () => {
+    requestsApi.getCipherAccessState.mockResolvedValue(
+      state({ approvedRequest: { id: REQUEST_ID } as never }),
+    );
+
+    await service.cancelOutstandingRequest(CIPHER_ID);
+
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ content: { key: "pamCancelRequestApprovedConfirm" } }),
+    );
+  });
+
+  it("withdraws nothing when the confirmation is dismissed", async () => {
+    requestsApi.getCipherAccessState.mockResolvedValue(
+      state({ pendingRequest: { id: REQUEST_ID } as never }),
+    );
+    dialogService.openSimpleDialog.mockResolvedValue(false);
+
+    await service.cancelOutstandingRequest(CIPHER_ID);
+
+    expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
+    expect(toastService.showToast).not.toHaveBeenCalled();
+  });
+
+  it("does not ask for confirmation when no request is outstanding anymore", async () => {
+    requestsApi.getCipherAccessState.mockResolvedValue(state());
+
+    await service.cancelOutstandingRequest(CIPHER_ID);
+
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
   });
 
   it("does nothing when no request is outstanding anymore", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
@@ -66,7 +66,7 @@ describe("AccessRequestCancelService", () => {
 
     expect(requestsApi.cancelAccessRequest).toHaveBeenCalledWith(REQUEST_ID);
     expect(toastService.showToast).toHaveBeenCalledWith(
-      expect.objectContaining({ variant: "success", message: "pendingStateCancelSuccess" }),
+      expect.objectContaining({ variant: "success", message: "pamCancelRequestCanceledToast" }),
     );
     expect(announced).toHaveBeenCalledWith(CIPHER_ID);
   });

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
@@ -93,6 +93,7 @@ describe("AccessRequestCancelService", () => {
         title: { key: "pamCancelRequestTitle" },
         content: { key: "pamCancelRequestPendingConfirm" },
         cancelButtonText: { key: "pamKeepRequest" },
+        type: "danger",
       }),
     );
   });

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
@@ -1,6 +1,6 @@
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { ToastService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { AccessRefreshService, AccessRequestSdkService } from "..";
 
@@ -19,23 +19,39 @@ export class AccessRequestCancelService {
   constructor(
     private readonly accessRequestSdkService: AccessRequestSdkService,
     private readonly accessRefreshService: AccessRefreshService,
+    private readonly dialogService: DialogService,
     private readonly toastService: ToastService,
     private readonly i18nService: I18nService,
     private readonly logService: LogService,
   ) {}
 
   /**
-   * Withdraw the cipher's outstanding request. Re-reads the access state at the moment of the
-   * call rather than trusting what the caller rendered — the request may have been decided or
-   * activated since. Never rejects: the outcome is surfaced as a toast here, and the shared
-   * refresh signal is always announced so every leasing surface reconciles through the usual
-   * path.
+   * Withdraw the cipher's outstanding request, after confirming. Re-reads the access state at the
+   * moment of the call rather than trusting what the caller rendered — the request may have been
+   * decided or activated since, and the confirmation has to describe the state that actually
+   * exists. Never rejects: the outcome is surfaced as a toast here, and the shared refresh signal
+   * is always announced so every leasing surface reconciles through the usual path.
    */
   async cancelOutstandingRequest(cipherId: string): Promise<void> {
     try {
       const state = await this.accessRequestSdkService.getCipherAccessState(cipherId);
       const request = state.pendingRequest ?? state.approvedRequest;
       if (request == null) {
+        return;
+      }
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamCancelRequestTitle" },
+        content: {
+          key:
+            state.pendingRequest != null
+              ? "pamCancelRequestPendingConfirm"
+              : "pamCancelRequestApprovedConfirm",
+        },
+        acceptButtonText: { key: "pendingStateCancelRequest" },
+        cancelButtonText: { key: "pamKeepRequest" },
+        type: "warning",
+      });
+      if (!confirmed) {
         return;
       }
       await this.accessRequestSdkService.cancelAccessRequest(request.id);

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
@@ -39,14 +39,13 @@ export class AccessRequestCancelService {
       if (request == null) {
         return;
       }
+      const contentKey =
+        state.pendingRequest != null
+          ? "pamCancelRequestPendingConfirm"
+          : "pamCancelRequestApprovedConfirm";
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamCancelRequestTitle" },
-        content: {
-          key:
-            state.pendingRequest != null
-              ? "pamCancelRequestPendingConfirm"
-              : "pamCancelRequestApprovedConfirm",
-        },
+        content: { key: contentKey },
         acceptButtonText: { key: "pendingStateCancelRequest" },
         cancelButtonText: { key: "pamKeepRequest" },
         type: "warning",

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
@@ -48,7 +48,7 @@ export class AccessRequestCancelService {
         content: { key: contentKey },
         acceptButtonText: { key: "pendingStateCancelRequest" },
         cancelButtonText: { key: "pamKeepRequest" },
-        type: "warning",
+        type: "danger",
       });
       if (!confirmed) {
         return;

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
@@ -56,7 +56,7 @@ export class AccessRequestCancelService {
       await this.accessRequestSdkService.cancelAccessRequest(request.id);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pendingStateCancelSuccess"),
+        message: this.i18nService.t("pamCancelRequestCanceledToast"),
       });
     } catch (e) {
       this.logService.error(e);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40467

## 📔 Objective

Cancelling an access request took effect immediately with no confirmation, from both the cipher-view
banner and the vault-row menu.

Adds a confirmation via `dialogService.openSimpleDialog` with `type: "danger"`, matching the design's
destructive red accept button. Copy varies by state: withdrawing a pending request reads differently
from giving up approved access. Buttons are "Cancel request" / "Keep request", avoiding the usual
ambiguity of a "Cancel" dismiss on a cancel dialog.

Also renames `pendingStateCancelSuccess` to `pamCancelRequestCanceledToast`, completing the one-l
spelling change begun in the previous PR.

## 📸 Screenshots
<img width="2880" height="1814" alt="01-before-confirm-dialog" src="https://github.com/user-attachments/assets/ef777980-f6c6-4fc7-95a0-e35b7b7f7912" />
<img width="2880" height="1814" alt="02-after-confirm-dialog" src="https://github.com/user-attachments/assets/8a5f9842-b5d2-4d39-b03d-5b80952e8159" />



## ⚠️ Known limitations

- **The design's warning callout is not implemented.** `openSimpleDialog`'s content is an interpolated
  string with no slot for one. This is a scope choice rather than a library constraint: a dedicated
  dialog carrying a `bit-callout` is buildable from existing `libs/components` exports, as the Secrets
  Manager delete dialogs demonstrate, but the brief directs PAM to follow the established End-access
  `openSimpleDialog` pattern rather than introduce a second dialog.
- The design's body copy names the cipher; the service takes only a `cipherId` and cannot resolve the
  name. Dropped, since the dialog opens modally over the cipher in both entry points.
- "Removed from the approver's queue" was dropped: nothing here models an approver queue the
  requester can observe, and automatic approval has no approver.
