### PR TITLE
feat(pam): show absolute expiry alongside the lease countdown

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -1,4 +1,4 @@
-@if (activeLease()) {
+@if (activeLease(); as lease) {
   <bit-callout
     type="success"
     [title]="'pamActiveLeaseBannerTitle' | i18n: leaseRemainingLabel()"
@@ -11,7 +11,7 @@
     -->
     <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
       <span bitTypography="body2" data-testid="active-lease-ends-at">
-        {{ "pamWindowUntil" | i18n: (activeLeaseEndsAt() | date: "short") }}
+        {{ "pamWindowUntil" | i18n: (lease.notAfter | date: "short") }}
       </span>
       <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
         @if (canExtendLease()) {
@@ -39,7 +39,7 @@
       </span>
     </div>
   </bit-callout>
-} @else if (approvedRequest()) {
+} @else if (approvedRequest(); as request) {
   <bit-callout
     type="success"
     [title]="'pamApprovedRequestBannerTitle' | i18n"
@@ -48,15 +48,14 @@
     <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
       <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
         <app-pam-access-state-badge [state]="badge()" />
-        @if (approvedAccessWindow(); as window) {
-          <span bitTypography="body2" data-testid="approved-access-window">
-            @if (window.startsAt) {
-              {{ window.startsAt | date: "short" }} &ndash; {{ window.endsAt | date: "short" }}
-            } @else {
-              {{ "pamWindowUntil" | i18n: (window.endsAt | date: "short") }}
-            }
-          </span>
-        }
+        <span bitTypography="body2" data-testid="approved-access-window">
+          @if (approvedRequestStartsNow()) {
+            {{ "pamWindowUntil" | i18n: (request.leaseNotAfter | date: "short") }}
+          } @else {
+            {{ request.leaseNotBefore | date: "short" }} &ndash;
+            {{ request.leaseNotAfter | date: "short" }}
+          }
+        </span>
       </span>
       <span class="tw-flex tw-items-center tw-gap-2">
         <button

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -48,9 +48,13 @@
     <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
       <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
         <app-pam-access-state-badge [state]="badge()" />
-        @if (approvedAccessEndsAt(); as endsAt) {
-          <span bitTypography="body2" data-testid="approved-access-ends-at">
-            {{ "pamWindowUntil" | i18n: (endsAt | date: "short") }}
+        @if (approvedAccessWindow(); as window) {
+          <span bitTypography="body2" data-testid="approved-access-window">
+            @if (window.startsAt) {
+              {{ window.startsAt | date: "short" }} &ndash; {{ window.endsAt | date: "short" }}
+            } @else {
+              {{ "pamWindowUntil" | i18n: (window.endsAt | date: "short") }}
+            }
           </span>
         }
       </span>

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -9,29 +9,34 @@
       "N left" / "Ending soon" pill would render a second copy of the same clock. The other three
       states have no countdown in their title, so they show the shared pill.
     -->
-    <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2">
-      @if (canExtendLease()) {
+    <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+      <span bitTypography="body2" data-testid="active-lease-ends-at">
+        {{ "pamWindowUntil" | i18n: (activeLeaseEndsAt() | date: "short") }}
+      </span>
+      <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+        @if (canExtendLease()) {
+          <button
+            type="button"
+            bitButton
+            buttonType="secondary"
+            size="small"
+            [bitAction]="extendLease"
+            id="pam-cipher-view-banner_button_extend"
+          >
+            {{ "pamExtendLeaseButton" | i18n }}
+          </button>
+        }
         <button
           type="button"
           bitButton
-          buttonType="secondary"
+          buttonType="danger"
           size="small"
-          [bitAction]="extendLease"
-          id="pam-cipher-view-banner_button_extend"
+          [bitAction]="endLease"
+          id="pam-cipher-view-banner_button_end"
         >
-          {{ "pamExtendLeaseButton" | i18n }}
+          {{ "pamEndLeaseButton" | i18n }}
         </button>
-      }
-      <button
-        type="button"
-        bitButton
-        buttonType="danger"
-        size="small"
-        [bitAction]="endLease"
-        id="pam-cipher-view-banner_button_end"
-      >
-        {{ "pamEndLeaseButton" | i18n }}
-      </button>
+      </span>
     </div>
   </bit-callout>
 } @else if (approvedRequest()) {
@@ -41,7 +46,14 @@
     data-testid="cipher-view-banner-approved"
   >
     <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
-      <app-pam-access-state-badge [state]="badge()" />
+      <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+        <app-pam-access-state-badge [state]="badge()" />
+        @if (approvedAccessEndsAt(); as endsAt) {
+          <span bitTypography="body2" data-testid="approved-access-ends-at">
+            {{ "pamWindowUntil" | i18n: (endsAt | date: "short") }}
+          </span>
+        }
+      </span>
       <span class="tw-flex tw-items-center tw-gap-2">
         <button
           type="button"

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -40,7 +40,14 @@ function leaseView(overrides: Partial<AccessLeaseView> = {}): AccessLeaseView {
 }
 
 function requestView(overrides: Partial<AccessRequestView> = {}): AccessRequestView {
-  return { id: "request-1", ...overrides } as unknown as AccessRequestView;
+  return {
+    id: "request-1",
+    // The server resolves both bounds at submit, so every real response carries them; a fixture
+    // omitting them would render a window the SDK's own type makes unrepresentable.
+    leaseNotBefore: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    leaseNotAfter: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+    ...overrides,
+  } as unknown as AccessRequestView;
 }
 
 /**
@@ -346,17 +353,6 @@ describe("CipherViewBannerComponent", () => {
           `${formatDate(STARTS_AT, "short", "en-US")} – ${formatDate(ENDS_AT, "short", "en-US")}`,
         ),
       );
-    });
-
-    it("renders no absolute time for an approved request with no window end", async () => {
-      requestsApi.getCipherAccessState.mockResolvedValue(
-        accessState({ approvedRequest: requestView() }),
-      );
-
-      await create(gatedCipher());
-
-      expect(query('[data-testid="cipher-view-banner-approved"]')).not.toBeNull();
-      expect(query('[data-testid="approved-access-window"]')).toBeNull();
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -308,6 +308,12 @@ describe("CipherViewBannerComponent", () => {
       return `pamWindowUntil ${formatDate(iso, "short", "en-US")}`;
     }
 
+    // Real time, for the same reason the clock above is pinned rather than faked: the banner's
+    // interval is a real one, so a tick can only be observed by outlasting its second.
+    function waitForTick(): Promise<void> {
+      return new Promise((resolve) => setTimeout(resolve, 1_100));
+    }
+
     it("pairs the active lease's countdown with the wall-clock time it ends", async () => {
       requestsApi.getCipherAccessState.mockResolvedValue(
         accessState({ activeLease: leaseView({ notAfter: ENDS_AT }) }),
@@ -352,6 +358,28 @@ describe("CipherViewBannerComponent", () => {
         collapseSpace(
           `${formatDate(STARTS_AT, "short", "en-US")} – ${formatDate(ENDS_AT, "short", "en-US")}`,
         ),
+      );
+    });
+
+    it("switches an approved request to the opened form once its window arrives", async () => {
+      const STARTS_AT = new Date(NOW + 30 * 1000).toISOString();
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({
+          approvedRequest: requestView({ leaseNotBefore: STARTS_AT, leaseNotAfter: ENDS_AT }),
+        }),
+      );
+
+      await create(gatedCipher());
+      expect(query('[data-testid="approved-access-window"]')?.textContent).not.toContain(
+        "pamWindowUntil",
+      );
+
+      jest.spyOn(Date, "now").mockReturnValue(NOW + 31 * 1000);
+      await waitForTick();
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approved-access-window"]')?.textContent?.trim()).toBe(
+        until(ENDS_AT),
       );
     });
   });

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -1,3 +1,4 @@
+import { formatDate } from "@angular/common";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, NEVER, of } from "rxjs";
@@ -273,6 +274,61 @@ describe("CipherViewBannerComponent", () => {
 
       expect(query('[data-testid="cipher-view-banner-active"]')).not.toBeNull();
       expect(query('[data-testid="cipher-view-banner-pending"]')).toBeNull();
+    });
+  });
+
+  describe("the absolute expiry beside the countdown", () => {
+    const NOW = Date.parse("2026-01-01T15:00:00.000Z");
+    const ENDS_AT = "2026-01-01T16:15:00.000Z";
+
+    // Pinned rather than faked with timers: the banner's countdown runs on a real `setInterval`,
+    // and replacing the timer implementation would stall `fixture.whenStable()`.
+    beforeEach(() => {
+      jest.spyOn(Date, "now").mockReturnValue(NOW);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    function until(iso: string): string {
+      return `pamWindowUntil ${formatDate(iso, "short", "en-US")}`;
+    }
+
+    it("pairs the active lease's countdown with the wall-clock time it ends", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ activeLease: leaseView({ notAfter: ENDS_AT }) }),
+      );
+
+      await create(gatedCipher());
+
+      expect(text()).toContain("pamActiveLeaseBannerTitle 1h 15m");
+      expect(query('[data-testid="active-lease-ends-at"]')?.textContent?.trim()).toBe(
+        until(ENDS_AT),
+      );
+    });
+
+    it("shows the end of the granted window on an approved request", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ approvedRequest: requestView({ leaseNotAfter: ENDS_AT }) }),
+      );
+
+      await create(gatedCipher());
+
+      expect(query('[data-testid="approved-access-ends-at"]')?.textContent?.trim()).toBe(
+        until(ENDS_AT),
+      );
+    });
+
+    it("renders no absolute time for an approved request with no window end", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ approvedRequest: requestView() }),
+      );
+
+      await create(gatedCipher());
+
+      expect(query('[data-testid="cipher-view-banner-approved"]')).not.toBeNull();
+      expect(query('[data-testid="approved-access-ends-at"]')).toBeNull();
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -291,6 +291,12 @@ describe("CipherViewBannerComponent", () => {
       jest.restoreAllMocks();
     });
 
+    // Both sides go through this: `formatDate` separates the meridiem with a narrow no-break space,
+    // which the template's own whitespace collapse would otherwise leave only on one side.
+    function collapseSpace(value: string | null | undefined): string {
+      return (value ?? "").replace(/\s+/g, " ").trim();
+    }
+
     function until(iso: string): string {
       return `pamWindowUntil ${formatDate(iso, "short", "en-US")}`;
     }
@@ -308,15 +314,37 @@ describe("CipherViewBannerComponent", () => {
       );
     });
 
-    it("shows the end of the granted window on an approved request", async () => {
+    it("shows the end of the granted window on an approved request already inside its window", async () => {
       requestsApi.getCipherAccessState.mockResolvedValue(
-        accessState({ approvedRequest: requestView({ leaseNotAfter: ENDS_AT }) }),
+        accessState({
+          approvedRequest: requestView({
+            leaseNotBefore: "2026-01-01T14:00:00.000Z",
+            leaseNotAfter: ENDS_AT,
+          }),
+        }),
       );
 
       await create(gatedCipher());
 
-      expect(query('[data-testid="approved-access-ends-at"]')?.textContent?.trim()).toBe(
+      expect(query('[data-testid="approved-access-window"]')?.textContent?.trim()).toBe(
         until(ENDS_AT),
+      );
+    });
+
+    it("shows the whole range for an approved request whose window has not opened yet", async () => {
+      const STARTS_AT = "2026-01-02T09:00:00.000Z";
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({
+          approvedRequest: requestView({ leaseNotBefore: STARTS_AT, leaseNotAfter: ENDS_AT }),
+        }),
+      );
+
+      await create(gatedCipher());
+
+      expect(collapseSpace(query('[data-testid="approved-access-window"]')?.textContent)).toBe(
+        collapseSpace(
+          `${formatDate(STARTS_AT, "short", "en-US")} – ${formatDate(ENDS_AT, "short", "en-US")}`,
+        ),
       );
     });
 
@@ -328,7 +356,7 @@ describe("CipherViewBannerComponent", () => {
       await create(gatedCipher());
 
       expect(query('[data-testid="cipher-view-banner-approved"]')).not.toBeNull();
-      expect(query('[data-testid="approved-access-ends-at"]')).toBeNull();
+      expect(query('[data-testid="approved-access-window"]')).toBeNull();
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -1,3 +1,4 @@
+import { DatePipe } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
@@ -92,6 +93,7 @@ import {
     ReactiveFormsModule,
     TypographyModule,
     AccessStateBadgeComponent,
+    DatePipe,
     DurationLongPipe,
     DurationShortPipe,
     I18nPipe,
@@ -188,6 +190,22 @@ export class CipherViewBannerComponent implements OnInit {
 
   protected readonly leaseRemainingLabel = computed(() =>
     this.activeLease() == null ? "" : formatRemaining(this.activeLeaseExpiryMs() - this.nowMs()),
+  );
+
+  /**
+   * The wall-clock end of the active lease, beside the countdown, so a requester can answer
+   * "can I finish this before it expires" without doing the arithmetic. Rendered through the same
+   * `date: "short"` format the Requests table uses for a lease window.
+   */
+  protected readonly activeLeaseEndsAt = computed(() => this.activeLease()?.notAfter ?? null);
+
+  /**
+   * The end of the window an approved request was granted. The lease itself is not minted until
+   * activation, so this is the point access cannot run past rather than a countdown that has
+   * started — the same value the Requests table shows for a startable row.
+   */
+  protected readonly approvedAccessEndsAt = computed(
+    () => this.approvedRequest()?.leaseNotAfter ?? null,
   );
 
   /** Whether the "Request access" entry point has folded out its form. */

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -200,13 +200,20 @@ export class CipherViewBannerComponent implements OnInit {
   protected readonly activeLeaseEndsAt = computed(() => this.activeLease()?.notAfter ?? null);
 
   /**
-   * The end of the window an approved request was granted. The lease itself is not minted until
-   * activation, so this is the point access cannot run past rather than a countdown that has
-   * started — the same value the Requests table shows for a startable row.
+   * The window an approved request was granted, as the Requests table states it
+   * (`my-requests-tab.component.html:63-68`): "until X" once the window has opened, and the full
+   * `notBefore – notAfter` range while it is still scheduled, since the banner otherwise describes
+   * a grant that cannot be started yet as available now.
    */
-  protected readonly approvedAccessEndsAt = computed(
-    () => this.approvedRequest()?.leaseNotAfter ?? null,
-  );
+  protected readonly approvedAccessWindow = computed(() => {
+    const request = this.approvedRequest();
+    if (request?.leaseNotAfter == null) {
+      return null;
+    }
+    const startsAt = request.leaseNotBefore;
+    const scheduled = startsAt != null && Date.parse(startsAt) > this.nowMs();
+    return { startsAt: scheduled ? startsAt : null, endsAt: request.leaseNotAfter };
+  });
 
   /** Whether the "Request access" entry point has folded out its form. */
   protected readonly requestFormExpanded = signal(false);

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -193,26 +193,15 @@ export class CipherViewBannerComponent implements OnInit {
   );
 
   /**
-   * The wall-clock end of the active lease, beside the countdown, so a requester can answer
-   * "can I finish this before it expires" without doing the arithmetic. Rendered through the same
-   * `date: "short"` format the Requests table uses for a lease window.
+   * Whether an approved request's window has already opened — the same question
+   * `my-requests-tab.component.ts` asks as `startsNow`, so both surfaces state a granted window the
+   * same way: "until X" once it has opened, and the full `notBefore – notAfter` range while it is
+   * still scheduled. Without the distinction the banner describes a grant that cannot be started
+   * yet as available now.
    */
-  protected readonly activeLeaseEndsAt = computed(() => this.activeLease()?.notAfter ?? null);
-
-  /**
-   * The window an approved request was granted, as the Requests table states it
-   * (`my-requests-tab.component.html:63-68`): "until X" once the window has opened, and the full
-   * `notBefore – notAfter` range while it is still scheduled, since the banner otherwise describes
-   * a grant that cannot be started yet as available now.
-   */
-  protected readonly approvedAccessWindow = computed(() => {
+  protected readonly approvedRequestStartsNow = computed(() => {
     const request = this.approvedRequest();
-    if (request?.leaseNotAfter == null) {
-      return null;
-    }
-    const startsAt = request.leaseNotBefore;
-    const scheduled = startsAt != null && Date.parse(startsAt) > this.nowMs();
-    return { startsAt: scheduled ? startsAt : null, endsAt: request.leaseNotAfter };
+    return request != null && Date.parse(request.leaseNotBefore) <= this.nowMs();
   });
 
   /** Whether the "Request access" entry point has folded out its form. */

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -117,7 +117,7 @@ export class CipherViewBannerComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
 
-  /** Ticks once a second so the active lease's countdown stays live. */
+  /** Ticks once a second so the live countdown and a scheduled window's opening stay current. */
   private readonly nowMs = signal(Date.now());
 
   private readonly enabled$ = this.configService.getFeatureFlag$(FeatureFlag.Pam);
@@ -204,6 +204,19 @@ export class CipherViewBannerComponent implements OnInit {
     return request != null && Date.parse(request.leaseNotBefore) <= this.nowMs();
   });
 
+  /**
+   * Whether anything on screen still reads {@link nowMs} — the only two readers are the active
+   * lease's countdown and an approved request waiting for its window to open. Everything else the
+   * banner renders is fixed for a given state, so ticking outside these two would write a signal
+   * once a second, and so run change detection, for a view that cannot move. The approved case is
+   * one-way: past its `leaseNotBefore` the branch settles on "until X" and stops needing the clock.
+   */
+  private readonly clockAdvances = computed(
+    () =>
+      this.activeLease() != null ||
+      (this.approvedRequest() != null && !this.approvedRequestStartsNow()),
+  );
+
   /** Whether the "Request access" entry point has folded out its form. */
   protected readonly requestFormExpanded = signal(false);
   /** Approval path resolved by the pre-check; `null` until the fold-out lands it. */
@@ -278,7 +291,7 @@ export class CipherViewBannerComponent implements OnInit {
     // drives change detection on its own.
     this.ngZone.runOutsideAngular(() => {
       const intervalId = setInterval(() => {
-        if (this.activeLease() != null) {
+        if (this.clockAdvances()) {
           this.nowMs.set(Date.now());
         }
       }, 1000);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40467
https://bitwarden.atlassian.net/browse/PM-39645

## 📔 Objective

The cipher-view banner stated a live lease only as a relative countdown ("18m left"), so a requester
could not tell whether they could finish a task before it expired without doing the arithmetic.

Adds the wall-clock time alongside it, in the two banner states that have a window:

- **Active lease.** An "Until X" line beside the countdown, using the same `date: "short"` format the
  Requests table uses.
- **Approved request.** The full `notBefore` to `notAfter` range while the window is still scheduled,
  collapsing to "Until X" once it opens. Without the scheduled case the banner would describe a grant
  that cannot be started yet as though it were available now.

Also fixes a latent bug: the per-second tick was guarded on `activeLease() != null`, so on the
approved-request banner the clock never advanced and a window opening while the user watched would not
flip to the "Until X" form without a refresh. The guard now covers exactly the states that read the
clock, and stops once the window opens.

## 📸 Screenshots

<img width="2880" height="1814" alt="01-before-view-dialog" src="https://github.com/user-attachments/assets/f307677b-2a91-472d-bf07-b12702b2c2c3" />
<img width="2880" height="1814" alt="02-after-approved-window" src="https://github.com/user-attachments/assets/d119c059-30cb-45ed-bcbe-82fa6657cedc" />
<img width="2880" height="1814" alt="02-after-view-dialog" src="https://github.com/user-attachments/assets/64c8948f-b2ce-4ee2-8724-e0fc923f97ba" />


## ⚠️ Known limitations

- **The scheduled-window flip is covered by unit test only.** The seeded fixtures have no approved
  request with a future `leaseNotBefore`, so it could not be exercised in a browser.
- The two new computeds restate window formatting that also lives in `my-requests-tab.component.html`.
  Extraction was considered and rejected: the only shared logic is one date comparison, and since
  Angular templates can only call component members, both call sites would keep a local member anyway.
  The banner's predicate is named `startsNow` to match the sibling so the duplication is visible.
- The `unavailable` banner state is unimplemented. See the first PR in this stack.
