### PR TITLE
fix(pam): render an em dash for ungated rows in the Controlled access column

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16834,6 +16834,10 @@
   "pamAccessRules": {
     "message": "Access rules"
   },
+  "pamNoAccessRule": {
+    "message": "No access rule",
+    "description": "Screen-reader text for a vault row in the Controlled access column that no access rule governs."
+  },
   "pamAccessRuleActive": {
     "message": "Active"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.spec.ts
@@ -37,6 +37,12 @@ describe("AccessStateBadgeComponent", () => {
     expect(component["recipe"]()).toBeNull();
   });
 
+  it("renders no placeholder text when there is no state, so the cipher-view modal stays empty", () => {
+    create(null);
+    expect(fixture.nativeElement.textContent.trim()).toBe("");
+    expect(fixture.nativeElement.innerHTML).not.toContain("\u2014");
+  });
+
   it.each([
     ["privileged", "primary", "bwi-key", "pamAccessBadgePrivileged"],
     ["pending", "warning", "bwi-clock", "pamAccessBadgePending"],

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.html
@@ -4,4 +4,5 @@
   <span class="tw-text-muted" data-testid="vault-row-no-access-rule" aria-hidden="true"
     >&mdash;</span
   >
+  <span class="tw-sr-only">{{ noAccessRuleLabel }}</span>
 }

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.html
@@ -1,1 +1,7 @@
-<app-pam-access-state-badge [state]="badge()" />
+@if (badge(); as state) {
+  <app-pam-access-state-badge [state]="state" />
+} @else if (showNoAccessRule()) {
+  <span class="tw-text-muted" data-testid="vault-row-no-access-rule" aria-hidden="true"
+    >&mdash;</span
+  >
+}

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, of } from "rxjs";
 
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
@@ -10,6 +12,9 @@ import { AccessRequestSdkService } from "../abstractions/access-request-sdk.serv
 
 import { VaultRowLeaseBadgeComponent } from "./vault-row-lease-badge.component";
 
+const PAM_ORG = "org-1";
+const PLAIN_ORG = "org-2";
+
 describe("VaultRowLeaseBadgeComponent", () => {
   let fixture: ComponentFixture<VaultRowLeaseBadgeComponent>;
   let component: VaultRowLeaseBadgeComponent;
@@ -17,6 +22,7 @@ describe("VaultRowLeaseBadgeComponent", () => {
   let accessRequestSdkService: {
     getCipherAccessState: jest.Mock<Promise<CipherAccessStateView>, [string]>;
   };
+  let organizations$: BehaviorSubject<{ id: string; usePam: boolean }[]>;
 
   function create(cipher: CipherView): void {
     fixture = TestBed.createComponent(VaultRowLeaseBadgeComponent);
@@ -25,29 +31,51 @@ describe("VaultRowLeaseBadgeComponent", () => {
     fixture.detectChanges();
   }
 
-  function createForCollection(collection: { hasEnabledAccessRule?: boolean }): void {
+  function createForCollection(collection: {
+    organizationId?: string;
+    hasEnabledAccessRule?: boolean;
+  }): void {
     fixture = TestBed.createComponent(VaultRowLeaseBadgeComponent);
     fixture.componentRef.setInput("collection", collection);
     component = fixture.componentInstance;
     fixture.detectChanges();
   }
 
-  function gatedCipher(): CipherView {
+  function gatedCipher(organizationId = PAM_ORG): CipherView {
     const cipher = new CipherView();
     cipher.id = "cipher-1";
     cipher.partial = true;
+    cipher.organizationId = organizationId as CipherView["organizationId"];
     return cipher;
+  }
+
+  function ungatedCipher(organizationId?: string): CipherView {
+    const cipher = new CipherView();
+    cipher.id = "cipher-1";
+    cipher.partial = false;
+    cipher.organizationId = (organizationId ?? null) as CipherView["organizationId"];
+    return cipher;
+  }
+
+  function placeholder(): HTMLElement | null {
+    return fixture.nativeElement.querySelector("[data-testid='vault-row-no-access-rule']");
   }
 
   beforeEach(() => {
     enabled$ = new BehaviorSubject<boolean>(true);
     accessRequestSdkService = { getCipherAccessState: jest.fn() };
+    organizations$ = new BehaviorSubject<{ id: string; usePam: boolean }[]>([
+      { id: PAM_ORG, usePam: true },
+      { id: PLAIN_ORG, usePam: false },
+    ]);
 
     TestBed.configureTestingModule({
       imports: [VaultRowLeaseBadgeComponent],
       providers: [
         { provide: ConfigService, useValue: { getFeatureFlag$: () => enabled$ } },
         { provide: AccessRequestSdkService, useValue: accessRequestSdkService },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+        { provide: OrganizationService, useValue: { organizations$: () => organizations$ } },
         {
           provide: I18nService,
           useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
@@ -58,11 +86,8 @@ describe("VaultRowLeaseBadgeComponent", () => {
 
   it("renders nothing for a non-gated cipher", async () => {
     accessRequestSdkService.getCipherAccessState.mockResolvedValue({} as CipherAccessStateView);
-    const cipher = new CipherView();
-    cipher.id = "cipher-1";
-    cipher.partial = false;
 
-    create(cipher);
+    create(ungatedCipher(PAM_ORG));
     await fixture.whenStable();
     fixture.detectChanges();
 
@@ -133,6 +158,84 @@ describe("VaultRowLeaseBadgeComponent", () => {
     fixture.detectChanges();
 
     expect(component["badge"]()).toBeNull();
+  });
+
+  describe("the no-access-rule placeholder", () => {
+    it("draws an em dash for an ungated cipher in a PAM organization", async () => {
+      create(ungatedCipher(PAM_ORG));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["showNoAccessRule"]()).toBe(true);
+      expect(placeholder()?.textContent?.trim()).toBe("\u2014");
+    });
+
+    it("draws an em dash for an ungoverned collection in a PAM organization", () => {
+      createForCollection({ organizationId: PAM_ORG, hasEnabledAccessRule: false });
+
+      expect(component["showNoAccessRule"]()).toBe(true);
+      expect(placeholder()).not.toBeNull();
+    });
+
+    it("draws no em dash for a cipher whose organization does not use PAM", async () => {
+      create(ungatedCipher(PLAIN_ORG));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["showNoAccessRule"]()).toBe(false);
+      expect(placeholder()).toBeNull();
+    });
+
+    it("draws no em dash for a collection whose organization does not use PAM", () => {
+      createForCollection({ organizationId: PLAIN_ORG, hasEnabledAccessRule: false });
+
+      expect(component["showNoAccessRule"]()).toBe(false);
+      expect(placeholder()).toBeNull();
+    });
+
+    it("draws no em dash for a personal cipher, which belongs to no organization", async () => {
+      create(ungatedCipher());
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["showNoAccessRule"]()).toBe(false);
+      expect(placeholder()).toBeNull();
+    });
+
+    it("draws no em dash while the PAM flag is off", async () => {
+      enabled$.next(false);
+
+      create(ungatedCipher(PAM_ORG));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["showNoAccessRule"]()).toBe(false);
+      expect(placeholder()).toBeNull();
+    });
+
+    it("draws no em dash when the access-state fetch fails, which is not evidence of no rule", async () => {
+      accessRequestSdkService.getCipherAccessState.mockRejectedValue(new Error("boom"));
+
+      create(gatedCipher(PAM_ORG));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["showNoAccessRule"]()).toBe(false);
+      expect(placeholder()).toBeNull();
+    });
+
+    it("draws the badge and no em dash when the row is governed", async () => {
+      accessRequestSdkService.getCipherAccessState.mockResolvedValue({
+        badgeState: "privileged",
+      } as unknown as CipherAccessStateView);
+
+      create(gatedCipher(PAM_ORG));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["showNoAccessRule"]()).toBe(false);
+      expect(placeholder()).toBeNull();
+    });
   });
 
   describe("on a collection row", () => {

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.spec.ts
@@ -31,10 +31,7 @@ describe("VaultRowLeaseBadgeComponent", () => {
     fixture.detectChanges();
   }
 
-  function createForCollection(collection: {
-    organizationId?: string;
-    hasEnabledAccessRule?: boolean;
-  }): void {
+  function createForCollection(collection: { hasEnabledAccessRule?: boolean }): void {
     fixture = TestBed.createComponent(VaultRowLeaseBadgeComponent);
     fixture.componentRef.setInput("collection", collection);
     component = fixture.componentInstance;
@@ -170,11 +167,24 @@ describe("VaultRowLeaseBadgeComponent", () => {
       expect(placeholder()?.textContent?.trim()).toBe("\u2014");
     });
 
-    it("draws an em dash for an ungoverned collection in a PAM organization", () => {
-      createForCollection({ organizationId: PAM_ORG, hasEnabledAccessRule: false });
+    it("names the empty state for screen readers, since the dash is aria-hidden", async () => {
+      create(ungatedCipher(PAM_ORG));
+      await fixture.whenStable();
+      fixture.detectChanges();
 
-      expect(component["showNoAccessRule"]()).toBe(true);
-      expect(placeholder()).not.toBeNull();
+      expect(placeholder()?.getAttribute("aria-hidden")).toBe("true");
+      expect(fixture.nativeElement.querySelector(".tw-sr-only")?.textContent?.trim()).toBe(
+        "pamNoAccessRule",
+      );
+    });
+
+    // `hasEnabledAccessRule` defaults to false and is read off the response as `|| false`, so a
+    // server too old to derive it looks exactly like one reporting no rule. Blank, not a dash.
+    it("draws no em dash for an ungoverned collection, whose flag cannot say it was checked", () => {
+      createForCollection({ hasEnabledAccessRule: false });
+
+      expect(component["showNoAccessRule"]()).toBe(false);
+      expect(placeholder()).toBeNull();
     });
 
     it("draws no em dash for a cipher whose organization does not use PAM", async () => {
@@ -186,8 +196,8 @@ describe("VaultRowLeaseBadgeComponent", () => {
       expect(placeholder()).toBeNull();
     });
 
-    it("draws no em dash for a collection whose organization does not use PAM", () => {
-      createForCollection({ organizationId: PLAIN_ORG, hasEnabledAccessRule: false });
+    it("draws no em dash for a collection a rule does govern", () => {
+      createForCollection({ hasEnabledAccessRule: true });
 
       expect(component["showNoAccessRule"]()).toBe(false);
       expect(placeholder()).toBeNull();

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.stories.ts
@@ -2,6 +2,9 @@ import { importProvidersFrom } from "@angular/core";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
 
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import type { CipherAccessStateView } from "@bitwarden/sdk-internal";
@@ -14,11 +17,15 @@ import { VaultRowLeaseBadgeComponent } from "./vault-row-lease-badge.component";
 /** The SDK spells the resting states as bare strings and the active one as a tagged variant. */
 type BadgeState = string | { active: { expiresAt: string } };
 
+/** The organization every cipher fixture below belongs to unless a story says otherwise. */
+const PAM_ORGANIZATION_ID = "org-1";
+
 /** A cipher the SDK has marked as gated. Only `partial` and `id` decide whether a row fetches. */
 function gatedCipher(): CipherView {
   const cipher = new CipherView();
   cipher.id = "cipher-1";
   cipher.partial = true;
+  cipher.organizationId = PAM_ORGANIZATION_ID;
   return cipher;
 }
 
@@ -27,6 +34,7 @@ function ungatedCipher(): CipherView {
   const cipher = new CipherView();
   cipher.id = "cipher-2";
   cipher.partial = false;
+  cipher.organizationId = PAM_ORGANIZATION_ID;
   return cipher;
 }
 
@@ -34,9 +42,26 @@ function ungatedCipher(): CipherView {
  * `state` is a factory, not a value, so an active lease's `expiresAt` is relative to when the story
  * renders rather than when this module loaded — a stale one would resolve straight to "Session
  * ended".
+ *
+ * `organizations` stands in for the account's PAM-eligible organizations, which the component
+ * reads to narrow the em dash placeholder to rows whose organization can actually carry access
+ * rules. Defaults to the one organization every cipher fixture belongs to; a story can pass an
+ * empty `usePam` to show a row the placeholder must not reach.
  */
-function pam(options: { enabled?: boolean; state?: () => BadgeState; fails?: boolean } = {}) {
-  const { enabled = true, state, fails = false } = options;
+function pam(
+  options: {
+    enabled?: boolean;
+    state?: () => BadgeState;
+    fails?: boolean;
+    organizations?: { id: string; usePam: boolean }[];
+  } = {},
+) {
+  const {
+    enabled = true,
+    state,
+    fails = false,
+    organizations = [{ id: PAM_ORGANIZATION_ID, usePam: true }],
+  } = options;
   return moduleMetadata({
     imports: [VaultRowLeaseBadgeComponent],
     providers: [
@@ -48,6 +73,13 @@ function pam(options: { enabled?: boolean; state?: () => BadgeState; fails?: boo
             fails
               ? Promise.reject(new Error("access-state read failed"))
               : Promise.resolve({ badgeState: state?.() } as unknown as CipherAccessStateView),
+        },
+      },
+      { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+      {
+        provide: OrganizationService,
+        useValue: {
+          organizations$: () => of(organizations as Organization[]),
         },
       },
     ],
@@ -109,6 +141,17 @@ export const CipherRowActiveLease: Story = {
 export const UngatedCipher: Story = {
   args: { cipher: ungatedCipher() },
   decorators: [pam({ state: () => "privileged" })],
+};
+
+/**
+ * An ungated row whose organization cannot have access rules. The placeholder narrows to
+ * `pamOrganizationIds`, so this row must render nothing, not the em dash `UngatedCipher` shows.
+ */
+export const UngatedCipherInNonPamOrganization: Story = {
+  args: { cipher: ungatedCipher() },
+  decorators: [
+    pam({ state: () => "privileged", organizations: [{ id: PAM_ORGANIZATION_ID, usePam: false }] }),
+  ],
 };
 
 /** With the PAM flag off nothing renders, and no row issues a request. */

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
@@ -1,9 +1,13 @@
-import { ChangeDetectionStrategy, Component, inject, input } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, inject, input } from "@angular/core";
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { catchError, combineLatest, from, map, Observable, of, switchMap } from "rxjs";
 
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   CipherViewLike,
   CipherViewLikeUtils,
@@ -14,12 +18,26 @@ import { AccessBadgeState, cipherAccessBadgeState } from "../access-state-badge/
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 
 /**
- * The collection field the badge reads, structurally — the host passes its own
+ * The collection fields the badge reads, structurally — the host passes its own
  * `CollectionView`/`CollectionAdminView`, which this component must not import to stay
- * decoupled from the admin-console models. Optional because the vault list also renders
- * pseudo-collections ("Unassigned"), which carry no server state at all.
+ * decoupled from the admin-console models. Both are optional because the vault list also
+ * renders pseudo-collections ("Unassigned"), which carry no server state at all.
  */
-type BadgeCollection = { hasEnabledAccessRule?: boolean };
+type BadgeCollection = { organizationId?: OrganizationId; hasEnabledAccessRule?: boolean };
+
+/**
+ * What the Controlled access cell shows for one row. The `none` case is distinct from `hidden`:
+ * it means the row was checked and is governed by no rule, which the cell draws as an em dash.
+ * `hidden` means there is nothing to say — the feature is off, the row belongs to no
+ * PAM-enabled organization, or the lookup failed — and leaves the cell blank.
+ */
+type LeaseBadgeCell =
+  | { readonly kind: "badge"; readonly state: AccessBadgeState }
+  | { readonly kind: "none" }
+  | { readonly kind: "hidden" };
+
+const NONE: LeaseBadgeCell = { kind: "none" };
+const HIDDEN: LeaseBadgeCell = { kind: "hidden" };
 
 /**
  * Binds `VAULT_ROW_LEASE_BADGE` for one row in the vault list — cipher or collection.
@@ -40,6 +58,11 @@ type BadgeCollection = { hasEnabledAccessRule?: boolean };
  * against the list it is rendered beside, and works for viewers who cannot read the
  * organization's access rules — notably provider users, whom `MemberRequirement` excludes from
  * the access-rules endpoint by design.
+ *
+ * A row with no rule draws an em dash rather than an empty cell, so "checked, not governed"
+ * is distinguishable from "not loaded yet". The placeholder lives here and not in
+ * {@link AccessStateBadgeComponent}, which the cipher-view modal and the Requests page also
+ * render and where the spec calls for nothing at all.
  */
 @Component({
   selector: "app-pam-vault-row-lease-badge",
@@ -53,43 +76,79 @@ export class VaultRowLeaseBadgeComponent {
 
   private readonly configService = inject(ConfigService);
   private readonly accessRequestSdkService = inject(AccessRequestSdkService);
+  private readonly accountService = inject(AccountService);
+  private readonly organizationService = inject(OrganizationService);
 
-  private readonly state$: Observable<AccessBadgeState | null> = combineLatest([
+  /**
+   * Ids of the organizations that actually carry Privileged Access. The column itself is
+   * table-wide — one PAM-enabled organization anywhere in view turns it on for every row — so the
+   * placeholder has to be narrowed to the row's own organization here, or a row from an
+   * organization that cannot have access rules would claim it was checked against them.
+   */
+  private readonly pamOrganizationIds$ = this.accountService.activeAccount$.pipe(
+    getOptionalUserId,
+    switchMap((userId) =>
+      userId == null ? of([]) : this.organizationService.organizations$(userId),
+    ),
+    map((organizations) => new Set(organizations.filter((o) => o.usePam).map((o) => o.id))),
+  );
+
+  private readonly cell$: Observable<LeaseBadgeCell> = combineLatest([
     toObservable(this.cipher),
     toObservable(this.collection),
     this.configService.getFeatureFlag$(FeatureFlag.Pam),
+    this.pamOrganizationIds$,
   ]).pipe(
-    switchMap(([cipher, collection, enabled]) => {
+    switchMap(([cipher, collection, enabled, pamOrganizationIds]) => {
       if (!enabled) {
-        return of(null);
+        return of(HIDDEN);
       }
       if (cipher != null) {
-        return this.cipherState$(cipher);
+        return this.cipherCell$(cipher, pamOrganizationIds);
       }
       if (collection != null) {
-        return this.collectionState$(collection);
+        return this.collectionCell$(collection, pamOrganizationIds);
       }
-      return of(null);
+      return of(HIDDEN);
     }),
   );
 
-  protected readonly badge = toSignal(this.state$, { initialValue: null });
+  private readonly cell = toSignal(this.cell$, { initialValue: HIDDEN });
 
-  private cipherState$(cipher: CipherViewLike): Observable<AccessBadgeState | null> {
+  protected readonly badge = computed<AccessBadgeState | null>(() => {
+    const cell = this.cell();
+    return cell.kind === "badge" ? cell.state : null;
+  });
+
+  protected readonly showNoAccessRule = computed(() => this.cell().kind === "none");
+
+  private cipherCell$(
+    cipher: CipherViewLike,
+    pamOrganizationIds: ReadonlySet<string>,
+  ): Observable<LeaseBadgeCell> {
+    const placeholder = pamOrganizationIds.has(cipher.organizationId ?? "") ? NONE : HIDDEN;
     // Gating is driven by the SDK's `partial` flag, which only some `CipherViewLike` members
     // carry — read it through the util rather than off the union. No flag or no id — no badge.
     if (!CipherViewLikeUtils.isPartial(cipher) || cipher.id == null) {
-      return of(null);
+      return of(placeholder);
     }
     return from(this.accessRequestSdkService.getCipherAccessState(String(cipher.id))).pipe(
-      map(cipherAccessBadgeState),
-      catchError(() => of(null)),
+      map((state): LeaseBadgeCell => {
+        const badge = cipherAccessBadgeState(state);
+        return badge == null ? placeholder : { kind: "badge", state: badge };
+      }),
+      // A failed read is not evidence of anything, so it must not draw the placeholder.
+      catchError(() => of(HIDDEN)),
     );
   }
 
-  private collectionState$({
-    hasEnabledAccessRule,
-  }: BadgeCollection): Observable<AccessBadgeState | null> {
-    return of(hasEnabledAccessRule === true ? { kind: "privileged" } : null);
+  private collectionCell$(
+    { organizationId, hasEnabledAccessRule }: BadgeCollection,
+    pamOrganizationIds: ReadonlySet<string>,
+  ): Observable<LeaseBadgeCell> {
+    if (hasEnabledAccessRule === true) {
+      return of({ kind: "badge", state: { kind: "privileged" } });
+    }
+    return of(pamOrganizationIds.has(organizationId ?? "") ? NONE : HIDDEN);
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
@@ -26,18 +26,11 @@ import { AccessStateBadgeComponent } from "../access-state-badge/access-state-ba
 type BadgeCollection = { organizationId?: OrganizationId; hasEnabledAccessRule?: boolean };
 
 /**
- * What the Controlled access cell shows for one row. The `none` case is distinct from `hidden`:
- * it means the row was checked and is governed by no rule, which the cell draws as an em dash.
- * `hidden` means there is nothing to say — the feature is off, the row belongs to no
- * PAM-enabled organization, or the lookup failed — and leaves the cell blank.
+ * What the row's lookup concluded: a badge state, `"none"` for "checked, governed by no rule",
+ * or `null` for "nothing to say" — the feature is off, there is no row to check, or the lookup
+ * failed. Only `"none"` can draw the em dash, and only a failed lookup must not.
  */
-type LeaseBadgeCell =
-  | { readonly kind: "badge"; readonly state: AccessBadgeState }
-  | { readonly kind: "none" }
-  | { readonly kind: "hidden" };
-
-const NONE: LeaseBadgeCell = { kind: "none" };
-const HIDDEN: LeaseBadgeCell = { kind: "hidden" };
+type LeaseBadgeCell = AccessBadgeState | "none" | null;
 
 /**
  * Binds `VAULT_ROW_LEASE_BADGE` for one row in the vault list — cipher or collection.
@@ -85,70 +78,67 @@ export class VaultRowLeaseBadgeComponent {
    * placeholder has to be narrowed to the row's own organization here, or a row from an
    * organization that cannot have access rules would claim it was checked against them.
    */
-  private readonly pamOrganizationIds$ = this.accountService.activeAccount$.pipe(
-    getOptionalUserId,
-    switchMap((userId) =>
-      userId == null ? of([]) : this.organizationService.organizations$(userId),
+  private readonly pamOrganizationIds = toSignal(
+    this.accountService.activeAccount$.pipe(
+      getOptionalUserId,
+      switchMap((userId) =>
+        userId == null ? of([]) : this.organizationService.organizations$(userId),
+      ),
+      map(
+        (organizations) => new Set<string>(organizations.filter((o) => o.usePam).map((o) => o.id)),
+      ),
     ),
-    map((organizations) => new Set(organizations.filter((o) => o.usePam).map((o) => o.id))),
+    { initialValue: new Set<string>() },
   );
 
   private readonly cell$: Observable<LeaseBadgeCell> = combineLatest([
     toObservable(this.cipher),
     toObservable(this.collection),
     this.configService.getFeatureFlag$(FeatureFlag.Pam),
-    this.pamOrganizationIds$,
   ]).pipe(
-    switchMap(([cipher, collection, enabled, pamOrganizationIds]) => {
+    switchMap(([cipher, collection, enabled]) => {
       if (!enabled) {
-        return of(HIDDEN);
+        return of(null);
       }
       if (cipher != null) {
-        return this.cipherCell$(cipher, pamOrganizationIds);
+        return this.cipherCell$(cipher);
       }
       if (collection != null) {
-        return this.collectionCell$(collection, pamOrganizationIds);
+        return this.collectionCell$(collection);
       }
-      return of(HIDDEN);
+      return of(null);
     }),
   );
 
-  private readonly cell = toSignal(this.cell$, { initialValue: HIDDEN });
+  private readonly cell = toSignal(this.cell$, { initialValue: null });
 
   protected readonly badge = computed<AccessBadgeState | null>(() => {
     const cell = this.cell();
-    return cell.kind === "badge" ? cell.state : null;
+    return cell === "none" ? null : cell;
   });
 
-  protected readonly showNoAccessRule = computed(() => this.cell().kind === "none");
+  protected readonly showNoAccessRule = computed(() => {
+    if (this.cell() !== "none") {
+      return false;
+    }
+    const organizationId = this.cipher()?.organizationId ?? this.collection()?.organizationId;
+    return organizationId != null && this.pamOrganizationIds().has(String(organizationId));
+  });
 
-  private cipherCell$(
-    cipher: CipherViewLike,
-    pamOrganizationIds: ReadonlySet<string>,
-  ): Observable<LeaseBadgeCell> {
-    const placeholder = pamOrganizationIds.has(cipher.organizationId ?? "") ? NONE : HIDDEN;
+  private cipherCell$(cipher: CipherViewLike): Observable<LeaseBadgeCell> {
     // Gating is driven by the SDK's `partial` flag, which only some `CipherViewLike` members
     // carry — read it through the util rather than off the union. No flag or no id — no badge.
     if (!CipherViewLikeUtils.isPartial(cipher) || cipher.id == null) {
-      return of(placeholder);
+      return of("none");
     }
     return from(this.accessRequestSdkService.getCipherAccessState(String(cipher.id))).pipe(
-      map((state): LeaseBadgeCell => {
-        const badge = cipherAccessBadgeState(state);
-        return badge == null ? placeholder : { kind: "badge", state: badge };
-      }),
+      map((state): LeaseBadgeCell => cipherAccessBadgeState(state) ?? "none"),
       // A failed read is not evidence of anything, so it must not draw the placeholder.
-      catchError(() => of(HIDDEN)),
+      catchError(() => of(null)),
     );
   }
 
-  private collectionCell$(
-    { organizationId, hasEnabledAccessRule }: BadgeCollection,
-    pamOrganizationIds: ReadonlySet<string>,
-  ): Observable<LeaseBadgeCell> {
-    if (hasEnabledAccessRule === true) {
-      return of({ kind: "badge", state: { kind: "privileged" } });
-    }
-    return of(pamOrganizationIds.has(organizationId ?? "") ? NONE : HIDDEN);
+  private collectionCell$({ hasEnabledAccessRule }: BadgeCollection): Observable<LeaseBadgeCell> {
+    return of(hasEnabledAccessRule === true ? { kind: "privileged" } : "none");
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
@@ -7,7 +7,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
-import { OrganizationId } from "@bitwarden/common/types/guid";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import {
   CipherViewLike,
   CipherViewLikeUtils,
@@ -18,12 +18,12 @@ import { AccessBadgeState, cipherAccessBadgeState } from "../access-state-badge/
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 
 /**
- * The collection fields the badge reads, structurally — the host passes its own
+ * The collection field the badge reads, structurally — the host passes its own
  * `CollectionView`/`CollectionAdminView`, which this component must not import to stay
- * decoupled from the admin-console models. Both are optional because the vault list also
- * renders pseudo-collections ("Unassigned"), which carry no server state at all.
+ * decoupled from the admin-console models. Optional because the vault list also renders
+ * pseudo-collections ("Unassigned"), which carry no server state at all.
  */
-type BadgeCollection = { organizationId?: OrganizationId; hasEnabledAccessRule?: boolean };
+type BadgeCollection = { hasEnabledAccessRule?: boolean };
 
 /**
  * What the row's lookup concluded: a badge state, `"none"` for "checked, governed by no rule",
@@ -52,10 +52,17 @@ type LeaseBadgeCell = AccessBadgeState | "none" | null;
  * organization's access rules — notably provider users, whom `MemberRequirement` excludes from
  * the access-rules endpoint by design.
  *
- * A row with no rule draws an em dash rather than an empty cell, so "checked, not governed"
- * is distinguishable from "not loaded yet". The placeholder lives here and not in
+ * A cipher row with no rule draws an em dash — paired with an equivalent screen-reader label,
+ * since the dash itself is decorative — rather than an empty cell, so "checked, not governed" is
+ * distinguishable from "not loaded yet". The placeholder lives here and not in
  * {@link AccessStateBadgeComponent}, which the cipher-view modal and the Requests page also
  * render and where the spec calls for nothing at all.
+ *
+ * A collection row never draws it. `hasEnabledAccessRule` is declared `boolean = false` and read
+ * as `getResponseProperty("HasEnabledAccessRule") || false`, so a server too old to derive the
+ * field is indistinguishable from one reporting no rule — the flag cannot express "I did not
+ * check". Blank is the honest answer there, and it is what this column already means by an empty
+ * cell.
  */
 @Component({
   selector: "app-pam-vault-row-lease-badge",
@@ -71,6 +78,8 @@ export class VaultRowLeaseBadgeComponent {
   private readonly accessRequestSdkService = inject(AccessRequestSdkService);
   private readonly accountService = inject(AccountService);
   private readonly organizationService = inject(OrganizationService);
+
+  protected readonly noAccessRuleLabel = inject(I18nService).t("pamNoAccessRule");
 
   /**
    * Ids of the organizations that actually carry Privileged Access. The column itself is
@@ -121,7 +130,7 @@ export class VaultRowLeaseBadgeComponent {
     if (this.cell() !== "none") {
       return false;
     }
-    const organizationId = this.cipher()?.organizationId ?? this.collection()?.organizationId;
+    const organizationId = this.cipher()?.organizationId;
     return organizationId != null && this.pamOrganizationIds().has(String(organizationId));
   });
 
@@ -139,6 +148,6 @@ export class VaultRowLeaseBadgeComponent {
   }
 
   private collectionCell$({ hasEnabledAccessRule }: BadgeCollection): Observable<LeaseBadgeCell> {
-    return of(hasEnabledAccessRule === true ? { kind: "privileged" } : "none");
+    return of(hasEnabledAccessRule === true ? { kind: "privileged" } : null);
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.ts
@@ -136,9 +136,13 @@ export class VaultRowLeaseBadgeComponent {
 
   private cipherCell$(cipher: CipherViewLike): Observable<LeaseBadgeCell> {
     // Gating is driven by the SDK's `partial` flag, which only some `CipherViewLike` members
-    // carry — read it through the util rather than off the union. No flag or no id — no badge.
-    if (!CipherViewLikeUtils.isPartial(cipher) || cipher.id == null) {
+    // carry; read it through the util rather than off the union. Not gated is a real answer;
+    // no id means the lookup could not run, which is not.
+    if (!CipherViewLikeUtils.isPartial(cipher)) {
       return of("none");
+    }
+    if (cipher.id == null) {
+      return of(null);
     }
     return from(this.accessRequestSdkService.getCipherAccessState(String(cipher.id))).pipe(
       map((state): LeaseBadgeCell => cipherAccessBadgeState(state) ?? "none"),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39642
https://bitwarden.atlassian.net/browse/PM-40498

## 📔 Objective

A vault row that no access rule governs rendered an empty Controlled access cell, indistinguishable
from a row whose lookup had not resolved. This gives "checked, governed by nothing" its own mark.

- **Three-valued cell model.** `LeaseBadgeCell = AccessBadgeState | "none" | null`: a badge state,
  `"none"` for "checked, no rule", or `null` for "nothing to say". Only `"none"` draws the placeholder.
  A failed SDK read maps to `null`, because a failed read is not evidence of anything.
- **The placeholder** is a muted `&mdash;` marked `aria-hidden` with an `sr-only` "No access rule"
  label. It lives in this host rather than in `AccessStateBadgeComponent`, which the cipher-view modal
  and Requests page also render and where the design calls for nothing.
- **Narrowed to the row's own organization**, so a row from an org that cannot have access rules does
  not claim it was checked against them.
- **Only cipher rows draw it.** A cipher row resolves through the SDK's `getCipherAccessState`, which
  genuinely reports "checked, no rule". A collection row reads `hasEnabledAccessRule`, declared
  `boolean = false` and parsed as `getResponseProperty(...) || false`, so a server too old to derive
  the field is indistinguishable from one reporting no rule. That flag cannot express "I did not
  check", and a dash there would assert a check that may never have happened, including against
  governed collections on an older self-hosted server. Blank is the honest answer.

## 📸 Screenshots
<img width="2880" height="1814" alt="01-before-vault-column" src="https://github.com/user-attachments/assets/15d7950b-dbf3-4aa1-8e3e-444159899ddf" />
<img width="2880" height="1814" alt="02-after-vault-column" src="https://github.com/user-attachments/assets/516a69ff-268f-472a-aae9-75e23f7a2a58" />


## ⚠️ Known limitations

The column is complete apart from `unavailable`, which no row can currently render; see the first PR
in this stack.
