### PR TITLE
fix(pam): match the delete rule dialog to the design's error glyph

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
@@ -40,10 +40,10 @@ requester's leasing flow, and the approver's inbox. Gated behind `FeatureFlag.Pa
   collection edit dialog.
 - `confirm-dialog/` — `PamConfirmDialogComponent`, a boolean confirm authored as
   `<bit-simple-dialog>`. Reach for it only when `dialogService.openSimpleDialog` cannot
-  express the design: that helper derives the glyph, the glyph's COLOUR and the accept
-  button's variant from one `type` field, so a red glyph over a blue accept button —
-  what the delete-rule design asks for — is unreachable through it. Everything else
-  stays on `openSimpleDialog`.
+  express the design: that helper lets you override the glyph but derives the glyph's
+  COLOUR and the accept button's variant from one `type` field, so a red glyph over a
+  blue accept button — what the delete-rule design asks for — is unreachable through it.
+  Everything else stays on `openSimpleDialog`.
 - `services/` — the SDK-backed implementations of the `abstractions/` contracts.
 - `testing/` — builders shared across specs (`decision-builders.ts`).
 

--- a/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
@@ -38,6 +38,12 @@ requester's leasing flow, and the approver's inbox. Gated behind `FeatureFlag.Pa
   Add a state by teaching the SDK, not by re-ranking the parts client-side.
 - `collection-access-rule-callout/` — names the rules governing a collection, inside the
   collection edit dialog.
+- `confirm-dialog/` — `PamConfirmDialogComponent`, a boolean confirm authored as
+  `<bit-simple-dialog>`. Reach for it only when `dialogService.openSimpleDialog` cannot
+  express the design: that helper derives the glyph, the glyph's COLOUR and the accept
+  button's variant from one `type` field, so a red glyph over a blue accept button —
+  what the delete-rule design asks for — is unreachable through it. Everything else
+  stays on `openSimpleDialog`.
 - `services/` — the SDK-backed implementations of the `abstractions/` contracts.
 - `testing/` — builders shared across specs (`decision-builders.ts`).
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -10,7 +10,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService, SelectItemView, ToastService } from "@bitwarden/components";
 
-import { AccessRuleSdkService, AccessRuleView } from "../..";
+import { AccessRuleSdkService, AccessRuleView, PamConfirmDialogComponent } from "../..";
 
 import { AccessRuleEditComponent } from "./access-rule-edit.component";
 import { CidrValidationService } from "./ip-allowlist/cidr-validation.service";
@@ -25,7 +25,10 @@ const i18nFake: Pick<I18nService, "t" | "translate"> = {
 // treating every non-empty row as valid keeps seeded IP-allowlist forms submittable.
 const cidrValidationStub: CidrValidationService = { isValid: () => true };
 
-const declinedDialogStub = { openSimpleDialog: () => Promise.resolve(false) };
+const declinedDialogStub = {
+  openSimpleDialog: () => Promise.resolve(false),
+  open: () => ({ closed: of(false) }),
+};
 
 /** The SDK's flat access-rule error: a `name`-tagged Error carrying a `variant`. */
 const accessRuleError = (variant: string, message: string) =>
@@ -226,7 +229,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     deleteAccessRule: jest.Mock;
   };
   let showToast: jest.Mock;
-  let dialog: { openSimpleDialog: jest.Mock };
+  let dialog: { openSimpleDialog: jest.Mock; open: jest.Mock };
 
   // The org's collections, as returned by the admin-console service.
   const ORG_COLLECTIONS = [
@@ -246,7 +249,10 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
       deleteAccessRule: jest.fn().mockResolvedValue(undefined),
     };
     showToast = jest.fn();
-    dialog = { openSimpleDialog: jest.fn().mockResolvedValue(true) };
+    dialog = {
+      openSimpleDialog: jest.fn().mockResolvedValue(true),
+      open: jest.fn().mockReturnValue({ closed: of(true) }),
+    };
 
     TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
     TestBed.configureTestingModule({
@@ -412,9 +418,12 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
 
     await component["remove"]();
 
-    expect(dialog.openSimpleDialog).toHaveBeenCalledWith(
+    expect(dialog.open).toHaveBeenCalledWith(
+      PamConfirmDialogComponent,
       expect.objectContaining({
-        content: { key: "pamAccessRuleDeleteConfirmContent", placeholders: ["Existing rule"] },
+        data: expect.objectContaining({
+          content: { key: "pamAccessRuleDeleteConfirmContent", placeholders: ["Existing rule"] },
+        }),
       }),
     );
     expect(pamApi.deleteAccessRule).toHaveBeenCalledWith("org-1", "rule-1");
@@ -431,7 +440,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
       collections: [],
       conditions: [],
     } as unknown as AccessRuleView);
-    dialog.openSimpleDialog.mockResolvedValue(false);
+    dialog.open.mockReturnValue({ closed: of(false) });
 
     await component["remove"]();
 
@@ -444,7 +453,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
 
     await component["remove"]();
 
-    expect(dialog.openSimpleDialog).not.toHaveBeenCalled();
+    expect(dialog.open).not.toHaveBeenCalled();
     expect(pamApi.deleteAccessRule).not.toHaveBeenCalled();
   });
 
@@ -520,7 +529,7 @@ describe("AccessRuleEditComponent — form states", () => {
   let component: AccessRuleEditComponent;
   let navigate: jest.SpyInstance;
   let showToast: jest.Mock;
-  let dialog: { openSimpleDialog: jest.Mock };
+  let dialog: { openSimpleDialog: jest.Mock; open: jest.Mock };
   let pamApi: {
     getAccessRule: jest.Mock;
     createAccessRule: jest.Mock;
@@ -543,7 +552,10 @@ describe("AccessRuleEditComponent — form states", () => {
       deleteAccessRule: jest.fn().mockResolvedValue(undefined),
     };
     showToast = jest.fn();
-    dialog = { openSimpleDialog: jest.fn().mockResolvedValue(true) };
+    dialog = {
+      openSimpleDialog: jest.fn().mockResolvedValue(true),
+      open: jest.fn().mockReturnValue({ closed: of(true) }),
+    };
 
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
@@ -904,7 +916,8 @@ describe("AccessRuleEditComponent — form states", () => {
       expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
       await expect(component.confirmDiscard()).resolves.toBe(true);
       // Only the delete confirmation itself; no discard prompt on the way out.
-      expect(dialog.openSimpleDialog).toHaveBeenCalledTimes(1);
+      expect(dialog.open).toHaveBeenCalledTimes(1);
+      expect(dialog.openSimpleDialog).not.toHaveBeenCalled();
     });
 
     it("does not ask a second time for the navigation Cancel already confirmed", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -52,7 +52,8 @@ import {
   AccessCondition,
   ACCESS_RULE_DURATION_PRESETS,
   ACCESS_RULE_NAME_MAX_LENGTH,
-  accessRuleDeleteConfirmOptions,
+  accessRuleDeleteConfirmParams,
+  PamConfirmDialogComponent,
   accessRuleErrorMessageKey,
   accessRuleToFormValue,
   AccessRuleSdkService,
@@ -509,8 +510,9 @@ export class AccessRuleEditComponent {
       return;
     }
 
-    const confirmed = await this.dialogService.openSimpleDialog(
-      accessRuleDeleteConfirmOptions(existing.name),
+    const confirmed = await PamConfirmDialogComponent.open(
+      this.dialogService,
+      accessRuleDeleteConfirmParams(existing.name),
     );
     if (!confirmed) {
       return;

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
@@ -57,15 +57,21 @@ type ProviderOverride = { provide: unknown; useValue: unknown };
 
 type SetupOptions = {
   overrides?: ProviderOverride[];
-  /** Resolves to the user's answer for every confirmation the test triggers. */
+  /** Resolves to the user's answer for every `openSimpleDialog` confirmation the test triggers. */
   openSimpleDialog?: jest.Mock;
+  /** The same answer for confirmations authored as their own dialog component, e.g. delete. */
+  openDialog?: jest.Mock;
 };
 
 // The component's own template pulls in the full table/toolbar stack; replace it so these
 // tests exercise the component logic, not the rendering of child widgets.
 const setup = async (
   rules: AccessRuleView[],
-  { overrides = [], openSimpleDialog = jest.fn().mockResolvedValue(true) }: SetupOptions = {},
+  {
+    overrides = [],
+    openSimpleDialog = jest.fn().mockResolvedValue(true),
+    openDialog = jest.fn().mockReturnValue({ closed: of(true) }),
+  }: SetupOptions = {},
 ): Promise<ComponentFixture<AccessRulesComponent>> => {
   TestBed.overrideComponent(AccessRulesComponent, { set: { template: "" } });
 
@@ -88,7 +94,7 @@ const setup = async (
 
   // Overridden rather than provided: the component's imported modules bring their own
   // `DialogService` into the standalone injector, which shadows a TestBed provider.
-  TestBed.overrideProvider(DialogService, { useValue: { openSimpleDialog } });
+  TestBed.overrideProvider(DialogService, { useValue: { openSimpleDialog, open: openDialog } });
 
   const fixture = TestBed.createComponent(AccessRulesComponent);
   // Cycle change detection + microtasks so the org-driven reload resolves.
@@ -102,6 +108,7 @@ const setup = async (
 /** The mocks every mutation test asserts against, rebuilt per fixture. */
 let showToast: jest.Mock;
 let openSimpleDialog: jest.Mock;
+let openDialog: jest.Mock;
 let updateAccessRule: jest.Mock;
 let deleteAccessRule: jest.Mock;
 let createAccessRule: jest.Mock;
@@ -118,6 +125,7 @@ const setupMutations = async (
 ): Promise<ComponentFixture<AccessRulesComponent>> => {
   showToast = jest.fn();
   openSimpleDialog = jest.fn().mockResolvedValue(confirmed);
+  openDialog = jest.fn().mockReturnValue({ closed: of(confirmed) });
   updateAccessRule = jest.fn().mockImplementation((_orgId, id) => Promise.resolve(rule(id)));
   deleteAccessRule = jest.fn().mockResolvedValue(undefined);
   // Echoes back the name it was asked for, so a test can assert on the created rule without
@@ -141,6 +149,7 @@ const setupMutations = async (
       ...overrides,
     ],
     openSimpleDialog,
+    openDialog,
   });
 };
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
@@ -38,7 +38,8 @@ import {
   AccessRuleView,
   AccessRuleStatusFilter,
   accessRuleDeactivateConfirmOptions,
-  accessRuleDeleteConfirmOptions,
+  accessRuleDeleteConfirmParams,
+  PamConfirmDialogComponent,
   accessRuleErrorMessageKey,
   accessRuleMatchesFilter,
   classifyAccessRuleError,
@@ -302,8 +303,9 @@ export class AccessRulesComponent {
   };
 
   protected readonly remove = async (rule: AccessRuleView): Promise<void> => {
-    const confirmed = await this.dialogService.openSimpleDialog(
-      accessRuleDeleteConfirmOptions(rule.name),
+    const confirmed = await PamConfirmDialogComponent.open(
+      this.dialogService,
+      accessRuleDeleteConfirmParams(rule.name),
     );
     if (!confirmed) {
       return;

--- a/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.html
@@ -1,0 +1,28 @@
+<bit-simple-dialog>
+  <i bitDialogIcon class="tw-text-3xl" [class]="iconClasses" aria-hidden="true"></i>
+
+  <span bitDialogTitle>{{ title }}</span>
+
+  <div bitDialogContent>{{ content }}</div>
+
+  <ng-container bitDialogFooter>
+    <button
+      type="button"
+      bitButton
+      [buttonType]="params.acceptButtonType"
+      id="pam-confirm-dialog_button_accept"
+      (click)="dialogRef.close(true)"
+    >
+      {{ acceptButtonText }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      buttonType="secondary"
+      id="pam-confirm-dialog_button_cancel"
+      (click)="dialogRef.close(false)"
+    >
+      {{ cancelButtonText }}
+    </button>
+  </ng-container>
+</bit-simple-dialog>

--- a/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.spec.ts
@@ -1,0 +1,109 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { of } from "rxjs";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { DIALOG_DATA, DialogRef, DialogService } from "@bitwarden/components";
+
+import { PamConfirmDialogComponent, PamConfirmDialogParams } from "./pam-confirm-dialog.component";
+
+const params: PamConfirmDialogParams = {
+  title: { key: "confirmTitle" },
+  content: { key: "confirmContent", placeholders: ["Prod database"] },
+  acceptButtonText: { key: "delete" },
+  cancelButtonText: { key: "cancel" },
+  icon: "bwi-clear",
+  iconClass: "tw-text-danger",
+  acceptButtonType: "primary",
+};
+
+describe("PamConfirmDialogComponent", () => {
+  let fixture: ComponentFixture<PamConfirmDialogComponent>;
+  const close = jest.fn();
+
+  async function create(overrides: Partial<PamConfirmDialogParams> = {}): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [PamConfirmDialogComponent, NoopAnimationsModule],
+      providers: [
+        { provide: DIALOG_DATA, useValue: { ...params, ...overrides } },
+        { provide: DialogRef, useValue: { close } },
+        {
+          provide: I18nService,
+          useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PamConfirmDialogComponent);
+    fixture.detectChanges();
+  }
+
+  function button(id: string): HTMLButtonElement {
+    return fixture.nativeElement.querySelector(`#${id}`);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it("renders the glyph in the colour the params ask for, not one derived from the button", async () => {
+    await create();
+
+    const icon: HTMLElement = fixture.nativeElement.querySelector("[bitDialogIcon]");
+    expect(icon.classList).toContain("bwi");
+    expect(icon.classList).toContain("bwi-clear");
+    expect(icon.classList).toContain("tw-text-danger");
+    expect(icon.classList).toContain("tw-text-3xl");
+  });
+
+  it("renders a primary accept button beside that danger glyph", async () => {
+    await create();
+
+    const accept = button("pam-confirm-dialog_button_accept");
+    expect(accept.classList).toContain("tw-bg-bg-brand");
+    expect(accept.classList).not.toContain("tw-bg-bg-danger");
+  });
+
+  it("localizes the title and content, passing the content placeholders through", async () => {
+    await create();
+
+    expect(fixture.nativeElement.textContent).toContain("confirmTitle");
+    expect(fixture.nativeElement.textContent).toContain("confirmContent Prod database");
+  });
+
+  it("closes with true when accepted and false when cancelled", async () => {
+    await create();
+
+    button("pam-confirm-dialog_button_accept").click();
+    expect(close).toHaveBeenCalledWith(true);
+
+    close.mockClear();
+    button("pam-confirm-dialog_button_cancel").click();
+    expect(close).toHaveBeenCalledWith(false);
+  });
+
+  describe("open", () => {
+    function dialogService(closed: boolean | undefined): DialogService {
+      return {
+        open: jest.fn().mockReturnValue({ closed: of(closed) }),
+      } as unknown as DialogService;
+    }
+
+    it("resolves true when the dialog closes with true", async () => {
+      await expect(PamConfirmDialogComponent.open(dialogService(true), params)).resolves.toBe(true);
+    });
+
+    it("resolves false when the dialog closes with false", async () => {
+      await expect(PamConfirmDialogComponent.open(dialogService(false), params)).resolves.toBe(
+        false,
+      );
+    });
+
+    it("resolves false when the dialog is dismissed without an answer", async () => {
+      await expect(PamConfirmDialogComponent.open(dialogService(undefined), params)).resolves.toBe(
+        false,
+      );
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.stories.ts
@@ -1,0 +1,57 @@
+import { importProvidersFrom } from "@angular/core";
+import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
+
+import { DIALOG_DATA, DialogRef } from "@bitwarden/components";
+import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
+
+import { accessRuleDeleteConfirmParams } from "../helpers/access-rule-delete-confirm";
+
+import { PamConfirmDialogComponent, PamConfirmDialogParams } from "./pam-confirm-dialog.component";
+
+/**
+ * The dialog reads `DIALOG_DATA` once at construction and exposes no inputs, so each story has
+ * to supply its own provider rather than driving the arrangement from args.
+ */
+function withParams(params: PamConfirmDialogParams) {
+  return moduleMetadata({
+    imports: [PamConfirmDialogComponent],
+    providers: [
+      { provide: DialogRef, useValue: { close: () => {} } },
+      { provide: DIALOG_DATA, useValue: params },
+    ],
+  });
+}
+
+export default {
+  title: "Web/PAM/Confirm Dialog",
+  component: PamConfirmDialogComponent,
+  decorators: [
+    applicationConfig({
+      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+    }),
+  ],
+  render: () => ({ template: `<pam-confirm-dialog />` }),
+} as Meta<PamConfirmDialogComponent>;
+
+type Story = StoryObj<PamConfirmDialogComponent>;
+
+/**
+ * The arrangement this component exists for, rendered from the same `accessRuleDeleteConfirmParams`
+ * the list and the edit page pass: a danger glyph above a primary accept button, which
+ * `openSimpleDialog` cannot produce because it locks the glyph's colour and the button's variant
+ * together.
+ */
+export const DeleteRule: Story = {
+  decorators: [withParams(accessRuleDeleteConfirmParams("Prod database"))],
+};
+
+/**
+ * The same copy with the accept button switched to `danger`, which is what `openSimpleDialog`
+ * would have given us. Kept beside `DeleteRule` so the pairing the design asked for stays legible
+ * as a choice rather than an accident.
+ */
+export const DangerAcceptButton: Story = {
+  decorators: [
+    withParams({ ...accessRuleDeleteConfirmParams("Prod database"), acceptButtonType: "danger" }),
+  ],
+};

--- a/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.ts
@@ -1,0 +1,77 @@
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { firstValueFrom } from "rxjs";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import {
+  ButtonModule,
+  CenterPositionStrategy,
+  DIALOG_DATA,
+  DialogModule,
+  DialogRef,
+  DialogService,
+  Translation,
+} from "@bitwarden/components";
+
+export type PamConfirmDialogParams = {
+  title: Translation;
+  content: Translation;
+  acceptButtonText: Translation;
+  cancelButtonText: Translation;
+  /** `bwi-*` class of the centred glyph. */
+  icon: string;
+  /** Tailwind text colour for that glyph, chosen independently of `acceptButtonType`. */
+  iconClass: string;
+  acceptButtonType: "primary" | "danger";
+};
+
+/**
+ * A yes/no confirmation that resolves to a boolean, matching `openSimpleDialog`'s contract.
+ *
+ * It exists because `openSimpleDialog` derives the glyph, the glyph's colour AND the accept
+ * button's variant from a single `type` field, so a red glyph above a blue accept button is
+ * inexpressible through it. Authoring `<bit-simple-dialog>` directly hands those three back to
+ * the caller as separate params.
+ */
+@Component({
+  selector: "pam-confirm-dialog",
+  templateUrl: "./pam-confirm-dialog.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, DialogModule],
+})
+export class PamConfirmDialogComponent {
+  private readonly i18nService = inject(I18nService);
+  protected readonly dialogRef = inject<DialogRef<boolean>>(DialogRef);
+  protected readonly params = inject<PamConfirmDialogParams>(DIALOG_DATA);
+
+  protected readonly title = this.translate(this.params.title);
+  protected readonly content = this.translate(this.params.content);
+  protected readonly acceptButtonText = this.translate(this.params.acceptButtonText);
+  protected readonly cancelButtonText = this.translate(this.params.cancelButtonText);
+
+  protected readonly iconClasses = ["bwi", this.params.icon, this.params.iconClass];
+
+  private translate(translation: Translation): string {
+    return this.i18nService.t(translation.key, ...(translation.placeholders ?? []));
+  }
+
+  /**
+   * Resolves `false` for every way out that is not the accept button — Escape and the backdrop
+   * included — which is the same collapse `openSimpleDialog` applies, so call sites keep reading
+   * the result as a plain "did they confirm".
+   */
+  static async open(
+    dialogService: DialogService,
+    params: PamConfirmDialogParams,
+  ): Promise<boolean> {
+    const dialogRef = dialogService.open<boolean, PamConfirmDialogParams>(
+      PamConfirmDialogComponent,
+      {
+        data: params,
+        // Simple dialogs stay centred; the default strategy turns them into a bottom sheet on mobile.
+        positionStrategy: new CenterPositionStrategy(),
+      },
+    );
+
+    return (await firstValueFrom(dialogRef.closed)) === true;
+  }
+}

--- a/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/confirm-dialog/pam-confirm-dialog.component.ts
@@ -27,10 +27,10 @@ export type PamConfirmDialogParams = {
 /**
  * A yes/no confirmation that resolves to a boolean, matching `openSimpleDialog`'s contract.
  *
- * It exists because `openSimpleDialog` derives the glyph, the glyph's colour AND the accept
- * button's variant from a single `type` field, so a red glyph above a blue accept button is
- * inexpressible through it. Authoring `<bit-simple-dialog>` directly hands those three back to
- * the caller as separate params.
+ * It exists because `openSimpleDialog` lets you override the glyph but derives the glyph's
+ * colour AND the accept button's variant from a single `type` field, so a red glyph above a
+ * blue accept button is inexpressible through it. Authoring `<bit-simple-dialog>` directly
+ * hands those three back to the caller as separate params.
  */
 @Component({
   selector: "pam-confirm-dialog",

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.spec.ts
@@ -1,8 +1,8 @@
-import { accessRuleDeleteConfirmOptions } from "./access-rule-delete-confirm";
+import { accessRuleDeleteConfirmParams } from "./access-rule-delete-confirm";
 
-describe("accessRuleDeleteConfirmOptions", () => {
-  it("asks the warning question with the rule name as the only placeholder", () => {
-    expect(accessRuleDeleteConfirmOptions("Prod database")).toEqual({
+describe("accessRuleDeleteConfirmParams", () => {
+  it("asks the delete question with the rule name as the only placeholder", () => {
+    expect(accessRuleDeleteConfirmParams("Prod database")).toEqual({
       title: { key: "pamAccessRuleDeleteConfirmTitle" },
       content: {
         key: "pamAccessRuleDeleteConfirmContent",
@@ -10,7 +10,9 @@ describe("accessRuleDeleteConfirmOptions", () => {
       },
       acceptButtonText: { key: "delete" },
       cancelButtonText: { key: "cancel" },
-      type: "warning",
+      icon: "bwi-clear",
+      iconClass: "tw-text-danger",
+      acceptButtonType: "primary",
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.ts
@@ -1,16 +1,22 @@
-import { SimpleDialogOptions } from "@bitwarden/components";
+import type { PamConfirmDialogParams } from "../confirm-dialog/pam-confirm-dialog.component";
 
 /**
  * Confirmation copy for deleting a single access rule. Shared so the list and the edit
  * page ask the same question — deleting from either place is the same destructive act,
  * and the two must not drift apart.
+ *
+ * The red glyph over a blue accept button is why this cannot go through `openSimpleDialog`;
+ * see `PamConfirmDialogComponent`. `bwi-clear` is the circled X — `bwi-error`, despite the
+ * name, draws an octagon.
  */
-export function accessRuleDeleteConfirmOptions(ruleName: string): SimpleDialogOptions {
+export function accessRuleDeleteConfirmParams(ruleName: string): PamConfirmDialogParams {
   return {
     title: { key: "pamAccessRuleDeleteConfirmTitle" },
     content: { key: "pamAccessRuleDeleteConfirmContent", placeholders: [ruleName] },
     acceptButtonText: { key: "delete" },
     cancelButtonText: { key: "cancel" },
-    type: "warning",
+    icon: "bwi-clear",
+    iconClass: "tw-text-danger",
+    acceptButtonType: "primary",
   };
 }

--- a/bitwarden_license/bit-web/src/app/pam/index.ts
+++ b/bitwarden_license/bit-web/src/app/pam/index.ts
@@ -52,9 +52,11 @@ export {
 export type { AccessRuleFormPatch, AccessRuleFormValue } from "./helpers/access-rule-request";
 export { accessRuleToCopyRequest, copyRuleName } from "./helpers/access-rule-copy";
 export { resolveCollectionNames } from "./helpers/collection-names";
-export { accessRuleDeleteConfirmOptions } from "./helpers/access-rule-delete-confirm";
+export { accessRuleDeleteConfirmParams } from "./helpers/access-rule-delete-confirm";
 export { accessRuleDeactivateConfirmOptions } from "./helpers/access-rule-deactivate-confirm";
 export { rulesChangingEnabled } from "./helpers/rules-changing-enabled";
+export { PamConfirmDialogComponent } from "./confirm-dialog/pam-confirm-dialog.component";
+export type { PamConfirmDialogParams } from "./confirm-dialog/pam-confirm-dialog.component";
 export { approvalMethodLabelKeys } from "./helpers/approval-method";
 export {
   AccessRuleStatusFilter,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42278

## 📔 Objective

The delete-access-rule confirmation used `openSimpleDialog` with `type: "warning"`, which renders an
amber glyph. The design calls for a red error mark above a blue primary Delete button, a combination
`openSimpleDialog` cannot express, since it derives glyph, glyph colour and accept-button variant from
the single `type` field and only the glyph is overridable.

Adds `PamConfirmDialogComponent`, a small dialog authored as `<bit-simple-dialog>` in
`bitwarden_license/bit-web/`, which separates those three concerns. No change to `libs/components`:
`DialogModule` already exports `SimpleDialogComponent` and the `bitDialogIcon` directive, and consumers
authoring the dialog directly supply the icon element and footer buttons themselves.

The glyph is **`bwi-clear`**, a circle containing an X. `bwi-error`, despite the name, draws an octagon.

`accessRuleDeleteConfirmOptions` is renamed `accessRuleDeleteConfirmParams` since it no longer returns
`SimpleDialogOptions`; `open()` still resolves a plain boolean, so both call sites keep their guards.

## 📸 Screenshots
<img width="2880" height="1814" alt="01-before-delete-dialog" src="https://github.com/user-attachments/assets/8a27835d-1483-4bb8-b4e0-bf5314936e68" />
<img width="2880" height="1814" alt="02-after-delete-dialog" src="https://github.com/user-attachments/assets/1a0a7f77-1414-4779-94c9-a3551667c5d0" />

## ⚠️ Known limitations

- **The before glyph reveals a library-level defect, not this milestone's bug.** `type: "warning"`
  renders the class `bwi-exclamation-triangle`, which maps to a font glyph whose internal
  `glyph-name` is `warning` and which draws a **circled exclamation**, not a triangle. Confirmed from
  the font source and by measuring the rendered glyph in two dialogs across both themes. Every
  `type: "warning"` dialog in the product is affected. Out of scope here; worth raising with UI
  Foundation.
- **Enter deletes the rule.** `SimpleDialogComponent` autofocuses the first footer button, which here
  is the destructive Delete. This matches `SimpleConfigurableDialogComponent`'s footer order, so the
  existing behaviour is preserved rather than diverged from, but it deserves a design call.
- `PamConfirmDialogComponent` is generic and reusable; the cancel-request confirm could adopt it with
  only a params factory. Giving that dialog its designed callout would additionally need a projected
  slot, deliberately not built speculatively.
- The accept button in the after capture shows a keyboard focus ring; a re-shot with focus cleared is
  pending so the glyph is the only variable.