### PR TITLE
perf(pam): share one clock across the access-state badges

### DIFF
--- a/apps/web/src/app/pam/user-nav-slot/pam-user-nav-slot.component.spec.ts
+++ b/apps/web/src/app/pam/user-nav-slot/pam-user-nav-slot.component.spec.ts
@@ -85,6 +85,14 @@ describe("PamUserNavSlotComponent", () => {
     expect(navItem()).toBeNull();
   });
 
+  it("generates no box of its own, so rendering nothing takes up no space", () => {
+    organizations$.next([nonPamOrg]);
+    fixture.detectChanges();
+
+    expect(navItem()).toBeNull();
+    expect(fixture.debugElement.nativeElement.classList).toContain("tw-contents");
+  });
+
   describe("the pending-count badge", () => {
     const badge = () => fixture.debugElement.query(By.css("[bitBadge]"));
 

--- a/apps/web/src/app/pam/user-nav-slot/pam-user-nav-slot.component.ts
+++ b/apps/web/src/app/pam/user-nav-slot/pam-user-nav-slot.component.ts
@@ -27,6 +27,7 @@ import { PamNavBadgeService } from "../pam-nav-badge.service";
 @Component({
   selector: "app-pam-user-nav-slot",
   templateUrl: "./pam-user-nav-slot.component.html",
+  host: { class: "tw-contents" },
   imports: [BadgeModule, I18nPipe, NavigationModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-badge-ticker.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-badge-ticker.service.spec.ts
@@ -1,0 +1,99 @@
+import { NgZone } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+
+import { AccessBadgeTickerService } from "./access-badge-ticker.service";
+
+describe("AccessBadgeTickerService", () => {
+  let service: AccessBadgeTickerService;
+  let runOutsideAngularSpy: jest.SpyInstance;
+  let setIntervalSpy: jest.SpyInstance;
+  let clearIntervalSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setIntervalSpy = jest.spyOn(global, "setInterval");
+    clearIntervalSpy = jest.spyOn(global, "clearInterval");
+
+    // Spy on the real NgZone rather than swapping in a full mock: NgZone is wired deeply into
+    // Angular's own change-detection scheduler, and a mock replacement breaks TestBed setup.
+    runOutsideAngularSpy = jest
+      .spyOn(NgZone.prototype, "runOutsideAngular")
+      .mockImplementation((fn) => fn());
+
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AccessBadgeTickerService);
+
+    // Angular's own framework setup also calls runOutsideAngular; only count calls made after
+    // the service exists, which is what the "outside the zone" assertions care about.
+    runOutsideAngularSpy.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("emits once a second to a subscriber", () => {
+    const next = jest.fn();
+    const subscription = service.ticks$.subscribe(next);
+
+    jest.advanceTimersByTime(3_000);
+
+    expect(next).toHaveBeenCalledTimes(3);
+    subscription.unsubscribe();
+  });
+
+  it("shares a single interval across multiple observers", () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const firstSub = service.ticks$.subscribe(first);
+    const secondSub = service.ticks$.subscribe(second);
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(1_000);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first.mock.calls[0][0]).toBe(second.mock.calls[0][0]);
+
+    firstSub.unsubscribe();
+    secondSub.unsubscribe();
+  });
+
+  it("creates the interval outside the Angular zone", () => {
+    const subscription = service.ticks$.subscribe();
+
+    expect(runOutsideAngularSpy).toHaveBeenCalledTimes(1);
+    subscription.unsubscribe();
+  });
+
+  it("tears down the interval once the last observer unsubscribes", () => {
+    const firstSub = service.ticks$.subscribe();
+    const secondSub = service.ticks$.subscribe();
+
+    firstSub.unsubscribe();
+    expect(clearIntervalSpy).not.toHaveBeenCalled();
+
+    secondSub.unsubscribe();
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a fresh interval if a later observer subscribes after teardown", () => {
+    const firstSub = service.ticks$.subscribe();
+    firstSub.unsubscribe();
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+    const next = jest.fn();
+    const secondSub = service.ticks$.subscribe(next);
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(1_000);
+    expect(next).toHaveBeenCalledTimes(1);
+
+    secondSub.unsubscribe();
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-badge-ticker.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-badge-ticker.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, NgZone, inject } from "@angular/core";
+import { Observable, share } from "rxjs";
+
+/**
+ * The one 1-second clock every {@link AccessStateBadgeComponent} shares while it shows an active
+ * lease countdown. A vault table can host dozens of badges; without this, each would own its own
+ * `setInterval`, so N active badges would mean N independent per-second timers.
+ *
+ * `share({ resetOnRefCountZero: true })` starts the underlying interval on the first subscriber
+ * and tears it down on the last unsubscribe, so a screen with zero active badges holds no timer at
+ * all. The interval itself is created inside `runOutsideAngular` from within the source factory,
+ * not from the constructor, because `share` re-subscribes to the source on every 0-to-1 transition
+ * and a subscriber may (re)trigger that from inside the Angular zone; wrapping the `setInterval`
+ * call site is the only way to guarantee it never runs in-zone. A periodic in-zone timer would
+ * trigger change detection every second for as long as any badge is active and would never let
+ * NgZone settle, which hangs `fixture.whenStable()` for any host that embeds a badge.
+ */
+@Injectable({ providedIn: "root" })
+export class AccessBadgeTickerService {
+  private readonly ngZone = inject(NgZone);
+
+  readonly ticks$: Observable<number> = new Observable<number>((subscriber) => {
+    let intervalId: ReturnType<typeof setInterval>;
+    this.ngZone.runOutsideAngular(() => {
+      intervalId = setInterval(() => subscriber.next(Date.now()), 1000);
+    });
+    return () => clearInterval(intervalId);
+  }).pipe(share({ resetOnRefCountZero: true }));
+}

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.spec.ts
@@ -84,3 +84,75 @@ describe("AccessStateBadgeComponent", () => {
     expect(recipe.label).toBe("pamAccessBadgeSessionEnded");
   });
 });
+
+describe("AccessStateBadgeComponent timer sharing", () => {
+  const fixtures: ComponentFixture<AccessStateBadgeComponent>[] = [];
+
+  function createBadge(
+    state: AccessBadgeState | null,
+  ): ComponentFixture<AccessStateBadgeComponent> {
+    const created = TestBed.createComponent(AccessStateBadgeComponent);
+    created.componentRef.setInput("state", state);
+    created.detectChanges();
+    fixtures.push(created);
+    return created;
+  }
+
+  function activeState(): AccessBadgeState {
+    return { kind: "active", expiresAt: new Date(Date.now() + 30 * 60_000) } as AccessBadgeState;
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    TestBed.configureTestingModule({
+      imports: [AccessStateBadgeComponent],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    while (fixtures.length > 0) {
+      fixtures.pop()!.destroy();
+    }
+    jest.useRealTimers();
+  });
+
+  it("starts no timer when every badge is resting", () => {
+    const setInterval = jest.spyOn(global, "setInterval");
+
+    createBadge({ kind: "privileged" } as AccessBadgeState);
+    createBadge({ kind: "pending" } as AccessBadgeState);
+    createBadge(null);
+
+    expect(setInterval).not.toHaveBeenCalled();
+  });
+
+  it("shares one timer across many active badges", () => {
+    const setInterval = jest.spyOn(global, "setInterval");
+
+    createBadge(activeState());
+    createBadge(activeState());
+    createBadge(activeState());
+
+    expect(setInterval).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the timer until the last active badge is gone", () => {
+    const clearInterval = jest.spyOn(global, "clearInterval");
+    const first = createBadge(activeState());
+    const second = createBadge(activeState());
+
+    first.destroy();
+    fixtures.splice(fixtures.indexOf(first), 1);
+    expect(clearInterval).not.toHaveBeenCalled();
+
+    second.destroy();
+    fixtures.splice(fixtures.indexOf(second), 1);
+    expect(clearInterval).toHaveBeenCalled();
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.ts
@@ -1,13 +1,6 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  inject,
-  input,
-  NgZone,
-  signal,
-} from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, inject, input } from "@angular/core";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
+import { EMPTY, switchMap } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { BadgeComponent, BadgeVariant } from "@bitwarden/components";
@@ -15,6 +8,7 @@ import { BadgeComponent, BadgeVariant } from "@bitwarden/components";
 import { formatRemaining } from "../date/format-remaining";
 
 import { AccessBadgeState } from "./access-badge-state";
+import { AccessBadgeTickerService } from "./access-badge-ticker.service";
 
 /** At or below this remaining time an active lease escalates to the danger "Ending soon" badge. */
 const ENDING_SOON_THRESHOLD_MS = 5 * 60 * 1000;
@@ -47,10 +41,19 @@ export class AccessStateBadgeComponent {
   readonly state = input.required<AccessBadgeState | null>();
 
   private readonly i18nService = inject(I18nService);
-  private readonly ngZone = inject(NgZone);
+  private readonly ticker = inject(AccessBadgeTickerService);
 
-  /** Ticks once a second while an active-lease countdown is showing so the label stays live. */
-  private readonly now = signal(Date.now());
+  /**
+   * Ticks once a second while an active-lease countdown is showing so the label stays live.
+   * Only an active badge observes the shared ticker, so a table of resting badges leaves the one
+   * timer torn down rather than each row owning its own.
+   */
+  private readonly now = toSignal(
+    toObservable(computed(() => this.state()?.kind === "active")).pipe(
+      switchMap((active) => (active ? this.ticker.ticks$ : EMPTY)),
+    ),
+    { initialValue: Date.now() },
+  );
 
   protected readonly recipe = computed<BadgeRecipe | null>(() => {
     const state = this.state();
@@ -83,22 +86,6 @@ export class AccessStateBadgeComponent {
 
     return this.staticRecipe(state.kind);
   });
-
-  constructor() {
-    effect((onCleanup) => {
-      if (this.state()?.kind !== "active") {
-        return;
-      }
-      // Outside the Angular zone: a table can host dozens of these at once, and a periodic in-zone
-      // timer both triggers change detection per badge per second and never lets NgZone settle,
-      // which would hang `fixture.whenStable()` for any host embedding them. The signal write
-      // still drives change detection on its own.
-      this.ngZone.runOutsideAngular(() => {
-        const id = setInterval(() => this.now.set(Date.now()), 1000);
-        onCleanup(() => clearInterval(id));
-      });
-    });
-  }
 
   private staticRecipe(kind: Exclude<AccessBadgeState["kind"], "active">): BadgeRecipe {
     switch (kind) {


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to a non-blocking review note on #22546: "Fine for now, but many badges would create many timers."

## 📔 Objective

`AccessStateBadgeComponent` started its own `setInterval` whenever it showed an active-lease
countdown, so a vault table with N running leases held N independent per-second timers. The badge
renders on five surfaces, and the vault-row host renders one per table row, so the count scales with
page size rather than with anything meaningful.

Adds `AccessBadgeTickerService`, a root-provided clock built on a single interval shared through
`share({ resetOnRefCountZero: true })`. The interval starts when the first active badge observes it
and is torn down when the last one stops, so a screen with no active lease holds no timer at all.

The badge gates its subscription on its own state, so resting rows never reach the ticker. This is
expressed as `toObservable(...)` piped into `switchMap` and read back through `toSignal`, which keeps
the subscription lifecycle owned by the framework rather than by a hand-managed `subscribe`.

The interval is still created inside `runOutsideAngular`. That rationale is unchanged and now lives
in one place: a periodic in-zone timer would trigger change detection every second for as long as any
badge is active and would never let `NgZone` settle, which hangs `fixture.whenStable()` for any host
embedding a badge.

No behaviour change: same one-second cadence, same countdown, same five-minute danger escalation,
same expired fallback.

## ✅ Tests

Three new component specs pin the property this PR exists for, all of which fail against the previous
implementation:

- resting badges start no timer at all
- three concurrent active badges share exactly one `setInterval`
- the interval survives the first badge's destruction and is cleared only with the last

Plus five service specs covering cadence, sharing, out-of-zone creation, ref-counted teardown, and
restart after a full teardown.

`bitwarden_license/bit-web/src/app/pam`: 63 suites, 653 tests passing. ESLint and Prettier clean on
the touched files; `tsc -p bitwarden_license/bit-web/tsconfig.json` reports nothing for them.

## ⚠️ Known limitations

- All badges now tick from one clock, so they update in lockstep rather than each on its own phase
  offset from when it mounted. For a whole-second countdown this is not observable, and arguably it
  is the more correct behaviour.
- The ticker is PAM-local. If another surface later wants a shared one-second clock, this is worth
  promoting rather than copying.
