### PR TITLE
Sign Windows Beta Appx in CI

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -896,15 +896,48 @@ jobs:
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
         run: ./scripts/validate-chromium-importer-thumbprint.ps1
 
+      # The Appx built above keeps the Microsoft-assigned publisher and stays unsigned,
+      # which is what the Store requires.
       - name: Rename appx files for store
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
         run: |
-          Copy-Item "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-ia32.appx" `
-            -Destination "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-ia32-store.appx"
-          Copy-Item "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-x64.appx" `
-            -Destination "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-x64-store.appx"
-          Copy-Item "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-arm64.appx" `
-            -Destination "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-arm64-store.appx"
+          Rename-Item -Path "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-ia32.appx" `
+            -NewName "Bitwarden-Beta-$env:_PACKAGE_VERSION-ia32-store.appx"
+          Rename-Item -Path "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-x64.appx" `
+            -NewName "Bitwarden-Beta-$env:_PACKAGE_VERSION-x64-store.appx"
+          Rename-Item -Path "./dist/Bitwarden-Beta-$env:_PACKAGE_VERSION-arm64.appx" `
+            -NewName "Bitwarden-Beta-$env:_PACKAGE_VERSION-arm64-store.appx"
+
+      # An Appx can only be signed when its manifest publisher matches the certificate
+      # subject, so read the subject from the signed binary.
+      - name: Read signing certificate subject
+        id: cert-subject
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        run: |
+          $signature = Get-AuthenticodeSignature "./dist/win-unpacked/Bitwarden Beta.exe"
+          if ($null -eq $signature.SignerCertificate) {
+            Write-Error "Expected a signed exe, got status '$($signature.Status)': $($signature.StatusMessage)"
+            exit 1
+          }
+          $subject = $signature.SignerCertificate.Subject
+          Write-Host "Signing certificate subject: $subject"
+          "publisher=$subject" >> $env:GITHUB_OUTPUT
+
+      # Packs and signs the Appx with the CI signing certificate and publisher.
+      # Reuses the compiled Rust and webpack builds from above, so we only need
+      # to swap out the manifest, recompress and sign.
+      - name: Pack & sign appx for direct download
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        env:
+          ELECTRON_BUILDER_SIGN: 1
+          ELECTRON_BUILDER_SIGN_APPX: 1
+          SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.code-signing-vault-url }}
+          SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.code-signing-client-id }}
+          SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.code-signing-tenant-id }}
+          SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.code-signing-client-secret }}
+          SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.code-signing-cert-name }}
+          _APPX_PUBLISHER: ${{ steps.cert-subject.outputs.publisher }}
+        run: node ./scripts/pack-signed-appx.mts --config electron-builder.beta.json --publisher $env:_APPX_PUBLISHER
 
       - name: Fix NSIS artifact names for auto-updater
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -939,6 +939,15 @@ jobs:
           _APPX_PUBLISHER: ${{ steps.cert-subject.outputs.publisher }}
         run: node ./scripts/pack-signed-appx.mts --config electron-builder.beta.json --publisher $env:_APPX_PUBLISHER
 
+      # A signed Store package is rejected at ingestion and an unsigned direct download
+      # installs for nobody, so confirm each package ended up as intended before we
+      # upload any of them.
+      - name: Verify appx signing state and publishers
+        if: ${{ needs.setup.outputs.has_secrets == 'true' }}
+        env:
+          _APPX_PUBLISHER: ${{ steps.cert-subject.outputs.publisher }}
+        run: ./scripts/validate-appx-signatures.ps1 -Config electron-builder.beta.json -SignedPublisher $env:_APPX_PUBLISHER
+
       - name: Fix NSIS artifact names for auto-updater
         if: ${{ needs.setup.outputs.has_secrets == 'true' }}
         run: |

--- a/apps/desktop/scripts/pack-signed-appx.mts
+++ b/apps/desktop/scripts/pack-signed-appx.mts
@@ -1,0 +1,106 @@
+/* eslint-disable no-console */
+
+/// Repackage an already-built Windows app directory as a signed Appx.
+///
+/// An Appx names its publisher in the package manifest, and signing fails unless that
+/// publisher matches the subject of the signing certificate. Store packages therefore have
+/// to keep the Microsoft-assigned publisher (a UUID) and stay unsigned, which leaves them
+/// uninstallable by anyone outside the Store.
+///
+/// To offer a directly installable Appx as well, this repackages the Appx target from
+/// the `dist/win*-unpacked` directories electron-builder already produced, overriding the
+/// publisher with the certificate subject and signing the result. Nothing is recompiled and
+/// the app binaries keep the signatures from the original pack, so this costs one Appx
+/// compression pass per architecture instead of a second full build.
+///
+/// The signed Appx lands on the configured `appx.artifactName`, so move or rename the
+/// unsigned Store package first if both are wanted. Cf .github/workflows/build-desktop.yml.
+///
+/// Signing is delegated to sign.js, which needs ELECTRON_BUILDER_SIGN=1 plus its Azure Key
+/// Vault environment, and ELECTRON_BUILDER_SIGN_APPX=1 to sign Appx files.
+///
+/// Usage:
+///   node scripts/pack-signed-appx.mts --publisher <certificate subject> \
+///     [--config electron-builder.beta.json] [--arch x64 --arch arm64]
+
+import { existsSync } from "fs";
+import path from "path";
+import { parseArgs } from "util";
+
+import { Arch, build, Platform } from "electron-builder";
+
+const ARCHITECTURES = ["ia32", "x64", "arm64"] as const;
+type Architecture = (typeof ARCHITECTURES)[number];
+
+const projectDir = path.resolve(import.meta.dirname, "..");
+
+function isArchitecture(value: string): value is Architecture {
+  return (ARCHITECTURES as readonly string[]).includes(value);
+}
+
+// electron-builder omits the arch suffix for the default architecture.
+function unpackedDir(arch: Architecture): string {
+  return path.join(projectDir, "dist", arch === "x64" ? "win-unpacked" : `win-${arch}-unpacked`);
+}
+
+async function packSignedAppx(
+  publisher: string,
+  configFile: string,
+  architectures: Architecture[],
+) {
+  for (const arch of architectures) {
+    const prepackaged = unpackedDir(arch);
+    if (!existsSync(prepackaged)) {
+      throw new Error(
+        `${prepackaged} not found. Pack the ${arch} app before repackaging it as a signed Appx.`,
+      );
+    }
+
+    console.log(`[*] Packaging signed ${arch} Appx from ${prepackaged} as '${publisher}'`);
+    await build({
+      projectDir,
+      prepackaged,
+      publish: "never",
+      targets: Platform.WINDOWS.createTarget("appx", Arch[arch]),
+      // `extends` names the config file to load; the rest is merged over it, the same way
+      // `--config <file> -c.appx.publisher=<publisher>` combines on the command line.
+      config: { extends: configFile, appx: { publisher } },
+    });
+  }
+}
+
+function parseArchitectures(values: string[] | undefined): Architecture[] {
+  if (values == null || values.length === 0) {
+    return [...ARCHITECTURES];
+  }
+
+  const unsupported = values.filter((value) => !isArchitecture(value));
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Unsupported architecture(s) ${unsupported.join(", ")}. Supported: ${ARCHITECTURES.join(", ")}.`,
+    );
+  }
+
+  return values.filter(isArchitecture);
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      publisher: { type: "string" },
+      config: { type: "string", default: "electron-builder.json" },
+      arch: { type: "string", multiple: true },
+    },
+  });
+
+  if (!values.publisher) {
+    throw new Error("--publisher is required: pass the subject of the signing certificate.");
+  }
+
+  await packSignedAppx(values.publisher, values.config, parseArchitectures(values.arch));
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/apps/desktop/scripts/validate-appx-signatures.ps1
+++ b/apps/desktop/scripts/validate-appx-signatures.ps1
@@ -1,0 +1,110 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+Validates the signing state and publisher of every Appx package in dist.
+
+.DESCRIPTION
+Two kinds of Appx come out of the same build. The `*-store.appx` packages have to stay
+unsigned and keep the Microsoft-assigned publisher, or the Store rejects them. The
+directly installable packages have to be signed and carry the signing certificate's
+subject as their publisher, or they install for nobody. Getting either wrong produces an
+artifact that looks fine until it is published, so this checks both before we ship.
+
+A package is signed when it contains an AppxSignature.p7x entry, which is what signtool
+adds. The publisher lives in the Identity element of the packaged AppxManifest.xml, and
+signing only succeeds when it matches the certificate subject, so checking the publisher
+also pins the signed packages to the expected certificate.
+
+.EXAMPLE
+./scripts/validate-appx-signatures.ps1 -Config electron-builder.beta.json -SignedPublisher $env:_APPX_PUBLISHER
+#>
+param(
+    [string]
+    # electron-builder config the packages were built from. Its appx.publisher is the
+    # Microsoft-assigned publisher that the Store packages must keep.
+    $Config = "electron-builder.json",
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    # Subject of the signing certificate, which the signed packages must name as publisher.
+    $SignedPublisher
+)
+
+$ErrorActionPreference = "Stop"
+
+$appDesktopDir = Split-Path $PSScriptRoot -Parent
+$distDir = Join-Path $appDesktopDir "dist"
+
+$configPath = Join-Path $appDesktopDir $Config
+$storePublisher = (Get-Content $configPath -Raw | ConvertFrom-Json).appx.publisher
+if ([string]::IsNullOrEmpty($storePublisher)) {
+    Write-Error "Could not read appx.publisher from $configPath"
+    exit 1
+}
+
+function Read-AppxIdentity {
+    param([string]$Path)
+
+    $package = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $manifestEntry = $package.GetEntry("AppxManifest.xml")
+        if ($null -eq $manifestEntry) {
+            Write-Error "No AppxManifest.xml in $Path"
+            exit 1
+        }
+
+        $stream = $manifestEntry.Open()
+        try {
+            $reader = New-Object System.IO.StreamReader($stream)
+            $manifest = [xml]$reader.ReadToEnd()
+        }
+        finally {
+            $stream.Dispose()
+        }
+
+        return @{
+            Publisher = $manifest.Package.Identity.Publisher
+            IsSigned  = $null -ne $package.GetEntry("AppxSignature.p7x")
+        }
+    }
+    finally {
+        $package.Dispose()
+    }
+}
+
+$packages = @(Get-ChildItem -Path $distDir -Filter *.appx)
+$storePackages = @($packages | Where-Object { $_.Name.EndsWith("-store.appx") })
+$signedPackages = @($packages | Where-Object { -not $_.Name.EndsWith("-store.appx") })
+if ($storePackages.Count -eq 0 -or $signedPackages.Count -eq 0) {
+    Write-Error "Expected both store and directly installable Appx packages in $distDir, found $($storePackages.Count) store and $($signedPackages.Count) other."
+    exit 1
+}
+
+$problems = @()
+foreach ($package in $packages) {
+    $isStorePackage = $package.Name.EndsWith("-store.appx")
+    $identity = Read-AppxIdentity -Path $package.FullName
+    $expectedPublisher = if ($isStorePackage) { $storePublisher } else { $SignedPublisher }
+
+    if ($isStorePackage -and $identity.IsSigned) {
+        $problems += "$($package.Name) is signed, but Store packages must be unsigned."
+    }
+    if (-not $isStorePackage -and -not $identity.IsSigned) {
+        $problems += "$($package.Name) is unsigned, but packages for direct download must be signed."
+    }
+    if ($identity.Publisher -ne $expectedPublisher) {
+        $problems += "$($package.Name) has publisher '$($identity.Publisher)', expected '$expectedPublisher'."
+    }
+
+    $signingState = if ($identity.IsSigned) { "signed" } else { "unsigned" }
+    Write-Host "$($package.Name): $signingState, publisher '$($identity.Publisher)'"
+}
+
+if ($problems.Count -gt 0) {
+    Write-Error ("Appx validation failed:`n" + ($problems -join "`n"))
+    exit 1
+}
+
+Write-Host "Verified $($storePackages.Count) unsigned Store and $($signedPackages.Count) signed Appx packages"

--- a/apps/desktop/sign.js
+++ b/apps/desktop/sign.js
@@ -3,7 +3,15 @@ const child_process = require("child_process");
 
 exports.default = async function (configuration) {
   const ext = configuration.path.split(".").at(-1);
-  if (parseInt(process.env.ELECTRON_BUILDER_SIGN) === 1 && ["exe", "dll", "node"].includes(ext)) {
+  // An Appx embeds its publisher in the manifest, and signing fails unless that
+  // publisher matches the certificate subject. Store packages are published unsigned
+  // under the Microsoft-assigned publisher, so Appx signing is opt-in per build rather
+  // than always on.
+  const signExts = ["exe", "dll", "node"];
+  if (parseInt(process.env.ELECTRON_BUILDER_SIGN_APPX) === 1) {
+    signExts.push("appx");
+  }
+  if (parseInt(process.env.ELECTRON_BUILDER_SIGN) === 1 && signExts.includes(ext)) {
     console.log(`[*] Signing file: ${configuration.path}`);
     child_process.execFileSync(
       "azuresigntool",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,7 +72,7 @@ export default tseslint.config(
   ...storybook.configs["flat/recommended"],
   {
     // Everything in this config object targets our TypeScript files (Components, Directives, Pipes etc)
-    files: ["**/*.ts", "**/*.js"],
+    files: ["**/*.ts", "**/*.mts", "**/*.js"],
     extends: [
       eslint.configs.recommended,
       ...tseslint.configs.recommended,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37680](https://bitwarden.atlassian.net/browse/PM-37680)

## 📔 Objective

This updates the CI workflow to sign the non-Store Beta Appx files with our CI signing certificate, which makes them installable.

In order to save on build time, this reuses the same beta build of the TypeScript and native code, but modifies the manifest, repacks and signs the Appx.

The Microsoft store beta builds are unaffected, and both the non-Store and Store builds of the stable build are unaffected.




[PM-37680]: https://bitwarden.atlassian.net/browse/PM-37680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ