### PR TITLE
ci: Beta Appx manifest changes

### DIFF
--- a/apps/desktop/custom-appx-extensions.beta.xml
+++ b/apps/desktop/custom-appx-extensions.beta.xml
@@ -1,0 +1,26 @@
+<!--
+    Merged into the manifest's <Extensions> by electron-builder (appx.customExtensionsPath)
+    and by scripts/appx-cross-build.ps1. It is inlined verbatim: electron-builder expands
+    none of its own macros here, and its manifest declares no `com` prefix, so this
+    declares its own.
+
+    The class ID is left as a clsid macro naming this channel's plugin config, and is filled
+    in by scripts/appx-manifest-created.js — and by the matching step in
+    appx-cross-build.ps1 — from that config, which is also what the app reads at runtime. A
+    package declaring a class ID it never serves hijacks it from the app that does, so the
+    class ID is defined in exactly one place.
+
+    Keep macro-shaped text out of this comment: the resolvers substitute anything matching,
+    comments included.
+-->
+          <com:Extension xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+            Category="windows.comServer">
+            <com:ComServer>
+              <com:ExeServer Executable="app\bitwarden_plugin_authenticator.exe"
+                Arguments="serve"
+                DisplayName="Bitwarden Beta Passkey Manager">
+                <com:Class Id="${clsid:windows_plugin_authenticator_config.beta.json}"
+                  DisplayName="Bitwarden Beta Passkey Manager" />
+              </com:ExeServer>
+            </com:ComServer>
+          </com:Extension>

--- a/apps/desktop/custom-appx-manifest.xml
+++ b/apps/desktop/custom-appx-manifest.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--suppress XmlUnusedNamespaceDeclaration -->
+<!--
+    Appx manifest template for scripts/appx-cross-build.ps1, which packages the Appx
+    without electron-builder (electron-builder can't cross-build one from macOS).
+
+    It mirrors electron-builder's own template so both paths produce the same package;
+    keep the two in sync when either changes. The customExtensions macro is filled from
+    the channel's appx.customExtensionsPath, so the COM server is declared in one place.
+-->
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
     xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
     xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
-    xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
     xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
     <!-- use single quotes to avoid double quotes escaping in the publisher value  -->
     <Identity Name="${identityName}"
@@ -81,18 +88,17 @@
         <Resource Language="zh-tw" />
     </Resources>
     <Dependencies>
-        <!-- MinVersion 10.0.14393.0 = Windows 10 Anniversary Update (1607), required for com:Extension -->
         <TargetDeviceFamily Name="Windows.Desktop"
-          MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" />
+          MinVersion="${minVersion}" MaxVersionTested="${maxVersionTested}" />
     </Dependencies>
     <Capabilities>
         <rescap:Capability Name="runFullTrust" />
     </Capabilities>
     <Applications>
-        <Application Id="bitwardendesktop" Executable="${executable}"
+        <Application Id="${applicationId}" Executable="${executable}"
             EntryPoint="Windows.FullTrustApplication">
             <uap:VisualElements
-                BackgroundColor="#175DDC"
+                BackgroundColor="${backgroundColor}"
                 DisplayName="${displayName}"
                 Square150x150Logo="assets\Square150x150Logo.png"
                 Square44x44Logo="assets\Square44x44Logo.png"
@@ -106,16 +112,7 @@
                         <uap:DisplayName>Bitwarden</uap:DisplayName>
                     </uap:Protocol>
                 </uap:Extension>
-                <com:Extension Category="windows.comServer">
-                    <com:ComServer>
-                        <com:ExeServer Executable="app\bitwarden_plugin_authenticator.exe"
-                            Arguments="serve"
-                            DisplayName="${displayName} Passkey Manager">
-                            <com:Class Id="0f7dc5d9-69ce-4652-8572-6877fd695062"
-                                DisplayName="${displayName} Passkey Manager" />
-                        </com:ExeServer>
-                    </com:ComServer>
-                </com:Extension>
+${customExtensions}
             </Extensions>
         </Application>
     </Applications>

--- a/apps/desktop/electron-builder.beta.json
+++ b/apps/desktop/electron-builder.beta.json
@@ -15,6 +15,7 @@
   "afterSign": "scripts/after-sign.js",
   "afterPack": "scripts/after-pack.js",
   "beforePack": "scripts/before-pack.js",
+  "appxManifestCreated": "scripts/appx-manifest-created.js",
   "files": [
     "!node_modules/@bitwarden/desktop-napi/scripts",
     "!node_modules/@bitwarden/desktop-napi/src",
@@ -161,7 +162,9 @@
   },
   "appx": {
     "artifactName": "Bitwarden-Beta-${version}-${arch}.${ext}",
-    "backgroundColor": "#175DDC",
+    "backgroundColor": "#FDC700",
+    "customExtensionsPath": "../custom-appx-extensions.beta.xml",
+    "minVersion": "10.0.14393.0",
     "applicationId": "BitwardenBeta",
     "identityName": "8bitSolutionsLLC.BitwardenBeta",
     "publisher": "CN=14D52771-DE3C-4886-B8BF-825BA7690418",

--- a/apps/desktop/scripts/appx-cross-build.ps1
+++ b/apps/desktop/scripts/appx-cross-build.ps1
@@ -107,7 +107,7 @@ else {
 
 $builderConfig = Get-Content $electronConfigFile | ConvertFrom-Json
 $packageConfig = Get-Content package.json | ConvertFrom-Json
-$manifestTemplate = Get-Content ($builderConfig.appx.customManifestPath ?? "custom-appx-manifest.xml")
+$manifestTemplate = Get-Content -Raw "custom-appx-manifest.xml"
 
 $srcDir = Get-Location
 $assetsDir = Get-Item $builderConfig.directories.buildResources
@@ -174,12 +174,24 @@ else {
 }
 
 Write-Host "Building Appx manifest"
+# electron-builder resolves appx.customExtensionsPath against directories.app, so we do too.
+$customExtensions = ""
+if ($builderConfig.appx.customExtensionsPath) {
+    $customExtensions = Get-Content -Raw (Join-Path $srcDir $builderConfig.directories.app $builderConfig.appx.customExtensionsPath)
+}
+
+# electron-builder's defaults when appx.minVersion is unset.
+$minVersion = $builderConfig.appx.minVersion ?? ($arch -eq "arm64" ? "10.0.16299.0" : "10.0.14316.0")
 $translationMap = @{
     'arch' = $arch
     'applicationId' = $builderConfig.appx.applicationId
+    'backgroundColor' = $builderConfig.appx.backgroundColor
+    'customExtensions' = $customExtensions
     'displayName' = $productName
     'executable' = "app\${productName}.exe"
     'identityName' = $builderConfig.appx.identityName
+    'maxVersionTested' = $builderConfig.appx.maxVersionTested ?? $minVersion
+    'minVersion' = $minVersion
     'publisher' = $builderConfig.appx.publisher
     'publisherDisplayName' = $builderConfig.appx.publisherDisplayName
     'version' = $version
@@ -190,17 +202,13 @@ $translationMap.Keys | ForEach-Object {
     $manifest = $manifest.Replace("`${$_}", $translationMap[$_])
 }
 
-# Manual Fixups for Beta
-# electron-builder can't template these variables, so we substitute known values with the ones we want:
-if ($Beta) {
-    # Update color
-    $manifest = $manifest.Replace("#175DDC", "#FDC700")
-
-    # Update COM ID
-    $PluginStableConfig = Get-Content $srcDir/resources/windows_plugin_authenticator_config.json | ConvertFrom-Json
-    $PluginBetaConfig = Get-Content $srcDir/resources/windows_plugin_authenticator_config.beta.json | ConvertFrom-Json
-    $manifest = $manifest.Replace($PluginStableConfig.clsid, $PluginBetaConfig.clsid)
-}
+# The extensions inlined above name their channel's plugin config rather than carrying the
+# COM class ID; resolve it the same way scripts/appx-manifest-created.js does for CI builds.
+$manifest = [regex]::Replace($manifest, '\$\{clsid:([\w.-]+)\}', {
+    param($clsidMacro)
+    $pluginConfigFile = Join-Path $srcDir resources $clsidMacro.Groups[1].Value
+    (Get-Content -Raw $pluginConfigFile | ConvertFrom-Json).clsid
+})
 
 $manifest | Out-File appx/AppxManifest.xml
 $unsignedArtifactpath = [System.IO.Path]::GetFileNameWithoutExtension($artifactName) + "-unsigned.$ext"

--- a/apps/desktop/scripts/appx-manifest-created.js
+++ b/apps/desktop/scripts/appx-manifest-created.js
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/no-require-imports, no-console */
+/**
+ * Fix up the Appx manifest electron-builder generates, before makeappx packs it.
+ *
+ * Three things need fixing that electron-builder's config can't express. All are the same
+ * for every channel, so any channel can register this hook as-is — the only channel
+ * specific input is the plugin config file the manifest itself names.
+ *
+ * - `${clsid:<file>}`: the COM class ID of the passkey provider. The manifest can't carry
+ *   it literally, because the app reads the class ID at runtime from
+ *   resources/windows_plugin_authenticator_config[.beta].json, and a package declaring a
+ *   class ID the app never serves hijacks it from the app that does. electron-builder
+ *   inlines custom-appx-extensions*.xml verbatim and expands no macros in it, so the
+ *   extensions file names its channel's config and the class ID is resolved here.
+ * - `<uap:LockScreen>`: electron-builder emits it for any package whose appx assets
+ *   include a BadgeLogo and offers no way to turn it off. resources/appx is shared
+ *   between channels, so the element is dropped here rather than by deleting the asset.
+ * - Comments: the template and the extensions file both document themselves, and none of
+ *   that belongs in a shipped package. Removing them reserializes the document, so the
+ *   packed manifest is normalized rather than formatted the way the sources are.
+ *
+ * The first two fail the build when there is nothing to fix, so a manifest that quietly
+ * stops needing one gets noticed rather than shipped.
+ */
+const fs = require("fs");
+const path = require("path");
+
+const { JSDOM } = require("jsdom");
+
+const CLSID_MACRO = /\$\{clsid:([\w.-]+)\}/g;
+// XMLSerializer emits no declaration, and Appx manifests are always UTF-8.
+const XML_DECLARATION = '<?xml version="1.0" encoding="utf-8"?>\n';
+const LOCK_SCREEN_LINE = /^[ \t]*<uap:LockScreen\b[^>]*\/>[ \t]*\r?\n/m;
+
+const configDir = path.resolve(__dirname, "../resources");
+
+function readClsid(configFile) {
+  const configPath = path.join(configDir, configFile);
+  const { clsid } = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  if (!clsid) {
+    throw new Error(`No plugin authenticator clsid found in ${configPath}`);
+  }
+  return clsid;
+}
+
+function resolveClsids(manifest, manifestPath) {
+  if (!CLSID_MACRO.test(manifest)) {
+    throw new Error(
+      `No \${clsid:<file>} macro to resolve in ${manifestPath}. Check that appx.customExtensionsPath ` +
+        `points at an extensions file declaring the COM server.`,
+    );
+  }
+  CLSID_MACRO.lastIndex = 0;
+
+  return manifest.replace(CLSID_MACRO, (_, configFile) => readClsid(configFile));
+}
+
+function removeLockScreen(manifest, manifestPath) {
+  if (!LOCK_SCREEN_LINE.test(manifest)) {
+    throw new Error(
+      `No <uap:LockScreen> element to remove from ${manifestPath}. If electron-builder no ` +
+        `longer emits one — say because resources/appx/BadgeLogo.png is gone — drop this fixup.`,
+    );
+  }
+
+  return manifest.replace(LOCK_SCREEN_LINE, "");
+}
+
+function removeComments(manifest, manifestPath) {
+  const { window } = new JSDOM();
+  const document = new window.DOMParser().parseFromString(manifest, "application/xml");
+  const parseError = document.querySelector("parsererror");
+  if (parseError) {
+    throw new Error(`${manifestPath} is not well-formed XML: ${parseError.textContent}`);
+  }
+
+  const walker = document.createTreeWalker(document, window.NodeFilter.SHOW_COMMENT);
+  const comments = [];
+  while (walker.nextNode()) {
+    comments.push(walker.currentNode);
+  }
+  comments.forEach((comment) => comment.remove());
+
+  return XML_DECLARATION + new window.XMLSerializer().serializeToString(document) + "\n";
+}
+
+exports.default = function (manifestPath) {
+  let manifest = fs.readFileSync(manifestPath, "utf8");
+  manifest = resolveClsids(manifest, manifestPath);
+  manifest = removeLockScreen(manifest, manifestPath);
+  manifest = removeComments(manifest, manifestPath);
+  fs.writeFileSync(manifestPath, manifest);
+  console.log(`[*] Rewrote ${manifestPath} for packing`);
+};


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37680](https://bitwarden.atlassian.net/browse/PM-37680)

## 📔 Objective

- Adds COM extension to manifest for Beta Appx.
- Bumps up minimum Windows version required for COM extension. This will affect whether this shows up in the Windows Store for users below this version. However, this is an unsupported Windows 10 version, so this is still safe for our customers.
- Strips unused `<uap:LockScreen>` element from, with a reminder to remove the workaround once #21229 lands.
- Removes XML comments from built XML.

(Note that the `custom-appx-manifest.xml` and `appx-cross-build.ps1` files are only used for local development, not in CI.)


[PM-37680]: https://bitwarden.atlassian.net/browse/PM-37680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ