### PR TITLE
fix(pam): coordinate the access-rule delete button with the save button submit state

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -275,6 +275,7 @@
             type="button"
             bitButton
             buttonType="danger"
+            bitFormButton
             [bitAction]="remove"
             class="tw-ms-auto"
             id="access-rule-edit_button_delete"


### PR DESCRIPTION
# fix(pam): coordinate the access-rule delete button with the save button submit state

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42254

## 📚 Stack

Standalone. Branch **`pam/access-rule-delete-button-form-coordination`** off **`pam/uat`**,
rooted directly on trunk rather than stacked on any other in-flight PAM PR. It touches a single
file and has no dependency on, or dependents in, the rest of the PAM work.

## 📔 Objective

A follow-up from review of #22505 (the PR that added the Delete button to the access-rule edit
form). The Delete button already had `bitButton`, `buttonType="danger"` and `[bitAction]="remove"`,
but was missing `bitFormButton`. Without it, Save and Delete could both be triggered in the same
tick: a rule could be saved after its delete request was already issued, or deleted while a save
was in flight, producing a spurious not-found or unexpected-error toast.

The Save button on this form already carries `bitFormButton`. This change adds the same attribute
to Delete, which is the only line the diff touches:

```html
<button
  type="button"
  bitButton
  buttonType="danger"
  bitFormButton
  [bitAction]="remove"
  class="tw-ms-auto"
  id="access-rule-edit_button_delete"
>
```

`BitFormButtonDirective` (`libs/components/src/async-actions/form-button.directive.ts`) is what
does the coordinating: on a non-submit button it subscribes to the form's `bitSubmit` loading
state and disables itself while the form is submitting; when that same button also carries
`bitAction`, it wires the action's loading state back into the submit directive's `disabled`
stream, which the submit-type button (Save) also subscribes to. Delete already met the
prerequisites for both directions (`bitButton` + `bitAction` inside a `bitSubmit` form); adding
`bitFormButton` is what activates the subscriptions. No component TypeScript changed.

This is an internal consistency fix, not a design change, so there is no Figma reference for it.

## 📸 Screenshots

Skipped for this milestone. Storybook would not build in the review worktree: the preview bundle
fails to compile with a `DialogService` type conflict in
`apps/web/src/app/auth/settings/webauthn-login-settings/webauthn-login-settings.component.ts`
(`TS2345`, two declarations of a private `dialog` property). This is a known aliasing artifact of
running in a git worktree that has no `node_modules` of its own and resolves `@bitwarden/*`
workspace packages against the main checkout's paths, giving `DialogService` two type identities.
It reproduced deterministically across two separate build attempts and does not reflect anything
in this diff, which touches only a template attribute unrelated to dialogs. It also does not
reproduce in the main checkout or in CI.

The behavior this milestone adds is also not really observable in a plain screenshot: the story's
backing service calls resolve near-instantly, so the disabled window only shows up if the
underlying promises are held open (for example by monkey-patching the injected service methods to
resolve manually), which is why Visual QA verified it that way rather than by screenshot diff.

## ⚠️ Known gaps

- No before/after screenshots (see above).
- Visual QA verified this change directly against Storybook (not this worktree) using
  `web-pam-access-rule-edit--edit`, confirming both directions of the disable coordination and dark
  theme rendering, and reported 0 failed assertions and 0 design mismatches. That verification was
  screenshot-free by nature of the change (a transient disabled state during an in-flight async
  action), consistent with the gap above.

## ✅ Verification

`git show --stat 879f98bf6b5e94d525b9d1a1cc52eab98926fb39` confirms the diff is exactly the
one-line template addition described above, in
`bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html`.
No other files changed.
