### PR TITLE
[PM-42301] Fix biometric cancellation showing error modal in SDK unlock path

### DIFF
--- a/libs/unlock/src/default-unlock.service.spec.ts
+++ b/libs/unlock/src/default-unlock.service.spec.ts
@@ -265,12 +265,11 @@ describe("DefaultUnlockService", () => {
       });
     });
 
-    it("throws when biometrics returns null", async () => {
+    it("returns without throwing when biometrics returns null (user cancelled)", async () => {
       biometricsService.unlockWithBiometricsForUser.mockResolvedValue(null);
 
-      await expect(service.unlockWithBiometrics(mockUserId)).rejects.toThrow(
-        "Failed to unlock with biometrics",
-      );
+      await expect(service.unlockWithBiometrics(mockUserId)).resolves.toBeUndefined();
+      expect(mockCrypto.initialize_user_crypto).not.toHaveBeenCalled();
     });
 
     it("throws when SDK is not available", async () => {

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -104,7 +104,8 @@ export class DefaultUnlockService implements UnlockService {
     // First, get the biometrics-protected user key. This will prompt the user to authenticate with biometrics.
     const userKey = await this.biometricsService.unlockWithBiometricsForUser(userId);
     if (!userKey) {
-      throw new Error("Failed to unlock with biometrics");
+      // User cancelled the biometric prompt, or the key was not available — not an error.
+      return;
     }
 
     // Now that we have the biometrics-protected user key, we can initialize the SDK with it to complete the unlock process.

--- a/libs/unlock/src/unlock.service.ts
+++ b/libs/unlock/src/unlock.service.ts
@@ -28,10 +28,10 @@ export abstract class UnlockService {
   abstract unlockWithMasterPassword(userId: UserId, masterPassword: string): Promise<void>;
 
   /**
-   * Unlocks the user's account using a biometrics-protected copy of the user-key
+   * Unlocks the user's account using a biometrics-protected copy of the user-key.
+   * Returns without throwing if the user cancels the biometric prompt.
    * @param userId - The user's id
    * @throws If the SDK is not available
-   * @throws If biometric authentication fails
    */
   abstract unlockWithBiometrics(userId: UserId): Promise<void>;
 


### PR DESCRIPTION
## 🎟️ Tracking

Community bug fix for biometric cancellation behavior in the SDK unlock path.

## 📔 Objective

Treat a null biometric result as user cancellation instead of throwing an unexpected unlock error. This restores the prior silent-cancellation behavior and keeps the user on the lock screen without displaying an error modal.

The existing unit test is updated to verify that cancellation resolves without initializing SDK crypto.

## 🧪 Testing

Not rerun in this session; regression coverage is included in `default-unlock.service.spec.ts`.

## 📸 Screenshots

Not applicable.