### PR TITLE
[PM-42302] Restore macOS Help menu search

### DIFF
--- a/apps/desktop/src/main/menu/menu.help.spec.ts
+++ b/apps/desktop/src/main/menu/menu.help.spec.ts
@@ -1,0 +1,48 @@
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+
+import { SafeShell } from "../../platform/main/safe-shell.main";
+import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
+
+import { AboutMenu } from "./menu.about";
+import { HelpMenu } from "./menu.help";
+
+jest.mock("electron", () => ({
+  app: { relaunch: jest.fn(), exit: jest.fn() },
+}));
+
+jest.mock("../../utils", () => ({
+  isMacAppStore: jest.fn().mockReturnValue(false),
+  isWindowsStore: jest.fn().mockReturnValue(false),
+}));
+
+function makeHelpMenu(): HelpMenu {
+  const i18nService = { t: (s: string) => s } as unknown as I18nService;
+  const messagingService = { send: jest.fn() } as unknown as MessagingService;
+  const desktopSettingsService = {} as unknown as DesktopSettingsService;
+  const aboutMenu = { items: [] } as unknown as AboutMenu;
+  const shell = { openExternal: jest.fn() } as unknown as SafeShell;
+  return new HelpMenu(
+    i18nService,
+    messagingService,
+    desktopSettingsService,
+    "https://vault.bitwarden.com",
+    false,
+    aboutMenu,
+    shell,
+  );
+}
+
+describe("HelpMenu", () => {
+  // Regression guard. macOS only renders the Help menu's search field when the
+  // top-level Help menu carries role: "help". This has regressed more than once
+  // (e.g. https://github.com/bitwarden/clients/issues/2582, and again in 2026),
+  // because the role is easy to drop silently while refactoring the menu tree.
+  it('declares role "help" so macOS shows the Help menu search field', () => {
+    expect(makeHelpMenu().role).toBe("help");
+  });
+
+  it('has id "help"', () => {
+    expect(makeHelpMenu().id).toBe("help");
+  });
+});

--- a/apps/desktop/src/main/menu/menu.help.ts
+++ b/apps/desktop/src/main/menu/menu.help.ts
@@ -13,6 +13,7 @@ import { IMenubarMenu } from "./menubar";
 
 export class HelpMenu implements IMenubarMenu {
   readonly id: string = "help";
+  readonly role: "help" = "help";
 
   get label(): string {
     return this.localize("help");

--- a/apps/desktop/src/main/menu/menubar.spec.ts
+++ b/apps/desktop/src/main/menu/menubar.spec.ts
@@ -1,0 +1,80 @@
+import { MenuItemConstructorOptions } from "electron";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+
+import { SafeShell } from "../../platform/main/safe-shell.main";
+import { VersionMain } from "../../platform/main/version.main";
+import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
+import { UpdaterMain } from "../updater.main";
+import { WindowMain } from "../window.main";
+
+import { IMenubarMenu, Menubar } from "./menubar";
+
+// Menu.buildFromTemplate is mocked as the identity function so the assembled
+// template is observable as the return value of the `menu` getter without
+// pulling in Electron's native runtime.
+jest.mock("electron", () => ({
+  Menu: { buildFromTemplate: jest.fn((template) => template) },
+  app: { relaunch: jest.fn(), exit: jest.fn(), getName: jest.fn(), isPackaged: false },
+  dialog: { showMessageBox: jest.fn() },
+  BrowserWindow: jest.fn(),
+  MenuItem: jest.fn(),
+  nativeImage: { createFromPath: jest.fn() },
+}));
+
+function makeMenubar(): Menubar {
+  const i18nService = { t: (s: string) => s } as unknown as I18nService;
+  const messagingService = { send: jest.fn() } as unknown as MessagingService;
+  const desktopSettingsService = {} as unknown as DesktopSettingsService;
+  const updaterMain = { checkForUpdate: jest.fn() } as unknown as UpdaterMain;
+  const windowMain = { win: {} } as unknown as WindowMain;
+  const versionMain = {} as unknown as VersionMain;
+  const shell = { openExternal: jest.fn() } as unknown as SafeShell;
+  return new Menubar(
+    i18nService,
+    messagingService,
+    desktopSettingsService,
+    updaterMain,
+    windowMain,
+    "https://vault.bitwarden.com",
+    "2026.5.0",
+    false,
+    versionMain,
+    shell,
+  );
+}
+
+// Returns the assembled top-level menu template (identity-mocked
+// buildFromTemplate hands it straight back).
+function templateFor(items: Array<IMenubarMenu | null>): MenuItemConstructorOptions[] {
+  const menubar = makeMenubar();
+  (menubar as any).items = items;
+  return menubar.menu as unknown as MenuItemConstructorOptions[];
+}
+
+describe("Menubar", () => {
+  describe("menu (template assembly)", () => {
+    // Regression guard for the role passthrough. macOS only renders the Help
+    // menu's search field when the top-level Help menu carries role: "help".
+    // The bug was that Menubar dropped `role` while assembling the template, so
+    // even a correct HelpMenu.role had no effect. See bitwarden/clients#2582.
+    it("forwards a menu's role into the assembled template", () => {
+      const template = templateFor([{ id: "help", label: "Help", role: "help", items: [] }]);
+      const help = template.find((i) => i.id === "help");
+      expect(help?.role).toBe("help");
+    });
+
+    it("leaves role undefined for menus that do not declare one", () => {
+      const template = templateFor([{ id: "file", label: "File", items: [] }]);
+      const file = template.find((i) => i.id === "file");
+      expect(file?.role).toBeUndefined();
+    });
+
+    it("skips null menu entries", () => {
+      const template = templateFor([null, { id: "help", label: "Help", role: "help", items: [] }]);
+      expect(template).toHaveLength(1);
+      expect(template[0].id).toBe("help");
+    });
+  });
+});

--- a/apps/desktop/src/main/menu/menubar.ts
+++ b/apps/desktop/src/main/menu/menubar.ts
@@ -25,6 +25,7 @@ import { WindowMenu } from "./menu.window";
 export interface IMenubarMenu {
   id: string;
   label: string;
+  role?: MenuItemConstructorOptions["role"];
   visible?: boolean; // Assumes true if null
   items: MenuItemConstructorOptions[];
 }
@@ -40,6 +41,7 @@ export class Menubar {
           template.push({
             id: item.id,
             label: item.label,
+            role: item.role,
             submenu: item.items,
             visible: item.visible ?? true,
           });


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #2582.

## 📔 Objective

Restore the native macOS Help-menu search field and Cmd-? menu search by assigning Electron’s `help` role to the custom Help menu.

Adds regression coverage for both the Help submenu role and menubar construction/wiring.

## 🧪 Testing

Verified on the branch: 3 desktop menu suites, 46 tests passing.

## 📸 Screenshots

Not applicable.