### PR TITLE
[PM-41475] Add the My folders page to desktop

### DIFF
--- a/apps/desktop/src/app/app-routing.module.ts
+++ b/apps/desktop/src/app/app-routing.module.ts
@@ -55,6 +55,7 @@ import { reactiveUnlockVaultGuard } from "../autofill/guards/reactive-vault-guar
 import { Fido2CreateComponent } from "../autofill/modal/credentials/fido2-create.component";
 import { Fido2ExcludedCiphersComponent } from "../autofill/modal/credentials/fido2-excluded-ciphers.component";
 import { Fido2VaultComponent } from "../autofill/modal/credentials/fido2-vault.component";
+import { MyFoldersComponent } from "../vault/app/my-folders/my-folders.component";
 import { VaultComponent } from "../vault/app/vault-v3/vault.component";
 
 import { DesktopLayoutComponent } from "./layout/desktop-layout.component";
@@ -466,6 +467,12 @@ const routes: Routes = [
             ],
           },
         ],
+      },
+      {
+        path: "folders",
+        component: MyFoldersComponent,
+        canActivate: [canAccessFeature(FeatureFlag.VFO1Foundation, true, "/vault")],
+        data: { pageTitle: { key: "myFolders" } } satisfies RouteDataProperties,
       },
       {
         path: "send",

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1232,6 +1232,24 @@
   "editFolder": {
     "message": "Edit folder"
   },
+  "editFolderNamed": {
+    "message": "Edit $NAME$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Social"
+      }
+    }
+  },
+  "deleteFolderNamed": {
+    "message": "Delete $NAME$",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Social"
+      }
+    }
+  },
   "regeneratePassword": {
     "message": "Regenerate password"
   },
@@ -1426,6 +1444,30 @@
   },
   "deletedFolder": {
     "message": "Folder deleted"
+  },
+  "foldersDeleted": {
+    "message": "Folders deleted"
+  },
+  "deleteFoldersCount": {
+    "message": "Delete $COUNT$ folders",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
+  },
+  "deleteFolderDescription": {
+    "message": "When you delete the $NAME$ folder, it will be removed from every item it's been applied to. The items themselves won't be deleted.",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "Banking"
+      }
+    }
+  },
+  "deleteFoldersDescription": {
+    "message": "When you delete these folders, they will be removed from every item they've been applied to. The items themselves won't be deleted."
   },
   "loginOrCreateNewAccount": {
     "message": "Log in or create a new account to access your secure vault."

--- a/apps/desktop/src/vault/app/my-folders/my-folders.component.html
+++ b/apps/desktop/src/vault/app/my-folders/my-folders.component.html
@@ -1,0 +1,3 @@
+<vault-my-folders>
+  <app-header></app-header>
+</vault-my-folders>

--- a/apps/desktop/src/vault/app/my-folders/my-folders.component.ts
+++ b/apps/desktop/src/vault/app/my-folders/my-folders.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+
+import { MyFoldersComponent as VaultMyFoldersComponent } from "@bitwarden/vault";
+
+import { DesktopHeaderComponent } from "../../../app/layout/header";
+
+@Component({
+  templateUrl: "./my-folders.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    // Desktop pages own their page padding; matches the vault page's spacing.
+    class: "tw-block tw-px-8 tw-py-6",
+  },
+  imports: [DesktopHeaderComponent, VaultMyFoldersComponent],
+})
+export class MyFoldersComponent {}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41475

## 📔 Objective

Adds the My folders page to desktop, behind the `VFO1Foundation` feature flag.

The Manage section of the restructured desktop side nav already renders a My folders entry pointing at `route="folders"` (via `VaultManageNavComponent`, from #22585), but no route was registered to serve it. This adds that route and the page it lands on.

The page itself is a thin desktop wrapper around the shared `MyFoldersComponent` in `libs/vault`, which web already uses — it projects the desktop `<app-header>` into the shared component and supplies the page padding desktop pages own for themselves. No folder logic is duplicated.

Also copies the six folder-management i18n keys the shared component needs into the desktop locale, per the repo's i18n rule that shared library strings need the key in each consuming app's `messages.json`.

## 📸 Screenshots

### My folders page
<img width="1408" height="1222" alt="image" src="https://github.com/user-attachments/assets/4da38a42-898d-4b96-96dd-74b496ceb147" />

### Folders page with delete dialog
<img width="1407" height="1221" alt="image" src="https://github.com/user-attachments/assets/ca82bdd7-ddd4-42b8-94d9-77c394fdf124" />

<img width="1408" height="1218" alt="image" src="https://github.com/user-attachments/assets/77f24254-750a-4473-9eb0-1951ec49bff6" />



