### PR TITLE
[PM-40157] Change compile-time flags to default off

### DIFF
--- a/libs/common/src/platform/misc/flags.spec.ts
+++ b/libs/common/src/platform/misc/flags.spec.ts
@@ -5,8 +5,8 @@ describe("flagEnabled", () => {
     process.env.FLAGS = JSON.stringify({});
   });
 
-  it("returns true by default", () => {
-    expect(flagEnabled<any>("nonExistentFlag")).toBe(true);
+  it("returns false by default", () => {
+    expect(flagEnabled<any>("nonExistentFlag")).toBe(false);
   });
 
   it("returns true if enabled", () => {

--- a/libs/common/src/platform/misc/flags.ts
+++ b/libs/common/src/platform/misc/flags.ts
@@ -26,14 +26,14 @@ function getFlags<T>(envFlags: string | T): T {
 
 /**
  * Gets the value of a feature flag from environment.
- * All flags default to "on" (true).
+ * Flags default to "off" (false) when not populated.
  * Only use for shared code in `libs`, otherwise use the client-specific function.
  * @param flag The name of the feature flag to check
  * @returns The value of the flag
  */
 export function flagEnabled<Flags extends SharedFlags>(flag: keyof Flags): boolean {
   const flags = getFlags<Flags>(process.env.FLAGS) ?? ({} as Flags);
-  return flags[flag] == null || !!flags[flag];
+  return !!flags[flag];
 }
 
 /**


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40157

## 📔 Objective

Reverses the logic of the compile-time `flags` so they default to `false` when not populated, rather than defaulting to `true`. This aligns with how our LaunchDarkly flags work and is safer against accidental enabling of a flag due to misunderstanding of the paradigm.

The only other flag currently in use is `sdk`, which is already set to `true` in all configurations, so there are no side-effects of this change for existing flags.

Split out of #22191 per review feedback so the change is documented independently of the beta icon work and is easy to revert if needed.