### PR TITLE
[PM-42586] Add translated beta name to desktop tray and about menu

### DIFF
--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2,8 +2,9 @@
   "bitwarden": {
     "message": "Bitwarden"
   },
-  "beta": {
-    "message": "Beta"
+  "bitwardenBeta": {
+    "message": "Bitwarden Beta",
+    "description": "Product name for the beta channel; shown in the tray tooltip and About dialog"
   },
   "filters": {
     "message": "Filters"

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -58,6 +58,7 @@ import { ChromiumImporterService } from "./main/tools/import/chromium-importer.s
 import { TrayMain } from "./main/tray.main";
 import { UpdaterMain } from "./main/updater.main";
 import { WindowMain } from "./main/window.main";
+import { flagEnabled } from "./platform/flags";
 import { ClipboardMain } from "./platform/main/clipboard.main";
 import { DesktopCredentialStorageListener } from "./platform/main/desktop-credential-storage-listener";
 import { ElectronStorageService } from "./platform/main/electron-storage.service";
@@ -384,7 +385,10 @@ export class Main {
         // FIXME: Verify that this floating promise is intentional. If it is, add an explanatory comment and ensure there is proper error handling.
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.menuMain.init();
-        await this.trayMain.init("Bitwarden", [
+        const trayName = this.i18nService.t(
+          flagEnabled("prereleaseBuild") ? "bitwardenBeta" : "bitwarden",
+        );
+        await this.trayMain.init(trayName, [
           {
             label: this.i18nService.t("lockVault"),
             enabled: false,

--- a/apps/desktop/src/main/menu/menu.about.ts
+++ b/apps/desktop/src/main/menu/menu.about.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, clipboard, dialog, MenuItemConstructorOptions } from "el
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
+import { flagEnabled } from "../../platform/flags";
 import { VersionMain } from "../../platform/main/version.main";
 import { isMacAppStore, isSnapStore, isWindowsStore } from "../platform-utils.main";
 import { UpdaterMain } from "../updater.main";
@@ -70,9 +71,12 @@ export class AboutMenu implements IMenubarMenu {
           process.versions.node +
           "\nArchitecture " +
           process.arch;
+        const productName = this.localize(
+          flagEnabled("prereleaseBuild") ? "bitwardenBeta" : "bitwarden",
+        );
         const result = await dialog.showMessageBox(this._window, {
-          title: "Bitwarden",
-          message: "Bitwarden",
+          title: productName,
+          message: productName,
           detail: aboutInformation,
           type: "info",
           noLink: true,

--- a/libs/components/src/anon-layout/anon-layout.component.ts
+++ b/libs/components/src/anon-layout/anon-layout.component.ts
@@ -12,7 +12,7 @@ import {
 import { RouterModule } from "@angular/router";
 import { firstValueFrom } from "rxjs";
 
-import { BitwardenLogo, BitSvg } from "@bitwarden/assets/svg";
+import { BitSvg } from "@bitwarden/assets/svg";
 import { ClientType } from "@bitwarden/common/enums";
 import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
@@ -80,7 +80,6 @@ export class AnonLayoutComponent implements OnInit, OnChanges {
    */
   readonly maxWidth = model<LandingContentMaxWidthType>(ANON_LAYOUT_DEFAULTS.maxWidth);
 
-  protected logo = BitwardenLogo;
   protected year: string;
   protected clientType: ClientType;
   protected hostname?: string;

--- a/libs/components/src/landing-layout/landing-header.component.ts
+++ b/libs/components/src/landing-layout/landing-header.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, input } from "@angular/core";
 import { RouterModule } from "@angular/router";
 
-import { BitwardenLogo } from "@bitwarden/assets/svg";
+import { BitwardenLogo, BitwardenLogoBeta } from "@bitwarden/assets/svg";
+import { flagEnabled } from "@bitwarden/common/platform/misc/flags";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { SvgModule } from "../svg";
@@ -38,5 +39,5 @@ import { SvgModule } from "../svg";
 })
 export class LandingHeaderComponent {
   readonly hideLogo = input<boolean>(false);
-  protected readonly logo = BitwardenLogo;
+  protected readonly logo = flagEnabled("prereleaseBuild") ? BitwardenLogoBeta : BitwardenLogo;
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42586

## 📔 Objective

Builds on https://github.com/bitwarden/clients/pull/22445.  

1. Adds the "Bitwarden" name on the desktop tray and the Help / About menu to reference "Bitwarden Beta" instead of "Bitwarden".
2. Introduces the Bitwarden logo on the landing pages for desktop (outside of the Vault).
3. Removes unused logo from `AnonLayout` that was orphaned in #17969.

### Layout hierarchy (what's used where)

Background on why the change is in the `landing-header` and not `anon-layout`:

- **`bit-landing-header`**: the header primitive. Renders the Bitwarden logo on the left and a projected slot for actions on the right. **This is the file changed in this PR.**
- **`auth-anon-layout` (`AnonLayoutComponent`)**: an auth-flavored composition of the primitives. Wires in the title, subtitle, hero icon, environment selector, hostname readout, and footer year plus version. Uses `<bit-landing-header>` internally, which is what pulls in the logo.

#### Why the browser extension is different

The extension does not go through `<bit-landing-header>`. `ExtensionAnonLayoutWrapperComponent` sets `[hideLogo]="true"` on `<auth-anon-layout>` and renders its own `<bit-svg>` inside the extension's popup header bar. This is required because the logo needs to sit at the top of the popup shell, not inside the anon-layout's card region. The extension wrapper carries its own `flagEnabled("prereleaseBuild") ? BitwardenLogoBeta : BitwardenLogo` binding to drive that render, and it already worked before this change.

## 📸 Screenshots

<img width="510" height="36" alt="image" src="https://github.com/user-attachments/assets/54358114-69e1-4d15-811d-3ad5bba45c65" />

<img width="312" height="243" alt="image" src="https://github.com/user-attachments/assets/c321b49a-0d13-4e08-84b8-cca7ef98aa00" />

<img width="1089" height="923" alt="image" src="https://github.com/user-attachments/assets/d794271e-3e32-4df0-a9f9-6cc3ee368028" />