### PR TITLE
refactor(unlock): extract AutoUnlockService

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -319,7 +319,13 @@ import {
   DefaultStateService,
   InlineDerivedStateProvider,
 } from "@bitwarden/state-internal";
-import { DefaultUnlockService, LockService, UnlockService } from "@bitwarden/unlock";
+import {
+  AutoUnlockService,
+  DefaultAutoUnlockService,
+  DefaultUnlockService,
+  LockService,
+  UnlockService,
+} from "@bitwarden/unlock";
 import {
   IndividualVaultExportService,
   IndividualVaultExportServiceAbstraction,
@@ -565,6 +571,7 @@ export default class MainBackground {
   sharedUnlockFollowerService: SharedUnlockFollowerService;
   sharedUnlockSettingsService: SharedUnlockSettingsService;
   unlockService: UnlockService;
+  autoUnlockService: AutoUnlockService;
 
   badgeService: BadgeService;
   authStatusBadgeUpdaterService: AuthStatusBadgeUpdaterService;
@@ -823,6 +830,14 @@ export default class MainBackground {
       browserBiometricsService,
     );
 
+    this.autoUnlockService = new DefaultAutoUnlockService(
+      this.keyService,
+      this.stateService,
+      this.stateProvider,
+      this.platformUtilsService,
+      this.logService,
+    );
+
     this.legacyCompatKeyService = new DefaultLegacyCompatKeyService(
       this.masterPasswordService,
       this.keyGenerationService,
@@ -864,7 +879,7 @@ export default class MainBackground {
     this.vaultTimeoutSettingsService = new DefaultVaultTimeoutSettingsService(
       this.accountService,
       this.userDecryptionOptionsService,
-      this.keyService,
+      this.autoUnlockService,
       this.tokenService,
       this.policyService,
       this.biometricStateService,
@@ -1004,11 +1019,9 @@ export default class MainBackground {
       this.stateProvider,
       this.logService,
       this.biometricsService,
-      this.platformUtilsService,
-      this.stateService,
       this.biometricStateService,
       this.v2UpgradeTokenStateService,
-      this.keyService,
+      this.autoUnlockService,
     );
     void browserBiometricsService.setUnlockService(this.unlockService);
 

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -228,6 +228,8 @@ import {
 } from "@bitwarden/state-internal";
 import { SerializedMemoryStorageService } from "@bitwarden/storage-core";
 import {
+  AutoUnlockService,
+  DefaultAutoUnlockService,
   DefaultLockService,
   LockService,
   DefaultUnlockService,
@@ -379,6 +381,7 @@ export class ServiceContainer {
   cipherArchiveService: CipherArchiveService;
   lockService: LockService;
   unlockService: UnlockService;
+  autoUnlockService: AutoUnlockService;
   private accountCryptographicStateService: DefaultAccountCryptographicStateService;
   private v2UpgradeTokenStateService: V2UpgradeTokenStateService;
 
@@ -542,6 +545,14 @@ export class ServiceContainer {
       new CliBiometricsService(),
     );
 
+    this.autoUnlockService = new DefaultAutoUnlockService(
+      this.keyService,
+      this.stateService,
+      this.stateProvider,
+      this.platformUtilsService,
+      this.logService,
+    );
+
     this.legacyCompatKeyService = new LegacyCompatKeyService(
       this.masterPasswordService,
       this.keyGenerationService,
@@ -590,7 +601,7 @@ export class ServiceContainer {
     this.vaultTimeoutSettingsService = new DefaultVaultTimeoutSettingsService(
       this.accountService,
       this.userDecryptionOptionsService,
-      this.keyService,
+      this.autoUnlockService,
       this.tokenService,
       this.policyService,
       this.biometricStateService,
@@ -762,11 +773,9 @@ export class ServiceContainer {
       this.stateProvider,
       this.logService,
       new CliBiometricsService(),
-      this.platformUtilsService,
-      this.stateService,
       this.biometricStateService,
       this.v2UpgradeTokenStateService,
-      this.keyService,
+      this.autoUnlockService,
     );
 
     this.sendTokenService = new DefaultSendTokenService(

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -55,6 +55,7 @@ import { BiometricStateService, BiometricsStatus, KeyService } from "@bitwarden/
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 // eslint-disable-next-line no-restricted-imports
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+import { AutoUnlockService } from "@bitwarden/unlock";
 import { VaultCopyButtonsService } from "@bitwarden/vault";
 
 import { SetPinComponent } from "../../auth/components/set-pin.component";
@@ -100,6 +101,7 @@ describe("SettingsDialogComponent", () => {
   const validationService = mock<ValidationService>();
   const messagingService = mock<MessagingService>();
   const keyService = mock<KeyService>();
+  const autoUnlockService = mock<AutoUnlockService>();
   const dialogService = mock<DialogService>();
   const desktopAutotypeMvpService = mock<DesktopAutotypeMvpService>();
   const billingAccountProfileStateService = mock<BillingAccountProfileStateService>();
@@ -156,6 +158,7 @@ describe("SettingsDialogComponent", () => {
           useValue: mock<NativeMessagingManifestService>(),
         },
         { provide: KeyService, useValue: keyService },
+        { provide: AutoUnlockService, useValue: autoUnlockService },
         { provide: PinServiceAbstraction, useValue: pinServiceAbstraction },
         { provide: PlatformUtilsService, useValue: platformUtilsService },
         { provide: PolicyService, useValue: policyService },
@@ -650,7 +653,7 @@ describe("SettingsDialogComponent", () => {
           false,
           mockUserId,
         );
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
+        expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
 
@@ -665,7 +668,7 @@ describe("SettingsDialogComponent", () => {
           await (component as any).updateBiometricHandler(true);
 
           expect(biometricStateService.setBiometricUnlockEnabled).not.toHaveBeenCalled();
-          expect(keyService.refreshAdditionalKeys).not.toHaveBeenCalled();
+          expect(autoUnlockService.refreshAutoUnlockKey).not.toHaveBeenCalled();
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
 
           if (dialogResult) {
@@ -694,7 +697,7 @@ describe("SettingsDialogComponent", () => {
           mockUserId,
         );
         expect((component as any).form.controls.biometric.value).toBe(true);
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+        expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
         expect(desktopBiometricsService.setBiometricProtectedUnlockKeyForUser).toHaveBeenCalledWith(
           mockUserId,
           mockUserKey,
@@ -729,7 +732,7 @@ describe("SettingsDialogComponent", () => {
             false,
             mockUserId,
           );
-          expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+          expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
           expect((component as any).form.controls.biometric.value).toBe(true);
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
         });
@@ -764,7 +767,7 @@ describe("SettingsDialogComponent", () => {
               false,
               mockUserId,
             );
-            expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+            expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
             expect((component as any).form.controls.biometric.value).toBe(true);
             expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
           });
@@ -801,7 +804,7 @@ describe("SettingsDialogComponent", () => {
                 false,
                 mockUserId,
               );
-              expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+              expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
               expect((component as any).form.controls.biometric.value).toBe(true);
               expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
             },
@@ -828,7 +831,7 @@ describe("SettingsDialogComponent", () => {
           false,
           mockUserId,
         );
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+        expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
         expect((component as any).form.controls.biometric.value).toBe(true);
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
@@ -852,7 +855,7 @@ describe("SettingsDialogComponent", () => {
 
           await (component as any).updateBiometricHandler(true);
 
-          expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+          expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
           expect((component as any).form.controls.biometric.value).toBe(false);
           expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
             true,
@@ -878,7 +881,7 @@ describe("SettingsDialogComponent", () => {
           false,
           mockUserId,
         );
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
+        expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
     });

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -637,6 +637,22 @@ describe("SettingsDialogComponent", () => {
       },
     );
 
+    describe("when updating to false", () => {
+      it("deletes the stored biometric unlock key", async () => {
+        await component.ngOnInit();
+
+        await (component as any).updateBiometricHandler(false);
+
+        expect(desktopBiometricsService.deleteBiometricUnlockKeyForUser).toHaveBeenCalledWith(
+          mockUserId,
+        );
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+          false,
+          mockUserId,
+        );
+      });
+    });
+
     describe("when updating to true", () => {
       beforeEach(async () => {
         await component.ngOnInit();

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -455,6 +455,7 @@ export class SettingsDialogComponent implements OnInit {
     if (!enabled || !this.supportsBiometric()) {
       this.form.controls.biometric.setValue(false, { emitEvent: false });
       await this.biometricStateService.setBiometricUnlockEnabled(false, activeUserId);
+      await this.biometricsService.deleteBiometricUnlockKeyForUser(activeUserId);
       await this.autoUnlockService.refreshAutoUnlockKey(activeUserId);
       return;
     }

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -55,6 +55,7 @@ import {
 import { KeyService, BiometricStateService, BiometricsStatus } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 import { I18nPipe } from "@bitwarden/ui-common";
+import { AutoUnlockService } from "@bitwarden/unlock";
 import {
   PermitCipherDetailsPopoverComponent,
   VaultCopyButtonsService,
@@ -116,6 +117,7 @@ export class SettingsDialogComponent implements OnInit {
   private readonly autofillSettingsService = inject(AutofillSettingsServiceAbstraction);
   private readonly messagingService = inject(MessagingService);
   private readonly keyService = inject(KeyService);
+  private readonly autoUnlockService = inject(AutoUnlockService);
   private readonly themeStateService = inject(ThemeStateService);
   private readonly domainSettingsService = inject(DomainSettingsService);
   private readonly dialogService = inject(DialogService);
@@ -453,7 +455,7 @@ export class SettingsDialogComponent implements OnInit {
     if (!enabled || !this.supportsBiometric()) {
       this.form.controls.biometric.setValue(false, { emitEvent: false });
       await this.biometricStateService.setBiometricUnlockEnabled(false, activeUserId);
-      await this.keyService.refreshAdditionalKeys(activeUserId);
+      await this.autoUnlockService.refreshAutoUnlockKey(activeUserId);
       return;
     }
 
@@ -493,7 +495,7 @@ export class SettingsDialogComponent implements OnInit {
     }
     const userKey = await firstValueFrom(this.keyService.userKey$(activeUserId));
     await this.biometricsService.setBiometricProtectedUnlockKeyForUser(activeUserId, userKey);
-    await this.keyService.refreshAdditionalKeys(activeUserId);
+    await this.autoUnlockService.refreshAutoUnlockKey(activeUserId);
 
     // Validate the key is stored in case biometrics fail.
     const biometricSet =

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -34,6 +34,7 @@ import { BiometricStateService, BiometricsStatus, KeyService } from "@bitwarden/
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 // eslint-disable-next-line no-restricted-imports
 import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+import { AutoUnlockService } from "@bitwarden/unlock";
 import { VaultCopyButtonsService } from "@bitwarden/vault";
 
 import { SetPinComponent } from "../../auth/components/set-pin.component";
@@ -79,6 +80,7 @@ describe("SettingsComponent", () => {
   const validationService = mock<ValidationService>();
   const messagingService = mock<MessagingService>();
   const keyService = mock<KeyService>();
+  const autoUnlockService = mock<AutoUnlockService>();
   const dialogService = mock<DialogService>();
   const desktopAutotypeMvpService = mock<DesktopAutotypeMvpService>();
   const billingAccountProfileStateService = mock<BillingAccountProfileStateService>();
@@ -136,6 +138,7 @@ describe("SettingsComponent", () => {
           useValue: mock<NativeMessagingManifestService>(),
         },
         { provide: KeyService, useValue: keyService },
+        { provide: AutoUnlockService, useValue: autoUnlockService },
         { provide: PinServiceAbstraction, useValue: pinServiceAbstraction },
         { provide: PlatformUtilsService, useValue: platformUtilsService },
         { provide: PolicyService, useValue: policyService },
@@ -614,7 +617,7 @@ describe("SettingsComponent", () => {
           false,
           mockUserId,
         );
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
+        expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
 
@@ -629,7 +632,7 @@ describe("SettingsComponent", () => {
           await component.updateBiometricHandler(true);
 
           expect(biometricStateService.setBiometricUnlockEnabled).not.toHaveBeenCalled();
-          expect(keyService.refreshAdditionalKeys).not.toHaveBeenCalled();
+          expect(autoUnlockService.refreshAutoUnlockKey).not.toHaveBeenCalled();
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
 
           if (dialogResult) {
@@ -658,7 +661,7 @@ describe("SettingsComponent", () => {
           mockUserId,
         );
         expect(component.form.controls.biometric.value).toBe(true);
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+        expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
         expect(desktopBiometricsService.setBiometricProtectedUnlockKeyForUser).toHaveBeenCalledWith(
           mockUserId,
           mockUserKey,
@@ -693,7 +696,7 @@ describe("SettingsComponent", () => {
             false,
             mockUserId,
           );
-          expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+          expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
           expect(component.form.controls.biometric.value).toBe(true);
           expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
         });
@@ -726,7 +729,7 @@ describe("SettingsComponent", () => {
               false,
               mockUserId,
             );
-            expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+            expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
             expect(component.form.controls.biometric.value).toBe(true);
             expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
           });
@@ -761,7 +764,7 @@ describe("SettingsComponent", () => {
                 false,
                 mockUserId,
               );
-              expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+              expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
               expect(component.form.controls.biometric.value).toBe(true);
               expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
             },
@@ -788,7 +791,7 @@ describe("SettingsComponent", () => {
           false,
           mockUserId,
         );
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+        expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
         expect(component.form.controls.biometric.value).toBe(true);
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
@@ -813,7 +816,7 @@ describe("SettingsComponent", () => {
 
           await component.updateBiometricHandler(true);
 
-          expect(keyService.refreshAdditionalKeys).toHaveBeenCalledWith(mockUserId);
+          expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
           expect(component.form.controls.biometric.value).toBe(false);
           expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
             true,
@@ -839,7 +842,7 @@ describe("SettingsComponent", () => {
           false,
           mockUserId,
         );
-        expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
+        expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalled();
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
     });

--- a/apps/desktop/src/app/accounts/settings.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings.component.spec.ts
@@ -601,6 +601,22 @@ describe("SettingsComponent", () => {
       },
     );
 
+    describe("when updating to false", () => {
+      it("deletes the stored biometric unlock key", async () => {
+        await component.ngOnInit();
+
+        await component.updateBiometricHandler(false);
+
+        expect(desktopBiometricsService.deleteBiometricUnlockKeyForUser).toHaveBeenCalledWith(
+          mockUserId,
+        );
+        expect(biometricStateService.setBiometricUnlockEnabled).toHaveBeenCalledWith(
+          false,
+          mockUserId,
+        );
+      });
+    });
+
     describe("when updating to true", () => {
       beforeEach(async () => {
         await component.ngOnInit();

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -51,6 +51,7 @@ import {
 import { KeyService, BiometricStateService, BiometricsStatus } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 import { I18nPipe } from "@bitwarden/ui-common";
+import { AutoUnlockService } from "@bitwarden/unlock";
 import {
   PermitCipherDetailsPopoverComponent,
   VaultCopyButtonsService,
@@ -182,6 +183,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     private autofillSettingsService: AutofillSettingsServiceAbstraction,
     private messagingService: MessagingService,
     private keyService: KeyService,
+    private autoUnlockService: AutoUnlockService,
     private themeStateService: ThemeStateService,
     private domainSettingsService: DomainSettingsService,
     private dialogService: DialogService,
@@ -435,7 +437,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     if (!enabled || !this.supportsBiometric) {
       this.form.controls.biometric.setValue(false, { emitEvent: false });
       await this.biometricStateService.setBiometricUnlockEnabled(false, activeUserId);
-      await this.keyService.refreshAdditionalKeys(activeUserId);
+      await this.autoUnlockService.refreshAutoUnlockKey(activeUserId);
       return;
     }
 
@@ -475,7 +477,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     }
     const userKey = await firstValueFrom(this.keyService.userKey$(activeUserId));
     await this.biometricsService.setBiometricProtectedUnlockKeyForUser(activeUserId, userKey);
-    await this.keyService.refreshAdditionalKeys(activeUserId);
+    await this.autoUnlockService.refreshAutoUnlockKey(activeUserId);
 
     // Validate the key is stored in case biometrics fail.
     const biometricSet =

--- a/apps/desktop/src/app/accounts/settings.component.ts
+++ b/apps/desktop/src/app/accounts/settings.component.ts
@@ -437,6 +437,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     if (!enabled || !this.supportsBiometric) {
       this.form.controls.biometric.setValue(false, { emitEvent: false });
       await this.biometricStateService.setBiometricUnlockEnabled(false, activeUserId);
+      await this.biometricsService.deleteBiometricUnlockKeyForUser(activeUserId);
       await this.autoUnlockService.refreshAutoUnlockKey(activeUserId);
       return;
     }

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -416,6 +416,8 @@ import {
 } from "@bitwarden/state-internal";
 import { SafeInjectionToken } from "@bitwarden/ui-common";
 import {
+  AutoUnlockService,
+  DefaultAutoUnlockService,
   DefaultLockService,
   LockService,
   DefaultUnlockService,
@@ -1053,11 +1055,20 @@ const safeProviders: SafeProvider[] = [
       StateProvider,
       LogService,
       BiometricsService,
-      PlatformUtilsServiceAbstraction,
-      StateServiceAbstraction,
       BiometricStateService,
       V2UpgradeTokenStateService,
+      AutoUnlockService,
+    ],
+  }),
+  safeProvider({
+    provide: AutoUnlockService,
+    useClass: DefaultAutoUnlockService,
+    deps: [
       KeyService,
+      StateServiceAbstraction,
+      StateProvider,
+      PlatformUtilsServiceAbstraction,
+      LogService,
     ],
   }),
   safeProvider({
@@ -1071,7 +1082,7 @@ const safeProviders: SafeProvider[] = [
     deps: [
       AccountServiceAbstraction,
       UserDecryptionOptionsServiceAbstraction,
-      KeyService,
+      AutoUnlockService,
       TokenServiceAbstraction,
       PolicyServiceAbstraction,
       BiometricStateService,

--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.spec.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.spec.ts
@@ -11,7 +11,8 @@ import {
 } from "@bitwarden/auth/common";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { BiometricStateService, KeyService } from "@bitwarden/key-management";
+import { BiometricStateService } from "@bitwarden/key-management";
+import { AutoUnlockService } from "@bitwarden/unlock";
 
 import { FakeAccountService, FakeStateProvider, mockAccountServiceWith } from "../../../../spec";
 import { PolicyService } from "../../../admin-console/abstractions/policy/policy.service.abstraction";
@@ -39,7 +40,7 @@ import { VAULT_TIMEOUT, VAULT_TIMEOUT_ACTION } from "./vault-timeout-settings.st
 describe("VaultTimeoutSettingsService", () => {
   let accountService: FakeAccountService;
   let userDecryptionOptionsService: MockProxy<UserDecryptionOptionsServiceAbstraction>;
-  let keyService: MockProxy<KeyService>;
+  let autoUnlockService: MockProxy<AutoUnlockService>;
   let tokenService: MockProxy<TokenService>;
   let policyService: MockProxy<PolicyService>;
   const biometricStateService = mock<BiometricStateService>();
@@ -56,7 +57,7 @@ describe("VaultTimeoutSettingsService", () => {
   beforeEach(() => {
     accountService = mockAccountServiceWith(mockUserId);
     userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
-    keyService = mock<KeyService>();
+    autoUnlockService = mock<AutoUnlockService>();
     tokenService = mock<TokenService>();
     policyService = mock<PolicyService>();
 
@@ -965,7 +966,7 @@ describe("VaultTimeoutSettingsService", () => {
         stateProvider.singleUser.getFake(mockUserId, VAULT_TIMEOUT).nextMock,
       ).toHaveBeenCalledWith(timeout);
 
-      expect(keyService.refreshAdditionalKeys).toHaveBeenCalled();
+      expect(autoUnlockService.refreshAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
     });
 
     it("should re-store the tokens when the timeout is not never and the action is log out", async () => {
@@ -1009,7 +1010,7 @@ describe("VaultTimeoutSettingsService", () => {
     return new VaultTimeoutSettingsService(
       accountService,
       userDecryptionOptionsService,
-      keyService,
+      autoUnlockService,
       tokenService,
       policyService,
       biometricStateService,

--- a/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts
+++ b/libs/common/src/key-management/vault-timeout/services/vault-timeout-settings.service.ts
@@ -20,7 +20,8 @@ import {
 import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 // eslint-disable-next-line no-restricted-imports
-import { BiometricStateService, KeyService } from "@bitwarden/key-management";
+import { BiometricStateService } from "@bitwarden/key-management";
+import { AutoUnlockService } from "@bitwarden/unlock";
 
 import { PolicyService } from "../../../admin-console/abstractions/policy/policy.service.abstraction";
 import { PolicyType } from "../../../admin-console/enums";
@@ -55,7 +56,7 @@ export class VaultTimeoutSettingsService implements VaultTimeoutSettingsServiceA
   constructor(
     private accountService: AccountService,
     private userDecryptionOptionsService: UserDecryptionOptionsServiceAbstraction,
-    private keyService: KeyService,
+    private autoUnlockService: AutoUnlockService,
     private tokenService: TokenService,
     private policyService: PolicyService,
     private biometricStateService: BiometricStateService,
@@ -88,7 +89,7 @@ export class VaultTimeoutSettingsService implements VaultTimeoutSettingsServiceA
 
     await this.migrateTokenStorage(userId, action, timeout);
 
-    await this.keyService.refreshAdditionalKeys(userId);
+    await this.autoUnlockService.refreshAutoUnlockKey(userId);
   }
 
   availableVaultTimeoutActions$(userId?: UserId): Observable<VaultTimeoutAction[]> {

--- a/libs/key-management/src/abstractions/key.service.ts
+++ b/libs/key-management/src/abstractions/key.service.ts
@@ -3,7 +3,6 @@ import { Observable } from "rxjs";
 import { ProfileOrganizationResponse } from "@bitwarden/common/admin-console/models/response/profile-organization.response";
 import { ProfileProviderOrganizationResponse } from "@bitwarden/common/admin-console/models/response/profile-provider-organization.response";
 import { ProfileProviderResponse } from "@bitwarden/common/admin-console/models/response/profile-provider.response";
-import { KeySuffixOptions } from "@bitwarden/common/platform/enums";
 import { OrganizationId, ProviderId, UserId } from "@bitwarden/common/types/guid";
 import {
   UserKey,
@@ -48,25 +47,6 @@ export abstract class KeyService {
    * @param userId The user id of the user to get the {@see UserKey} for.
    */
   abstract userKey$(userId: UserId): Observable<UserKey | null>;
-  /**
-   * Sets the provided user key and stores
-   * any other necessary versions (such as auto, biometrics,
-   * or pin)
-   *
-   * @throws Error when key or userId is null. Lock the account to clear a key.
-   * @param key The user key to set
-   * @param userId The desired user
-   */
-  abstract setUserKey(key: UserKey, userId: UserId): Promise<void>;
-  /**
-   * Gets the user key from memory and sets it again,
-   * kicking off a refresh of any additional keys
-   * (such as auto, biometrics, or pin)
-   * @param userId The target user to refresh keys for.
-   * @throws Error when userId is null or undefined.
-   * @throws When userKey doesn't exist in memory for the target user.
-   */
-  abstract refreshAdditionalKeys(userId: UserId): Promise<void>;
 
   /**
    * Observable value that returns whether or not the user has ever had a userKey,
@@ -75,25 +55,11 @@ export abstract class KeyService {
   abstract everHadUserKey$(userId: UserId): Observable<boolean>;
 
   /**
-   * Retrieves the user key
+   * Clears every stored copy of the user's key, including platform-specific copies
+   * such as the desktop biometric unlock key.
    * @param userId The desired user
-   * @returns The user key
-   *
-   * @deprecated Use {@link userKey$} with a required {@link UserId} instead.
    */
-  abstract getUserKey(userId?: string): Promise<UserKey | null>;
-
-  /**
-   * Retrieves the user key from storage
-   * @param keySuffix The desired version of the user's key to retrieve
-   * @param userId The desired user
-   * @returns The user key
-   * @throws Error when userId is null or undefined.
-   */
-  abstract getUserKeyFromStorage(
-    keySuffix: KeySuffixOptions,
-    userId: string,
-  ): Promise<UserKey | null>;
+  abstract clearAllStoredUserKeys(userId: UserId): Promise<void>;
 
   /**
    * Determines whether the user key is available for the given user in memory.

--- a/libs/key-management/src/key.service.spec.ts
+++ b/libs/key-management/src/key.service.spec.ts
@@ -1,7 +1,6 @@
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, bufferCount, firstValueFrom, lastValueFrom, of, take } from "rxjs";
 
-import { ClientType } from "@bitwarden/client-type";
 import { EncryptedOrganizationKeyData } from "@bitwarden/common/admin-console/models/data/encrypted-organization-key.data";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import { FakeMasterPasswordService } from "@bitwarden/common/key-management/master-password/services/fake-master-password.service";
@@ -96,64 +95,6 @@ describe("keyService", () => {
     expect(keyService).not.toBeFalsy();
   });
 
-  describe("refreshAdditionalKeys", () => {
-    test.each([null as unknown as UserId, undefined as unknown as UserId])(
-      "throws when the provided userId is %s",
-      async (userId) => {
-        await expect(keyService.refreshAdditionalKeys(userId)).rejects.toThrow(
-          "UserId is required",
-        );
-      },
-    );
-
-    it("throws error if user key not found", async () => {
-      setUserKeyState(mockUserId, null);
-
-      await expect(keyService.refreshAdditionalKeys(mockUserId)).rejects.toThrow(
-        "No user key found for: " + mockUserId,
-      );
-    });
-
-    it("refreshes additional keys when user key is available", async () => {
-      const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
-      setUserKeyState(mockUserId, mockUserKey);
-      const setUserKeySpy = jest.spyOn(keyService, "setUserKey");
-
-      await keyService.refreshAdditionalKeys(mockUserId);
-
-      expect(setUserKeySpy).toHaveBeenCalledWith(mockUserKey, mockUserId);
-    });
-  });
-
-  describe("getUserKey", () => {
-    let mockUserKey: UserKey;
-
-    beforeEach(() => {
-      const mockRandomBytes = new Uint8Array(64) as CsprngArray;
-      mockUserKey = new SymmetricCryptoKey(mockRandomBytes) as UserKey;
-    });
-
-    it("retrieves the key state of the requested user", async () => {
-      await keyService.getUserKey(mockUserId);
-
-      expect(stateProvider.mock.getUserState$).toHaveBeenCalledWith(USER_KEY, mockUserId);
-    });
-
-    it("returns the User Key if available", async () => {
-      setUserKeyState(mockUserId, mockUserKey);
-
-      const userKey = await keyService.getUserKey(mockUserId);
-
-      expect(userKey).toEqual(mockUserKey);
-    });
-
-    it("returns nullish if the user key is not set", async () => {
-      const userKey = await keyService.getUserKey(mockUserId);
-
-      expect(userKey).toBeFalsy();
-    });
-  });
-
   describe("hasUserKey", () => {
     let mockUserKey: UserKey;
 
@@ -198,71 +139,6 @@ describe("keyService", () => {
       everHadUserKeyState.nextState(null);
 
       expect(await firstValueFrom(keyService.everHadUserKey$(mockUserId))).toBe(false);
-    });
-  });
-
-  describe("setUserKey", () => {
-    let mockUserKey: UserKey;
-    let everHadUserKeyState: FakeSingleUserState<boolean>;
-
-    beforeEach(() => {
-      const mockRandomBytes = new Uint8Array(64) as CsprngArray;
-      mockUserKey = new SymmetricCryptoKey(mockRandomBytes) as UserKey;
-      everHadUserKeyState = stateProvider.singleUser.getFake(mockUserId, USER_EVER_HAD_USER_KEY);
-
-      // Initialize storage
-      everHadUserKeyState.nextState(null);
-    });
-
-    it("should set everHadUserKey if key is not null to true", async () => {
-      await keyService.setUserKey(mockUserKey, mockUserId);
-
-      expect(await firstValueFrom(everHadUserKeyState.state$)).toBe(true);
-    });
-
-    describe("Auto Key refresh", () => {
-      it("sets an Auto key if vault timeout is set to 'never'", async () => {
-        await stateProvider.setUserState(VAULT_TIMEOUT, VaultTimeoutStringType.Never, mockUserId);
-
-        await keyService.setUserKey(mockUserKey, mockUserId);
-
-        expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(mockUserKey.keyB64, {
-          userId: mockUserId,
-        });
-      });
-
-      it("sets an Auto key if vault timeout is set to 10 minutes and is Cli", async () => {
-        await stateProvider.setUserState(VAULT_TIMEOUT, 10, mockUserId);
-        platformUtilService.getClientType.mockReturnValue(ClientType.Cli);
-
-        await keyService.setUserKey(mockUserKey, mockUserId);
-
-        expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(mockUserKey.keyB64, {
-          userId: mockUserId,
-        });
-      });
-
-      it("clears the Auto key if vault timeout is set to 10 minutes", async () => {
-        await stateProvider.setUserState(VAULT_TIMEOUT, 10, mockUserId);
-
-        await keyService.setUserKey(mockUserKey, mockUserId);
-
-        expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(null, {
-          userId: mockUserId,
-        });
-      });
-    });
-
-    it("throws if key is null", async () => {
-      await expect(keyService.setUserKey(null as unknown as UserKey, mockUserId)).rejects.toThrow(
-        "No key provided.",
-      );
-    });
-
-    it("throws if userId is null", async () => {
-      await expect(keyService.setUserKey(mockUserKey, null as unknown as UserId)).rejects.toThrow(
-        "No userId provided.",
-      );
     });
   });
 
@@ -692,85 +568,6 @@ describe("keyService", () => {
       expect(key).toEqual({
         privateKey: "private key",
         publicKey: Utils.fromUtf8ToArray("public key") as UnsignedPublicKey,
-      });
-    });
-  });
-
-  describe("getUserKeyFromStorage", () => {
-    let mockUserKey: UserKey;
-    let validateUserKeySpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
-      validateUserKeySpy = jest.spyOn(keyService, "validateUserKey");
-    });
-
-    afterEach(() => {
-      validateUserKeySpy.mockRestore();
-    });
-
-    describe("input validation", () => {
-      const invalidUserIdTestCases = [
-        { keySuffix: KeySuffixOptions.Auto, userId: null as unknown as UserId },
-        { keySuffix: KeySuffixOptions.Auto, userId: undefined as unknown as UserId },
-        { keySuffix: KeySuffixOptions.Pin, userId: null as unknown as UserId },
-        { keySuffix: KeySuffixOptions.Pin, userId: undefined as unknown as UserId },
-      ];
-
-      test.each(invalidUserIdTestCases)(
-        "throws when keySuffix is $keySuffix and userId is $userId",
-        async ({ keySuffix, userId }) => {
-          await expect(keyService.getUserKeyFromStorage(keySuffix, userId)).rejects.toThrow(
-            "UserId is required",
-          );
-        },
-      );
-    });
-
-    describe("with Pin keySuffix", () => {
-      it("returns null and doesn't validate the key", async () => {
-        const result = await keyService.getUserKeyFromStorage(KeySuffixOptions.Pin, mockUserId);
-
-        expect(result).toBeNull();
-        expect(validateUserKeySpy).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("with Auto keySuffix", () => {
-      it("returns validated key from storage when key exists and is valid", async () => {
-        stateService.getUserKeyAutoUnlock.mockResolvedValue(mockUserKey.keyB64);
-        validateUserKeySpy.mockResolvedValue(true);
-
-        const result = await keyService.getUserKeyFromStorage(KeySuffixOptions.Auto, mockUserId);
-
-        expect(result).toEqual(mockUserKey);
-        expect(validateUserKeySpy).toHaveBeenCalledWith(mockUserKey, mockUserId);
-        expect(stateService.getUserKeyAutoUnlock).toHaveBeenCalledWith({
-          userId: mockUserId,
-        });
-      });
-
-      it("returns null when no key is found in storage", async () => {
-        stateService.getUserKeyAutoUnlock.mockResolvedValue(null as unknown as string);
-
-        const result = await keyService.getUserKeyFromStorage(KeySuffixOptions.Auto, mockUserId);
-
-        expect(result).toBeNull();
-        expect(validateUserKeySpy).not.toHaveBeenCalled();
-      });
-
-      it("clears stored keys when userKey validation fails", async () => {
-        stateService.getUserKeyAutoUnlock.mockResolvedValue(mockUserKey.keyB64);
-        validateUserKeySpy.mockResolvedValue(false);
-
-        const result = await keyService.getUserKeyFromStorage(KeySuffixOptions.Auto, mockUserId);
-
-        expect(result).toEqual(mockUserKey);
-        expect(validateUserKeySpy).toHaveBeenCalledWith(mockUserKey, mockUserId);
-        expect(logService.warning).toHaveBeenCalledWith("Invalid key, throwing away stored keys");
-        expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(null, {
-          userId: mockUserId,
-        });
       });
     });
   });

--- a/libs/key-management/src/key.service.ts
+++ b/libs/key-management/src/key.service.ts
@@ -13,7 +13,6 @@ import {
   switchMap,
 } from "rxjs";
 
-import { ClientType } from "@bitwarden/client-type";
 import { EncryptedOrganizationKeyData } from "@bitwarden/common/admin-console/models/data/encrypted-organization-key.data";
 import { BaseEncryptedOrganizationKey } from "@bitwarden/common/admin-console/models/domain/encrypted-organization-key";
 import { ProfileOrganizationResponse } from "@bitwarden/common/admin-console/models/response/profile-organization.response";
@@ -21,14 +20,10 @@ import { ProfileProviderOrganizationResponse } from "@bitwarden/common/admin-con
 import { ProfileProviderResponse } from "@bitwarden/common/admin-console/models/response/profile-provider.response";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import { USER_KEY } from "@bitwarden/common/key-management/state-definitions";
-import { VaultTimeoutStringType } from "@bitwarden/common/key-management/vault-timeout";
-import { VAULT_TIMEOUT } from "@bitwarden/common/key-management/vault-timeout/services/vault-timeout-settings.state";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { StateService } from "@bitwarden/common/platform/abstractions/state.service";
-import { KeySuffixOptions } from "@bitwarden/common/platform/enums";
 import { convertValues } from "@bitwarden/common/platform/misc/convert-values";
-import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { USER_ENCRYPTED_ORGANIZATION_KEYS } from "@bitwarden/common/platform/services/key-state/org-keys.state";
 import { USER_ENCRYPTED_PROVIDER_KEYS } from "@bitwarden/common/platform/services/key-state/provider-keys.state";
 import { USER_EVER_HAD_USER_KEY } from "@bitwarden/common/platform/services/key-state/user-key.state";
@@ -88,72 +83,10 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     ) as Observable<Record<OrganizationId, OrgKey>>;
   }
 
-  async setUserKey(key: UserKey, userId: UserId): Promise<void> {
-    if (key == null) {
-      throw new Error("No key provided. Lock the user to clear the key");
-    }
-    if (userId == null) {
-      throw new Error("No userId provided.");
-    }
-
-    // Set userId to ensure we have one for the account status update
-    await this.stateProvider.setUserState(USER_KEY, key, userId);
-    await this.stateProvider.setUserState(USER_EVER_HAD_USER_KEY, true, userId);
-
-    await this.storeAdditionalKeys(key, userId);
-
-    // Await the key actually being set. This ensures that any subsequent callers know the key is already in state.
-    // There were bugs related to the stateprovider observables in the past that caused issues around this.
-    const userKey = await firstValueFrom(this.userKey$(userId).pipe(filter((k) => k != null)));
-    if (userKey == null) {
-      throw new Error("Failed to set user key");
-    }
-  }
-
-  async refreshAdditionalKeys(userId: UserId): Promise<void> {
-    if (userId == null) {
-      throw new Error("UserId is required.");
-    }
-
-    const key = await firstValueFrom(this.userKey$(userId));
-    if (key == null) {
-      throw new Error("No user key found for: " + userId);
-    }
-
-    await this.setUserKey(key, userId);
-  }
-
   everHadUserKey$(userId: UserId): Observable<boolean> {
     return this.stateProvider
       .getUser(userId, USER_EVER_HAD_USER_KEY)
       .state$.pipe(map((x) => x ?? false));
-  }
-
-  /**
-   * @deprecated Use {@link userKey$} with a required {@link UserId} instead.
-   */
-  async getUserKey(userId?: UserId): Promise<UserKey | null> {
-    return await firstValueFrom(this.stateProvider.getUserState$(USER_KEY, userId));
-  }
-
-  async getUserKeyFromStorage(
-    keySuffix: KeySuffixOptions,
-    userId: UserId,
-  ): Promise<UserKey | null> {
-    if (userId == null) {
-      throw new Error("UserId is required");
-    }
-
-    const userKey = await this.getKeyFromStorage(keySuffix, userId);
-    if (userKey == null) {
-      return null;
-    }
-
-    if (!(await this.validateUserKey(userKey, userId))) {
-      this.logService.warning("Invalid key, throwing away stored keys");
-      await this.clearAllStoredUserKeys(userId);
-    }
-    return userKey;
   }
 
   async hasUserKey(userId: UserId): Promise<boolean> {
@@ -307,64 +240,7 @@ export class DefaultKeyService implements KeyServiceAbstraction {
     return true;
   }
 
-  /**
-   * Generates any additional keys if needed. Additional keys are
-   * keys such as biometrics, auto, and pin keys.
-   * Useful to make sure other keys stay in sync when the user key
-   * has been rotated.
-   * @param key The user key
-   * @param userId The desired user
-   */
-  protected async storeAdditionalKeys(key: UserKey, userId: UserId) {
-    const storeAuto = await this.shouldStoreKey(KeySuffixOptions.Auto, userId);
-    if (storeAuto) {
-      await this.stateService.setUserKeyAutoUnlock(key.keyB64, { userId: userId });
-    } else {
-      await this.stateService.setUserKeyAutoUnlock(null, { userId: userId });
-    }
-  }
-
-  protected async shouldStoreKey(keySuffix: KeySuffixOptions, userId: UserId) {
-    switch (keySuffix) {
-      case KeySuffixOptions.Auto: {
-        // Cli has fixed Never vault timeout, and it should not be affected by a policy.
-        if (this.platformUtilService.getClientType() == ClientType.Cli) {
-          return true;
-        }
-
-        // TODO: Sharing the UserKeyDefinition is temporary to get around a circ dep issue between
-        // the VaultTimeoutSettingsSvc and this service.
-        // This should be fixed as part of the PM-7082 - Auto Key Service work.
-        const vaultTimeout = await firstValueFrom(
-          this.stateProvider
-            .getUserState$(VAULT_TIMEOUT, userId)
-            .pipe(filter((timeout) => timeout != null)),
-        );
-
-        this.logService.debug(
-          `[KeyService] Should store auto key for vault timeout ${vaultTimeout}`,
-        );
-
-        return vaultTimeout == VaultTimeoutStringType.Never;
-      }
-    }
-    return false;
-  }
-
-  protected async getKeyFromStorage(
-    keySuffix: KeySuffixOptions,
-    userId: UserId,
-  ): Promise<UserKey | null> {
-    if (keySuffix === KeySuffixOptions.Auto) {
-      const userKey = await this.stateService.getUserKeyAutoUnlock({ userId: userId });
-      if (userKey) {
-        return new SymmetricCryptoKey(Utils.fromB64ToArray(userKey)) as UserKey;
-      }
-    }
-    return null;
-  }
-
-  protected async clearAllStoredUserKeys(userId: UserId): Promise<void> {
+  async clearAllStoredUserKeys(userId: UserId): Promise<void> {
     // No-op on platforms that do not store a biometrics-protected copy of the user key.
     await this.biometricsService.deleteBiometricUnlockKeyForUser(userId);
     await this.stateService.setUserKeyAutoUnlock(null, { userId: userId });

--- a/libs/unlock/src/auto-unlock.service.ts
+++ b/libs/unlock/src/auto-unlock.service.ts
@@ -1,0 +1,35 @@
+import { UserId } from "@bitwarden/common/types/guid";
+import { UserKey } from "@bitwarden/common/types/key";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+
+/**
+ * The auto unlock service is responsible for the never-lock key
+ */
+export abstract class AutoUnlockService {
+  /**
+   * Retrieves the user's never-lock key, if one is stored.
+   *
+   * @param userId - The user's id
+   * @returns The never-lock user key, or null when none is stored
+   */
+  abstract getAutoUnlockKey(userId: UserId): Promise<UserKey | null>;
+
+  /**
+   * Writes or clears the never-lock user key, according to whether the user's vault timeout allows
+   * storing it. Called during unlock, where the freshly decrypted user key is already in hand.
+   *
+   * @param userId - The user's id
+   * @param userKey - The user's decrypted user key
+   */
+  abstract setAutoUnlockKey(userId: UserId, userKey: SymmetricCryptoKey): Promise<void>;
+
+  /**
+   * Re-evaluates never-lock storage for an already-unlocked user. Call after changing a setting that
+   * affects whether the user key may be stored.
+   *
+   * @param userId - The user's id
+   * @throws If the user is locked
+   */
+  abstract refreshAutoUnlockKey(userId: UserId): Promise<void>;
+}

--- a/libs/unlock/src/auto-unlock.service.ts
+++ b/libs/unlock/src/auto-unlock.service.ts
@@ -17,7 +17,7 @@ export abstract class AutoUnlockService {
 
   /**
    * Writes or clears the never-lock user key, according to whether the user's vault timeout allows
-   * storing it. Called during unlock, where the freshly decrypted user key is already in hand.
+   * storing it. Called during unlock.
    *
    * @param userId - The user's id
    * @param userKey - The user's decrypted user key

--- a/libs/unlock/src/default-auto-unlock.service.spec.ts
+++ b/libs/unlock/src/default-auto-unlock.service.spec.ts
@@ -1,0 +1,155 @@
+import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { ClientType } from "@bitwarden/client-type";
+import {
+  VAULT_TIMEOUT,
+  VaultTimeoutStringType,
+} from "@bitwarden/common/key-management/vault-timeout";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { UserKey } from "@bitwarden/common/types/key";
+import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { CsprngArray, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+import { LogService } from "@bitwarden/logging";
+import { StateProvider, StateService } from "@bitwarden/state";
+
+import { DefaultAutoUnlockService } from "./default-auto-unlock.service";
+
+describe("DefaultAutoUnlockService", () => {
+  const mockUserId = "b1e2d3c4-a1b2-c3d4-e5f6-a1b2c3d4e5f6" as UserId;
+  const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64) as CsprngArray) as UserKey;
+
+  const keyService = mock<KeyService>();
+  const stateService = mock<StateService>();
+  const stateProvider = mock<StateProvider>();
+  const platformUtilsService = mock<PlatformUtilsService>();
+  const logService = mock<LogService>();
+
+  let sut: DefaultAutoUnlockService;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    platformUtilsService.getClientType.mockReturnValue(ClientType.Browser);
+    stateProvider.getUserState$.mockReturnValue(of(VaultTimeoutStringType.Never));
+    keyService.userKey$.mockReturnValue(of(mockUserKey));
+
+    sut = new DefaultAutoUnlockService(
+      keyService,
+      stateService,
+      stateProvider,
+      platformUtilsService,
+      logService,
+    );
+  });
+
+  describe("setAutoUnlockKey", () => {
+    it("stores the key when the vault timeout is never", async () => {
+      await sut.setAutoUnlockKey(mockUserId, mockUserKey);
+
+      expect(stateProvider.getUserState$).toHaveBeenCalledWith(VAULT_TIMEOUT, mockUserId);
+      expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(mockUserKey.toBase64(), {
+        userId: mockUserId,
+      });
+    });
+
+    it("stores the key on the cli without reading the vault timeout", async () => {
+      platformUtilsService.getClientType.mockReturnValue(ClientType.Cli);
+      stateProvider.getUserState$.mockReturnValue(of(60));
+
+      await sut.setAutoUnlockKey(mockUserId, mockUserKey);
+
+      expect(stateProvider.getUserState$).not.toHaveBeenCalled();
+      expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(mockUserKey.toBase64(), {
+        userId: mockUserId,
+      });
+    });
+
+    it.each([60, VaultTimeoutStringType.OnRestart, VaultTimeoutStringType.OnLocked])(
+      "clears the key when the vault timeout is %s",
+      async (timeout) => {
+        stateProvider.getUserState$.mockReturnValue(of(timeout));
+
+        await sut.setAutoUnlockKey(mockUserId, mockUserKey);
+
+        expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(null, {
+          userId: mockUserId,
+        });
+      },
+    );
+  });
+
+  describe("getAutoUnlockKey", () => {
+    it("returns null when no never-lock key is stored", async () => {
+      stateService.getUserKeyAutoUnlock.mockResolvedValue(null);
+
+      const result = await sut.getAutoUnlockKey(mockUserId);
+
+      expect(result).toBeNull();
+      expect(stateService.getUserKeyAutoUnlock).toHaveBeenCalledWith({ userId: mockUserId });
+      expect(keyService.validateUserKey).not.toHaveBeenCalled();
+    });
+
+    it("returns the stored key when it is valid", async () => {
+      stateService.getUserKeyAutoUnlock.mockResolvedValue(mockUserKey.keyB64);
+      keyService.validateUserKey.mockResolvedValue(true);
+
+      const result = await sut.getAutoUnlockKey(mockUserId);
+
+      expect(result).toEqual(mockUserKey);
+      expect(keyService.validateUserKey).toHaveBeenCalledWith(mockUserKey, mockUserId);
+      expect(keyService.clearAllStoredUserKeys).not.toHaveBeenCalled();
+    });
+
+    it("throws away the stored keys and returns null when the stored key fails validation", async () => {
+      stateService.getUserKeyAutoUnlock.mockResolvedValue(mockUserKey.keyB64);
+      keyService.validateUserKey.mockResolvedValue(false);
+
+      const result = await sut.getAutoUnlockKey(mockUserId);
+
+      expect(result).toBeNull();
+      expect(logService.warning).toHaveBeenCalledWith("Invalid key, throwing away stored keys");
+      expect(keyService.clearAllStoredUserKeys).toHaveBeenCalledWith(mockUserId);
+    });
+  });
+
+  describe("refreshAutoUnlockKey", () => {
+    it("re-stores the in-memory user key", async () => {
+      await sut.refreshAutoUnlockKey(mockUserId);
+
+      expect(keyService.userKey$).toHaveBeenCalledWith(mockUserId);
+      expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(mockUserKey.toBase64(), {
+        userId: mockUserId,
+      });
+    });
+
+    it("clears the stored key when the vault timeout no longer allows it", async () => {
+      stateProvider.getUserState$.mockReturnValue(of(VaultTimeoutStringType.OnLocked));
+
+      await sut.refreshAutoUnlockKey(mockUserId);
+
+      expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(null, { userId: mockUserId });
+    });
+
+    it.each([null as unknown as UserId, undefined as unknown as UserId])(
+      "throws when the provided userId is %s",
+      async (userId) => {
+        await expect(sut.refreshAutoUnlockKey(userId)).rejects.toThrow("UserId is required.");
+
+        expect(stateService.setUserKeyAutoUnlock).not.toHaveBeenCalled();
+      },
+    );
+
+    it("throws when the user is locked", async () => {
+      keyService.userKey$.mockReturnValue(of(null));
+
+      await expect(sut.refreshAutoUnlockKey(mockUserId)).rejects.toThrow(
+        "No user key found for: " + mockUserId,
+      );
+
+      expect(stateService.setUserKeyAutoUnlock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/unlock/src/default-auto-unlock.service.ts
+++ b/libs/unlock/src/default-auto-unlock.service.ts
@@ -1,0 +1,85 @@
+import { filter, firstValueFrom } from "rxjs";
+
+import { ClientType } from "@bitwarden/client-type";
+import {
+  VAULT_TIMEOUT,
+  VaultTimeoutStringType,
+} from "@bitwarden/common/key-management/vault-timeout";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { UserKey } from "@bitwarden/common/types/key";
+import { KeyService } from "@bitwarden/key-management";
+// eslint-disable-next-line no-restricted-imports
+import { SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+import { LogService } from "@bitwarden/logging";
+import { StateProvider, StateService } from "@bitwarden/state";
+import { UserId } from "@bitwarden/user-core";
+
+import { AutoUnlockService } from "./auto-unlock.service";
+
+export class DefaultAutoUnlockService implements AutoUnlockService {
+  constructor(
+    private keyService: KeyService,
+    private stateService: StateService,
+    private stateProvider: StateProvider,
+    private platformUtilsService: PlatformUtilsService,
+    private logService: LogService,
+  ) {}
+
+  async getAutoUnlockKey(userId: UserId): Promise<UserKey | null> {
+    const autoUnlockKeyB64 = await this.stateService.getUserKeyAutoUnlock({ userId: userId });
+    if (autoUnlockKeyB64 == null) {
+      return null;
+    }
+
+    const autoUnlockKey = new SymmetricCryptoKey(Utils.fromB64ToArray(autoUnlockKeyB64)) as UserKey;
+
+    if (!(await this.keyService.validateUserKey(autoUnlockKey, userId))) {
+      this.logService.warning("Invalid key, throwing away stored keys");
+      await this.keyService.clearAllStoredUserKeys(userId);
+      return null;
+    }
+
+    return autoUnlockKey;
+  }
+
+  async setAutoUnlockKey(userId: UserId, userKey: SymmetricCryptoKey): Promise<void> {
+    if (await this.shouldStoreAutoUnlockKey(userId)) {
+      await this.stateService.setUserKeyAutoUnlock(userKey.toBase64(), { userId: userId });
+    } else {
+      await this.stateService.setUserKeyAutoUnlock(null, { userId: userId });
+    }
+  }
+
+  async refreshAutoUnlockKey(userId: UserId): Promise<void> {
+    if (userId == null) {
+      throw new Error("UserId is required.");
+    }
+
+    const userKey = await firstValueFrom(this.keyService.userKey$(userId));
+    if (userKey == null) {
+      throw new Error("No user key found for: " + userId);
+    }
+
+    await this.setAutoUnlockKey(userId, userKey);
+  }
+
+  private async shouldStoreAutoUnlockKey(userId: UserId): Promise<boolean> {
+    // Cli has fixed Never vault timeout, and it should not be affected by a policy.
+    if (this.platformUtilsService.getClientType() === ClientType.Cli) {
+      return true;
+    }
+
+    const vaultTimeout = await firstValueFrom(
+      this.stateProvider
+        .getUserState$(VAULT_TIMEOUT, userId)
+        .pipe(filter((timeout) => timeout != null)),
+    );
+
+    this.logService.debug(
+      `[AutoUnlockService] Should store never-lock key for vault timeout ${vaultTimeout}`,
+    );
+
+    return vaultTimeout === VaultTimeoutStringType.Never;
+  }
+}

--- a/libs/unlock/src/default-unlock.service.spec.ts
+++ b/libs/unlock/src/default-unlock.service.spec.ts
@@ -4,17 +4,13 @@ import "core-js/proposals/explicit-resource-management";
 import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
 
-import { ClientType } from "@bitwarden/client-type";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import { MASTER_KEY } from "@bitwarden/common/key-management/master-password/services/master-password.service";
 import { V2UpgradeTokenStateService } from "@bitwarden/common/key-management/upgrade-token/abstractions/v2-upgrade-token-state.service.abstraction";
-import { VaultTimeoutStringType } from "@bitwarden/common/key-management/vault-timeout";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { RegisterSdkService } from "@bitwarden/common/platform/abstractions/sdk/register-sdk.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
-import { KeySuffixOptions } from "@bitwarden/common/platform/enums";
 import { USER_EVER_HAD_USER_KEY } from "@bitwarden/common/platform/services/key-state/user-key.state";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
@@ -22,14 +18,14 @@ import {
   BiometricsService,
   BiometricStateService,
   KdfConfigService,
-  KeyService,
 } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { CsprngArray, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import { LogService } from "@bitwarden/logging";
 import { EncString, PureCrypto, V2UpgradeToken } from "@bitwarden/sdk-internal";
-import { StateProvider, StateService } from "@bitwarden/state";
+import { StateProvider } from "@bitwarden/state";
 
+import { AutoUnlockService } from "./auto-unlock.service";
 import { DefaultUnlockService } from "./default-unlock.service";
 
 const mockUserId = "b1e2d3c4-a1b2-c3d4-e5f6-a1b2c3d4e5f6" as UserId;
@@ -51,13 +47,11 @@ describe("DefaultUnlockService", () => {
   const accountService = mock<AccountService>();
   const masterPasswordService = mock<InternalMasterPasswordServiceAbstraction>();
   const stateProvider = mock<StateProvider>();
-  const stateService = mock<StateService>();
   const logService = mock<LogService>();
   const biometricsService = mock<BiometricsService>();
-  const platformUtilsService = mock<PlatformUtilsService>();
   const biometricStateService = mock<BiometricStateService>();
   const v2UpgradeTokenStateService = mock<V2UpgradeTokenStateService>();
-  const keyService = mock<KeyService>();
+  const autoUnlockService = mock<AutoUnlockService>();
 
   let service: DefaultUnlockService;
   let mockSdkRef: any;
@@ -97,11 +91,9 @@ describe("DefaultUnlockService", () => {
     masterPasswordService.masterPasswordUnlockData$.mockReturnValue(
       of({ toSdk: () => mockMasterPasswordUnlockData } as any),
     );
-    stateProvider.getUserState$.mockReturnValue(of(VaultTimeoutStringType.Never));
-    stateService.setUserKeyAutoUnlock.mockResolvedValue(undefined);
+    autoUnlockService.setAutoUnlockKey.mockResolvedValue(undefined);
     biometricsService.setBiometricProtectedUnlockKeyForUser.mockResolvedValue(undefined);
     biometricStateService.biometricUnlockEnabled$.mockReturnValue(of(true));
-    platformUtilsService.getClientType.mockReturnValue(ClientType.Browser);
     v2UpgradeTokenStateService.v2UpgradeToken$.mockReturnValue(of(null));
 
     Object.defineProperty(SdkLoadService, "Ready", {
@@ -125,11 +117,9 @@ describe("DefaultUnlockService", () => {
       stateProvider,
       logService,
       biometricsService,
-      platformUtilsService,
-      stateService,
       biometricStateService,
       v2UpgradeTokenStateService,
-      keyService,
+      autoUnlockService,
     );
 
     setLegacyMasterKeyFromUnlockDataSpy = jest
@@ -181,9 +171,10 @@ describe("DefaultUnlockService", () => {
         mockUserId,
         expect.any(SymmetricCryptoKey),
       );
-      expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(userEncryptionKey.toBase64(), {
-        userId: mockUserId,
-      });
+      expect(autoUnlockService.setAutoUnlockKey).toHaveBeenCalledWith(
+        mockUserId,
+        expect.objectContaining({ keyB64: userEncryptionKey.toBase64() }),
+      );
       expect(stateProvider.setUserState).toHaveBeenCalledWith(
         USER_EVER_HAD_USER_KEY,
         true,
@@ -239,9 +230,10 @@ describe("DefaultUnlockService", () => {
         mockUserId,
         expect.any(SymmetricCryptoKey),
       );
-      expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(userEncryptionKey.toBase64(), {
-        userId: mockUserId,
-      });
+      expect(autoUnlockService.setAutoUnlockKey).toHaveBeenCalledWith(
+        mockUserId,
+        expect.objectContaining({ keyB64: userEncryptionKey.toBase64() }),
+      );
       expect(stateProvider.setUserState).toHaveBeenCalledWith(
         USER_EVER_HAD_USER_KEY,
         true,
@@ -310,9 +302,10 @@ describe("DefaultUnlockService", () => {
         mockUserId,
         expect.any(SymmetricCryptoKey),
       );
-      expect(stateService.setUserKeyAutoUnlock).toHaveBeenCalledWith(userEncryptionKey.toBase64(), {
-        userId: mockUserId,
-      });
+      expect(autoUnlockService.setAutoUnlockKey).toHaveBeenCalledWith(
+        mockUserId,
+        expect.objectContaining({ keyB64: userEncryptionKey.toBase64() }),
+      );
       expect(stateProvider.setUserState).toHaveBeenCalledWith(
         USER_EVER_HAD_USER_KEY,
         true,
@@ -366,80 +359,37 @@ describe("DefaultUnlockService", () => {
   });
 
   describe("unlockWithAutoUnlockKey", () => {
-    const mockAutoUserKey = new SymmetricCryptoKey(new Uint8Array(64) as CsprngArray) as UserKey;
+    const mockAutoUnlockKey = new SymmetricCryptoKey(new Uint8Array(64) as CsprngArray) as UserKey;
 
-    it("returns false without reading storage when the userId is null", async () => {
+    it("does nothing when the userId is null", async () => {
       const result = await service.unlockWithAutoUnlockKey(null as unknown as UserId);
 
       expect(result).toBe(false);
-      expect(keyService.getUserKeyFromStorage).not.toHaveBeenCalled();
+      expect(autoUnlockService.getAutoUnlockKey).not.toHaveBeenCalled();
       expect(mockCrypto.initialize_user_crypto).not.toHaveBeenCalled();
     });
 
-    it("returns false without unlocking when no never-lock key is stored", async () => {
-      keyService.getUserKeyFromStorage.mockResolvedValue(null);
+    it("does nothing when no never-lock key is stored", async () => {
+      autoUnlockService.getAutoUnlockKey.mockResolvedValue(null);
 
       const result = await service.unlockWithAutoUnlockKey(mockUserId);
 
       expect(result).toBe(false);
-      expect(keyService.getUserKeyFromStorage).toHaveBeenCalledWith(
-        KeySuffixOptions.Auto,
-        mockUserId,
-      );
+      expect(autoUnlockService.getAutoUnlockKey).toHaveBeenCalledWith(mockUserId);
       expect(mockCrypto.initialize_user_crypto).not.toHaveBeenCalled();
     });
 
-    it("calls SDK initialize_user_crypto with the stored key and returns true", async () => {
-      keyService.getUserKeyFromStorage.mockResolvedValue(mockAutoUserKey);
+    it("unlocks with the stored never-lock key", async () => {
+      autoUnlockService.getAutoUnlockKey.mockResolvedValue(mockAutoUnlockKey);
 
       const result = await service.unlockWithAutoUnlockKey(mockUserId);
 
       expect(result).toBe(true);
-      expect(keyService.getUserKeyFromStorage).toHaveBeenCalledWith(
-        KeySuffixOptions.Auto,
-        mockUserId,
+      expect(mockCrypto.initialize_user_crypto).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: { decryptedKey: { decrypted_user_key: mockAutoUnlockKey.toSdk() } },
+        }),
       );
-      expect(mockCrypto.initialize_user_crypto).toHaveBeenCalledWith({
-        userId: mockUserId,
-        kdfParams: mockKdfParams,
-        email: mockEmail,
-        accountCryptographicState: mockAccountCryptographicState,
-        method: {
-          decryptedKey: {
-            decrypted_user_key: mockAutoUserKey.toBase64(),
-          },
-        },
-      });
-    });
-
-    it("throws when SDK is not available", async () => {
-      keyService.getUserKeyFromStorage.mockResolvedValue(mockAutoUserKey);
-      registerSdkService.registerClient$.mockReturnValue(of(null as any));
-
-      await expect(service.unlockWithAutoUnlockKey(mockUserId)).rejects.toThrow(
-        "SDK not available",
-      );
-    });
-  });
-
-  describe("shouldStoreUserKeyAutoUnlock", () => {
-    it("returns true for cli without checking vault timeout", async () => {
-      platformUtilsService.getClientType.mockReturnValue(ClientType.Cli);
-
-      const result = await (service as any).shouldStoreUserKeyAutoUnlock(mockUserId);
-
-      expect(result).toBe(true);
-      expect(stateProvider.getUserState$).not.toHaveBeenCalled();
-    });
-
-    it("returns true when vault timeout is Never", async () => {
-      platformUtilsService.getClientType.mockReturnValue(ClientType.Browser);
-      stateProvider.getUserState$.mockReturnValue(of(VaultTimeoutStringType.Never));
-
-      const result = await (service as any).shouldStoreUserKeyAutoUnlock(mockUserId);
-
-      expect(result).toBe(true);
-      expect(stateProvider.getUserState$).toHaveBeenCalledWith(expect.anything(), mockUserId);
     });
   });
 

--- a/libs/unlock/src/default-unlock.service.ts
+++ b/libs/unlock/src/default-unlock.service.ts
@@ -1,21 +1,14 @@
-import { filter, firstValueFrom, map } from "rxjs";
+import { firstValueFrom, map } from "rxjs";
 
-import { ClientType } from "@bitwarden/client-type";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { assertNonNullish } from "@bitwarden/common/auth/utils";
 import { AccountCryptographicStateService } from "@bitwarden/common/key-management/account-cryptography/account-cryptographic-state.service";
 import { InternalMasterPasswordServiceAbstraction } from "@bitwarden/common/key-management/master-password/abstractions/master-password.service.abstraction";
 import { MASTER_KEY } from "@bitwarden/common/key-management/master-password/services/master-password.service";
 import { V2UpgradeTokenStateService } from "@bitwarden/common/key-management/upgrade-token/abstractions/v2-upgrade-token-state.service.abstraction";
-import {
-  VAULT_TIMEOUT,
-  VaultTimeoutStringType,
-} from "@bitwarden/common/key-management/vault-timeout";
-import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { RegisterSdkService } from "@bitwarden/common/platform/abstractions/sdk/register-sdk.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
-import { KeySuffixOptions } from "@bitwarden/common/platform/enums";
 import { Ref } from "@bitwarden/common/platform/misc/reference-counting/rc";
 import { USER_EVER_HAD_USER_KEY } from "@bitwarden/common/platform/services/key-state/user-key.state";
 import { MasterKey } from "@bitwarden/common/types/key";
@@ -23,7 +16,6 @@ import {
   BiometricsService,
   BiometricStateService,
   KdfConfigService,
-  KeyService,
 } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { KdfConfig, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
@@ -38,9 +30,10 @@ import {
   V2UpgradeToken,
   WrappedAccountCryptographicState,
 } from "@bitwarden/sdk-internal";
-import { StateProvider, StateService } from "@bitwarden/state";
+import { StateProvider } from "@bitwarden/state";
 import { UserId } from "@bitwarden/user-core";
 
+import { AutoUnlockService } from "./auto-unlock.service";
 import { UnlockSource } from "./unlock-source.enum";
 import { UnlockService } from "./unlock.service";
 
@@ -69,11 +62,9 @@ export class DefaultUnlockService implements UnlockService {
     private stateProvider: StateProvider,
     private logService: LogService,
     private biometricsService: BiometricsService,
-    private platformUtilsService: PlatformUtilsService,
-    private stateService: StateService,
     private biometricStateService: BiometricStateService,
     private v2UpgradeTokenStateService: V2UpgradeTokenStateService,
-    private keyService: KeyService,
+    private autoUnlockService: AutoUnlockService,
   ) {}
 
   registerOnUnlockAction(
@@ -187,7 +178,7 @@ export class DefaultUnlockService implements UnlockService {
       return false;
     }
 
-    const userKey = await this.keyService.getUserKeyFromStorage(KeySuffixOptions.Auto, userId);
+    const userKey = await this.autoUnlockService.getAutoUnlockKey(userId);
     if (userKey == null) {
       return false;
     }
@@ -317,27 +308,11 @@ export class DefaultUnlockService implements UnlockService {
     if (await firstValueFrom(this.biometricStateService.biometricUnlockEnabled$(userId))) {
       await this.biometricsService.setBiometricProtectedUnlockKeyForUser(userId, userKey);
     }
-    if (await this.shouldStoreUserKeyAutoUnlock(userId)) {
-      await this.stateService.setUserKeyAutoUnlock(userKey.toBase64(), { userId: userId });
-    }
+    await this.autoUnlockService.setAutoUnlockKey(userId, userKey);
     await this.stateProvider.setUserState(USER_EVER_HAD_USER_KEY, true, userId);
 
     for (const action of this.onUnlockActions) {
       await action(userId, userKey, source);
     }
-  }
-
-  private async shouldStoreUserKeyAutoUnlock(userId: UserId): Promise<boolean> {
-    if (this.platformUtilsService.getClientType() === ClientType.Cli) {
-      return true;
-    }
-
-    const vaultTimeout = await firstValueFrom(
-      this.stateProvider
-        .getUserState$(VAULT_TIMEOUT, userId)
-        .pipe(filter((timeout) => timeout != null)),
-    );
-
-    return vaultTimeout == VaultTimeoutStringType.Never;
   }
 }

--- a/libs/unlock/src/index.ts
+++ b/libs/unlock/src/index.ts
@@ -4,3 +4,5 @@ export { LockSource } from "./lock-source.enum";
 export { UnlockService } from "./unlock.service";
 export { UnlockSource } from "./unlock-source.enum";
 export { DefaultUnlockService, KeyConnectorUnlockData } from "./default-unlock.service";
+export { AutoUnlockService } from "./auto-unlock.service";
+export { DefaultAutoUnlockService } from "./default-auto-unlock.service";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41489

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Extract the auto-unlock service out of the key service. This simplifies the dependency graph, since less things need to depend on the key-service / since the auto-unlock functionality is moved out.

Cleans up the key service and all the old functions in it / removes setUserKey.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->