### PR TITLE
[PM-42203] Gate basic auth listeners behind a feature flag

### DIFF
--- a/apps/browser/src/autofill/background/web-request.background.ts
+++ b/apps/browser/src/autofill/background/web-request.background.ts
@@ -4,7 +4,9 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 
@@ -18,6 +20,7 @@ export default class WebRequestBackground {
     private authService: AuthService,
     private accountService: AccountService,
     private readonly webRequest: typeof chrome.webRequest,
+    private configService: ConfigService,
   ) {
     this.isFirefox = platformUtilsService.isFirefox();
   }
@@ -27,7 +30,15 @@ export default class WebRequestBackground {
    *
    * While registered, `webRequest.onAuthRequired` fires for any request that receives a 401.
    */
-  startListening() {
+  async startListening() {
+    const basicAuthResponseIsEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.EnableBasicAuthResponse,
+    );
+
+    if (!basicAuthResponseIsEnabled) {
+      return;
+    }
+
     this.webRequest.onAuthRequired.addListener(
       (async (
         details: chrome.webRequest.OnAuthRequiredDetails,

--- a/apps/browser/src/autofill/background/web-request.background.ts
+++ b/apps/browser/src/autofill/background/web-request.background.ts
@@ -22,6 +22,11 @@ export default class WebRequestBackground {
     this.isFirefox = platformUtilsService.isFirefox();
   }
 
+  /**
+   * Registers the handler that answers HTTP auth challenges with a matching vault credential.
+   *
+   * While registered, `webRequest.onAuthRequired` fires for any request that receives a 401.
+   */
   startListening() {
     this.webRequest.onAuthRequired.addListener(
       (async (

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1715,16 +1715,6 @@ export default class MainBackground {
       this.accountService,
     );
 
-    if (chrome.webRequest != null && chrome.webRequest.onAuthRequired != null) {
-      this.webRequestBackground = new WebRequestBackground(
-        this.platformUtilsService,
-        this.cipherService,
-        this.authService,
-        this.accountService,
-        chrome.webRequest,
-      );
-    }
-
     this.cipherAuthorizationService = new DefaultCipherAuthorizationService(
       this.collectionService,
       this.organizationService,
@@ -1844,7 +1834,23 @@ export default class MainBackground {
       await BrowserApi.setSidePanelOptions({ enabled: false });
     }
     this.idleBackground.init();
-    this.webRequestBackground?.startListening();
+    const basicAuthResponseIsEnabled = await this.configService.getFeatureFlag(
+      FeatureFlag.EnableBasicAuthResponse,
+    );
+    if (
+      basicAuthResponseIsEnabled &&
+      chrome.webRequest != null &&
+      chrome.webRequest.onAuthRequired != null
+    ) {
+      this.webRequestBackground = new WebRequestBackground(
+        this.platformUtilsService,
+        this.cipherService,
+        this.authService,
+        this.accountService,
+        chrome.webRequest,
+      );
+      this.webRequestBackground.startListening();
+    }
     this.syncServiceListener?.listener$().subscribe();
     await this.autoSubmitLoginBackground.init();
     await this.targetingRulesDataService.init();

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1715,6 +1715,17 @@ export default class MainBackground {
       this.accountService,
     );
 
+    if (chrome.webRequest != null && chrome.webRequest.onAuthRequired != null) {
+      this.webRequestBackground = new WebRequestBackground(
+        this.platformUtilsService,
+        this.cipherService,
+        this.authService,
+        this.accountService,
+        chrome.webRequest,
+        this.configService,
+      );
+    }
+
     this.cipherAuthorizationService = new DefaultCipherAuthorizationService(
       this.collectionService,
       this.organizationService,
@@ -1834,23 +1845,7 @@ export default class MainBackground {
       await BrowserApi.setSidePanelOptions({ enabled: false });
     }
     this.idleBackground.init();
-    const basicAuthResponseIsEnabled = await this.configService.getFeatureFlag(
-      FeatureFlag.EnableBasicAuthResponse,
-    );
-    if (
-      basicAuthResponseIsEnabled &&
-      chrome.webRequest != null &&
-      chrome.webRequest.onAuthRequired != null
-    ) {
-      this.webRequestBackground = new WebRequestBackground(
-        this.platformUtilsService,
-        this.cipherService,
-        this.authService,
-        this.accountService,
-        chrome.webRequest,
-      );
-      this.webRequestBackground.startListening();
-    }
+    await this.webRequestBackground?.startListening();
     this.syncServiceListener?.listener$().subscribe();
     await this.autoSubmitLoginBackground.init();
     await this.targetingRulesDataService.init();

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -32,6 +32,7 @@ export enum FeatureFlag {
   FillAssistTargetingRules = "fill-assist-targeting-rules",
   DefaultPasswordManagerPrompt = "pm-39071-default-password-manager-prompt",
   LitInlineMenuComponents = "lit-inline-menu-components",
+  EnableBasicAuthResponse = "enable-basic-auth-response",
 
   /* Desktop Native */
   MacOsNativeCredentialSync = "macos-native-credential-sync",
@@ -153,6 +154,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.DefaultPasswordManagerPrompt]: FALSE,
   [FeatureFlag.LitInlineMenuComponents]: FALSE,
   [FeatureFlag.PM31039ItemActionInExtension]: FALSE,
+  [FeatureFlag.EnableBasicAuthResponse]: FALSE,
 
   /* Desktop Native */
   [FeatureFlag.MacOsNativeCredentialSync]: FALSE,

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -32,6 +32,8 @@ export enum FeatureFlag {
   FillAssistTargetingRules = "fill-assist-targeting-rules",
   DefaultPasswordManagerPrompt = "pm-39071-default-password-manager-prompt",
   LitInlineMenuComponents = "lit-inline-menu-components",
+  // Note: This flag gates security risks and should not be turned on without
+  // changes to the underlying experience
   EnableBasicAuthResponse = "enable-basic-auth-response",
 
   /* Desktop Native */


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42203](https://bitwarden.atlassian.net/browse/PM-42203)

## 📔 Objective

Presently, there is no user-confirmation/interaction step in our web auth response experience; we automatically and silently respond to 401 responses with vault credentials. As a security concern, we're gating the feature behind a feature flag (`enable-basic-auth-response`) so that we can evaluate the options of sunsetting the feature or building a safer user-experience around it.

see corresponding `server` work: https://github.com/bitwarden/server/pull/8248

[PM-42203]: https://bitwarden.atlassian.net/browse/PM-42203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ