### PR TITLE
[PM-29095] Move autofill attributes to gated settings

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1419,16 +1419,16 @@
     "message": "About Fill Assist"
   },
   "honorDataBitwardenIgnoreAttributeLabel": {
-    "message": "Allow websites exclude fields to autofill"
+    "message": "Allow websites to exclude fields to autofill"
   },
   "honorDataBitwardenIgnoreAttributeHint": {
     "message": "Skip fields that a website marks with the `data-bwignore` attribute."
   },
   "honorDataBitwardenAutofillAttributeLabel": {
-    "message": "Allow websites add fields to autofill"
+    "message": "Allow websites to add fields to autofill"
   },
   "honorDataBitwardenAutofillAttributeHint": {
-    "message": "Use any elements that a website marks with the `data-bwautofill` attribute."
+    "message": "Use any span elements that a website marks with the `data-bwautofill` attribute."
   },
   "enableContextMenuItem": {
     "message": "Show context menu options"

--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -1418,6 +1418,18 @@
   "aboutFillAssistLabel": {
     "message": "About Fill Assist"
   },
+  "honorDataBitwardenIgnoreAttributeLabel": {
+    "message": "Allow websites exclude fields to autofill"
+  },
+  "honorDataBitwardenIgnoreAttributeHint": {
+    "message": "Skip fields that a website marks with the `data-bwignore` attribute."
+  },
+  "honorDataBitwardenAutofillAttributeLabel": {
+    "message": "Allow websites add fields to autofill"
+  },
+  "honorDataBitwardenAutofillAttributeHint": {
+    "message": "Use any elements that a website marks with the `data-bwautofill` attribute."
+  },
   "enableContextMenuItem": {
     "message": "Show context menu options"
   },
@@ -7924,7 +7936,7 @@
   },
   "weakPasswordsDescription": {
     "message": "These passwords can be easily guessed because they are too short or simple. Strengthen them by making them more complex."
-  },    
+  },
   "reusedPasswordsTitle": {
     "message": "Reused passwords"
   },
@@ -7953,7 +7965,7 @@
   },
   "exposedPasswordsEmpty": {
     "message": "None of your passwords were found in data breaches."
-  },  
+  },
   "weakPasswordEmpty": {
     "message": "All your passwords are strong."
   },

--- a/apps/browser/src/autofill/popup/settings/autofill.component.html
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.html
@@ -294,6 +294,36 @@
               </bit-label>
             </bit-form-control>
           }
+          @if (bitwardenAutofillAttributesSettingsVisible) {
+            <bit-form-control>
+              <input
+                formControlName="honorBitwardenIgnoreAttribute"
+                bitCheckbox
+                id="honor-bitwarden-ignore-attribute"
+                type="checkbox"
+              />
+              <bit-label for="honor-bitwarden-ignore-attribute">
+                {{ "honorDataBitwardenIgnoreAttributeLabel" | i18n }}
+              </bit-label>
+              <bit-hint class="tw-text-sm">
+                {{ "honorDataBitwardenIgnoreAttributeHint" | i18n }}
+              </bit-hint>
+            </bit-form-control>
+            <bit-form-control>
+              <input
+                formControlName="honorBitwardenAutofillAttribute"
+                bitCheckbox
+                id="honor-bitwarden-autofill-attribute"
+                type="checkbox"
+              />
+              <bit-label for="honor-bitwarden-autofill-attribute">
+                {{ "honorDataBitwardenAutofillAttributeLabel" | i18n }}
+              </bit-label>
+              <bit-hint class="tw-text-sm">
+                {{ "honorDataBitwardenAutofillAttributeHint" | i18n }}
+              </bit-hint>
+            </bit-form-control>
+          }
           <bit-form-control>
             <input
               formControlName="enableContextMenuItem"

--- a/apps/browser/src/autofill/popup/settings/autofill.component.ts
+++ b/apps/browser/src/autofill/popup/settings/autofill.component.ts
@@ -66,6 +66,7 @@ import { AdvancedUriOptionDialogComponent } from "@bitwarden/vault";
 
 import { AutofillBrowserSettingsService } from "../../../autofill/services/autofill-browser-settings.service";
 import { BrowserApi } from "../../../platform/browser/browser-api";
+import { devFlagEnabled } from "../../../platform/flags";
 import { PopOutComponent } from "../../../platform/popup/components/pop-out.component";
 import { PopupHeaderComponent } from "../../../platform/popup/layout/popup-header.component";
 import { PopupPageComponent } from "../../../platform/popup/layout/popup-page.component";
@@ -140,8 +141,18 @@ export class AutofillComponent implements OnInit {
     defaultAutofill: new FormControl(),
   });
 
+  /**
+   * Gates the settings UI for controlling if `data-bwignore` and
+   * `data-bwautofill` attributes should be honored by autofill heuristics.
+   */
+  protected bitwardenAutofillAttributesSettingsVisible = devFlagEnabled(
+    "useBitwardenAutofillAttributes",
+  );
+
   protected additionalOptionsForm = new FormGroup({
     enableFillAssist: new FormControl(),
+    honorBitwardenIgnoreAttribute: new FormControl(),
+    honorBitwardenAutofillAttribute: new FormControl(),
     enableContextMenuItem: new FormControl(),
     enableAutoTotpCopy: new FormControl(),
     clearClipboard: new FormControl(),
@@ -321,6 +332,36 @@ export class AutofillComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => {
         void this.domainSettingsService.setEnableFillAssist(value);
+      });
+
+    const honorBitwardenIgnoreAttribute = await firstValueFrom(
+      this.autofillSettingsService.honorBitwardenIgnoreAttribute$,
+    );
+
+    this.additionalOptionsForm.controls.honorBitwardenIgnoreAttribute.patchValue(
+      honorBitwardenIgnoreAttribute,
+      { emitEvent: false },
+    );
+
+    this.additionalOptionsForm.controls.honorBitwardenIgnoreAttribute.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => {
+        void this.autofillSettingsService.setHonorBitwardenIgnoreAttribute(value);
+      });
+
+    const honorBitwardenAutofillAttribute = await firstValueFrom(
+      this.autofillSettingsService.honorBitwardenAutofillAttribute$,
+    );
+
+    this.additionalOptionsForm.controls.honorBitwardenAutofillAttribute.patchValue(
+      honorBitwardenAutofillAttribute,
+      { emitEvent: false },
+    );
+
+    this.additionalOptionsForm.controls.honorBitwardenAutofillAttribute.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => {
+        void this.autofillSettingsService.setHonorBitwardenAutofillAttribute(value);
       });
 
     this.enableContextMenuItem = await firstValueFrom(

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.spec.ts
@@ -25,6 +25,8 @@ jest.mock("../utils", () => {
   return {
     ...utils,
     debounce: jest.fn((fn) => fn),
+    // Implementation is (re)installed per test; see the top-level beforeEach.
+    sendExtensionMessage: jest.fn(),
     // Call-through spy so scheduling tests can assert on it without changing behavior.
     requestIdleCallbackPolyfill: jest.fn((cb, opts) => utils.requestIdleCallbackPolyfill(cb, opts)),
   };
@@ -41,6 +43,9 @@ const mockLoginForm = `
 
 const waitForIdleCallback = () => new Promise((resolve) => globalThis.requestIdleCallback(resolve));
 
+const { sendExtensionMessage: actualSendExtensionMessage } =
+  jest.requireActual<typeof autofillUtils>("../utils");
+
 describe("CollectAutofillContentService", () => {
   const mockQuerySelectorAll = mockQuerySelectorAllDefinedCall();
   const domElementVisibilityService = new DomElementVisibilityService();
@@ -54,7 +59,28 @@ describe("CollectAutofillContentService", () => {
   let collectAutofillContentService: CollectAutofillContentService;
   const mockIntersectionObserver = mock<IntersectionObserver>();
 
+  /**
+   * Opts into the page-controlled `data-bwignore` and `data-bwautofill` attributes,
+   * which are unhonored by default.
+   */
+  const honorBitwardenAttributes = () => {
+    collectAutofillContentService["honorBitwardenIgnoreAttribute"] = true;
+    collectAutofillContentService["honorBitwardenAutofillAttribute"] = true;
+    collectAutofillContentService["formFieldQueryString"] =
+      collectAutofillContentService["buildFormFieldQueryString"]();
+  };
+
   beforeEach(() => {
+    // The constructor's one-time settings fetch runs before any per-instance spy can be
+    // installed, so that one command is answered here. Everything else calls through,
+    // since the chrome.runtime.sendMessage stub never invokes its callback.
+    jest
+      .mocked(autofillUtils.sendExtensionMessage)
+      .mockImplementation(async (command: string, options?: Record<string, any>) =>
+        command === "getBitwardenAutofillAttributeSettings"
+          ? null
+          : actualSendExtensionMessage(command, options),
+      );
     globalThis.requestIdleCallback = jest.fn((cb, options) => setTimeout(cb, 100));
     globalThis.cancelIdleCallback = jest.fn((id) => clearTimeout(id));
     document.body.innerHTML = mockLoginForm;
@@ -1111,6 +1137,10 @@ describe("CollectAutofillContentService", () => {
   });
 
   describe("getAutofillFieldElements", () => {
+    beforeEach(() => {
+      honorBitwardenAttributes();
+    });
+
     it("returns all form elements from the targeted document if no limit is set", () => {
       document.body.innerHTML = `
       <div id="root">
@@ -1300,6 +1330,79 @@ describe("CollectAutofillContentService", () => {
         inputRadioA,
         inputRadioB,
       ]);
+    });
+  });
+
+  describe("Bitwarden autofill attribute settings", () => {
+    const attributeMarkup = `
+      <div>
+        <input type="text" id="ignored-input" data-bwignore />
+        <textarea id="ignored-textarea" data-bwignore></textarea>
+        <select id="ignored-select" data-bwignore></select>
+        <span id="marked-span" data-bwautofill></span>
+      </div>
+    `;
+
+    it("collects `data-bwignore` fields and skips `data-bwautofill` spans by default", () => {
+      document.body.innerHTML = attributeMarkup;
+
+      const formElements = collectAutofillContentService["getAutofillFieldElements"]();
+
+      expect(formElements).toEqual([
+        document.getElementById("ignored-input"),
+        document.getElementById("ignored-textarea"),
+        document.getElementById("ignored-select"),
+      ]);
+    });
+
+    it("skips `data-bwignore` fields and collects `data-bwautofill` spans once both settings are honored", () => {
+      document.body.innerHTML = attributeMarkup;
+      honorBitwardenAttributes();
+
+      const formElements = collectAutofillContentService["getAutofillFieldElements"]();
+
+      expect(formElements).toEqual([document.getElementById("marked-span")]);
+    });
+
+    it("applies each setting independently", () => {
+      document.body.innerHTML = attributeMarkup;
+      collectAutofillContentService["honorBitwardenIgnoreAttribute"] = true;
+      collectAutofillContentService["formFieldQueryString"] =
+        collectAutofillContentService["buildFormFieldQueryString"]();
+
+      expect(collectAutofillContentService["getAutofillFieldElements"]()).toEqual([]);
+    });
+
+    it("adopts the fetched settings and rebuilds the field query string", async () => {
+      jest.mocked(autofillUtils.sendExtensionMessage).mockResolvedValue({
+        result: {
+          honorBitwardenIgnoreAttribute: true,
+          honorBitwardenAutofillAttribute: true,
+        },
+      });
+
+      await collectAutofillContentService["fetchAndSetBitwardenAttributeSettings"]();
+
+      expect(collectAutofillContentService["honorBitwardenIgnoreAttribute"]).toBe(true);
+      expect(collectAutofillContentService["honorBitwardenAutofillAttribute"]).toBe(true);
+      expect(collectAutofillContentService["formFieldQueryString"]).toContain(
+        "span[data-bwautofill]",
+      );
+      expect(collectAutofillContentService["formFieldQueryString"]).toContain(
+        ":not([data-bwignore])",
+      );
+    });
+
+    it("leaves both attributes unhonored when the settings fetch fails", async () => {
+      jest
+        .mocked(autofillUtils.sendExtensionMessage)
+        .mockRejectedValue(new Error("no receiving end"));
+
+      await collectAutofillContentService["fetchAndSetBitwardenAttributeSettings"]();
+
+      expect(collectAutofillContentService["honorBitwardenIgnoreAttribute"]).toBe(false);
+      expect(collectAutofillContentService["honorBitwardenAutofillAttribute"]).toBe(false);
+      expect(collectAutofillContentService["formFieldQueryString"]).not.toContain("data-bw");
     });
   });
 
@@ -3900,6 +4003,10 @@ describe("CollectAutofillContentService", () => {
   describe("mutationAddsOrRemovesFormField (relevance gate)", () => {
     // Containers we append to body for real NodeList construction; torn down after each test.
     const createdContainers: HTMLElement[] = [];
+
+    beforeEach(() => {
+      honorBitwardenAttributes();
+    });
 
     const makeContainer = (): HTMLElement => {
       const container = document.createElement("div");

--- a/apps/browser/src/autofill/services/collect-autofill-content.service.ts
+++ b/apps/browser/src/autofill/services/collect-autofill-content.service.ts
@@ -92,7 +92,15 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
   private mutationBurstCount = 0;
   private readonly mutationCooldownMs = 500;
   private readonly maxMutationWaitMs = 5000;
-  private readonly formFieldQueryString;
+  private formFieldQueryString;
+  /**
+   * Opt-in state for the page-controlled `data-bwignore` and `data-bwautofill`
+   * attributes. Both stay `false` until {@link attributeSettingsFetched} resolves,
+   * so an unanswered or failed fetch leaves the attributes unhonored.
+   */
+  private honorBitwardenIgnoreAttribute = false;
+  private honorBitwardenAutofillAttribute = false;
+  private readonly attributeSettingsFetched: Promise<void>;
 
   private readonly nonInputFormFieldTags = new Set(["textarea", "select"]);
   private readonly ignoredInputTypes = new Set([
@@ -118,11 +126,8 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     private domQueryService: DomQueryService,
     private autofillOverlayContentService?: AutofillOverlayContentService,
   ) {
-    let inputQuery = "input:not([data-bwignore])";
-    for (const type of this.ignoredInputTypes) {
-      inputQuery += `:not([type="${type}"])`;
-    }
-    this.formFieldQueryString = `${inputQuery}, textarea:not([data-bwignore]), select:not([data-bwignore]), span[data-bwautofill]`;
+    this.formFieldQueryString = this.buildFormFieldQueryString();
+    this.attributeSettingsFetched = this.fetchAndSetBitwardenAttributeSettings();
 
     this.mutationObserver = new MutationObserver(this.handleMutationObserverMutation);
     this.intersectionObserver = new IntersectionObserver(this.handleFormElementIntersection, {
@@ -143,6 +148,53 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
       this.mutationObserver,
       () => this.debouncedRequirePageDetailsUpdate(),
     );
+  }
+
+  /**
+   * Builds the selector used to find candidate form fields. The page-controlled
+   * `data-bwignore` and `data-bwautofill` attributes are only considered when
+   * the user has opted into honoring them.
+   */
+  private buildFormFieldQueryString(): string {
+    const ignoreAttributeFilter = this.honorBitwardenIgnoreAttribute ? ":not([data-bwignore])" : "";
+
+    let inputQuery = `input${ignoreAttributeFilter}`;
+    for (const type of this.ignoredInputTypes) {
+      inputQuery += `:not([type="${type}"])`;
+    }
+
+    const selectors = [
+      inputQuery,
+      `textarea${ignoreAttributeFilter}`,
+      `select${ignoreAttributeFilter}`,
+    ];
+
+    if (this.honorBitwardenAutofillAttribute) {
+      selectors.push("span[data-bwautofill]");
+    }
+
+    return selectors.join(", ");
+  }
+
+  /**
+   * Reads the Bitwarden-attribute opt-in settings once per content-script lifetime.
+   * A change to either setting takes effect on the next page load.
+   */
+  private async fetchAndSetBitwardenAttributeSettings(): Promise<void> {
+    let settings;
+    try {
+      settings = (await this.sendExtensionMessage("getBitwardenAutofillAttributeSettings"))?.result;
+    } catch {
+      return;
+    }
+
+    if (!settings) {
+      return;
+    }
+
+    this.honorBitwardenIgnoreAttribute = settings.honorBitwardenIgnoreAttribute === true;
+    this.honorBitwardenAutofillAttribute = settings.honorBitwardenAutofillAttribute === true;
+    this.formFieldQueryString = this.buildFormFieldQueryString();
   }
 
   /**
@@ -216,6 +268,8 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     if (this.autofillOverlayContentService) {
       this.setupInitialTopLayerListeners();
     }
+
+    await this.attributeSettingsFetched;
 
     // Check for targeting rules before running heuristic collection
     if (this.pageTargetingRules === undefined) {
@@ -1409,12 +1463,15 @@ export class CollectAutofillContentService implements CollectAutofillContentServ
     const nodeTagName = element.tagName.toLowerCase();
 
     const nodeIsSpanElementWithAutofillAttribute =
-      nodeTagName === "span" && element.hasAttribute("data-bwautofill");
+      this.honorBitwardenAutofillAttribute &&
+      nodeTagName === "span" &&
+      element.hasAttribute("data-bwautofill");
     if (nodeIsSpanElementWithAutofillAttribute) {
       return true;
     }
 
-    const nodeHasBwIgnoreAttribute = element.hasAttribute("data-bwignore");
+    const nodeHasBwIgnoreAttribute =
+      this.honorBitwardenIgnoreAttribute && element.hasAttribute("data-bwignore");
     const nodeIsValidInputElement =
       nodeTagName === "input" && !this.ignoredInputTypes.has((element as HTMLInputElement).type);
     if (nodeIsValidInputElement && !nodeHasBwIgnoreAttribute) {

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -105,6 +105,7 @@ export default class RuntimeBackground {
         BiometricsCommands.CanEnableBiometricUnlock,
         "getUserPremiumStatus",
         "getUrlAutofillTargetingRules",
+        "getBitwardenAutofillAttributeSettings",
       ];
 
       if (messagesWithResponse.includes(msg.command)) {
@@ -230,6 +231,14 @@ export default class RuntimeBackground {
           await this.main.domainSettingsService.getTargetingRulesForUrl(senderURL);
 
         return targetingRulesForUrl;
+      }
+      case "getBitwardenAutofillAttributeSettings": {
+        const [honorBitwardenIgnoreAttribute, honorBitwardenAutofillAttribute] = await Promise.all([
+          firstValueFrom(this.autofillSettingsService.honorBitwardenIgnoreAttribute$),
+          firstValueFrom(this.autofillSettingsService.honorBitwardenAutofillAttribute$),
+        ]);
+
+        return { honorBitwardenIgnoreAttribute, honorBitwardenAutofillAttribute };
       }
       case "authResult": {
         if (!(await this.isValidVaultReferrer(msg.referrer))) {

--- a/libs/common/src/autofill/services/autofill-settings.service.ts
+++ b/libs/common/src/autofill/services/autofill-settings.service.ts
@@ -92,6 +92,22 @@ const SHOW_INLINE_MENU_SSH_KEYS = new UserKeyDefinition(
   },
 );
 
+const HONOR_BITWARDEN_IGNORE_ATTRIBUTE = new KeyDefinition(
+  AUTOFILL_SETTINGS_DISK_LOCAL,
+  "honorBitwardenIgnoreAttribute",
+  {
+    deserializer: (value: boolean) => value ?? false,
+  },
+);
+
+const HONOR_BITWARDEN_AUTOFILL_ATTRIBUTE = new KeyDefinition(
+  AUTOFILL_SETTINGS_DISK_LOCAL,
+  "honorBitwardenAutofillAttribute",
+  {
+    deserializer: (value: boolean) => value ?? false,
+  },
+);
+
 const ENABLE_CONTEXT_MENU = new KeyDefinition(AUTOFILL_SETTINGS_DISK, "enableContextMenu", {
   deserializer: (value: boolean) => value ?? true,
 });
@@ -143,6 +159,10 @@ export abstract class AutofillSettingsServiceAbstraction {
   setShowInlineMenuCards: (newValue: boolean) => Promise<void>;
   showInlineMenuSshKeys$: Observable<boolean>;
   setShowInlineMenuSshKeys: (newValue: boolean) => Promise<void>;
+  honorBitwardenIgnoreAttribute$: Observable<boolean>;
+  setHonorBitwardenIgnoreAttribute: (newValue: boolean) => Promise<void>;
+  honorBitwardenAutofillAttribute$: Observable<boolean>;
+  setHonorBitwardenAutofillAttribute: (newValue: boolean) => Promise<void>;
   enableContextMenu$: Observable<boolean>;
   setEnableContextMenu: (newValue: boolean) => Promise<void>;
   clearClipboardDelay$: Observable<ClearClipboardDelaySetting>;
@@ -182,6 +202,12 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
 
   private showInlineMenuSshKeysState: ActiveUserState<boolean>;
   readonly showInlineMenuSshKeys$: Observable<boolean>;
+
+  private honorBitwardenIgnoreAttributeState: GlobalState<boolean>;
+  readonly honorBitwardenIgnoreAttribute$: Observable<boolean>;
+
+  private honorBitwardenAutofillAttributeState: GlobalState<boolean>;
+  readonly honorBitwardenAutofillAttribute$: Observable<boolean>;
 
   private enableContextMenuState: GlobalState<boolean>;
   readonly enableContextMenu$: Observable<boolean>;
@@ -269,6 +295,20 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
       ),
     );
 
+    this.honorBitwardenIgnoreAttributeState = this.stateProvider.getGlobal(
+      HONOR_BITWARDEN_IGNORE_ATTRIBUTE,
+    );
+    this.honorBitwardenIgnoreAttribute$ = this.honorBitwardenIgnoreAttributeState.state$.pipe(
+      map((x) => x ?? false),
+    );
+
+    this.honorBitwardenAutofillAttributeState = this.stateProvider.getGlobal(
+      HONOR_BITWARDEN_AUTOFILL_ATTRIBUTE,
+    );
+    this.honorBitwardenAutofillAttribute$ = this.honorBitwardenAutofillAttributeState.state$.pipe(
+      map((x) => x ?? false),
+    );
+
     this.enableContextMenuState = this.stateProvider.getGlobal(ENABLE_CONTEXT_MENU);
     this.enableContextMenu$ = this.enableContextMenuState.state$.pipe(map((x) => x ?? true));
 
@@ -338,6 +378,14 @@ export class AutofillSettingsService implements AutofillSettingsServiceAbstracti
 
   async setShowInlineMenuSshKeys(newValue: boolean): Promise<void> {
     await this.showInlineMenuSshKeysState.update(() => newValue);
+  }
+
+  async setHonorBitwardenIgnoreAttribute(newValue: boolean): Promise<void> {
+    await this.honorBitwardenIgnoreAttributeState.update(() => newValue);
+  }
+
+  async setHonorBitwardenAutofillAttribute(newValue: boolean): Promise<void> {
+    await this.honorBitwardenAutofillAttributeState.update(() => newValue);
   }
 
   async setEnableContextMenu(newValue: boolean): Promise<void> {

--- a/libs/common/src/platform/misc/flags.ts
+++ b/libs/common/src/platform/misc/flags.ts
@@ -13,6 +13,7 @@ export type SharedDevFlags = {
   configRetrievalIntervalMs: number;
   showRiskInsightsDebug: boolean;
   fillAssistDevTools: boolean;
+  useBitwardenAutofillAttributes: boolean;
   testPhishingUrls: string[];
 };
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29095](https://bitwarden.atlassian.net/browse/PM-29095)

## 📔 Objective

This puts logic honoring autofill-controlling attributes behind dev-only settings.

- Adds the `useBitwardenAutofillAttributes` devFlag
- Adds a UI to Autofill settings to control non-spec attributes used to alter the behaviour of autofill (off by default)
- Includes the custom attributes when enabled by the settings (requires a page reload for setting updates)

[PM-29095]: https://bitwarden.atlassian.net/browse/PM-29095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ