### PR TITLE
ci: Copy macOS autofill extension in after-pack to avoid re-signing

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -85,7 +85,7 @@
     "signIgnore": [
       "MacOS/desktop_proxy",
       "MacOS/desktop_proxy.inherit",
-      "Contents/Plugins/autofill-extension.appex",
+      "Contents/PlugIns/autofill-extension.appex",
       "Frameworks/Electron Framework.framework/(Electron Framework|Libraries|Resources|Versions/Current)/.*"
     ],
     "target": ["dmg", "zip"]

--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -35,6 +35,27 @@ async function run(context) {
     console.log("Copied memory-protection wrapper script");
   }
 
+  // The autofill extension is copied in here, before electron-builder signs the app, so that
+  // the app's own signature seals it. Copying it in after signing leaves the outer bundle
+  // invalid ("a sealed resource is missing or invalid") and notarization rejects it unless the
+  // whole package is signed a second time. electron-builder never signs anything under
+  // Contents/PlugIns, so the extension keeps the signature and entitlements Xcode gave it.
+  const isMasDevBuild =
+    context.electronPlatformName === "mas" && context.targets.at(0)?.name === "mas-dev";
+  if (context.electronPlatformName === "darwin" || isMasDevBuild) {
+    console.log("### Copying autofill extension");
+    // cannot use extraFiles because it modifies the extension's .plist and makes it invalid
+    const extensionPath = path.join(__dirname, "../macos/dist/autofill-extension.appex");
+    if (!fse.existsSync(extensionPath)) {
+      console.log("### Autofill extension not found - skipping");
+    } else {
+      const appName = context.packager.appInfo.productFilename;
+      const plugInsPath = path.join(context.appOutDir, `${appName}.app`, "Contents/PlugIns");
+      fse.mkdirSync(plugInsPath, { recursive: true });
+      fse.copySync(extensionPath, path.join(plugInsPath, "autofill-extension.appex"));
+    }
+  }
+
   if (["darwin", "mas"].includes(context.electronPlatformName)) {
     const is_mas = context.electronPlatformName === "mas";
 

--- a/apps/desktop/scripts/after-sign.js
+++ b/apps/desktop/scripts/after-sign.js
@@ -16,25 +16,8 @@ async function run(context) {
   const appPath = `${context.appOutDir}/${appName}.app`;
   const macBuild = context.electronPlatformName === "darwin";
   const copySafariExtension = ["darwin", "mas"].includes(context.electronPlatformName);
-  const isMasDevBuild =
-    context.electronPlatformName === "mas" && context.targets.at(0)?.name === "mas-dev";
-  const copyAutofillExtension = ["darwin"].includes(context.electronPlatformName) || isMasDevBuild;
 
   let shouldResign = false;
-
-  // cannot use extraFiles because it modifies the extensions .plist and makes it invalid
-  if (copyAutofillExtension) {
-    console.log("### Copying autofill extension");
-    const extensionPath = path.join(__dirname, "../macos/dist/autofill-extension.appex");
-    if (!fse.existsSync(extensionPath)) {
-      console.log("### Autofill extension not found - skipping");
-    } else {
-      if (!fse.existsSync(path.join(appPath, "Contents/PlugIns"))) {
-        fse.mkdirSync(path.join(appPath, "Contents/PlugIns"));
-      }
-      fse.copySync(extensionPath, path.join(appPath, "Contents/PlugIns/autofill-extension.appex"));
-    }
-  }
 
   if (copySafariExtension) {
     console.log("### Copying safari extension");


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37679](https://bitwarden.atlassian.net/browse/PM-37679)

## 📔 Objective

Copies the autofill extension into the macOS build during after-pack instead of after-sign to avoid re-signing the whole app unnecessarily, which burns local dev and CI time.

The Mac App Store - Development gate is still preserved, so this is not present in any builds in CI yet.

[PM-37679]: https://bitwarden.atlassian.net/browse/PM-37679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ