### PR TITLE
PM-42417: Fix access rule form vocabulary and event log link

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -201,14 +201,13 @@
               formControlName="humanApprovalEnabled"
             />
             <bit-label>{{ "pamAccessRuleConditionHumanApproval" | i18n }}</bit-label>
+            @if (formGroup.controls.humanApprovalEnabled.value) {
+              <bit-hint
+                >{{ "pamAccessRuleApprovers" | i18n }}:
+                {{ "pamAccessRuleApproversCollectionManagers" | i18n }}</bit-hint
+              >
+            }
           </bit-form-control>
-
-          @if (formGroup.controls.humanApprovalEnabled.value) {
-            <p bitTypography="body2" class="tw-ml-7 tw-mb-4 tw--mt-3 tw-text-muted">
-              {{ "pamAccessRuleApprovers" | i18n }}:
-              {{ "pamAccessRuleApproversCollectionManagers" | i18n }}
-            </p>
-          }
 
           <bit-form-control>
             <input

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -244,14 +244,14 @@ describe("AccessRuleEditComponent — page furniture", () => {
     expect(section.querySelectorAll("input")).toHaveLength(1);
   });
 
-  it("links the event logs at the organization's reporting route", async () => {
+  it("links the event log notice at the organization's PAM audit route", async () => {
     const fixture = await render({});
 
     const link = fixture.nativeElement.querySelector(
       "#access-rule-edit_anchor_event-logs",
     ) as HTMLAnchorElement | null;
     expect(link).not.toBeNull();
-    expect(link!.getAttribute("href")).toBe("/organizations/org-1/reporting/events");
+    expect(link!.getAttribute("href")).toBe("/organizations/org-1/pam/audit");
   });
 
   it("drops the event log notice for an organization without event log access", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -244,6 +244,28 @@ describe("AccessRuleEditComponent — page furniture", () => {
     expect(section.querySelectorAll("input")).toHaveLength(1);
   });
 
+  it("hangs the approvers hint off the human-approval checkbox once it is ticked", async () => {
+    const fixture = await render({});
+    const checkbox = fixture.nativeElement.querySelector(
+      "#access-rule-edit_checkbox_human-approval",
+    ) as HTMLInputElement;
+
+    // The hint sits in bit-form-control's `bit-hint` projection slot behind an `@if`, so it has to
+    // be asserted through the rendered control rather than the template: content projection out of
+    // a control-flow block is where this silently stops working.
+    const control = checkbox.closest("bit-form-control") as HTMLElement;
+    expect(control.querySelector("bit-hint")).toBeNull();
+
+    checkbox.click();
+    fixture.detectChanges();
+
+    const hint = control.querySelector("bit-hint");
+    expect(hint).not.toBeNull();
+    expect(hint!.textContent!.replace(/\s+/g, " ").trim()).toBe(
+      "pamAccessRuleApprovers: pamAccessRuleApproversCollectionManagers",
+    );
+  });
+
   it("links the event log notice at the organization's PAM audit route", async () => {
     const fixture = await render({});
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -186,12 +186,12 @@ export class AccessRuleEditComponent {
     () => this.existing()?.name ?? this.i18nService.t(this.pageTypeKey),
   );
 
-  protected readonly eventLogRoute = ["/organizations", this.organizationId, "reporting", "events"];
+  protected readonly eventLogRoute = ["/organizations", this.organizationId, "pam", "audit"];
 
   /**
    * Gates the footer notice. `canManageAccessRules` (this page's guard) does not imply access to
    * event logs: `canAccessEventLogs` also requires the organization's `useEvents` entitlement, and
-   * without it the reporting route bounces the admin straight back out.
+   * without it the PAM audit route's own guard bounces the admin straight back out.
    */
   protected readonly canAccessEventLogs = toSignal(
     this.activeUserId$.pipe(

--- a/bitwarden_license/bit-web/src/app/pam/approvals/can-view-approvals.guard.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/can-view-approvals.guard.spec.ts
@@ -26,7 +26,7 @@ describe("canViewApprovalsGuard", () => {
   /** Runs the guard in an injection context and normalises its result to a promise. */
   async function run(segments = ["pam", "approvals"]): Promise<GuardResult> {
     const result = TestBed.runInInjectionContext(() =>
-      canViewApprovalsGuard(snapshotFor(segments), null as never),
+      canViewApprovalsGuard(snapshotFor(segments)),
     );
     return isObservable(result) ? await firstValueFrom(result) : await result;
   }

--- a/bitwarden_license/bit-web/src/app/pam/approvals/can-view-approvals.guard.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/can-view-approvals.guard.spec.ts
@@ -1,5 +1,12 @@
 import { TestBed } from "@angular/core/testing";
-import { ActivatedRouteSnapshot, GuardResult, Router, UrlSegment } from "@angular/router";
+import {
+  ActivatedRouteSnapshot,
+  GuardResult,
+  Router,
+  RouterStateSnapshot,
+  UrlSegment,
+} from "@angular/router";
+import { mock } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom, isObservable, of } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -23,10 +30,17 @@ describe("canViewApprovalsGuard", () => {
   let organizations$: BehaviorSubject<Organization[]>;
   let router: Router;
 
-  /** Runs the guard in an injection context and normalises its result to a promise. */
+  /**
+   * Runs the guard in an injection context and normalises its result to a promise.
+   *
+   * The guard is typed `CanActivateFn`, so call sites must pass both `route` and `state` even though
+   * this implementation ignores the second one. Static analysis reads the arrow function's arity
+   * rather than the annotation and flags the argument as superfluous — it is not, and dropping it
+   * fails the build with TS2554.
+   */
   async function run(segments = ["pam", "approvals"]): Promise<GuardResult> {
     const result = TestBed.runInInjectionContext(() =>
-      canViewApprovalsGuard(snapshotFor(segments)),
+      canViewApprovalsGuard(snapshotFor(segments), mock<RouterStateSnapshot>()),
     );
     return isObservable(result) ? await firstValueFrom(result) : await result;
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42417

## 📔 Objective

Two small fixes to the access rule edit form:

- The footer "View event logs" link pointed at Reporting's org-wide event log page instead of PAM's own Audit log. It now routes to `/organizations/:organizationId/pam/audit`, which is guarded the same way this page already checks for event-log access.
- The "Approvers: Collection managers" hint under the human-approval checkbox was a hand-rolled paragraph instead of the design system's `bit-hint`. It now uses `bit-hint`, matching every other hint in this form.

Note: the footer link's destination was corrected, but its label and notice copy still say "event log(s)" rather than "Audit log". That is a copy decision left for design, not changed in this batch.

## 📸 Screenshots

Not captured for this batch. The change is a link target and a markup swap for an existing hint style; no new visual states were introduced.
