### PR TITLE
PM-42418: Fix access rules table layout and delete flow

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16943,8 +16943,8 @@
   "pamAccessRuleDuration8h": {
     "message": "8 hours"
   },
-  "pamAccessRuleDuration24h": {
-    "message": "24 hours"
+  "pamAccessRuleDuration1d": {
+    "message": "1 day"
   },
   "pamAccessRuleDuration7d": {
     "message": "7 days"

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.html
@@ -65,129 +65,158 @@
       />
     </div>
 
-    <bit-table [dataSource]="dataSource">
-      <ng-container header>
-        <tr>
-          <th bitCell class="tw-w-0">
-            <input
-              type="checkbox"
-              bitCheckbox
-              id="access-rules_checkbox_select-all"
-              [checked]="allSelected()"
-              [indeterminate]="someSelected()"
-              (change)="toggleAll()"
-            />
-            <label for="access-rules_checkbox_select-all" class="tw-sr-only">{{
-              "selectAll" | i18n
-            }}</label>
-          </th>
-          <th bitCell bitSortable="name">{{ "pamAccessRuleName" | i18n }}</th>
-          <th bitCell>{{ "pamAccessRuleAppliesTo" | i18n }}</th>
-          <th bitCell>{{ "pamAccessRuleApprovalMethodColumn" | i18n }}</th>
-          <th bitCell>{{ "pamAccessRuleDurationColumn" | i18n }}</th>
-          <th bitCell bitSortable="status" [fn]="sortByStatus">{{ "status" | i18n }}</th>
-          <th bitCell bitSortable="revisionDate" default="desc" [fn]="sortByRevisionDate">
-            {{ "pamAccessRuleLastModified" | i18n }}
-          </th>
-          <th bitCell class="tw-w-0">{{ "options" | i18n }}</th>
-        </tr>
-      </ng-container>
-      <ng-template body let-rows$>
-        <tr bitRow *ngFor="let r of rows$ | async">
-          <td bitCell>
-            <input
-              type="checkbox"
-              bitCheckbox
-              [id]="'access-rules_checkbox_' + r.id"
-              [checked]="selection.isSelected(r.id)"
-              (change)="selection.toggle(r.id)"
-            />
-            <label [for]="'access-rules_checkbox_' + r.id" class="tw-sr-only">{{ r.name }}</label>
-          </td>
-          <td bitCell>
-            <button type="button" bitLink linkType="primary" (click)="openEdit(r)">
-              {{ r.name }}
-            </button>
-            @if (r.description) {
-              <div class="tw-text-sm tw-text-muted">{{ r.description }}</div>
-            }
-          </td>
-          <td bitCell>
-            <pam-access-rule-collection-badges
-              [collectionIds]="r.collections"
-              [collections]="collections()"
-            />
-          </td>
-          <td bitCell>
-            {{ r.conditions | approvalMethod }}
-          </td>
-          <td bitCell>
-            @if (r.maxLeaseDurationSeconds; as maxSeconds) {
-              {{ maxSeconds | durationLong }}
-            } @else {
-              <span class="tw-text-muted">{{ "pamAccessRuleMaxDurationNoCap" | i18n }}</span>
-            }
-          </td>
-          <td bitCell>
-            @if (r.enabled) {
-              <span bitBadge variant="success">{{ "pamAccessRuleActive" | i18n }}</span>
-            } @else {
-              <span bitBadge variant="subtle" startIcon="bwi-subtract-circle">{{
-                "pamAccessRuleInactive" | i18n
-              }}</span>
-            }
-          </td>
-          <td bitCell>
-            <span class="tw-text-muted" [title]="r.revisionDate | date: 'medium'">{{
-              r.revisionDate | relativeTime
-            }}</span>
-          </td>
-          <td bitCell>
-            <button
-              type="button"
-              bitIconButton="bwi-ellipsis-h"
-              [bitMenuTriggerFor]="rowMenu"
-              label="{{ 'options' | i18n }}"
-            ></button>
-            <bit-menu #rowMenu>
-              <!--
+    <div class="tw-overflow-x-auto">
+      <bit-table [dataSource]="dataSource">
+        <ng-container header>
+          <tr>
+            <th bitCell class="tw-w-0">
+              <input
+                type="checkbox"
+                bitCheckbox
+                id="access-rules_checkbox_select-all"
+                [checked]="allSelected()"
+                [indeterminate]="someSelected()"
+                (change)="toggleAll()"
+              />
+              <label for="access-rules_checkbox_select-all" class="tw-sr-only">{{
+                "selectAll" | i18n
+              }}</label>
+            </th>
+            <th bitCell bitSortable="name">{{ "pamAccessRuleName" | i18n }}</th>
+            <th bitCell class="tw-w-0 tw-whitespace-nowrap">
+              {{ "pamAccessRuleAppliesTo" | i18n }}
+            </th>
+            <th bitCell class="tw-w-0 tw-whitespace-nowrap">
+              {{ "pamAccessRuleApprovalMethodColumn" | i18n }}
+            </th>
+            <th bitCell class="tw-w-0 tw-whitespace-nowrap">
+              {{ "pamAccessRuleDurationColumn" | i18n }}
+            </th>
+            <th
+              bitCell
+              bitSortable="status"
+              [fn]="sortByStatus"
+              class="tw-w-0 tw-whitespace-nowrap"
+            >
+              {{ "status" | i18n }}
+            </th>
+            <th
+              bitCell
+              bitSortable="revisionDate"
+              default="desc"
+              [fn]="sortByRevisionDate"
+              class="tw-w-0 tw-whitespace-nowrap"
+            >
+              {{ "pamAccessRuleLastModified" | i18n }}
+            </th>
+            <th bitCell class="tw-w-0">{{ "options" | i18n }}</th>
+          </tr>
+        </ng-container>
+        <ng-template body let-rows$>
+          <tr bitRow *ngFor="let r of rows$ | async">
+            <td bitCell>
+              <input
+                type="checkbox"
+                bitCheckbox
+                [id]="'access-rules_checkbox_' + r.id"
+                [checked]="selection.isSelected(r.id)"
+                (change)="selection.toggle(r.id)"
+              />
+              <label [for]="'access-rules_checkbox_' + r.id" class="tw-sr-only">{{ r.name }}</label>
+            </td>
+            <td bitCell>
+              <button type="button" bitLink linkType="primary" (click)="openEdit(r)">
+                {{ r.name }}
+              </button>
+              @if (r.description) {
+                <div
+                  class="tw-text-sm tw-text-muted tw-line-clamp-2 tw-text-ellipsis tw-break-words"
+                >
+                  {{ r.description }}
+                </div>
+              }
+            </td>
+            <td bitCell class="tw-w-0 tw-whitespace-nowrap">
+              <pam-access-rule-collection-badges
+                [collectionIds]="r.collections"
+                [collections]="collections()"
+              />
+            </td>
+            <td bitCell class="tw-w-0 tw-whitespace-nowrap">
+              {{ r.conditions | approvalMethod }}
+            </td>
+            <td bitCell class="tw-w-0 tw-whitespace-nowrap">
+              @if (r.maxLeaseDurationSeconds; as maxSeconds) {
+                {{ maxSeconds | durationLong }}
+              } @else {
+                <span class="tw-text-muted">{{ "pamAccessRuleMaxDurationNoCap" | i18n }}</span>
+              }
+            </td>
+            <td bitCell class="tw-w-0 tw-whitespace-nowrap">
+              @if (r.enabled) {
+                <span bitBadge variant="success">{{ "pamAccessRuleActive" | i18n }}</span>
+              } @else {
+                <span bitBadge variant="subtle" startIcon="bwi-subtract-circle">{{
+                  "pamAccessRuleInactive" | i18n
+                }}</span>
+              }
+            </td>
+            <td bitCell class="tw-w-0 tw-whitespace-nowrap">
+              <span
+                class="tw-text-muted"
+                tabindex="0"
+                [bitTooltip]="r.revisionDate | date: 'medium'"
+                [addTooltipToDescribedby]="true"
+                >{{ r.revisionDate | relativeTime }}</span
+              >
+            </td>
+            <td bitCell>
+              <button
+                type="button"
+                bitIconButton="bwi-ellipsis-h"
+                [bitMenuTriggerFor]="rowMenu"
+                label="{{ 'options' | i18n }}"
+              ></button>
+              <bit-menu #rowMenu>
+                <!--
                 Edit stays first: `bitMenuTriggerFor` focuses the first item on every open,
                 so a stray Enter must land on a navigation, not on the unconfirmed
                 activate/deactivate toggle.
               -->
-              <button type="button" bitMenuItem (click)="openEdit(r)">
-                <bit-icon name="bwi-pencil" class="tw-text-muted" />
-                {{ "edit" | i18n }}
-              </button>
-              <button type="button" bitMenuItem (click)="makeCopy(r)">
-                <bit-icon name="bwi-clone" class="tw-text-muted" />
-                {{ "makeACopy" | i18n }}
-              </button>
-              <button type="button" bitMenuItem (click)="toggleEnabled(r)">
-                @if (r.enabled) {
-                  <bit-icon name="bwi-subtract-circle" class="tw-text-muted" />
-                  {{ "pamAccessRuleDeactivate" | i18n }}
-                } @else {
-                  <bit-icon name="bwi-check-circle" class="tw-text-muted" />
-                  {{ "pamAccessRuleActivate" | i18n }}
-                }
-              </button>
-              <button type="button" bitMenuItem (click)="remove(r)">
-                <bit-icon name="bwi-trash" class="tw-text-danger" />
-                <span class="tw-text-danger">{{ "delete" | i18n }}</span>
-              </button>
-            </bit-menu>
-          </td>
-        </tr>
-        @if (processedRows().length === 0) {
-          <tr bitRow>
-            <td bitCell colspan="8" class="tw-py-6 tw-text-center tw-text-muted">
-              {{ "pamAccessRulesNoResults" | i18n }}
+                <button type="button" bitMenuItem (click)="openEdit(r)">
+                  <bit-icon name="bwi-pencil" class="tw-text-muted" />
+                  {{ "edit" | i18n }}
+                </button>
+                <button type="button" bitMenuItem (click)="makeCopy(r)">
+                  <bit-icon name="bwi-clone" class="tw-text-muted" />
+                  {{ "makeACopy" | i18n }}
+                </button>
+                <button type="button" bitMenuItem (click)="toggleEnabled(r)">
+                  @if (r.enabled) {
+                    <bit-icon name="bwi-subtract-circle" class="tw-text-muted" />
+                    {{ "pamAccessRuleDeactivate" | i18n }}
+                  } @else {
+                    <bit-icon name="bwi-check-circle" class="tw-text-muted" />
+                    {{ "pamAccessRuleActivate" | i18n }}
+                  }
+                </button>
+                <button type="button" bitMenuItem (click)="remove(r)">
+                  <bit-icon name="bwi-trash" class="tw-text-danger" />
+                  <span class="tw-text-danger">{{ "delete" | i18n }}</span>
+                </button>
+              </bit-menu>
             </td>
           </tr>
-        }
-      </ng-template>
-    </bit-table>
+          @if (processedRows().length === 0) {
+            <tr bitRow>
+              <td bitCell colspan="8" class="tw-py-6 tw-text-center tw-text-muted">
+                {{ "pamAccessRulesNoResults" | i18n }}
+              </td>
+            </tr>
+          }
+        </ng-template>
+      </bit-table>
+    </div>
 
     <bit-bulk-actions-bar [selectedCount]="selectedCount()" (clear)="clearSelection()">
       <bit-bulk-action

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
@@ -399,6 +399,18 @@ describe("AccessRulesComponent — activation toasts", () => {
     expect(openSimpleDialog).not.toHaveBeenCalled();
     expect(updateAccessRule).toHaveBeenCalled();
   });
+
+  it("reports a success toast after deleting a single rule", async () => {
+    const target = rule("rule-1", "VPN");
+    const fixture = await setupMutations([target]);
+
+    await fixture.componentInstance["remove"](target);
+
+    expect(showToast).toHaveBeenCalledWith({
+      variant: "success",
+      message: "pamAccessRuleDeleted",
+    });
+  });
 });
 
 describe("AccessRulesComponent — failed mutations", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
@@ -342,7 +342,7 @@ describe("AccessRulesComponent — make a copy", () => {
   });
 });
 
-describe("AccessRulesComponent — activation toasts", () => {
+describe("AccessRulesComponent — mutation success toasts", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
@@ -28,6 +28,7 @@ import {
   TableDataSource,
   TableModule,
   ToastService,
+  TooltipDirective,
   TypographyModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -77,6 +78,7 @@ import { ApprovalMethodPipe } from "./approval-method.pipe";
     MenuModule,
     SearchModule,
     TableModule,
+    TooltipDirective,
     TypographyModule,
     I18nPipe,
     RelativeTimePipe,
@@ -310,6 +312,10 @@ export class AccessRulesComponent {
     }
     try {
       await this.accessRules.delete(rule);
+      this.toastService.showToast({
+        variant: "success",
+        message: this.i18nService.t("pamAccessRuleDeleted"),
+      });
     } catch (e) {
       this.showError(e);
     }
@@ -382,7 +388,7 @@ export class AccessRulesComponent {
       },
       acceptButtonText: { key: "delete" },
       cancelButtonText: { key: "cancel" },
-      type: "warning",
+      type: "danger",
     });
     if (!confirmed) {
       return;

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.spec.ts
@@ -1,7 +1,7 @@
 import { accessRuleDeleteConfirmOptions } from "./access-rule-delete-confirm";
 
 describe("accessRuleDeleteConfirmOptions", () => {
-  it("asks the warning question with the rule name as the only placeholder", () => {
+  it("asks the delete question with the rule name as the only placeholder", () => {
     expect(accessRuleDeleteConfirmOptions("Prod database")).toEqual({
       title: { key: "pamAccessRuleDeleteConfirmTitle" },
       content: {

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.spec.ts
@@ -10,7 +10,7 @@ describe("accessRuleDeleteConfirmOptions", () => {
       },
       acceptButtonText: { key: "delete" },
       cancelButtonText: { key: "cancel" },
-      type: "warning",
+      type: "danger",
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-delete-confirm.ts
@@ -11,6 +11,6 @@ export function accessRuleDeleteConfirmOptions(ruleName: string): SimpleDialogOp
     content: { key: "pamAccessRuleDeleteConfirmContent", placeholders: [ruleName] },
     acceptButtonText: { key: "delete" },
     cancelButtonText: { key: "cancel" },
-    type: "warning",
+    type: "danger",
   };
 }

--- a/bitwarden_license/bit-web/src/app/pam/helpers/lease-window.utils.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/lease-window.utils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  ACCESS_RULE_DURATION_PRESETS,
   DEFAULT_ACCESS_RULE_DURATION_SECONDS,
   REQUEST_ACCESS_DURATION_PRESETS,
   pickDurationUnit,
@@ -6,6 +7,16 @@ import {
   snapToNearestAccessRuleDuration,
   snapToNearestDuration,
 } from "./lease-window.utils";
+
+describe("ACCESS_RULE_DURATION_PRESETS", () => {
+  it("labels the 24-hour preset to match what the list renders for the same value", () => {
+    // pickDurationUnit promotes 86400s to "1 day" in the list's Maximum duration cell
+    // (see pickDurationUnit below); the editor's own label must read the same way.
+    const preset = ACCESS_RULE_DURATION_PRESETS.find((p) => p.seconds === 24 * 60 * 60);
+
+    expect(preset?.labelKey).toBe("pamAccessRuleDuration1d");
+  });
+});
 
 describe("pickDurationUnit", () => {
   it("picks whole-day durations as days", () => {

--- a/bitwarden_license/bit-web/src/app/pam/helpers/lease-window.utils.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/lease-window.utils.ts
@@ -10,7 +10,7 @@ export const ACCESS_RULE_DURATION_PRESETS: ReadonlyArray<{ seconds: number; labe
   { seconds: 60 * 60, labelKey: "pamAccessRuleDuration1h" },
   { seconds: 4 * 60 * 60, labelKey: "pamAccessRuleDuration4h" },
   { seconds: 8 * 60 * 60, labelKey: "pamAccessRuleDuration8h" },
-  { seconds: 24 * 60 * 60, labelKey: "pamAccessRuleDuration24h" },
+  { seconds: 24 * 60 * 60, labelKey: "pamAccessRuleDuration1d" },
   { seconds: 7 * 24 * 60 * 60, labelKey: "pamAccessRuleDuration7d" },
 ];
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42418
https://bitwarden.atlassian.net/browse/PM-42424
https://bitwarden.atlassian.net/browse/PM-42425
https://bitwarden.atlassian.net/browse/PM-42427

## 📔 Objective

Layout and delete-flow fixes on the Access rules table:

- Name is now the only column that grows; the other columns (Applies to, Approval method, Maximum duration, Status, Last modified) are fixed-width so the Name column has room.
- Long rule descriptions are clamped to two lines instead of overflowing the row.
- The table is wrapped in its own horizontally scrolling container so it no longer overflows the page at 1024px viewport width.
- The "24 hours" duration label is renamed to "1 day" everywhere it appears (list and rule editor), so the two surfaces agree.
- The Last-modified timestamp's tooltip is now keyboard reachable, using the design system's tooltip directive instead of a native `title` attribute.
- The delete confirmation dialog now uses "danger" styling instead of "warning", and deleting a single rule now shows the success toast that was previously missing (bulk delete already had one).

## 📸 Screenshots

Not captured for this batch. Changes are column widths, text clamping, a scroll container, a label rename, a tooltip mechanism swap, and a dialog color/toast fix, none of which introduce a new screen.
