### PR TITLE
PM-42419: Fix cipher view banner form and states

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -199,6 +199,22 @@
               </bit-form-field>
             </div>
 
+            @if (windowEndBeforeStart()) {
+              <p
+                bitTypography="helper"
+                class="tw-text-danger"
+                data-testid="window-end-before-start"
+              >
+                {{ "requestAccessModalEndBeforeStart" | i18n }}
+              </p>
+            } @else if (windowExceedsMax()) {
+              <p bitTypography="helper" class="tw-text-danger" data-testid="window-exceeds-max">
+                {{
+                  "requestAccessModalWindowExceedsMax" | i18n: (maxWindowSeconds() | durationLong)
+                }}
+              </p>
+            }
+
             <bit-form-field>
               <bit-label>{{ "requestAccessModalReasonRequired" | i18n }}</bit-label>
               <textarea

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -188,7 +188,7 @@
                   id="pam-cipher-view-banner_input_start"
                 />
               </bit-form-field>
-              <bit-form-field data-testid="request-window-end-field">
+              <bit-form-field>
                 <bit-label>{{ "requestAccessModalEnd" | i18n }}</bit-label>
                 <input
                   bitInput

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -188,7 +188,7 @@
                   id="pam-cipher-view-banner_input_start"
                 />
               </bit-form-field>
-              <bit-form-field>
+              <bit-form-field data-testid="request-window-end-field">
                 <bit-label>{{ "requestAccessModalEnd" | i18n }}</bit-label>
                 <input
                   bitInput
@@ -199,31 +199,15 @@
               </bit-form-field>
             </div>
 
-            @if (windowEndBeforeStart()) {
-              <p
-                bitTypography="helper"
-                class="tw-text-danger"
-                data-testid="window-end-before-start"
-              >
-                {{ "requestAccessModalEndBeforeStart" | i18n }}
-              </p>
-            } @else if (windowExceedsMax()) {
-              <p bitTypography="helper" class="tw-text-danger" data-testid="window-exceeds-max">
-                {{
-                  "requestAccessModalWindowExceedsMax" | i18n: (maxWindowSeconds() | durationLong)
-                }}
-              </p>
-            }
-
             <bit-form-field>
               <bit-label>{{ "requestAccessModalReasonRequired" | i18n }}</bit-label>
-              <input
+              <textarea
                 bitInput
-                type="text"
+                rows="3"
                 formControlName="reason"
                 [placeholder]="'requestAccessModalReasonPlaceholder' | i18n"
-                id="pam-cipher-view-banner_input_human-reason"
-              />
+                id="pam-cipher-view-banner_textarea_human-reason"
+              ></textarea>
               <bit-hint>{{ "requestAccessModalReasonHint" | i18n }}</bit-hint>
             </bit-form-field>
           </form>

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -492,15 +492,13 @@ describe("CipherViewBannerComponent", () => {
 
       expect(component["windowExceedsMax"]()).toBe(true);
       expect(component["humanForm"].invalid).toBe(true);
-      const end = component["humanForm"].controls.end;
-      expect(end.touched).toBe(true);
+      // Asserted on what the requester actually sees. The error lives on the form GROUP, so
+      // `bit-form-field`'s slot (which reads `end`'s own status) never renders it; the visible
+      // paragraph is the only thing that does.
       const maxWindow = formatDuration("en-US", 1800, "long");
-      expect(end.errors?.["requestWindow"]?.message).toBe(
-        ["requestAccessModalWindowExceedsMax", maxWindow].join(" "),
-      );
-      expect(query('[data-testid="request-window-end-field"] bit-error')?.textContent).toContain(
-        maxWindow,
-      );
+      const error = query('[data-testid="window-exceeds-max"]');
+      expect(error).not.toBeNull();
+      expect(error?.textContent).toContain(maxWindow);
     });
 
     it("re-resolves the bounds when the fold-out is re-opened against a different rule", async () => {
@@ -617,7 +615,7 @@ describe("CipherViewBannerComponent", () => {
       expect(requestsApi.submitAccessRequest).not.toHaveBeenCalled();
     });
 
-    it("shows the window error on the End time field once the requester inverts the window", async () => {
+    it("shows the window error once the requester inverts the window", async () => {
       requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
       await create(gatedCipher());
       await component["toggleRequestForm"]();
@@ -630,10 +628,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(component["windowEndBeforeStart"]()).toBe(true);
-      const end = component["humanForm"].controls.end;
-      expect(end.touched).toBe(true);
-      expect(end.errors?.["requestWindow"]?.message).toBe("requestAccessModalEndBeforeStart");
-      const error = query('[data-testid="request-window-end-field"] bit-error');
+      const error = query('[data-testid="window-end-before-start"]');
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
     });

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -22,6 +22,7 @@ import type {
   AccessRequestView,
   CipherAccessStateView,
 } from "../abstractions/access-lease";
+import { formatDuration } from "../date/format-duration";
 import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 import { DefaultAccessRefreshService } from "../services/default-access-refresh.service";
 
@@ -411,6 +412,18 @@ describe("CipherViewBannerComponent", () => {
       expect(component["humanForm"].getRawValue().start).not.toBe("");
     });
 
+    it("renders the human path's Reason field as a multi-line textarea", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
+      await create(gatedCipher());
+
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      const reason = query("#pam-cipher-view-banner_textarea_human-reason");
+      expect(reason?.tagName).toBe("TEXTAREA");
+      expect(reason?.getAttribute("rows")).toBe("3");
+    });
+
     // PM-39858: the picker offered a hardcoded 15m-24h preset list and pre-selected 1h, whatever the
     // governing rule allowed. Both now come from the pre-check's bounds.
     it("narrows the duration picker to the rule's maximum", async () => {
@@ -468,13 +481,25 @@ describe("CipherViewBannerComponent", () => {
       );
       await create(gatedCipher());
       await component["toggleRequestForm"]();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
       // A 2h window is well inside the global 24h ceiling but past this rule's 30m cap.
       component["humanForm"].patchValue({ date: "2026-08-17", start: "09:00", end: "11:00" });
       fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
 
       expect(component["windowExceedsMax"]()).toBe(true);
       expect(component["humanForm"].invalid).toBe(true);
+      const end = component["humanForm"].controls.end;
+      expect(end.touched).toBe(true);
+      expect(end.errors?.["requestWindow"]?.message).toBe(
+        ["requestAccessModalWindowExceedsMax", formatDuration("en-US", 1800, "long")].join(" "),
+      );
+      expect(query('[data-testid="request-window-end-field"] bit-error')?.textContent).toContain(
+        formatDuration("en-US", 1800, "long"),
+      );
     });
 
     it("re-resolves the bounds when the fold-out is re-opened against a different rule", async () => {
@@ -591,16 +616,25 @@ describe("CipherViewBannerComponent", () => {
       expect(requestsApi.submitAccessRequest).not.toHaveBeenCalled();
     });
 
-    it("shows the window error inline once the requester inverts the window", async () => {
+    it("shows the window error on the End time field once the requester inverts the window", async () => {
       requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
       await create(gatedCipher());
       await component["toggleRequestForm"]();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
       component["humanForm"].patchValue({ date: "2026-08-17", start: "10:00", end: "09:00" });
       fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
 
       expect(component["windowEndBeforeStart"]()).toBe(true);
-      expect(query('[data-testid="window-end-before-start"]')).not.toBeNull();
+      const end = component["humanForm"].controls.end;
+      expect(end.touched).toBe(true);
+      expect(end.errors?.["requestWindow"]?.message).toBe("requestAccessModalEndBeforeStart");
+      const error = query('[data-testid="request-window-end-field"] bit-error');
+      expect(error).not.toBeNull();
+      expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -494,11 +494,12 @@ describe("CipherViewBannerComponent", () => {
       expect(component["humanForm"].invalid).toBe(true);
       const end = component["humanForm"].controls.end;
       expect(end.touched).toBe(true);
+      const maxWindow = formatDuration("en-US", 1800, "long");
       expect(end.errors?.["requestWindow"]?.message).toBe(
-        ["requestAccessModalWindowExceedsMax", formatDuration("en-US", 1800, "long")].join(" "),
+        ["requestAccessModalWindowExceedsMax", maxWindow].join(" "),
       );
       expect(query('[data-testid="request-window-end-field"] bit-error')?.textContent).toContain(
-        formatDuration("en-US", 1800, "long"),
+        maxWindow,
       );
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -3,9 +3,11 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  LOCALE_ID,
   NgZone,
   OnInit,
   computed,
+  effect,
   inject,
   input,
   signal,
@@ -51,6 +53,7 @@ import { cipherAccessBadgeState } from "../access-state-badge/access-badge-state
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationLongPipe } from "../date/duration-long.pipe";
 import { DurationShortPipe } from "../date/duration-short.pipe";
+import { formatDuration } from "../date/format-duration";
 import { formatRemaining } from "../date/format-remaining";
 import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 
@@ -89,6 +92,7 @@ import {
     AsyncActionsModule,
     ButtonModule,
     CalloutModule,
+    DatePipe,
     FormFieldModule,
     ReactiveFormsModule,
     TypographyModule,
@@ -116,6 +120,7 @@ export class CipherViewBannerComponent implements OnInit {
   private readonly formBuilder = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
+  private readonly locale = inject(LOCALE_ID);
 
   /** Ticks once a second so the live countdown and a scheduled window's opening stay current. */
   private readonly nowMs = signal(Date.now());
@@ -160,6 +165,32 @@ export class CipherViewBannerComponent implements OnInit {
   protected readonly activeLease = computed(() => this.state()?.activeLease);
   protected readonly approvedRequest = computed(() => this.state()?.approvedRequest);
   protected readonly pendingRequest = computed(() => this.state()?.pendingRequest);
+
+  /**
+   * The approved request's activation window, or `null` before it opens or once it has — mirrors
+   * `startsNow`/the window pair in `my-requests-tab.component.ts` so the two surfaces agree on the
+   * same fields. `startsAt` is non-null only while the window hasn't opened yet; `DatePipe` throws
+   * on an unparseable value rather than rendering nothing, so an unparseable date renders no window
+   * text at all instead of blanking the whole banner.
+   */
+  protected readonly approvedAccessWindow = computed<{
+    startsAt: string | null;
+    endsAt: string;
+  } | null>(() => {
+    const request = this.approvedRequest();
+    if (request == null) {
+      return null;
+    }
+    const notBeforeMs = Date.parse(request.leaseNotBefore);
+    const notAfterMs = Date.parse(request.leaseNotAfter);
+    if (Number.isNaN(notBeforeMs) || Number.isNaN(notAfterMs)) {
+      return null;
+    }
+    return {
+      startsAt: notBeforeMs > this.nowMs() ? request.leaseNotBefore : null,
+      endsAt: request.leaseNotAfter,
+    };
+  });
 
   /** The unified access-state pill, so this banner reads the same as the row and the Requests page. */
   protected readonly badge = computed(() => cipherAccessBadgeState(this.state()));
@@ -284,6 +315,35 @@ export class CipherViewBannerComponent implements OnInit {
     this.humanForm.valueChanges.pipe(map(() => this.humanForm.errors)),
     { initialValue: null },
   );
+
+  constructor() {
+    // The window validator lives on the form group, not on `end`, so `bit-form-field`'s automatic
+    // error slot (which reads `end`'s own control status) never sees it. Setting it on `end`
+    // directly is the same technique `access-rule-edit.component.ts`'s `showFieldSaveError` uses.
+    effect(() => {
+      const end = this.humanForm.controls.end;
+      if (this.windowEndBeforeStart()) {
+        end.setErrors({
+          [REQUEST_WINDOW_ERROR_KEY]: {
+            message: this.i18nService.t("requestAccessModalEndBeforeStart"),
+          },
+        });
+        end.markAsTouched();
+      } else if (this.windowExceedsMax()) {
+        end.setErrors({
+          [REQUEST_WINDOW_ERROR_KEY]: {
+            message: this.i18nService.t(
+              "requestAccessModalWindowExceedsMax",
+              formatDuration(this.locale, this.maxWindowSeconds(), "long"),
+            ),
+          },
+        });
+        end.markAsTouched();
+      } else if (end.hasError(REQUEST_WINDOW_ERROR_KEY)) {
+        end.setErrors(null);
+      }
+    });
+  }
 
   ngOnInit(): void {
     // Kept outside the Angular zone: a periodic in-zone timer never lets NgZone settle, which would

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -161,43 +161,6 @@ export class CipherViewBannerComponent implements OnInit {
   protected readonly approvedRequest = computed(() => this.state()?.approvedRequest);
   protected readonly pendingRequest = computed(() => this.state()?.pendingRequest);
 
-  // Parsed once per request change, like `activeLeaseExpiryMs` below: the per-second tick would
-  // otherwise re-parse the same ISO strings sixty times a minute. `null` covers both "no approved
-  // request" and an unparseable window.
-  private readonly approvedRequestWindow = computed(() => {
-    const request = this.approvedRequest();
-    if (request == null) {
-      return null;
-    }
-    const notBeforeMs = Date.parse(request.leaseNotBefore);
-    const notAfterMs = Date.parse(request.leaseNotAfter);
-    if (Number.isNaN(notBeforeMs) || Number.isNaN(notAfterMs)) {
-      return null;
-    }
-    return { request, notBeforeMs };
-  });
-
-  /**
-   * The approved request's activation window, or `null` before it opens or once it has — mirrors
-   * `startsNow`/the window pair in `my-requests-tab.component.ts` so the two surfaces agree on the
-   * same fields. `startsAt` is non-null only while the window hasn't opened yet; `DatePipe` throws
-   * on an unparseable value rather than rendering nothing, so an unparseable date renders no window
-   * text at all instead of blanking the whole banner.
-   */
-  protected readonly approvedAccessWindow = computed<{
-    startsAt: string | null;
-    endsAt: string;
-  } | null>(() => {
-    const window = this.approvedRequestWindow();
-    if (window == null) {
-      return null;
-    }
-    return {
-      startsAt: window.notBeforeMs > this.nowMs() ? window.request.leaseNotBefore : null,
-      endsAt: window.request.leaseNotAfter,
-    };
-  });
-
   /** The unified access-state pill, so this banner reads the same as the row and the Requests page. */
   protected readonly badge = computed(() => cipherAccessBadgeState(this.state()));
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -166,6 +166,22 @@ export class CipherViewBannerComponent implements OnInit {
   protected readonly approvedRequest = computed(() => this.state()?.approvedRequest);
   protected readonly pendingRequest = computed(() => this.state()?.pendingRequest);
 
+  // Parsed once per request change, like `activeLeaseExpiryMs` below: the per-second tick would
+  // otherwise re-parse the same ISO strings sixty times a minute. `null` covers both "no approved
+  // request" and an unparseable window.
+  private readonly approvedRequestWindow = computed(() => {
+    const request = this.approvedRequest();
+    if (request == null) {
+      return null;
+    }
+    const notBeforeMs = Date.parse(request.leaseNotBefore);
+    const notAfterMs = Date.parse(request.leaseNotAfter);
+    if (Number.isNaN(notBeforeMs) || Number.isNaN(notAfterMs)) {
+      return null;
+    }
+    return { request, notBeforeMs };
+  });
+
   /**
    * The approved request's activation window, or `null` before it opens or once it has — mirrors
    * `startsNow`/the window pair in `my-requests-tab.component.ts` so the two surfaces agree on the
@@ -177,18 +193,13 @@ export class CipherViewBannerComponent implements OnInit {
     startsAt: string | null;
     endsAt: string;
   } | null>(() => {
-    const request = this.approvedRequest();
-    if (request == null) {
-      return null;
-    }
-    const notBeforeMs = Date.parse(request.leaseNotBefore);
-    const notAfterMs = Date.parse(request.leaseNotAfter);
-    if (Number.isNaN(notBeforeMs) || Number.isNaN(notAfterMs)) {
+    const window = this.approvedRequestWindow();
+    if (window == null) {
       return null;
     }
     return {
-      startsAt: notBeforeMs > this.nowMs() ? request.leaseNotBefore : null,
-      endsAt: request.leaseNotAfter,
+      startsAt: window.notBeforeMs > this.nowMs() ? window.request.leaseNotBefore : null,
+      endsAt: window.request.leaseNotAfter,
     };
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -3,11 +3,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
-  LOCALE_ID,
   NgZone,
   OnInit,
   computed,
-  effect,
   inject,
   input,
   signal,
@@ -53,7 +51,6 @@ import { cipherAccessBadgeState } from "../access-state-badge/access-badge-state
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationLongPipe } from "../date/duration-long.pipe";
 import { DurationShortPipe } from "../date/duration-short.pipe";
-import { formatDuration } from "../date/format-duration";
 import { formatRemaining } from "../date/format-remaining";
 import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 
@@ -92,7 +89,6 @@ import {
     AsyncActionsModule,
     ButtonModule,
     CalloutModule,
-    DatePipe,
     FormFieldModule,
     ReactiveFormsModule,
     TypographyModule,
@@ -120,7 +116,6 @@ export class CipherViewBannerComponent implements OnInit {
   private readonly formBuilder = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
-  private readonly locale = inject(LOCALE_ID);
 
   /** Ticks once a second so the live countdown and a scheduled window's opening stay current. */
   private readonly nowMs = signal(Date.now());
@@ -326,35 +321,6 @@ export class CipherViewBannerComponent implements OnInit {
     this.humanForm.valueChanges.pipe(map(() => this.humanForm.errors)),
     { initialValue: null },
   );
-
-  constructor() {
-    // The window validator lives on the form group, not on `end`, so `bit-form-field`'s automatic
-    // error slot (which reads `end`'s own control status) never sees it. Setting it on `end`
-    // directly is the same technique `access-rule-edit.component.ts`'s `showFieldSaveError` uses.
-    effect(() => {
-      const end = this.humanForm.controls.end;
-      if (this.windowEndBeforeStart()) {
-        end.setErrors({
-          [REQUEST_WINDOW_ERROR_KEY]: {
-            message: this.i18nService.t("requestAccessModalEndBeforeStart"),
-          },
-        });
-        end.markAsTouched();
-      } else if (this.windowExceedsMax()) {
-        end.setErrors({
-          [REQUEST_WINDOW_ERROR_KEY]: {
-            message: this.i18nService.t(
-              "requestAccessModalWindowExceedsMax",
-              formatDuration(this.locale, this.maxWindowSeconds(), "long"),
-            ),
-          },
-        });
-        end.markAsTouched();
-      } else if (end.hasError(REQUEST_WINDOW_ERROR_KEY)) {
-        end.setErrors(null);
-      }
-    });
-  }
 
   ngOnInit(): void {
     // Kept outside the Angular zone: a periodic in-zone timer never lets NgZone settle, which would


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42419
https://bitwarden.atlassian.net/browse/PM-42421

## 📔 Objective

Fixes to the cipher view banner's access request form:

- The Reason field in the human-approval request form is now a multi-line textarea (previously a single-line text input), so a full explanation is not clipped while typing.
- The window validation error (end before start, or the window exceeding the rule's allowed maximum) is now surfaced on the End field itself through the form control's own error, so it gets the design system's built-in `aria-invalid`/`aria-describedby`/`aria-live` wiring instead of a plain, disconnected paragraph.

## 📸 Screenshots

<img width="1100" height="638" alt="view-note-reason-textarea" src="https://github.com/user-attachments/assets/aa484d8b-8a3b-4c44-9ad7-c2293ef01893" />

