### PR TITLE
PM-42420: Fix access requests shell copy and badges

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.html
@@ -8,14 +8,14 @@
     <bit-tab-link route="my-requests" [berryValue]="myRequestsCount()">{{
       "pamTabMyRequests" | i18n
     }}</bit-tab-link>
-    <bit-tab-link route="history" [berryValue]="historyCount()">{{
-      "pamTabHistory" | i18n
-    }}</bit-tab-link>
+    <bit-tab-link route="history">{{ "pamTabHistory" | i18n }}</bit-tab-link>
   </bit-tab-nav-bar>
 </app-header>
 
-<p bitTypography="body1" class="tw-mb-6 tw-text-muted">
-  {{ "pamAccessRequestsSubtitle" | i18n }}
-</p>
+@if (canApprove()) {
+  <p bitTypography="body1" class="tw-mb-6 tw-text-muted">
+    {{ "pamAccessRequestsSubtitle" | i18n }}
+  </p>
+}
 
 <router-outlet></router-outlet>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.stories.ts
@@ -23,7 +23,6 @@ type ShellOptions = {
   extensions?: number;
   leases?: number;
   approvals?: number;
-  history?: number;
   canApprove?: boolean;
 };
 
@@ -36,14 +35,7 @@ type ShellOptions = {
  * environment injector, so a module-level provider is invisible to it.
  */
 function shell(options: ShellOptions = {}) {
-  const {
-    pending = 0,
-    extensions = 0,
-    leases = 0,
-    approvals = 0,
-    history = 0,
-    canApprove = true,
-  } = options;
+  const { pending = 0, extensions = 0, leases = 0, approvals = 0, canApprove = true } = options;
   const rows = (count: number) => of(Array.from({ length: count }, (_, i) => ({ id: `row-${i}` })));
 
   return [
@@ -56,7 +48,6 @@ function shell(options: ShellOptions = {}) {
             pendingRows$: rows(pending),
             extensionRows$: rows(extensions),
             leases$: rows(leases),
-            historyRows$: rows(history),
             loadError$: of(null),
             load: () => Promise.resolve(),
           },
@@ -110,7 +101,7 @@ type Story = StoryObj<AccessRequestsComponent>;
  * requests and active leases — everything the caller still holds or can act on.
  */
 export const Default: Story = {
-  decorators: shell({ pending: 2, extensions: 1, leases: 3, approvals: 4, history: 12 }),
+  decorators: shell({ pending: 2, extensions: 1, leases: 3, approvals: 4 }),
 };
 
 /** Nothing anywhere: a zero count renders no berry rather than a "0". */
@@ -123,5 +114,5 @@ export const NoCounts: Story = {
  * never hold anything is noise, and the route guard redirects the deep link to match.
  */
 export const WithoutApprovals: Story = {
-  decorators: shell({ canApprove: false, pending: 1, leases: 1, history: 5 }),
+  decorators: shell({ canApprove: false, pending: 1, leases: 1 }),
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
@@ -22,7 +22,10 @@ import { MyAccessService } from "./my-access.service";
  *    member with no approval privileges, rather than shown empty: a tab that can never have anything
  *    in it is noise, and `canViewApprovalsGuard` redirects the deep link to match.
  *  - My requests — the caller's own pending/extension requests and active leases.
- *  - History — the caller's terminal requests, plus (for approvers) the ones they decided.
+ *  - History — the caller's terminal requests, plus (for approvers) the ones they decided. No
+ *    berry: {@link MyAccessService.historyRows$} only grows (terminal requests never leave
+ *    history), so a live count there would read as permanent unattended work rather than
+ *    something to act on — unlike the My requests and Approvals berries below.
  *
  * Each tab is a child route rendered in the shell's `<router-outlet>`; the shell stays mounted
  * across tab navigation. {@link MyAccessService} is provided at the parent route (see the routing
@@ -47,13 +50,6 @@ export class AccessRequestsComponent implements OnInit {
   private readonly toastService = inject(ToastService);
   private readonly logService = inject(LogService);
   private readonly destroyRef = inject(DestroyRef);
-
-  /**
-   * The History tab intentionally shows no berry: {@link MyAccessService.historyRows$} only grows
-   * (terminal requests never leave history), so a live count there would read as permanent
-   * unattended work rather than something to act on — unlike the My requests and Approvals
-   * berries below, which count outstanding work.
-   */
 
   /**
    * The "My requests" berry: everything the caller still holds or can act on — pending requests,

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
@@ -49,6 +49,13 @@ export class AccessRequestsComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   /**
+   * The History tab intentionally shows no berry: {@link MyAccessService.historyRows$} only grows
+   * (terminal requests never leave history), so a live count there would read as permanent
+   * unattended work rather than something to act on — unlike the My requests and Approvals
+   * berries below, which count outstanding work.
+   */
+
+  /**
    * The "My requests" berry: everything the caller still holds or can act on — pending requests,
    * open extension requests, and active leases. Zero renders no berry (see `bit-tab-link`).
    */
@@ -73,12 +80,6 @@ export class AccessRequestsComponent implements OnInit {
 
   /** The "Approvals" berry: requests awaiting the caller's decision. */
   protected readonly approvalsCount = toSignal(this.inbox.pendingCount$, { initialValue: 0 });
-
-  /** The "History" berry: the caller's terminal requests. */
-  protected readonly historyCount = toSignal(
-    this.myAccess.historyRows$.pipe(map((rows) => rows.length)),
-    { initialValue: 0 },
-  );
 
   ngOnInit(): void {
     void this.myAccess.load();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42420
https://bitwarden.atlassian.net/browse/PM-42431

## 📔 Objective

Two fixes to the Access requests shell:

- The subtitle ("Approve, monitor, and audit time-limited access to your credentials.") was shown to every user on every tab, including requesters with no approval privileges and no Approvals tab. It is now gated behind the same signal that decides whether the Approvals tab itself renders, so only approvers see it.
- The History tab's berry badge counted the caller's terminal (completed) requests. Since that count only ever grows and never represents outstanding work, it read as unattended work rather than something to act on. The berry has been removed along with the now-dead count.

## 📸 Screenshots

Not captured for this batch. Both changes are visibility/removal of existing elements, not new screens.
