### PR TITLE
PM-42423: Fix access audit page and states

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -25,35 +25,38 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
 
 describe("auditRowMatchesFilter", () => {
   it("matches everything when the filter is empty", () => {
-    expect(auditRowMatchesFilter(row(), { text: "", kind: null })).toBe(true);
+    expect(auditRowMatchesFilter(row(), { text: "", kindLabelKey: null })).toBe(true);
   });
 
   it("matches free text against the haystack, case-insensitively", () => {
-    expect(auditRowMatchesFilter(row(), { text: "PROD", kind: null })).toBe(true);
-    expect(auditRowMatchesFilter(row(), { text: "  production ", kind: null })).toBe(true);
-    expect(auditRowMatchesFilter(row(), { text: "staging", kind: null })).toBe(false);
+    expect(auditRowMatchesFilter(row(), { text: "PROD", kindLabelKey: null })).toBe(true);
+    expect(auditRowMatchesFilter(row(), { text: "  production ", kindLabelKey: null })).toBe(true);
+    expect(auditRowMatchesFilter(row(), { text: "staging", kindLabelKey: null })).toBe(false);
   });
 
-  it("filters by event kind", () => {
-    const deleted = row({ kind: AccessAuditEventKind.RuleDeleted });
+  it("filters by event-kind label key", () => {
+    const deleted = row({ kindLabelKey: "pamAuditKindRuleDeleted" });
     expect(
-      auditRowMatchesFilter(deleted, { text: "", kind: AccessAuditEventKind.RuleDeleted }),
+      auditRowMatchesFilter(deleted, { text: "", kindLabelKey: "pamAuditKindRuleDeleted" }),
     ).toBe(true);
     expect(
-      auditRowMatchesFilter(deleted, { text: "", kind: AccessAuditEventKind.RequestSubmitted }),
+      auditRowMatchesFilter(deleted, { text: "", kindLabelKey: "pamAuditKindRequestSubmitted" }),
     ).toBe(false);
   });
 
   it("requires both text and kind to match when both are set", () => {
-    const revoked = row({ kind: AccessAuditEventKind.LeaseRevoked, searchText: "bob server" });
+    const revoked = row({ kindLabelKey: "pamAuditKindLeaseRevoked", searchText: "bob server" });
     expect(
-      auditRowMatchesFilter(revoked, { text: "bob", kind: AccessAuditEventKind.LeaseRevoked }),
+      auditRowMatchesFilter(revoked, { text: "bob", kindLabelKey: "pamAuditKindLeaseRevoked" }),
     ).toBe(true);
     expect(
-      auditRowMatchesFilter(revoked, { text: "bob", kind: AccessAuditEventKind.RequestSubmitted }),
+      auditRowMatchesFilter(revoked, {
+        text: "bob",
+        kindLabelKey: "pamAuditKindRequestSubmitted",
+      }),
     ).toBe(false);
     expect(
-      auditRowMatchesFilter(revoked, { text: "carol", kind: AccessAuditEventKind.LeaseRevoked }),
+      auditRowMatchesFilter(revoked, { text: "carol", kindLabelKey: "pamAuditKindLeaseRevoked" }),
     ).toBe(false);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -7,7 +7,6 @@ import {
 function row(overrides: Partial<AuditRow> = {}): AuditRow {
   return {
     occurredAt: new Date("2026-06-30T12:00:00Z"),
-    kind: AccessAuditEventKind.RequestSubmitted,
     kindLabelKey: "pamAuditKindRequestSubmitted",
     actor: "alice",
     requester: "alice",

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -125,12 +125,12 @@ export function toAuditRow(
   };
 }
 
-/** The active audit-log filter: free-text plus an optional event kind. */
-export type AuditFilter = { text: string; kind: AccessAuditEventKind | null };
+/** The active audit-log filter: free-text plus an optional event-kind label key. */
+export type AuditFilter = { text: string; kindLabelKey: string | null };
 
 /** Whether a row passes the filter. Empty text and a null kind match everything. */
 export function auditRowMatchesFilter(row: AuditRow, filter: AuditFilter): boolean {
-  if (filter.kind != null && row.kind !== filter.kind) {
+  if (filter.kindLabelKey != null && row.kindLabelKey !== filter.kindLabelKey) {
     return false;
   }
   const text = filter.text.trim().toLowerCase();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -11,7 +11,6 @@ import {
  */
 export type AuditRow = {
   occurredAt: Date;
-  kind: AccessAuditEventKind;
   /** i18n key for the human-readable event label (see {@link auditKindLabelKey}). */
   kindLabelKey: string;
   /** Who performed it (name, falling back to email); null for a system / automatic event. */
@@ -107,7 +106,6 @@ export function toAuditRow(
     (event.collectionId != null ? collectionNameById.get(event.collectionId) : undefined) ?? null;
   return {
     occurredAt: new Date(event.occurredAt),
-    kind: event.kind,
     kindLabelKey: selfEnded ? "pamAuditKindLeaseEndedByHolder" : auditKindLabelKey(event.kind),
     actor,
     requester,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -1,3 +1,5 @@
+<app-header [title]="'pamAuditLog' | i18n"></app-header>
+
 @switch (status()) {
   @case ("loading") {
     <p class="tw-text-muted">{{ "loading" | i18n }}</p>
@@ -5,12 +7,34 @@
   @case ("error") {
     <bit-callout type="danger" [title]="'errorOccurred' | i18n">
       {{ "pamAuditLoadError" | i18n }}
+      <button
+        type="button"
+        bitLink
+        linkType="danger"
+        class="tw-ms-2 tw-font-bold"
+        id="access-audit_button_retry"
+        (click)="load()"
+      >
+        {{ "tryAgain" | i18n }}
+      </button>
     </bit-callout>
   }
   @case ("empty") {
-    <bit-callout type="info" [title]="'pamAuditEmptyTitle' | i18n">
-      {{ "pamAuditEmptyMessage" | i18n }}
-    </bit-callout>
+    <bit-no-items>
+      <span slot="title">{{ "pamAuditEmptyTitle" | i18n }}</span>
+      <span slot="description">{{ "pamAuditEmptyMessage" | i18n }}</span>
+      @if (canManageAccessRules()) {
+        <a
+          slot="button"
+          bitButton
+          buttonType="secondary"
+          routerLink="../access-rules"
+          id="access-audit_link_access-rules"
+        >
+          {{ "pamAccessRules" | i18n }}
+        </a>
+      }
+    </bit-no-items>
   }
   @case ("ready") {
     <div class="tw-mb-4 tw-flex tw-items-center tw-gap-3">

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -4,9 +4,12 @@ import { ActivatedRoute } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
 
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { I18nMockService } from "@bitwarden/components";
+import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import {
   AccessNameResolverService,
@@ -54,6 +57,13 @@ describe("AccessAuditComponent", () => {
           provide: ActivatedRoute,
           useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
         },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+        {
+          provide: OrganizationService,
+          useValue: {
+            organizations$: () => of([{ id: ORGANIZATION_ID, canManageAccessRules: true }]),
+          },
+        },
         {
           provide: I18nService,
           // I18nMockService throws on an unknown key, so this covers every key the template can
@@ -61,9 +71,12 @@ describe("AccessAuditComponent", () => {
           useValue: new I18nMockService({
             loading: "Loading",
             errorOccurred: "An error has occurred",
+            pamAuditLog: "Audit log",
             pamAuditLoadError: "Could not load the audit trail",
+            tryAgain: "Try again",
             pamAuditEmptyTitle: "No audit activity",
             pamAuditEmptyMessage: "Activity will appear here.",
+            pamAccessRules: "Access rules",
             pamAuditSearchPlaceholder: "Search the audit log",
             pamAuditNoMatchesTitle: "No matching events",
             pamAuditNoMatchesMessage: "No events match the current filters.",
@@ -84,8 +97,12 @@ describe("AccessAuditComponent", () => {
       ],
     })
       // Stub the design-system children so these tests exercise this component's own
-      // load / filter / status logic rather than table and chip rendering.
-      .overrideComponent(AccessAuditComponent, { add: { schemas: [NO_ERRORS_SCHEMA] } })
+      // load / filter / status logic rather than table and chip rendering; the header module pulls
+      // in page chrome (route.data) this test has no interest in wiring up.
+      .overrideComponent(AccessAuditComponent, {
+        remove: { imports: [HeaderModule] },
+        add: { schemas: [NO_ERRORS_SCHEMA] },
+      })
       .compileComponents();
 
     fixture = TestBed.createComponent(AccessAuditComponent);
@@ -124,6 +141,19 @@ describe("AccessAuditComponent", () => {
     expect(TestBed.inject(LogService).error).toHaveBeenCalled();
   });
 
+  it("recovers from the error state when load() is retried", async () => {
+    auditApiService.listAccessAuditTrail.mockRejectedValueOnce(new Error("boom"));
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(component().status()).toBe("error");
+
+    auditApiService.listAccessAuditTrail.mockResolvedValueOnce([event()]);
+    await component().load();
+
+    expect(component().status()).toBe("ready");
+  });
+
   // Only an event naming both a cipher and its collection can be matched to a local vault item, so
   // the others must not be sent to the resolver.
   it("asks the name resolver only about events naming both a cipher and a collection", async () => {
@@ -151,10 +181,10 @@ describe("AccessAuditComponent", () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    // Labelled and sorted alphabetically, one entry per distinct kind.
+    // Labelled and sorted alphabetically, one entry per distinct kind label key.
     expect(component().kindOptions()).toEqual([
-      { label: "Lease activated", value: "leaseActivated" },
-      { label: "Request approved", value: "requestApproved" },
+      { label: "Lease activated", value: "pamAuditKindLeaseActivated" },
+      { label: "Request approved", value: "pamAuditKindRequestApproved" },
     ]);
   });
 
@@ -168,10 +198,10 @@ describe("AccessAuditComponent", () => {
     await fixture.whenStable();
     expect(component().filteredRows()).toHaveLength(2);
 
-    component().kindControl.setValue("leaseActivated");
+    component().kindControl.setValue("pamAuditKindLeaseActivated");
 
     expect(component().filteredRows()).toHaveLength(1);
-    expect(component().filteredRows()[0].kind).toBe("leaseActivated");
+    expect(component().filteredRows()[0].kindLabelKey).toBe("pamAuditKindLeaseActivated");
   });
 
   it("filters rows by free text over actor, requester, item, and detail", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -42,11 +42,7 @@ describe("AccessAuditComponent", () => {
   let auditApiService: MockProxy<AuditApiService>;
   let nameResolver: MockProxy<AccessNameResolverService>;
 
-  beforeEach(async () => {
-    auditApiService = mock<AuditApiService>();
-    nameResolver = mock<AccessNameResolverService>();
-    nameResolver.resolveNames.mockResolvedValue(emptyResolvedNames());
-
+  const configureTestBed = async (canManageAccessRules = true) => {
     await TestBed.configureTestingModule({
       imports: [AccessAuditComponent],
       providers: [
@@ -61,7 +57,7 @@ describe("AccessAuditComponent", () => {
         {
           provide: OrganizationService,
           useValue: {
-            organizations$: () => of([{ id: ORGANIZATION_ID, canManageAccessRules: true }]),
+            organizations$: () => of([{ id: ORGANIZATION_ID, canManageAccessRules }]),
           },
         },
         {
@@ -106,6 +102,14 @@ describe("AccessAuditComponent", () => {
       .compileComponents();
 
     fixture = TestBed.createComponent(AccessAuditComponent);
+  };
+
+  beforeEach(async () => {
+    auditApiService = mock<AuditApiService>();
+    nameResolver = mock<AccessNameResolverService>();
+    nameResolver.resolveNames.mockResolvedValue(emptyResolvedNames());
+
+    await configureTestBed();
   });
 
   /** The component's protected surface, reached the way the template reaches it. */
@@ -129,6 +133,30 @@ describe("AccessAuditComponent", () => {
     await fixture.whenStable();
 
     expect(component().status()).toBe("empty");
+  });
+
+  it("shows the empty state's Access rules link for a viewer who can manage access rules", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const link = fixture.nativeElement.querySelector("#access-audit_link_access-rules");
+    expect(link).not.toBeNull();
+  });
+
+  it("drops the empty state's Access rules link for a viewer who cannot manage access rules", async () => {
+    TestBed.resetTestingModule();
+    await configureTestBed(false);
+    auditApiService.listAccessAuditTrail.mockResolvedValue([]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const link = fixture.nativeElement.querySelector("#access-audit_link_access-rules");
+    expect(link).toBeNull();
   });
 
   it("reports error when the read fails, and logs it", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -135,7 +135,10 @@ function audit(options: { events?: AccessAuditEventResponse[]; fails?: boolean }
         provide: AccessNameResolverService,
         useValue: { resolveNames: () => Promise.resolve(names) },
       },
-      { provide: ActivatedRoute, useValue: { params: of({ organizationId: "org-1" }) } },
+      {
+        provide: ActivatedRoute,
+        useValue: { params: of({ organizationId: "org-1" }), data: of({}) },
+      },
       { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
       {
         provide: OrganizationService,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -1,8 +1,10 @@
 import { importProvidersFrom } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
 
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AccessNameResolverService } from "../access-requests/access-name-resolver.service";
@@ -134,6 +136,11 @@ function audit(options: { events?: AccessAuditEventResponse[]; fails?: boolean }
         useValue: { resolveNames: () => Promise.resolve(names) },
       },
       { provide: ActivatedRoute, useValue: { params: of({ organizationId: "org-1" }) } },
+      { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+      {
+        provide: OrganizationService,
+        useValue: { organizations$: () => of([{ id: "org-1", canManageAccessRules: true }]) },
+      },
     ],
   });
 }
@@ -146,6 +153,7 @@ export default {
       providers: [
         provideStoryChangeDetection(),
         importProvidersFrom(PreloadedEnglishI18nModule),
+        importProvidersFrom(RouterModule.forRoot([])),
         provideStoryLogService(),
       ],
     }),

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -9,27 +9,34 @@ import {
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
-import { ActivatedRoute } from "@angular/router";
-import { map } from "rxjs";
+import { ActivatedRoute, RouterLink } from "@angular/router";
+import { map, switchMap } from "rxjs";
 
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { getById } from "@bitwarden/common/platform/misc/rxjs-operators";
 import {
   BadgeModule,
+  ButtonModule,
   CalloutModule,
   ChipFilterComponent,
   ChipFilterOption,
+  LinkModule,
+  NoItemsModule,
   SearchModule,
   TableModule,
   TooltipDirective,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
+import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import { AccessNameResolverService } from "../access-requests/access-name-resolver.service";
 
-import { AuditRow, auditKindLabelKey, auditRowMatchesFilter, toAuditRow } from "./access-audit-row";
+import { AuditRow, auditRowMatchesFilter, toAuditRow } from "./access-audit-row";
 import { AuditApiService } from "./audit-api.service";
-import { AccessAuditEventKind } from "./responses/access-audit-event.response";
 
 type AuditStatus = "loading" | "ready" | "empty" | "error";
 
@@ -56,9 +63,14 @@ type AuditStatus = "loading" | "ready" | "empty" | "error";
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    RouterLink,
     BadgeModule,
+    ButtonModule,
     CalloutModule,
     ChipFilterComponent,
+    HeaderModule,
+    LinkModule,
+    NoItemsModule,
     SearchModule,
     TableModule,
     TooltipDirective,
@@ -71,6 +83,8 @@ export class AccessAuditComponent implements OnInit {
   private readonly nameResolver = inject(AccessNameResolverService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
+  private readonly accountService = inject(AccountService);
+  private readonly organizationService = inject(OrganizationService);
 
   /**
    * The organization whose trail to show, from the route. `requireSync` holds because `params` emits
@@ -81,30 +95,51 @@ export class AccessAuditComponent implements OnInit {
     { requireSync: true },
   );
 
+  private readonly activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
+
+  /**
+   * Gates the empty state's "Access rules" link. This page's own guard, `canAccessEventLogs`, does
+   * not imply `canManageAccessRules` (the target route's guard) — an auditor holding only the events
+   * permission would follow the link into an "Access denied" bounce.
+   */
+  protected readonly canManageAccessRules = toSignal(
+    this.activeUserId$.pipe(
+      switchMap((userId) => this.organizationService.organizations$(userId)),
+      getById(this.organizationId()),
+      map((organization) => organization?.canManageAccessRules ?? false),
+    ),
+    { initialValue: false },
+  );
+
   protected readonly status = signal<AuditStatus>("loading");
   protected readonly rows = signal<AuditRow[]>([]);
 
   // --- Toolbar filters (client-side over the fetched window) ---
   protected readonly searchControl = new FormControl("", { nonNullable: true });
-  protected readonly kindControl = new FormControl<AccessAuditEventKind | null>(null);
+  protected readonly kindControl = new FormControl<string | null>(null);
 
   private readonly searchText = toSignal(this.searchControl.valueChanges, { initialValue: "" });
   private readonly kindValue = toSignal(this.kindControl.valueChanges, { initialValue: null });
 
-  /** Event-kind chip options, limited to the kinds actually present in the trail, labelled and sorted. */
-  protected readonly kindOptions = computed<ChipFilterOption<AccessAuditEventKind>[]>(() =>
-    [...new Set(this.rows().map((row) => row.kind))]
-      .map((kind) => ({ label: this.i18nService.t(auditKindLabelKey(kind)), value: kind }))
+  /** Event-kind chip options, limited to the labels actually present in the trail, sorted. */
+  protected readonly kindOptions = computed<ChipFilterOption<string>[]>(() =>
+    [...new Set(this.rows().map((row) => row.kindLabelKey))]
+      .map((labelKey) => ({ label: this.i18nService.t(labelKey), value: labelKey }))
       .sort((a, b) => a.label.localeCompare(b.label)),
   );
 
   protected readonly filteredRows = computed(() =>
     this.rows().filter((row) =>
-      auditRowMatchesFilter(row, { text: this.searchText(), kind: this.kindValue() }),
+      auditRowMatchesFilter(row, { text: this.searchText(), kindLabelKey: this.kindValue() }),
     ),
   );
 
   async ngOnInit(): Promise<void> {
+    await this.load();
+  }
+
+  protected async load(): Promise<void> {
+    this.status.set("loading");
     try {
       const events = await this.auditApiService.listAccessAuditTrail(this.organizationId());
       // Only events naming both a cipher and its collection can be resolved to a local vault item.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42423
https://bitwarden.atlassian.net/browse/PM-42428
https://bitwarden.atlassian.net/browse/PM-42429

## 📔 Objective

Fixes to the PAM Access audit page:

- Added the page's missing header ("Audit log"), matching the sibling Access rules page.
- The event-kind filter now keys off the same label the row actually displays, instead of the raw event kind. This matters for a self-ended lease, which renders under a different label than an operator-initiated revoke but previously shared the same underlying kind, so filtering and the visible label could disagree.
- Replaced the bare "no activity" callout with a real empty state, including a link to Access rules for viewers who can manage them (gated separately, since this page's own guard does not imply that permission).
- Added a retry action to the error state so a failed load can be retried without leaving the page.

## 📸 Screenshots
<img width="1100" height="638" alt="audit-log-empty-state" src="https://github.com/user-attachments/assets/07ab98b3-7735-4f5e-aa72-ed6d429e9415" />
<img width="1100" height="638" alt="audit-log-error-state" src="https://github.com/user-attachments/assets/7c413de5-1a3c-43e3-86b3-01e2ad84bebd" />
<img width="1100" height="638" alt="audit-log-header" src="https://github.com/user-attachments/assets/8a6504b3-398d-4a10-90aa-1360351af88f" />

