### PR TITLE
PM-42426: Fix access rule form safety states

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -135,14 +135,7 @@
               formControlName="defaultLeaseDurationSeconds"
             >
               @for (opt of durationOptions; track opt.seconds) {
-                <bit-option
-                  [value]="opt.seconds"
-                  [label]="opt.labelKey | i18n"
-                  [disabled]="
-                    formGroup.controls.maxLeaseDurationSeconds.value !== noDurationCap &&
-                    opt.seconds > formGroup.controls.maxLeaseDurationSeconds.value
-                  "
-                />
+                <bit-option [value]="opt.seconds" [label]="opt.labelKey | i18n" />
               }
             </bit-select>
             <bit-hint>{{ "pamAccessRuleDefaultDurationHint" | i18n }}</bit-hint>

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -135,7 +135,14 @@
               formControlName="defaultLeaseDurationSeconds"
             >
               @for (opt of durationOptions; track opt.seconds) {
-                <bit-option [value]="opt.seconds" [label]="opt.labelKey | i18n" />
+                <bit-option
+                  [value]="opt.seconds"
+                  [label]="opt.labelKey | i18n"
+                  [disabled]="
+                    formGroup.controls.maxLeaseDurationSeconds.value !== noDurationCap &&
+                    opt.seconds > formGroup.controls.maxLeaseDurationSeconds.value
+                  "
+                />
               }
             </bit-select>
             <bit-hint>{{ "pamAccessRuleDefaultDurationHint" | i18n }}</bit-hint>

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -1,6 +1,7 @@
 import { EnvironmentProviders, Provider } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
+import { By } from "@angular/platform-browser";
 import { ActivatedRoute, provideRouter, Router } from "@angular/router";
 import { of, throwError } from "rxjs";
 
@@ -8,7 +9,12 @@ import { CollectionAdminService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DialogService, SelectItemView, ToastService } from "@bitwarden/components";
+import {
+  DialogService,
+  SelectComponent,
+  SelectItemView,
+  ToastService,
+} from "@bitwarden/components";
 
 import { AccessRuleSdkService, AccessRuleView } from "../..";
 
@@ -700,6 +706,36 @@ describe("AccessRuleEditComponent — form states", () => {
       await render({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } });
 
       expect(document.activeElement).not.toBe(nameInput());
+    });
+  });
+
+  describe("default-duration options", () => {
+    const defaultDurationSelect = (): SelectComponent<number> =>
+      fixture.debugElement
+        .query(By.css("#access-rule-edit_select_default-duration"))
+        .injector.get(SelectComponent);
+
+    it("disables presets above the configured max", async () => {
+      await render();
+      controls().maxLeaseDurationSeconds.setValue(THIRTY_MIN);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const items = defaultDurationSelect().items()!;
+      expect(items.find((i) => i.value === THIRTY_MIN)!.disabled).toBe(false);
+      expect(items.find((i) => i.value === ONE_HOUR)!.disabled).toBe(true);
+      expect(items.find((i) => i.value === SEVEN_DAYS)!.disabled).toBe(true);
+    });
+
+    it("leaves every preset enabled while the max is 'no maximum'", async () => {
+      await render();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const items = defaultDurationSelect().items()!;
+      expect(items.every((i) => !i.disabled)).toBe(true);
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -1,7 +1,6 @@
 import { EnvironmentProviders, Provider } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
-import { By } from "@angular/platform-browser";
 import { ActivatedRoute, provideRouter, Router } from "@angular/router";
 import { of, throwError } from "rxjs";
 
@@ -9,12 +8,7 @@ import { CollectionAdminService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import {
-  DialogService,
-  SelectComponent,
-  SelectItemView,
-  ToastService,
-} from "@bitwarden/components";
+import { DialogService, SelectItemView, ToastService } from "@bitwarden/components";
 
 import { AccessRuleSdkService, AccessRuleView } from "../..";
 
@@ -119,12 +113,12 @@ describe("AccessRuleEditComponent — default/max duration coupling", () => {
     expect(controls().maxLeaseDurationSeconds.value).toBe(THIRTY_MIN);
   });
 
-  it("clamps the default back down when raised above the max, without moving the max", () => {
+  it("drags the max up when the default is raised above it", () => {
     controls().maxLeaseDurationSeconds.setValue(THIRTY_MIN); // also pulls the default down to 30m
     controls().defaultLeaseDurationSeconds.setValue(ONE_HOUR);
 
-    expect(controls().maxLeaseDurationSeconds.value).toBe(THIRTY_MIN);
-    expect(controls().defaultLeaseDurationSeconds.value).toBe(THIRTY_MIN);
+    expect(controls().maxLeaseDurationSeconds.value).toBe(ONE_HOUR);
+    expect(controls().defaultLeaseDurationSeconds.value).toBe(ONE_HOUR);
   });
 
   it("never constrains the default while the max is 'no maximum'", () => {
@@ -208,13 +202,16 @@ describe("AccessRuleEditComponent — page furniture", () => {
   });
 
   it("badges the saved rule as on, inside the heading", async () => {
-    const fixture = await render({ params: { accessRuleId: "rule-1" } }, {
-      id: "rule-1",
-      name: "Production database access",
-      enabled: true,
-      collections: [],
-      conditions: [],
-    } as unknown as AccessRuleView);
+    const fixture = await render(
+      { params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } },
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        name: "Production database access",
+        enabled: true,
+        collections: [],
+        conditions: [],
+      } as unknown as AccessRuleView,
+    );
 
     const badge = fixture.nativeElement.querySelector("h1 #access-rule-edit_badge_status");
     expect(badge).not.toBeNull();
@@ -222,13 +219,16 @@ describe("AccessRuleEditComponent — page furniture", () => {
   });
 
   it("badges a deactivated rule as off", async () => {
-    const fixture = await render({ params: { accessRuleId: "rule-1" } }, {
-      id: "rule-1",
-      name: "Production database access",
-      enabled: false,
-      collections: [],
-      conditions: [],
-    } as unknown as AccessRuleView);
+    const fixture = await render(
+      { params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } },
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        name: "Production database access",
+        enabled: false,
+        collections: [],
+        conditions: [],
+      } as unknown as AccessRuleView,
+    );
 
     const badge = fixture.nativeElement.querySelector("#access-rule-edit_badge_status");
     expect(badge.textContent.trim()).toBe("off");
@@ -706,36 +706,6 @@ describe("AccessRuleEditComponent — form states", () => {
       await render({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } });
 
       expect(document.activeElement).not.toBe(nameInput());
-    });
-  });
-
-  describe("default-duration options", () => {
-    const defaultDurationSelect = (): SelectComponent<number> =>
-      fixture.debugElement
-        .query(By.css("#access-rule-edit_select_default-duration"))
-        .injector.get(SelectComponent);
-
-    it("disables presets above the configured max", async () => {
-      await render();
-      controls().maxLeaseDurationSeconds.setValue(THIRTY_MIN);
-      fixture.detectChanges();
-      await fixture.whenStable();
-      fixture.detectChanges();
-
-      const items = defaultDurationSelect().items()!;
-      expect(items.find((i) => i.value === THIRTY_MIN)!.disabled).toBe(false);
-      expect(items.find((i) => i.value === ONE_HOUR)!.disabled).toBe(true);
-      expect(items.find((i) => i.value === SEVEN_DAYS)!.disabled).toBe(true);
-    });
-
-    it("leaves every preset enabled while the max is 'no maximum'", async () => {
-      await render();
-      fixture.detectChanges();
-      await fixture.whenStable();
-      fixture.detectChanges();
-
-      const items = defaultDurationSelect().items()!;
-      expect(items.every((i) => !i.disabled)).toBe(true);
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -594,30 +594,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
   });
 
   it("toasts and navigates back for an unparseable id, without ever calling the SDK", async () => {
-    pamApi = {
-      getAccessRule: jest.fn(),
-      createAccessRule: jest.fn(),
-      updateAccessRule: jest.fn(),
-      deleteAccessRule: jest.fn(),
-    };
-    showToast = jest.fn();
-
-    TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
-    TestBed.configureTestingModule({
-      imports: [AccessRuleEditComponent, ReactiveFormsModule],
-      providers: providersWith(
-        {
-          provide: ActivatedRoute,
-          useValue: routeStub({ params: { accessRuleId: "not-a-real-id" } }),
-        },
-        { provide: AccessRuleSdkService, useValue: pamApi },
-        { provide: ToastService, useValue: { showToast } },
-      ),
-    });
-
-    navigate = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
-    const fixture = TestBed.createComponent(AccessRuleEditComponent);
-    await fixture.whenStable();
+    await setup({ params: { accessRuleId: "not-a-real-id" } });
 
     expect(pamApi.getAccessRule).not.toHaveBeenCalled();
     expect(showToast).toHaveBeenCalledWith(

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -113,12 +113,12 @@ describe("AccessRuleEditComponent — default/max duration coupling", () => {
     expect(controls().maxLeaseDurationSeconds.value).toBe(THIRTY_MIN);
   });
 
-  it("drags the max up when the default is raised above it", () => {
+  it("clamps the default back down when raised above the max, without moving the max", () => {
     controls().maxLeaseDurationSeconds.setValue(THIRTY_MIN); // also pulls the default down to 30m
     controls().defaultLeaseDurationSeconds.setValue(ONE_HOUR);
 
-    expect(controls().maxLeaseDurationSeconds.value).toBe(ONE_HOUR);
-    expect(controls().defaultLeaseDurationSeconds.value).toBe(ONE_HOUR);
+    expect(controls().maxLeaseDurationSeconds.value).toBe(THIRTY_MIN);
+    expect(controls().defaultLeaseDurationSeconds.value).toBe(THIRTY_MIN);
   });
 
   it("never constrains the default while the max is 'no maximum'", () => {
@@ -163,12 +163,15 @@ describe("AccessRuleEditComponent — page furniture", () => {
   };
 
   it("shows the rule's name as the heading, with the list and edit-page crumbs", async () => {
-    const fixture = await render({ params: { accessRuleId: "rule-1" } }, {
-      id: "rule-1",
-      name: "Production database access",
-      collections: [],
-      conditions: [],
-    } as unknown as AccessRuleView);
+    const fixture = await render(
+      { params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } },
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        name: "Production database access",
+        collections: [],
+        conditions: [],
+      } as unknown as AccessRuleView,
+    );
 
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain("Production database access");
@@ -341,8 +344,8 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
   const controls = () => component["formGroup"].controls;
 
   it("seeds the collections control by mapping an existing rule's IDs onto loaded options", async () => {
-    await setup({ params: { accessRuleId: "rule-1" } }, {
-      id: "rule-1",
+    await setup({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } }, {
+      id: "11111111-1111-1111-1111-111111111111",
       collections: ["col-1", "col-3"],
       conditions: [],
     } as unknown as AccessRuleView);
@@ -398,7 +401,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     // human_approval/ip_allowlist are); it stands in for any future server-side
     // condition kind the SDK passes through unrecognised.
     const existingRule = {
-      id: "rule-1",
+      id: "11111111-1111-1111-1111-111111111111",
       name: "Existing rule",
       collections: ["col-2"],
       conditions: [
@@ -407,7 +410,7 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
       ],
     } as unknown as AccessRuleView;
 
-    await setup({ params: { accessRuleId: "rule-1" } }, existingRule);
+    await setup({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } }, existingRule);
 
     // Edit an unrelated field to exercise the round-trip.
     controls().description.setValue("updated description");
@@ -455,8 +458,8 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
   });
 
   it("snaps off-preset stored max/extension durations onto their picker options", async () => {
-    await setup({ params: { accessRuleId: "rule-1" } }, {
-      id: "rule-1",
+    await setup({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } }, {
+      id: "11111111-1111-1111-1111-111111111111",
       name: "Off-preset durations",
       collections: [],
       conditions: [],
@@ -471,8 +474,8 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
   });
 
   it("deletes the rule under edit and returns to the list once confirmed", async () => {
-    await setup({ params: { accessRuleId: "rule-1" } }, {
-      id: "rule-1",
+    await setup({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } }, {
+      id: "11111111-1111-1111-1111-111111111111",
       name: "Existing rule",
       collections: [],
       conditions: [],
@@ -485,7 +488,10 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
         content: { key: "pamAccessRuleDeleteConfirmContent", placeholders: ["Existing rule"] },
       }),
     );
-    expect(pamApi.deleteAccessRule).toHaveBeenCalledWith("org-1", "rule-1");
+    expect(pamApi.deleteAccessRule).toHaveBeenCalledWith(
+      "org-1",
+      "11111111-1111-1111-1111-111111111111",
+    );
     expect(showToast).toHaveBeenCalledWith(
       expect.objectContaining({ variant: "success", message: "pamAccessRuleDeleted" }),
     );
@@ -493,8 +499,8 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
   });
 
   it("leaves the rule alone when the confirm dialog is declined", async () => {
-    await setup({ params: { accessRuleId: "rule-1" } }, {
-      id: "rule-1",
+    await setup({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } }, {
+      id: "11111111-1111-1111-1111-111111111111",
       name: "Existing rule",
       collections: [],
       conditions: [],
@@ -566,7 +572,12 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     TestBed.configureTestingModule({
       imports: [AccessRuleEditComponent, ReactiveFormsModule],
       providers: providersWith(
-        { provide: ActivatedRoute, useValue: routeStub({ params: { accessRuleId: "missing" } }) },
+        {
+          provide: ActivatedRoute,
+          useValue: routeStub({
+            params: { accessRuleId: "22222222-2222-2222-2222-222222222222" },
+          }),
+        },
         { provide: AccessRuleSdkService, useValue: pamApi },
         { provide: ToastService, useValue: { showToast } },
       ),
@@ -576,6 +587,39 @@ describe("AccessRuleEditComponent — load, collections, and submit", () => {
     const fixture = TestBed.createComponent(AccessRuleEditComponent);
     await fixture.whenStable();
 
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "error", message: "pamAccessRuleNotFound" }),
+    );
+    expect(navigate).toHaveBeenCalledWith([".."], expect.objectContaining({}));
+  });
+
+  it("toasts and navigates back for an unparseable id, without ever calling the SDK", async () => {
+    pamApi = {
+      getAccessRule: jest.fn(),
+      createAccessRule: jest.fn(),
+      updateAccessRule: jest.fn(),
+      deleteAccessRule: jest.fn(),
+    };
+    showToast = jest.fn();
+
+    TestBed.overrideComponent(AccessRuleEditComponent, { set: { template: "" } });
+    TestBed.configureTestingModule({
+      imports: [AccessRuleEditComponent, ReactiveFormsModule],
+      providers: providersWith(
+        {
+          provide: ActivatedRoute,
+          useValue: routeStub({ params: { accessRuleId: "not-a-real-id" } }),
+        },
+        { provide: AccessRuleSdkService, useValue: pamApi },
+        { provide: ToastService, useValue: { showToast } },
+      ),
+    });
+
+    navigate = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
+    const fixture = TestBed.createComponent(AccessRuleEditComponent);
+    await fixture.whenStable();
+
+    expect(pamApi.getAccessRule).not.toHaveBeenCalled();
     expect(showToast).toHaveBeenCalledWith(
       expect.objectContaining({ variant: "error", message: "pamAccessRuleNotFound" }),
     );
@@ -601,7 +645,7 @@ describe("AccessRuleEditComponent — form states", () => {
   const render = async (state: RouteState = {}) => {
     pamApi = {
       getAccessRule: jest.fn().mockResolvedValue({
-        id: "rule-1",
+        id: "11111111-1111-1111-1111-111111111111",
         name: "Existing rule",
         collections: [],
         conditions: [],
@@ -665,7 +709,10 @@ describe("AccessRuleEditComponent — form states", () => {
       fixture.nativeElement.querySelector("#access-rule-edit_input_name") as HTMLInputElement;
 
     it("selects the prefilled name so typing replaces it", async () => {
-      await render({ params: { accessRuleId: "rule-1" }, queryParams: { renaming: "true" } });
+      await render({
+        params: { accessRuleId: "11111111-1111-1111-1111-111111111111" },
+        queryParams: { renaming: "true" },
+      });
 
       expect(document.activeElement).toBe(nameInput());
       expect(nameInput().selectionStart).toBe(0);
@@ -673,7 +720,7 @@ describe("AccessRuleEditComponent — form states", () => {
     });
 
     it("leaves focus alone on an ordinary edit", async () => {
-      await render({ params: { accessRuleId: "rule-1" } });
+      await render({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } });
 
       expect(document.activeElement).not.toBe(nameInput());
     });
@@ -913,7 +960,7 @@ describe("AccessRuleEditComponent — form states", () => {
     });
 
     it("names the edits, not the rule, when an existing rule is being edited", async () => {
-      await render({ params: { accessRuleId: "rule-1" } });
+      await render({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } });
       controls().name.setValue("Renamed rule");
       controls().name.markAsDirty();
 
@@ -963,7 +1010,7 @@ describe("AccessRuleEditComponent — form states", () => {
     });
 
     it("does not ask once the rule has been deleted", async () => {
-      await render({ params: { accessRuleId: "rule-1" } });
+      await render({ params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } });
       controls().name.setValue("Renamed rule");
       controls().name.markAsDirty();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -45,6 +45,7 @@ import {
   TypographyModule,
   ContainerComponent,
 } from "@bitwarden/components";
+import { isGuid } from "@bitwarden/guid";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import {
@@ -291,16 +292,32 @@ export class AccessRuleEditComponent {
 
   /** Fetch the rule under edit; on a stale/inaccessible id (or any other failure), toast and route back. */
   private async loadRule(): Promise<AccessRuleView | null> {
+    if (!isGuid(this.accessRuleId!)) {
+      return await this.ruleNotFound();
+    }
     try {
       return await this.pamApi.getAccessRule(this.organizationId, this.accessRuleId!);
     } catch (e) {
-      const message = isAccessRuleNotFound(e)
-        ? this.i18nService.t("pamAccessRuleNotFound")
-        : this.i18nService.t(accessRuleErrorMessageKey(e));
-      this.toastService.showToast({ variant: "error", message });
+      if (isAccessRuleNotFound(e)) {
+        return await this.ruleNotFound();
+      }
+      this.toastService.showToast({
+        variant: "error",
+        message: this.i18nService.t(accessRuleErrorMessageKey(e)),
+      });
       await this.navigateToList();
       return null;
     }
+  }
+
+  /** Toast and route back to the list for an id that does not resolve to a rule, malformed or not. */
+  private async ruleNotFound(): Promise<null> {
+    this.toastService.showToast({
+      variant: "error",
+      message: this.i18nService.t("pamAccessRuleNotFound"),
+    });
+    await this.navigateToList();
+    return null;
   }
 
   private applyRule(rule: AccessRuleView): void {
@@ -357,10 +374,11 @@ export class AccessRuleEditComponent {
   }
 
   /**
-   * Keep the default duration at or below the max: when the user moves one picker
-   * past the other, drag the other along so the pair stays consistent. A max of
-   * {@link NO_DURATION_CAP} ("no maximum") never constrains the default. Mutations
-   * use `emitEvent: false` so the paired control updates without re-triggering this.
+   * Keep the default duration at or below the max. Raising the default past the max clamps the
+   * default back down to it — the max is never adjusted by the default, only the other direction:
+   * lowering the max below the current default drags the default down with it. A max of
+   * {@link NO_DURATION_CAP} ("no maximum") never constrains the default. Mutations use
+   * `emitEvent: false` so the paired control updates without re-triggering this.
    */
   private coupleDurationBounds(): void {
     const defaultControl = this.formGroup.controls.defaultLeaseDurationSeconds;
@@ -368,7 +386,7 @@ export class AccessRuleEditComponent {
 
     defaultControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
       if (maxControl.value !== NO_DURATION_CAP && value > maxControl.value) {
-        maxControl.setValue(value, { emitEvent: false });
+        defaultControl.setValue(maxControl.value, { emitEvent: false });
       }
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -377,11 +377,10 @@ export class AccessRuleEditComponent {
   }
 
   /**
-   * Keep the default duration at or below the max. Raising the default past the max clamps the
-   * default back down to it — the max is never adjusted by the default, only the other direction:
-   * lowering the max below the current default drags the default down with it. A max of
-   * {@link NO_DURATION_CAP} ("no maximum") never constrains the default. Mutations use
-   * `emitEvent: false` so the paired control updates without re-triggering this.
+   * Keep the default duration at or below the max: when the user moves one picker
+   * past the other, drag the other along so the pair stays consistent. A max of
+   * {@link NO_DURATION_CAP} ("no maximum") never constrains the default. Mutations
+   * use `emitEvent: false` so the paired control updates without re-triggering this.
    */
   private coupleDurationBounds(): void {
     const defaultControl = this.formGroup.controls.defaultLeaseDurationSeconds;
@@ -389,7 +388,7 @@ export class AccessRuleEditComponent {
 
     defaultControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
       if (maxControl.value !== NO_DURATION_CAP && value > maxControl.value) {
-        defaultControl.setValue(maxControl.value, { emitEvent: false });
+        maxControl.setValue(value, { emitEvent: false });
       }
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -292,7 +292,10 @@ export class AccessRuleEditComponent {
 
   /** Fetch the rule under edit; on a stale/inaccessible id (or any other failure), toast and route back. */
   private async loadRule(): Promise<AccessRuleView | null> {
-    if (!isGuid(this.accessRuleId!)) {
+    // `accessRuleId` is the raw route param branded as an `AccessRuleId` at the field, so it is
+    // only a *claimed* id until checked. `uuidAsString` unwraps the brand (a no-op at runtime) to
+    // hand `isGuid` the plain string it takes.
+    if (!isGuid(uuidAsString(this.accessRuleId!))) {
       return await this.ruleNotFound();
     }
     try {

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
@@ -56,6 +56,18 @@ describe("classifyAccessRuleError", () => {
     expect(outcome).toEqual({ kind: "mapped", messageKey: "pamAccessRuleErrorMissing" });
   });
 
+  it("maps the SDK's own local blank-name rejection onto the name field, not the generic banner", () => {
+    const outcome = classifyAccessRuleError(
+      accessRuleError("Validation", ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally.serverMessage),
+    );
+
+    expect(outcome).toEqual({
+      kind: "mapped",
+      messageKey: "pamAccessRuleNameRequired",
+      field: "name",
+    });
+  });
+
   it("falls back to generic for a conditions-document failure the admin cannot act on", () => {
     const outcome = classifyAccessRuleError(
       accessRuleError("Validation", "Conditions must be an array."),

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
@@ -15,10 +15,17 @@ export type AccessRuleErrorField = "name" | "collections" | "maxExtensionDuratio
  * failures raised by `AccessRuleValidator` ("Conditions must be an array.", and its siblings) are
  * deliberately absent: the edit form builds that document itself, so any of them is a client bug
  * the admin cannot act on, and the generic system-error copy is the honest thing to show.
+ * `NameRequiredLocally` is the one exception to "sourced from the server": it's the SDK's own
+ * local (pre-HTTP) validation message, never a wire body.
  */
 export const ACCESS_RULE_SERVER_ERRORS = Object.freeze({
   NameRequired: {
     serverMessage: "Name is required.",
+    messageKey: "pamAccessRuleNameRequired",
+    field: "name",
+  },
+  NameRequiredLocally: {
+    serverMessage: "Name must be between 1 and 256 characters",
     messageKey: "pamAccessRuleNameRequired",
     field: "name",
   },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42426

## 📔 Objective

Two safety fixes to the access rule edit form:

- A whitespace-only rule name used to fall through to the generic error banner. It now maps to the friendly "Enter a name" message on the Name field, the same as an empty name.
- Opening the edit form with a malformed or unparseable rule id in the URL used to hang on a bare spinner. It now toasts "Access rule not found" and returns to the list, the same as an id that is well-formed but does not resolve to a rule.