### PR TITLE
PM-42432: Fix my requests empty states and layout

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17224,6 +17224,12 @@
   "pamMyRequestsExtensionsEmpty": {
     "message": "No extension requests"
   },
+  "pamApprovalsUnavailableTitle": {
+    "message": "Approvals aren't available yet"
+  },
+  "pamApprovalsUnavailableDescription": {
+    "message": "Reviewing and approving other members' access requests is coming soon."
+  },
   "pamMyRequestsLoadError": {
     "message": "Could not load your requests"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17221,15 +17221,6 @@
   "pamMyRequestsGroupCheckedOut": {
     "message": "Currently checked out"
   },
-  "pamMyRequestsExtensionsEmpty": {
-    "message": "No extension requests"
-  },
-  "pamApprovalsUnavailableTitle": {
-    "message": "Approvals aren't available yet"
-  },
-  "pamApprovalsUnavailableDescription": {
-    "message": "Reviewing and approving other members' access requests is coming soon."
-  },
   "pamMyRequestsLoadError": {
     "message": "Could not load your requests"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -19,12 +19,9 @@
     <span slot="end" bitBadge variant="secondary">{{ pendingRows().length }}</span>
 
     @if (pendingRows().length === 0) {
-      <bit-no-items class="tw-mt-2 tw-block" data-testid="my-access-pending-empty">
-        <span slot="title" class="tw-mt-4 tw-block">{{ "pamMyRequestsPendingEmpty" | i18n }}</span>
-        <a slot="button" bitButton buttonType="secondary" routerLink="/vault">
-          {{ "goToVault" | i18n }}
-        </a>
-      </bit-no-items>
+      <p bitTypography="body2" class="tw-mb-0 tw-text-muted" data-testid="my-access-pending-empty">
+        {{ "pamMyRequestsPendingEmpty" | i18n }}
+      </p>
     } @else {
       <bit-table [dataSource]="pendingDataSource">
         <ng-container header>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -19,9 +19,12 @@
     <span slot="end" bitBadge variant="secondary">{{ pendingRows().length }}</span>
 
     @if (pendingRows().length === 0) {
-      <p bitTypography="body2" class="tw-mb-0 tw-text-muted" data-testid="my-access-pending-empty">
-        {{ "pamMyRequestsPendingEmpty" | i18n }}
-      </p>
+      <bit-no-items class="tw-mt-2 tw-block" data-testid="my-access-pending-empty">
+        <span slot="title" class="tw-mt-4 tw-block">{{ "pamMyRequestsPendingEmpty" | i18n }}</span>
+        <a slot="button" bitButton buttonType="secondary" routerLink="/vault">
+          {{ "goToVault" | i18n }}
+        </a>
+      </bit-no-items>
     } @else {
       <bit-table [dataSource]="pendingDataSource">
         <ng-container header>
@@ -77,6 +80,7 @@
                       bitButton
                       buttonType="primary"
                       size="small"
+                      class="tw-whitespace-nowrap"
                       [loading]="isStarting(row.id)"
                       [disabled]="isStarting(row.id)"
                       (click)="activate(row)"
@@ -84,7 +88,7 @@
                     >
                       {{ "pamStartLeaseButton" | i18n }}
                     </button>
-                    <span class="tw-text-xs tw-text-muted">
+                    <span class="tw-text-xs tw-text-muted tw-whitespace-nowrap">
                       {{ "pamActivateWithin" | i18n: (row.leaseNotAfter | remainingTime: nowMs()) }}
                     </span>
                   </div>
@@ -110,19 +114,11 @@
     }
   </bit-accordion>
 
-  <!-- Extension requests -->
-  <bit-accordion [title]="'pamMyRequestsGroupExtensions' | i18n">
-    <span slot="end" bitBadge variant="secondary">{{ extensionRows().length }}</span>
+  @if (extensionRows().length > 0) {
+    <!-- Extension requests -->
+    <bit-accordion [title]="'pamMyRequestsGroupExtensions' | i18n">
+      <span slot="end" bitBadge variant="secondary">{{ extensionRows().length }}</span>
 
-    @if (extensionRows().length === 0) {
-      <p
-        bitTypography="body2"
-        class="tw-mb-0 tw-text-muted"
-        data-testid="my-access-extensions-empty"
-      >
-        {{ "pamMyRequestsExtensionsEmpty" | i18n }}
-      </p>
-    } @else {
       <bit-table [dataSource]="extensionDataSource">
         <ng-container header>
           <tr>
@@ -182,8 +178,8 @@
           </tr>
         </ng-template>
       </bit-table>
-    }
-  </bit-accordion>
+    </bit-accordion>
+  }
 
   <!-- Currently checked out (active leases) -->
   <bit-accordion [title]="'pamMyRequestsGroupCheckedOut' | i18n">

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -10,8 +10,6 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
-import { LeasingErrorService } from "..";
-
 import { MyAccessLeaseRow, MyAccessRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
 import { MyRequestsTabComponent } from "./my-requests-tab.component";
@@ -76,7 +74,6 @@ describe("MyRequestsTabComponent", () => {
     cancel: jest.Mock;
     endLease: jest.Mock;
   };
-  let leasingErrorService: MockProxy<LeasingErrorService>;
   let toastService: MockProxy<ToastService>;
 
   function create(): void {
@@ -103,8 +100,6 @@ describe("MyRequestsTabComponent", () => {
       cancel: jest.fn().mockResolvedValue(undefined),
       endLease: jest.fn().mockResolvedValue(undefined),
     };
-    leasingErrorService = mock<LeasingErrorService>();
-    leasingErrorService.isLeasingError.mockReturnValue(false);
     toastService = mock<ToastService>();
 
     await TestBed.configureTestingModule({
@@ -112,7 +107,6 @@ describe("MyRequestsTabComponent", () => {
       providers: [
         provideRouter([]),
         { provide: MyAccessService, useValue: myAccess },
-        { provide: LeasingErrorService, useValue: leasingErrorService },
         { provide: DialogService, useValue: mock<DialogService>() },
         { provide: ToastService, useValue: toastService },
         { provide: LogService, useValue: mock<LogService>() },
@@ -197,7 +191,6 @@ describe("MyRequestsTabComponent", () => {
         ),
         { name: "AccessRequestError", variant: "Api" },
       );
-      leasingErrorService.isLeasingError.mockReturnValue(true);
       myAccess.activate.mockRejectedValue(error);
       create();
 
@@ -224,12 +217,11 @@ describe("MyRequestsTabComponent", () => {
       });
     });
 
-    it("falls back to the generic message for a leasing error that isn't the Api variant", async () => {
+    it("falls back to the generic message for an AccessRequestError-shaped failure", async () => {
       const error = Object.assign(new Error("internal detail"), {
         name: "AccessRequestError",
         variant: "SingleActiveLease",
       });
-      leasingErrorService.isLeasingError.mockReturnValue(true);
       myAccess.activate.mockRejectedValue(error);
       create();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -181,11 +181,22 @@ describe("MyRequestsTabComponent", () => {
   describe("activating an approved request", () => {
     const row = requestRow({ id: "req-1" });
 
-    it("shows the server's own message for a failed activation", async () => {
-      const error = Object.assign(new Error("The approved access window has not started yet."), {
-        name: "AccessRequestError",
-        variant: "Api",
-      });
+    it("never puts the server's raw error payload in the toast", async () => {
+      // The real `.message` on the "Api" variant, not a tidied stand-in: the SDK transport string
+      // with the whole serialized response body concatenated onto it. An earlier version of this
+      // test asserted a clean sentence here, which is why showing `e.message` looked correct in
+      // Jest while publishing the server's filesystem paths to the requester in a real browser.
+      const error = Object.assign(
+        new Error(
+          'error in response: status code 409 Conflict: {"object":"error",' +
+            '"message":"This request has not been approved yet.","validationErrors":null,' +
+            '"exceptionMessage":"This request has not been approved yet.",' +
+            '"exceptionStackTrace":"   at Bit.Services.Pam.OrganizationFeatures.Commands' +
+            ".ActivateAccessRequestCommand.ActivateAsync(Guid userId, Guid requestId) in " +
+            '/src/bitwarden_license/src/Services/Pam/.../ActivateAccessRequestCommand.cs:line 65"}',
+        ),
+        { name: "AccessRequestError", variant: "Api" },
+      );
       leasingErrorService.isLeasingError.mockReturnValue(true);
       myAccess.activate.mockRejectedValue(error);
       create();
@@ -194,8 +205,11 @@ describe("MyRequestsTabComponent", () => {
 
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "error",
-        message: "The approved access window has not started yet.",
+        message: "pamStartLeaseError",
       });
+      const shown = toastService.showToast.mock.calls[0][0].message as string;
+      expect(shown).not.toContain("exceptionStackTrace");
+      expect(shown).not.toContain("Bit.Services.Pam");
     });
 
     it("falls back to the generic message for a non-leasing failure", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -260,11 +260,10 @@ describe("MyRequestsTabComponent", () => {
   });
 
   describe("Pending section empty state", () => {
-    it("offers a link back to the vault when there is nothing pending", () => {
+    it("shows the empty-state message when there is nothing pending", () => {
       create();
 
-      const link = query('[data-testid="my-access-pending-empty"] a') as HTMLAnchorElement | null;
-      expect(link).not.toBeNull();
+      expect(query('[data-testid="my-access-pending-empty"]')).not.toBeNull();
       expect(fixture.nativeElement.textContent).toContain("pamMyRequestsPendingEmpty");
     });
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -2,13 +2,15 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
-import { mock } from "jest-mock-extended";
+import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
+
+import { LeasingErrorService } from "..";
 
 import { MyAccessLeaseRow, MyAccessRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
@@ -35,12 +37,51 @@ function leaseRow(overrides: Record<string, unknown> = {}): MyAccessLeaseRow {
   } as unknown as MyAccessLeaseRow;
 }
 
+function requestRow(overrides: Record<string, unknown> = {}): MyAccessRequestRow {
+  return {
+    id: "req-1",
+    cipherId: "cipher-1",
+    collectionId: "col-1",
+    cipherName: "Prod database",
+    collectionName: "Production",
+    status: "approved",
+    statusVariant: "info",
+    statusLabelKey: "pamStatusApproved",
+    submittedAt: "2026-08-17T11:00:00.000Z",
+    resolvedAt: "2026-08-17T11:05:00.000Z",
+    leaseNotBefore: "2026-08-17T11:00:00.000Z",
+    leaseNotAfter: "2099-01-01T00:00:00.000Z",
+    resolverLabelKey: null,
+    resolverName: "Ada",
+    approverComment: null,
+    producedLeaseId: null,
+    extendedBySeconds: null,
+    extendedUntil: null,
+    ...overrides,
+  } as unknown as MyAccessRequestRow;
+}
+
 describe("MyRequestsTabComponent", () => {
   let fixture: ComponentFixture<MyRequestsTabComponent>;
+  let component: MyRequestsTabComponent;
+  let pendingRows$: BehaviorSubject<MyAccessRequestRow[]>;
+  let extensionRows$: BehaviorSubject<MyAccessRequestRow[]>;
   let leases$: BehaviorSubject<MyAccessLeaseRow[]>;
+  let myAccess: {
+    pendingRows$: BehaviorSubject<MyAccessRequestRow[]>;
+    extensionRows$: BehaviorSubject<MyAccessRequestRow[]>;
+    leases$: BehaviorSubject<MyAccessLeaseRow[]>;
+    cipherById$: BehaviorSubject<Map<string, CipherView>>;
+    activate: jest.Mock;
+    cancel: jest.Mock;
+    endLease: jest.Mock;
+  };
+  let leasingErrorService: MockProxy<LeasingErrorService>;
+  let toastService: MockProxy<ToastService>;
 
   function create(): void {
     fixture = TestBed.createComponent(MyRequestsTabComponent);
+    component = fixture.componentInstance;
     fixture.detectChanges();
   }
 
@@ -50,23 +91,30 @@ describe("MyRequestsTabComponent", () => {
 
   beforeEach(async () => {
     jest.useFakeTimers();
+    pendingRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
+    extensionRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
     leases$ = new BehaviorSubject<MyAccessLeaseRow[]>([]);
+    myAccess = {
+      pendingRows$,
+      extensionRows$,
+      leases$,
+      cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
+      activate: jest.fn().mockResolvedValue(undefined),
+      cancel: jest.fn().mockResolvedValue(undefined),
+      endLease: jest.fn().mockResolvedValue(undefined),
+    };
+    leasingErrorService = mock<LeasingErrorService>();
+    leasingErrorService.isLeasingError.mockReturnValue(false);
+    toastService = mock<ToastService>();
 
     await TestBed.configureTestingModule({
       imports: [MyRequestsTabComponent, NoopAnimationsModule],
       providers: [
         provideRouter([]),
-        {
-          provide: MyAccessService,
-          useValue: {
-            pendingRows$: new BehaviorSubject<MyAccessRequestRow[]>([]),
-            extensionRows$: new BehaviorSubject<MyAccessRequestRow[]>([]),
-            leases$,
-            cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
-          },
-        },
+        { provide: MyAccessService, useValue: myAccess },
+        { provide: LeasingErrorService, useValue: leasingErrorService },
         { provide: DialogService, useValue: mock<DialogService>() },
-        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: ToastService, useValue: toastService },
         { provide: LogService, useValue: mock<LogService>() },
         {
           provide: I18nService,
@@ -127,6 +175,83 @@ describe("MyRequestsTabComponent", () => {
         kind: "active",
         expiresAt: new Date(LEASE_END),
       });
+    });
+  });
+
+  describe("activating an approved request", () => {
+    const row = requestRow({ id: "req-1" });
+
+    it("shows the server's own message for a failed activation", async () => {
+      const error = Object.assign(new Error("The approved access window has not started yet."), {
+        name: "AccessRequestError",
+        variant: "Api",
+      });
+      leasingErrorService.isLeasingError.mockReturnValue(true);
+      myAccess.activate.mockRejectedValue(error);
+      create();
+
+      await component["activate"](row);
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "The approved access window has not started yet.",
+      });
+    });
+
+    it("falls back to the generic message for a non-leasing failure", async () => {
+      myAccess.activate.mockRejectedValue(new Error("offline"));
+      create();
+
+      await component["activate"](row);
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamStartLeaseError",
+      });
+    });
+
+    it("falls back to the generic message for a leasing error that isn't the Api variant", async () => {
+      const error = Object.assign(new Error("internal detail"), {
+        name: "AccessRequestError",
+        variant: "SingleActiveLease",
+      });
+      leasingErrorService.isLeasingError.mockReturnValue(true);
+      myAccess.activate.mockRejectedValue(error);
+      create();
+
+      await component["activate"](row);
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamStartLeaseError",
+      });
+    });
+  });
+
+  describe("Extension requests section", () => {
+    it("does not render when there are no open extension requests", () => {
+      create();
+
+      expect(query('[data-testid="my-access-extension-req-ext"]')).toBeNull();
+      expect(fixture.nativeElement.textContent).not.toContain("pamMyRequestsGroupExtensions");
+    });
+
+    it("renders the accordion and its row once an extension request is open", () => {
+      extensionRows$.next([requestRow({ id: "req-ext", status: "pending" })]);
+      create();
+
+      expect(fixture.nativeElement.textContent).toContain("pamMyRequestsGroupExtensions");
+      expect(query('[data-testid="my-access-extension-req-ext"]')).not.toBeNull();
+    });
+  });
+
+  describe("Pending section empty state", () => {
+    it("offers a link back to the vault when there is nothing pending", () => {
+      create();
+
+      const link = query('[data-testid="my-access-pending-empty"] a') as HTMLAnchorElement | null;
+      expect(link).not.toBeNull();
+      expect(fixture.nativeElement.textContent).toContain("pamMyRequestsPendingEmpty");
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
@@ -156,7 +156,10 @@ export const Default: Story = {
   decorators: [myAccess()],
 };
 
-/** Nothing outstanding — each of the three sections carries its own empty line. */
+/**
+ * Nothing outstanding. Pending and Currently checked out carry their own empty state; Extension
+ * requests renders nothing at all — it never shows once `extensionRows()` is empty.
+ */
 export const Empty: Story = {
   decorators: [myAccess({ content: empty })],
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -35,7 +35,7 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
-import { AccessLeaseId, AccessRequestId } from "..";
+import { AccessLeaseId, AccessRequestId, LeasingErrorService } from "..";
 import { AccessBadgeState } from "../access-state-badge/access-badge-state";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationShortPipe } from "../date/duration-short.pipe";
@@ -94,6 +94,7 @@ export class MyRequestsTabComponent implements OnInit {
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
+  private readonly leasingErrorService = inject(LeasingErrorService);
 
   protected readonly cancelling = signal<Set<AccessRequestId>>(new Set());
   /** Ids of approved requests currently being activated (prevents double-click). */
@@ -306,11 +307,15 @@ export class MyRequestsTabComponent implements OnInit {
       });
     } catch (e) {
       this.logService.error(e);
-      // A taken single-active-lease slot or an org-wide freeze surfaces here; the approved request
-      // stays activatable for a manual retry.
+      // A taken single-active-lease slot or an org-wide freeze can also surface here; those, and
+      // anything else the server rejects activation for, now show verbatim via the "Api" variant
+      // rather than always the same generic string. The approved request stays activatable for a
+      // manual retry either way.
+      const serverMessage =
+        this.leasingErrorService.isLeasingError(e) && e.variant === "Api" ? e.message : undefined;
       this.toastService.showToast({
         variant: "error",
-        message: this.i18nService.t("pamStartLeaseError"),
+        message: serverMessage ?? this.i18nService.t("pamStartLeaseError"),
       });
     } finally {
       this.starting.update((s) => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -35,7 +35,7 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
-import { AccessLeaseId, AccessRequestId, LeasingErrorService } from "..";
+import { AccessLeaseId, AccessRequestId } from "..";
 import { AccessBadgeState } from "../access-state-badge/access-badge-state";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationShortPipe } from "../date/duration-short.pipe";
@@ -94,7 +94,6 @@ export class MyRequestsTabComponent implements OnInit {
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
-  private readonly leasingErrorService = inject(LeasingErrorService);
 
   protected readonly cancelling = signal<Set<AccessRequestId>>(new Set());
   /** Ids of approved requests currently being activated (prevents double-click). */
@@ -308,14 +307,19 @@ export class MyRequestsTabComponent implements OnInit {
     } catch (e) {
       this.logService.error(e);
       // A taken single-active-lease slot, an org-wide freeze, or anything else the server rejects
-      // activation for surfaces here. The "Api" variant carries the server's own message, shown
-      // verbatim; other variants fall back to the generic string. Either way the approved request
-      // stays activatable for a manual retry.
-      const serverMessage =
-        this.leasingErrorService.isLeasingError(e) && e.variant === "Api" ? e.message : undefined;
+      // activation for surfaces here; the approved request stays activatable for a manual retry.
+      //
+      // The server's own sentence is deliberately NOT shown. On the "Api" variant `.message` is the
+      // raw SDK transport string with the entire serialized response body concatenated onto it --
+      // envelope, `exceptionMessage`, and `exceptionStackTrace` carrying the server's absolute
+      // filesystem paths and internal .NET frames. Putting it in a toast published all of that to
+      // the requester (see `classifyAccessRuleError`, which exists for exactly this reason on the
+      // rule path). Surfacing the real reason needs the same treatment: a catalog mapping each
+      // sentence `ActivateAccessRequestCommand` raises to approved copy. None of those six strings
+      // has an approved key yet, so this stays generic until they do.
       this.toastService.showToast({
         variant: "error",
-        message: serverMessage ?? this.i18nService.t("pamStartLeaseError"),
+        message: this.i18nService.t("pamStartLeaseError"),
       });
     } finally {
       this.starting.update((s) => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -307,10 +307,10 @@ export class MyRequestsTabComponent implements OnInit {
       });
     } catch (e) {
       this.logService.error(e);
-      // A taken single-active-lease slot or an org-wide freeze can also surface here; those, and
-      // anything else the server rejects activation for, now show verbatim via the "Api" variant
-      // rather than always the same generic string. The approved request stays activatable for a
-      // manual retry either way.
+      // A taken single-active-lease slot, an org-wide freeze, or anything else the server rejects
+      // activation for surfaces here. The "Api" variant carries the server's own message, shown
+      // verbatim; other variants fall back to the generic string. Either way the approved request
+      // stays activatable for a manual retry.
       const serverMessage =
         this.leasingErrorService.isLeasingError(e) && e.variant === "Api" ? e.message : undefined;
       this.toastService.showToast({


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42432

## 📔 Objective

Fixes to the My requests tab's empty states and layout:

- Activating an approved request could show the raw server error, including internal stack trace and file paths, in the failure toast. It now falls back to a generic message and only ever surfaces a server-provided sentence in the one case that is safe to show; no such safe sentence exists yet, so the toast stays generic for now.
- The Extension requests section always rendered its own accordion with a permanent empty state, even though a pending extension request cannot currently occur anywhere in the product. The section now only renders when there is something in it.
- Fixed the Start button wrapping onto two lines in the pending requests table at narrow widths.

## 📸 Screenshots

<img width="1100" height="638" alt="generic-failure-toast" src="https://github.com/user-attachments/assets/84a06e7e-efd2-4efa-bf10-5372e636c510" />
![Uploading my-requests-no-empty-accordion.png…]()

