### PR TITLE
fix(pam): share approval-method label logic between the access-rules table and the collection callout

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.spec.ts
@@ -25,11 +25,10 @@ describe("accessRuleSummaryKeys", () => {
     ]);
   });
 
-  it("adds the IP restriction", () => {
+  it("reports only the IP restriction when there is no human-approval condition", () => {
     const conditions = [{ kind: "ip_allowlist", cidrs: ["10.0.0.0/8"] }];
 
     expect(accessRuleSummaryKeys(rule({ conditions }))).toEqual([
-      "pamAccessRuleConditionAutoApproved",
       "pamAccessRuleConditionIpRestricted",
     ]);
   });

--- a/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.ts
+++ b/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.ts
@@ -1,5 +1,5 @@
 import type { AccessRuleView } from "../abstractions/access-rule";
-import { isHumanApproval, isIpAllowlist } from "../abstractions/access-rule";
+import { approvalMethodLabelKeys } from "../helpers/approval-method";
 
 /** The rule fields the summary reads. */
 type SummarizableRule = Pick<AccessRuleView, "conditions" | "singleActiveLease">;
@@ -8,18 +8,15 @@ type SummarizableRule = Pick<AccessRuleView, "conditions" | "singleActiveLease">
  * The i18n keys summarising what a rule enforces, in a fixed order — approval mode first (every rule
  * has one), then the optional restrictions.
  *
+ * Delegates the approval/IP keys to `approvalMethodLabelKeys` so this always agrees with the
+ * access-rules table on how a rule grants access; only the single-active-user addition is specific
+ * to this summary.
+ *
  * Returns keys rather than translated text so this stays free of `I18nService` and unit-testable
  * without one; the template joins and translates them.
  */
 export function accessRuleSummaryKeys(rule: SummarizableRule): string[] {
-  const keys: string[] = [
-    rule.conditions.some(isHumanApproval)
-      ? "pamAccessRuleConditionRequiresApproval"
-      : "pamAccessRuleConditionAutoApproved",
-  ];
-  if (rule.conditions.some(isIpAllowlist)) {
-    keys.push("pamAccessRuleConditionIpRestricted");
-  }
+  const keys = approvalMethodLabelKeys(rule.conditions);
   if (rule.singleActiveLease) {
     keys.push("pamAccessRuleSingleActiveUser");
   }

--- a/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.ts
+++ b/bitwarden_license/bit-web/src/app/pam/collection-access-rule-callout/access-rule-summary.ts
@@ -5,8 +5,8 @@ import { approvalMethodLabelKeys } from "../helpers/approval-method";
 type SummarizableRule = Pick<AccessRuleView, "conditions" | "singleActiveLease">;
 
 /**
- * The i18n keys summarising what a rule enforces, in a fixed order — approval mode first (every rule
- * has one), then the optional restrictions.
+ * The i18n keys summarising what a rule enforces, in a fixed order — how the rule grants access
+ * first, then the optional restrictions.
  *
  * Delegates the approval/IP keys to `approvalMethodLabelKeys` so this always agrees with the
  * access-rules table on how a rule grants access; only the single-active-user addition is specific


### PR DESCRIPTION
# fix(pam): share approval-method label logic between the access-rules table and the collection callout

This PR targets `pam/uat`, not the default branch, and is part of a stack rooted on `pam/uat`. It follows the access-rules table and badge work already in the stack (the PR that introduced `approvalMethodLabelKeys` in `bitwarden_license/bit-web/src/app/pam/helpers/approval-method.ts`); read that PR first, since this one only changes a second caller of the helper it added.

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42252

## 📔 Objective

`access-rule-summary.ts` (used by the collection access-rule callout) had its own inline derivation of the approval-method and IP-restriction i18n keys, duplicating the logic already centralized in `approvalMethodLabelKeys()` for the access-rules table. This PR switches `accessRuleSummaryKeys()` to call that shared helper instead of re-deriving the same keys locally, so the callout and the table can no longer drift out of sync on how a rule's access method is described.

The behavior changes in one respect: previously, a rule with only an `ip_allowlist` condition (no `human_approval` condition) reported both `pamAccessRuleConditionAutoApproved` and `pamAccessRuleConditionIpRestricted`. The shared helper only falls back to the auto-approved key when neither `human_approval` nor `ip_allowlist` is present, so such a rule now reports `pamAccessRuleConditionIpRestricted` alone, matching how the access-rules table already described the same rule. The spec in this PR is updated to assert that corrected behavior.

The single-active-user addition (`pamAccessRuleSingleActiveUser`) stays local to `accessRuleSummaryKeys()`, since it is specific to the collection callout and not part of the shared helper's contract.

## 📸 Screenshots

Known gap: screenshots could not be captured for this PR. Storybook was started locally on port 6100 and progressed through a healthy webpack build (build events observed up to roughly the halfway point), but did not finish compiling before this check had to conclude, so no before/after screenshots were captured for `web-pam-collection-access-rule-callout--multiple-rules` or `web-pam-collection-access-rule-callout--all-conditions`. This was a build-time issue only, not a code or environment failure; a re-run with more time budget should succeed.

## Known gaps

- No before/after screenshots (see above). The change is a pure logic delegation with a one-line spec update, so a reviewer can verify correctness by reading `access-rule-summary.ts` and `access-rule-summary.spec.ts` directly, but visual confirmation of the callout rendering is still outstanding.
- Visual QA on this same milestone separately reported it could not complete browser-based verification (`darkThemeOk=false`, 2 failed assertions) because chrome-devtools-mcp's browser lock was held by sibling agents running concurrently in this session, not because of any problem found in the change. Storybook itself was confirmed up and freshly built from this HEAD during that check. Recommend re-running Visual QA once the sibling agents release the shared browser profile, or with a dedicated `--isolated` profile.


---

_Reopened as a new PR: #22565 could not be reopened after its branch was rebuilt on top of the current `pam/uat`. The original PR showed a 222-file diff because `pam/uat` was rebased on 2026-08-21, which orphaned this branch's commits and caused CODEOWNERS to request review from teams that own none of these files. The branch now contains a single commit and a 2-file diff._
