### PR TITLE
[PM-39460] Add `v2_encrypted_migrations_grace_period_start` to state bridge

### DIFF
--- a/libs/common/src/key-management/state-bridge.ts
+++ b/libs/common/src/key-management/state-bridge.ts
@@ -4,10 +4,12 @@ import { filter, firstValueFrom, map, race, timer } from "rxjs";
 // eslint-disable-next-line no-restricted-imports
 import { fromSdkKdfConfig, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
 import {
+  DateTime,
   EncString,
   MasterPasswordUnlockData as SdkMasterPasswordUnlockData,
   PasswordProtectedKeyEnvelope,
   SymmetricKey,
+  Utc,
   V2UpgradeToken,
   WasmStateBridge,
   WebAuthnPrfUnlockData as SdkWebAuthnPrfUnlockData,
@@ -31,6 +33,7 @@ import {
   USER_KEY,
   USER_KEY_ENCRYPTED_PIN,
   USER_KEY_ID,
+  V2_ENCRYPTED_MIGRATIONS_GRACE_PERIOD_START,
   V2_UPGRADE_TOKEN,
   WEBAUTHN_PRF_OPTIONS,
 } from "./state-definitions";
@@ -236,5 +239,27 @@ export class JsWasmStateBridge implements WasmStateBridge {
 
   async clear_user_key_id(): Promise<void> {
     await deleteAtomic(this.stateProvider, this.userId, USER_KEY_ID);
+  }
+
+  async set_v2_encrypted_migrations_grace_period_start(value: DateTime<Utc>): Promise<void> {
+    await writeAtomic(
+      this.stateProvider,
+      this.userId,
+      V2_ENCRYPTED_MIGRATIONS_GRACE_PERIOD_START,
+      new Date(value),
+    );
+  }
+
+  async get_v2_encrypted_migrations_grace_period_start(): Promise<DateTime<Utc> | null> {
+    const value = await readAtomic(
+      this.stateProvider,
+      this.userId,
+      V2_ENCRYPTED_MIGRATIONS_GRACE_PERIOD_START,
+    );
+    return value?.toISOString() ?? null;
+  }
+
+  async clear_v2_encrypted_migrations_grace_period_start(): Promise<void> {
+    await deleteAtomic(this.stateProvider, this.userId, V2_ENCRYPTED_MIGRATIONS_GRACE_PERIOD_START);
   }
 }

--- a/libs/common/src/key-management/state-definitions.ts
+++ b/libs/common/src/key-management/state-definitions.ts
@@ -20,6 +20,7 @@ import {
 import {
   CRYPTO_DISK,
   CRYPTO_MEMORY,
+  ENCRYPTED_MIGRATION_DISK,
   KDF_CONFIG_DISK,
   MASTER_PASSWORD_UNLOCK_DISK,
   PIN_DISK,
@@ -168,6 +169,21 @@ export const USER_KEY_ENCRYPTED_PIN = new UserKeyDefinition<EncString>(
   {
     deserializer: (jsonValue) => jsonValue,
     clearOn: ["logout"],
+    cleanupDelayMs: 0, // Prevents the state from caching and rxjs observable becoming hot observable.
+  },
+);
+
+/**
+ * Timestamp for delaying v2 encrypted migrations. Stored on disk, the timestamp
+ * records the first time a user logs in while eligible for v2 encrypted migrations.
+ * User prompts are only shown once a grace period has elapsed since the timestamp.
+ */
+export const V2_ENCRYPTED_MIGRATIONS_GRACE_PERIOD_START = new UserKeyDefinition<Date>(
+  ENCRYPTED_MIGRATION_DISK,
+  "v2EncryptedMigrationsGracePeriodStart",
+  {
+    deserializer: (obj: string) => (obj != null ? new Date(obj) : null),
+    clearOn: [], // Doesn't clear on logout, we don't want users who regularly log in to indefinitely avoid the migration prompt.
     cleanupDelayMs: 0, // Prevents the state from caching and rxjs observable becoming hot observable.
   },
 );


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39460

## 📔 Objective

Adds support to KM state bridge bridge for soon-to-be-added `v2_encrypted_migrations_grace_period_start` state. State is stored in already existing `ENCRYPTED_MIGRATION_DISK` state repository. `v2_encrypted_migrations_grace_period_start` will be added in [sdk-internal#1419](https://github.com/bitwarden/sdk-internal/pull/1419)
