### PR TITLE
Confirm before withdrawing an access request

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
@@ -116,12 +116,22 @@ Two services drive every refresh:
 - `AccessEventService` — the server's `RefreshAccessRequest` push, filtered to a bare tick.
 - `AccessRefreshService` — merges that push with this client's own mutations and fans it
   out per cipher, so the cipher-view banner and the gated-cipher reloader react to a local
-  change and a remote one through exactly the same path.
+  change and a remote one through exactly the same path. Subscribing without a cipher id
+  means "whichever item changed, tell me": the reading a surface whose state spans the
+  caller's whole vault needs, since a request for an item it holds no row for yet still
+  belongs on it.
 
-Page-level services (`MyAccessService`, `ApproverInboxService`,
-`AccessRequestDetailService`) subscribe to the push directly and reload. Use `concatMap`,
-not `switchMap`: two pushes arriving together must not interleave their loads and leave
-several subjects describing different moments.
+`MyAccessService` subscribes to `AccessRefreshService` unscoped, so a withdrawal made in the
+request drawer — which announces through the shared cancel flow — reconciles the list behind
+it. `ApproverInboxService` and `AccessRequestDetailService` subscribe to the push directly.
+Use `concatMap`, not `switchMap`: two announcements arriving together must not interleave
+their loads and leave several subjects describing different moments.
+
+A surface that reconciles its own mutation optimistically must not announce that mutation:
+the announcement comes straight back as a reload that discards the patch. `MyAccessService`
+therefore stays quiet on `cancel`/`endLease`, and the "My requests" rows borrow only the
+shared _confirmation_ (`AccessRequestCancelService.confirmWithdrawal`), not the shared
+withdrawal.
 
 ## OSS seams
 

--- a/bitwarden_license/bit-web/src/app/pam/abstractions/access-refresh.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/abstractions/access-refresh.service.ts
@@ -18,8 +18,12 @@ export abstract class AccessRefreshService {
    * Emits whenever `cipherId`'s access state may have changed — either because this client mutated
    * it or because every cipher was invalidated at once (see {@link notifyAccessChanged}). Never
    * completes; consumers own their teardown.
+   *
+   * Omit `cipherId` to hear every announcement whichever item it names: the reading a page-level
+   * surface needs, since its state spans the caller's whole vault and any one of those mutations
+   * can add, remove, or re-status a row on it.
    */
-  abstract accessChanged$(cipherId: string): Observable<void>;
+  abstract accessChanged$(cipherId?: string): Observable<void>;
 
   /**
    * Announce that access changed. Pass a `cipherId` to invalidate one item, or omit it to

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.spec.ts
@@ -158,13 +158,12 @@ describe("AccessRequestDetailService", () => {
   });
 
   describe("mutations re-fetch to reconcile", () => {
-    it("cancels then re-fetches", async () => {
+    it("re-reads the loaded request on demand", async () => {
       await setup();
       requestsApi.getAccessRequest.mockClear();
 
-      await service.cancel();
+      await service.reload();
 
-      expect(requestsApi.cancelAccessRequest).toHaveBeenCalledWith(REQUEST_ID);
       expect(requestsApi.getAccessRequest).toHaveBeenCalledTimes(1);
     });
 
@@ -192,10 +191,12 @@ describe("AccessRequestDetailService", () => {
       requestsApi.getAccessRequest.mockRejectedValue(new Error("boom"));
       await setup();
 
-      await service.cancel();
+      requestsApi.getAccessRequest.mockClear();
+
+      await service.reload();
       await service.activate();
 
-      expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
+      expect(requestsApi.getAccessRequest).not.toHaveBeenCalled();
       expect(requestsApi.activateAccessRequest).not.toHaveBeenCalled();
     });
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.ts
@@ -32,7 +32,9 @@ import {
 /**
  * Loads and holds the single access request behind the request drawer — one of the caller's own
  * requests — resolving display names from local vault state and owning the requester-facing
- * mutations (cancel / activate / end lease). Approve/Deny is not offered here: a requester never
+ * mutations (activate / end lease). Withdrawal is not one of them: it runs through the shared
+ * `AccessRequestCancelService`, which every surface that withdraws a request goes through, and the
+ * drawer just reloads afterwards. Approve/Deny is not offered here either: a requester never
  * decides their own request (that's the deferred approver-inbox flow).
  *
  * Drawer-scoped (provided on the drawer component, not root), so each open gets its own instance.
@@ -87,13 +89,16 @@ export class AccessRequestDetailService {
     this._id$.next(id);
   }
 
-  /** Cancel/withdraw the loaded request, then reload to surface the canceled status. */
-  async cancel(): Promise<void> {
+  /**
+   * Re-read the loaded request. Withdrawal is not one of the mutations owned here: it runs through
+   * the shared `AccessRequestCancelService` flow, which confirms first, so the drawer reloads
+   * through this instead of cancelling itself.
+   */
+  async reload(): Promise<void> {
     const id = this._request$.value?.id;
     if (id == null) {
       return;
     }
-    await this.requestsApi.cancelAccessRequest(id);
     await this.fetch(id);
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
@@ -142,13 +142,13 @@
         <button
           type="button"
           bitButton
-          buttonType="secondary"
+          buttonType="danger"
           id="access-request_button_cancel"
           [loading]="cancelling()"
           [disabled]="cancelling()"
           (click)="cancel()"
         >
-          {{ "cancel" | i18n }}
+          {{ "pendingStateCancelRequest" | i18n }}
         </button>
       }
       @if (canEndLease()) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
@@ -2,7 +2,7 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, NEVER } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
@@ -16,6 +16,10 @@ import {
 } from "@bitwarden/components";
 
 import type { AccessRequestView } from "../../abstractions/access-lease";
+import { AccessRefreshService } from "../../abstractions/access-refresh.service";
+import { AccessRequestSdkService } from "../../abstractions/access-request-sdk.service";
+import { AccessRequestCancelService } from "../../services/access-request-cancel.service";
+import { DefaultAccessRefreshService } from "../../services/default-access-refresh.service";
 import { automaticDecision, humanDecision, selfEndDecision } from "../../testing/decision-builders";
 import {
   AccessNameResolverService,
@@ -55,13 +59,14 @@ describe("AccessRequestRouteComponent", () => {
     loadError$: BehaviorSubject<unknown | null>;
     names$: BehaviorSubject<ResolvedNames>;
     cipherById$: BehaviorSubject<Map<string, CipherView>>;
-    cancel: jest.Mock;
+    reload: jest.Mock;
     activate: jest.Mock;
     endLease: jest.Mock;
     setRequest: jest.Mock;
   };
   let dialogService: MockProxy<DialogService>;
   let toastService: MockProxy<ToastService>;
+  let requestsApi: MockProxy<AccessRequestSdkService>;
   let drawerRef: { isDrawer: true; close: jest.Mock };
 
   function create(): void {
@@ -86,7 +91,7 @@ describe("AccessRequestRouteComponent", () => {
         collectionNameById: new Map([["col-1", "Production"]]),
       }),
       cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
-      cancel: jest.fn().mockResolvedValue(undefined),
+      reload: jest.fn().mockResolvedValue(undefined),
       activate: jest.fn().mockResolvedValue(undefined),
       endLease: jest.fn().mockResolvedValue(undefined),
       setRequest: jest.fn(),
@@ -95,18 +100,43 @@ describe("AccessRequestRouteComponent", () => {
     dialogService = mock<DialogService>();
     toastService = mock<ToastService>();
     dialogService.openSimpleDialog.mockResolvedValue(true);
+    requestsApi = mock<AccessRequestSdkService>();
+    // The shared cancel flow re-reads the request rather than trusting what was rendered, so the
+    // read tracks whatever the drawer is currently showing.
+    requestsApi.getAccessRequest.mockImplementation(async () => detail.request$.value!);
+    const logService = mock<LogService>();
+    const i18nService = {
+      t: (key: string, ...args: unknown[]) => [key, ...args].join(" "),
+    } as I18nService;
+    // No push in these tests: the flow is exercised through local mutations only.
+    const accessRefresh = new DefaultAccessRefreshService({
+      accessChanged$: () => NEVER,
+      approverInboxChanged$: () => NEVER,
+    });
 
     await TestBed.configureTestingModule({
       imports: [AccessRequestRouteComponent, NoopAnimationsModule],
       providers: [
         { provide: DialogService, useValue: dialogService },
         { provide: ToastService, useValue: toastService },
-        { provide: LogService, useValue: mock<LogService>() },
+        { provide: LogService, useValue: logService },
         { provide: DIALOG_DATA, useValue: { requestId: "req-1" } },
         { provide: DrawerRef, useValue: drawerRef },
+        { provide: I18nService, useValue: i18nService },
+        { provide: AccessRequestSdkService, useValue: requestsApi },
+        { provide: AccessRefreshService, useValue: accessRefresh },
+        // The real shared cancel flow over the same mocks, so the drawer's withdraw behaviour —
+        // confirmation included — is exercised end to end rather than stubbed past.
         {
-          provide: I18nService,
-          useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
+          provide: AccessRequestCancelService,
+          useValue: new AccessRequestCancelService(
+            requestsApi,
+            accessRefresh,
+            dialogService,
+            toastService,
+            i18nService,
+            logService,
+          ),
         },
       ],
     })
@@ -179,6 +209,17 @@ describe("AccessRequestRouteComponent", () => {
 
       expect(component["cipherName"]()).toBe("cipher-1");
       expect(component["collectionName"]()).toBeNull();
+    });
+
+    it("names the withdraw action and renders it as the destructive one", () => {
+      create();
+
+      const button = fixture.nativeElement.querySelector(
+        "#access-request_button_cancel",
+      ) as HTMLElement;
+      expect(button).not.toBeNull();
+      expect(button.textContent?.trim()).toBe("pendingStateCancelRequest");
+      expect(button.getAttribute("buttonType")).toBe("danger");
     });
 
     it("identifies the requester by name, then email, then id", () => {
@@ -459,28 +500,62 @@ describe("AccessRequestRouteComponent", () => {
   });
 
   describe("actions", () => {
-    it("cancels and toasts", async () => {
+    it("asks the shared confirmation before withdrawing, then cancels and reloads", async () => {
       create();
 
       await component["cancel"]();
 
-      expect(detail.cancel).toHaveBeenCalled();
-      expect(toastService.showToast).toHaveBeenCalledWith({
-        variant: "success",
-        message: "pamMyRequestsCanceledToast",
-      });
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: { key: "pamCancelRequestTitle" },
+          content: { key: "pamCancelRequestPendingConfirm" },
+          acceptButtonText: { key: "pendingStateCancelRequest" },
+          cancelButtonText: { key: "pamKeepRequest" },
+          type: "danger",
+        }),
+      );
+      expect(requestsApi.cancelAccessRequest).toHaveBeenCalledWith("req-1");
+      expect(detail.reload).toHaveBeenCalled();
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "success",
+          message: "pamCancelRequestCanceledToast",
+        }),
+      );
+    });
+
+    it("describes an approved request's withdrawal in its own words", async () => {
+      detail.request$.next(request({ status: "approved" }));
+      create();
+
+      await component["cancel"]();
+
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ content: { key: "pamCancelRequestApprovedConfirm" } }),
+      );
+    });
+
+    it("withdraws nothing when the confirmation is declined", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+      create();
+
+      await component["cancel"]();
+
+      expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
+      expect(detail.reload).not.toHaveBeenCalled();
+      expect(toastService.showToast).not.toHaveBeenCalled();
     });
 
     it("toasts an error when cancelling fails", async () => {
-      detail.cancel.mockRejectedValue(new Error("boom"));
+      requestsApi.cancelAccessRequest.mockRejectedValue(new Error("boom"));
       create();
 
       await component["cancel"]();
 
-      expect(toastService.showToast).toHaveBeenCalledWith({
-        variant: "error",
-        message: "pamMyRequestsCancelError",
-      });
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error", message: "pendingStateCancelError" }),
+      );
+      expect(detail.reload).not.toHaveBeenCalled();
     });
 
     it("starts access and toasts", async () => {
@@ -528,7 +603,7 @@ describe("AccessRequestRouteComponent", () => {
       await component["startAccess"]();
       await component["endLease"]();
 
-      expect(detail.cancel).not.toHaveBeenCalled();
+      expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
       expect(detail.activate).not.toHaveBeenCalled();
       expect(detail.endLease).not.toHaveBeenCalled();
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.stories.ts
@@ -11,6 +11,7 @@ import type { AccessRequestView } from "../../abstractions/access-lease";
 import { AccessLeaseSdkService } from "../../abstractions/access-lease-sdk.service";
 import { AccessRequestSdkService } from "../../abstractions/access-request-sdk.service";
 import { LeasingErrorService } from "../../abstractions/leasing-error.service";
+import { AccessRequestCancelService } from "../../services/access-request-cancel.service";
 import {
   DAY,
   HOUR,
@@ -75,6 +76,12 @@ function detail(options: { request?: () => AccessRequestView; error?: unknown } 
       { provide: DIALOG_DATA, useValue: { requestId: "req-1" } },
       { provide: DrawerRef, useValue: { isDrawer: true, close: () => {} } },
       { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
+      // Withdrawal runs through the shared cancel flow, which owns its own confirmation. The
+      // stub declines, matching the DialogService stub above.
+      {
+        provide: AccessRequestCancelService,
+        useValue: { cancelRequestById: () => Promise.resolve(false) },
+      },
       { provide: ToastService, useValue: { showToast: () => {} } },
     ],
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -45,6 +45,7 @@ import {
 } from "../..";
 import { AccessStateBadgeComponent } from "../../access-state-badge/access-state-badge.component";
 import { RemainingTimePipe } from "../../date/remaining-time.pipe";
+import { AccessRequestCancelService } from "../../services/access-request-cancel.service";
 import { AccessNameResolverService, emptyResolvedNames } from "../access-name-resolver.service";
 import { historyDisplayStatus } from "../my-access-row";
 
@@ -118,6 +119,7 @@ export class AccessRequestRouteComponent implements OnInit {
   }
 
   private readonly detail = inject(AccessRequestDetailService);
+  private readonly cancelService = inject(AccessRequestCancelService);
   private readonly drawerRef = inject<DrawerRef<undefined>>(DrawerRef);
   private readonly params = inject<AccessRequestDrawerParams>(DIALOG_DATA);
   private readonly dialogService = inject(DialogService);
@@ -312,22 +314,15 @@ export class AccessRequestRouteComponent implements OnInit {
   }
 
   protected async cancel(): Promise<void> {
-    if (!this.canCancel() || this.cancelling()) {
+    const request = this.request();
+    if (request == null || !this.canCancel() || this.cancelling()) {
       return;
     }
     this.cancelling.set(true);
     try {
-      await this.detail.cancel();
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamMyRequestsCanceledToast"),
-      });
-    } catch (e) {
-      this.logService.error(e);
-      this.toastService.showToast({
-        variant: "error",
-        message: this.i18nService.t("pamMyRequestsCancelError"),
-      });
+      if (await this.cancelService.cancelRequestById(request.id)) {
+        await this.detail.reload();
+      }
     } finally {
       this.cancelling.set(false);
     }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from "@angular/core/testing";
 import { mock, MockProxy } from "jest-mock-extended";
-import { firstValueFrom, Subject } from "rxjs";
+import { firstValueFrom, NEVER, Subject } from "rxjs";
 
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { DialogService, ToastService } from "@bitwarden/components";
 import type {
   AccessLeaseId,
   AccessLeaseView,
@@ -9,7 +12,9 @@ import type {
   AccessRequestView,
 } from "@bitwarden/sdk-internal";
 
-import { AccessEventService, AccessLeaseSdkService, AccessRequestSdkService } from "..";
+import { AccessLeaseSdkService, AccessRefreshService, AccessRequestSdkService } from "..";
+import { AccessRequestCancelService } from "../services/access-request-cancel.service";
+import { DefaultAccessRefreshService } from "../services/default-access-refresh.service";
 
 import {
   AccessNameResolverService,
@@ -59,18 +64,30 @@ function lease(id: string, overrides: Record<string, unknown> = {}): AccessLease
   } as unknown as AccessLeaseView;
 }
 
+/** Lets the reload triggered by an announcement settle before the assertions read state. */
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("MyAccessService", () => {
   let service: MyAccessService;
   let requestsApi: MockProxy<AccessRequestSdkService>;
   let leasesApi: MockProxy<AccessLeaseSdkService>;
   let nameResolver: MockProxy<AccessNameResolverService>;
   let push$: Subject<void>;
+  let accessRefresh: DefaultAccessRefreshService;
 
   beforeEach(() => {
     push$ = new Subject<void>();
     requestsApi = mock<AccessRequestSdkService>();
     leasesApi = mock<AccessLeaseSdkService>();
     nameResolver = mock<AccessNameResolverService>();
+    // The real fan-out, not a mock: the point of these tests is that the page reacts to what the
+    // shared signal actually merges — the server push and this client's own mutations alike.
+    accessRefresh = new DefaultAccessRefreshService({
+      accessChanged$: () => push$.asObservable(),
+      approverInboxChanged$: () => NEVER,
+    });
 
     requestsApi.listMyAccessRequests.mockResolvedValue([]);
     leasesApi.listMyLeases.mockResolvedValue([]);
@@ -79,7 +96,7 @@ describe("MyAccessService", () => {
     TestBed.configureTestingModule({
       providers: [
         MyAccessService,
-        { provide: AccessEventService, useValue: { accessChanged$: () => push$.asObservable() } },
+        { provide: AccessRefreshService, useValue: accessRefresh },
         { provide: AccessRequestSdkService, useValue: requestsApi },
         { provide: AccessLeaseSdkService, useValue: leasesApi },
         { provide: AccessNameResolverService, useValue: nameResolver },
@@ -287,6 +304,73 @@ describe("MyAccessService", () => {
       const rows = await firstValueFrom(service.pendingRows$);
       expect(rows).toHaveLength(1);
       expect(rows[0].status).toBe("approved");
+    });
+
+    it("reloads when another surface announces a change to one of the caller's items", async () => {
+      await service.load();
+      requestsApi.listMyAccessRequests.mockClear();
+      leasesApi.listMyLeases.mockClear();
+
+      accessRefresh.notifyAccessChanged("cipher-1");
+      await flushMicrotasks();
+
+      expect(requestsApi.listMyAccessRequests).toHaveBeenCalledTimes(1);
+      expect(leasesApi.listMyLeases).toHaveBeenCalledTimes(1);
+    });
+
+    it("reloads when the announcement names no cipher", async () => {
+      await service.load();
+      requestsApi.listMyAccessRequests.mockClear();
+
+      // What a failed re-read announces: no id to scope to, so every surface re-reads.
+      accessRefresh.notifyAccessChanged(undefined);
+      await flushMicrotasks();
+
+      expect(requestsApi.listMyAccessRequests).toHaveBeenCalledTimes(1);
+    });
+
+    it("reconciles the list when the shared cancel flow withdraws a request from another surface", async () => {
+      requestsApi.listMyAccessRequests.mockResolvedValue([request("req-1", { status: "pending" })]);
+      await service.load();
+      expect(await firstValueFrom(service.pendingRows$)).toHaveLength(1);
+
+      // The request drawer's withdrawal: a different surface, sharing only the refresh signal.
+      const dialogService = mock<DialogService>();
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+      const i18nService = mock<I18nService>();
+      i18nService.t.mockImplementation((key) => key);
+      const cancelService = new AccessRequestCancelService(
+        requestsApi,
+        accessRefresh,
+        dialogService,
+        mock<ToastService>(),
+        i18nService,
+        mock<LogService>(),
+      );
+      requestsApi.getAccessRequest.mockResolvedValue(request("req-1", { status: "pending" }));
+      requestsApi.listMyAccessRequests.mockResolvedValue([
+        request("req-1", { status: "canceled", resolvedAt: "2024-01-01T00:30:00.000Z" }),
+      ]);
+
+      await cancelService.cancelRequestById("req-1" as unknown as AccessRequestId);
+      await flushMicrotasks();
+
+      expect(await firstValueFrom(service.pendingRows$)).toEqual([]);
+      const history = await firstValueFrom(service.historyRows$);
+      expect(history.map((r) => r.id)).toEqual(["req-1"]);
+    });
+
+    it("does not reload after its own optimistic mutation", async () => {
+      requestsApi.listMyAccessRequests.mockResolvedValue([request("req-1", { status: "pending" })]);
+      await service.load();
+      requestsApi.listMyAccessRequests.mockClear();
+
+      await service.cancel("req-1" as unknown as AccessRequestId);
+      await flushMicrotasks();
+
+      // Announcing its own patch would only replace it with a load, and each load would announce
+      // again; the page reconciles locally and stays quiet.
+      expect(requestsApi.listMyAccessRequests).not.toHaveBeenCalled();
     });
 
     it("serialises overlapping pushes so state never mixes two loads", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
@@ -6,10 +6,10 @@ import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.se
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
 import {
-  AccessEventService,
   AccessLeaseId,
   AccessLeaseSdkService,
   AccessLeaseView,
+  AccessRefreshService,
   AccessRequestId,
   AccessRequestSdkService,
   AccessRequestView,
@@ -35,9 +35,11 @@ import {
  * loads them, resolves display names, and performs the request/lease lifecycle mutations
  * (activate, cancel, end) via the Rust-SDK-served services
  * (`AccessRequestSdkService`/`AccessLeaseSdkService`). The page loads on open, reloads on every
- * server-pushed access event ({@link AccessEventService}) so an approver's decision appears without a
- * refresh, and after its own mutations reconciles itself either via an optimistic local patch
- * (cancel/endLease) or an explicit reload (activate).
+ * announcement from {@link AccessRefreshService} — the server push merged with the mutations other
+ * surfaces make, so an approver's decision and a withdrawal made in the request drawer both land
+ * here without a refresh — and after its own mutations reconciles itself either via an optimistic
+ * local patch (cancel/endLease) or an explicit reload (activate). Its own mutations deliberately do
+ * not announce: they have already reconciled, and announcing would replace that patch with a load.
  *
  * Provided on the "Access requests" shell route so each visit gets one instance shared across its
  * tabs. View concerns (toasts, confirm dialogs, the live countdown clock, action gating) stay in
@@ -48,7 +50,7 @@ export class MyAccessService {
   private readonly requestsApi = inject(AccessRequestSdkService);
   private readonly leasesApi = inject(AccessLeaseSdkService);
   private readonly nameResolver = inject(AccessNameResolverService);
-  private readonly accessEvents = inject(AccessEventService);
+  private readonly accessRefresh = inject(AccessRefreshService);
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly _requests$ = new BehaviorSubject<AccessRequestView[]>([]);
@@ -149,10 +151,14 @@ export class MyAccessService {
   );
 
   constructor() {
-    // Reload on every access push. `concatMap` (not `switchMap`) so two pushes arriving close
-    // together cannot interleave their loads and leave the three subjects describing different
-    // moments; an in-flight load always finishes before the next starts.
-    this.accessEvents
+    // Unscoped: this page's rows span every item the caller has asked for, so a change to any one
+    // of them can add or re-status a row here — including a request for an item that has none yet,
+    // which a cipher-scoped subscription could not have been listening for.
+    //
+    // `concatMap` (not `switchMap`) so two announcements arriving close together cannot interleave
+    // their loads and leave the three subjects describing different moments; an in-flight load
+    // always finishes before the next starts.
+    this.accessRefresh
       .accessChanged$()
       .pipe(
         concatMap(() => from(this.load())),

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -107,13 +107,13 @@
                   <button
                     type="button"
                     bitButton
-                    buttonType="secondary"
+                    buttonType="danger"
                     size="small"
                     [disabled]="isCancelling(row.id)"
                     (click)="cancel(row)"
                     [attr.data-testid]="'my-access-pending-cancel-' + row.id"
                   >
-                    {{ "cancel" | i18n }}
+                    {{ "pendingStateCancelRequest" | i18n }}
                   </button>
                 }
               </div>
@@ -188,13 +188,13 @@
                 <button
                   type="button"
                   bitButton
-                  buttonType="secondary"
+                  buttonType="danger"
                   size="small"
                   [disabled]="isCancelling(row.id)"
                   (click)="cancel(row)"
                   [attr.data-testid]="'my-access-extension-cancel-' + row.id"
                 >
-                  {{ "cancel" | i18n }}
+                  {{ "pendingStateCancelRequest" | i18n }}
                 </button>
               }
             </td>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -107,13 +107,13 @@
                   <button
                     type="button"
                     bitButton
-                    buttonType="danger"
+                    buttonType="secondary"
                     size="small"
                     [disabled]="isCancelling(row.id)"
                     (click)="cancel(row)"
                     [attr.data-testid]="'my-access-pending-cancel-' + row.id"
                   >
-                    {{ "pendingStateCancelRequest" | i18n }}
+                    {{ "cancel" | i18n }}
                   </button>
                 }
               </div>
@@ -188,13 +188,13 @@
                 <button
                   type="button"
                   bitButton
-                  buttonType="danger"
+                  buttonType="secondary"
                   size="small"
                   [disabled]="isCancelling(row.id)"
                   (click)="cancel(row)"
                   [attr.data-testid]="'my-access-extension-cancel-' + row.id"
                 >
-                  {{ "pendingStateCancelRequest" | i18n }}
+                  {{ "cancel" | i18n }}
                 </button>
               }
             </td>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -11,6 +11,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
+import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 import { tableColumnVisibility } from "../testing/table-columns";
 
 import { MyAccessLeaseRow, MyAccessRequestRow } from "./my-access-row";
@@ -78,6 +79,7 @@ describe("MyRequestsTabComponent", () => {
     endLease: jest.Mock;
   };
   let toastService: MockProxy<ToastService>;
+  let cancelService: MockProxy<AccessRequestCancelService>;
 
   function create(): void {
     fixture = TestBed.createComponent(MyRequestsTabComponent);
@@ -104,12 +106,15 @@ describe("MyRequestsTabComponent", () => {
       endLease: jest.fn().mockResolvedValue(undefined),
     };
     toastService = mock<ToastService>();
+    cancelService = mock<AccessRequestCancelService>();
+    cancelService.confirmWithdrawal.mockResolvedValue(true);
 
     await TestBed.configureTestingModule({
       imports: [MyRequestsTabComponent, NoopAnimationsModule],
       providers: [
         provideRouter([]),
         { provide: MyAccessService, useValue: myAccess },
+        { provide: AccessRequestCancelService, useValue: cancelService },
         { provide: DialogService, useValue: mock<DialogService>() },
         { provide: ToastService, useValue: toastService },
         { provide: LogService, useValue: mock<LogService>() },
@@ -297,6 +302,96 @@ describe("MyRequestsTabComponent", () => {
         header: [null, "@lg", "@2xl", null],
         body: [null, "@lg", "@2xl", null],
       });
+    });
+  });
+
+  describe("withdrawing from a row", () => {
+    it("asks the shared confirmation before withdrawing, then withdraws and toasts", async () => {
+      const row = requestRow({ status: "pending" });
+      pendingRows$.next([row]);
+      create();
+
+      await component["cancel"](row);
+
+      expect(cancelService.confirmWithdrawal).toHaveBeenCalledWith(true);
+      expect(myAccess.cancel).toHaveBeenCalledWith(row.id);
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "success", message: "pamMyRequestsCanceledToast" }),
+      );
+    });
+
+    it("describes an approved-but-unstarted request's withdrawal in its own words", async () => {
+      const row = requestRow({ status: "approved" });
+      pendingRows$.next([row]);
+      create();
+
+      await component["cancel"](row);
+
+      expect(cancelService.confirmWithdrawal).toHaveBeenCalledWith(false);
+    });
+
+    it("withdraws nothing when the confirmation is declined", async () => {
+      cancelService.confirmWithdrawal.mockResolvedValue(false);
+      const row = requestRow({ status: "pending" });
+      pendingRows$.next([row]);
+      create();
+
+      await component["cancel"](row);
+
+      expect(myAccess.cancel).not.toHaveBeenCalled();
+      expect(toastService.showToast).not.toHaveBeenCalled();
+      expect(component["isCancelling"](row.id)).toBe(false);
+    });
+
+    it("keeps the row busy across the confirmation, so a second click cannot re-ask", async () => {
+      const row = requestRow({ status: "pending" });
+      pendingRows$.next([row]);
+      create();
+      let confirm: (confirmed: boolean) => void = () => {};
+      cancelService.confirmWithdrawal.mockReturnValue(
+        new Promise<boolean>((resolve) => (confirm = resolve)),
+      );
+
+      const first = component["cancel"](row);
+      expect(component["isCancelling"](row.id)).toBe(true);
+      await component["cancel"](row);
+      expect(cancelService.confirmWithdrawal).toHaveBeenCalledTimes(1);
+
+      confirm(true);
+      await first;
+
+      expect(myAccess.cancel).toHaveBeenCalledTimes(1);
+      expect(component["isCancelling"](row.id)).toBe(false);
+    });
+
+    it("toasts and clears the row when the withdrawal fails", async () => {
+      const row = requestRow({ status: "pending" });
+      pendingRows$.next([row]);
+      create();
+      myAccess.cancel.mockRejectedValue(new Error("boom"));
+
+      await component["cancel"](row);
+
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error", message: "pamMyRequestsCancelError" }),
+      );
+      expect(component["isCancelling"](row.id)).toBe(false);
+    });
+
+    it("offers the withdrawal as a destructive action in both tables", () => {
+      pendingRows$.next([requestRow({ id: "req-pending", status: "pending" })]);
+      extensionRows$.next([requestRow({ id: "req-ext", status: "pending" })]);
+      create();
+
+      for (const testid of [
+        "my-access-pending-cancel-req-pending",
+        "my-access-extension-cancel-req-ext",
+      ]) {
+        const button = query(`[data-testid="${testid}"]`);
+        expect(button).not.toBeNull();
+        expect(button!.className).toContain("tw-bg-bg-danger");
+        expect(button!.textContent?.trim()).toBe("pendingStateCancelRequest");
+      }
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -378,7 +378,7 @@ describe("MyRequestsTabComponent", () => {
       expect(component["isCancelling"](row.id)).toBe(false);
     });
 
-    it("offers the withdrawal as a destructive action in both tables", () => {
+    it("offers the withdrawal as a plain secondary button in both tables", () => {
       pendingRows$.next([requestRow({ id: "req-pending", status: "pending" })]);
       extensionRows$.next([requestRow({ id: "req-ext", status: "pending" })]);
       create();
@@ -389,8 +389,9 @@ describe("MyRequestsTabComponent", () => {
       ]) {
         const button = query(`[data-testid="${testid}"]`);
         expect(button).not.toBeNull();
-        expect(button!.className).toContain("tw-bg-bg-danger");
-        expect(button!.textContent?.trim()).toBe("pendingStateCancelRequest");
+        expect(button!.className).toContain("tw-bg-bg-secondary");
+        expect(button!.className).not.toContain("tw-bg-bg-danger");
+        expect(button!.textContent?.trim()).toBe("cancel");
       }
     });
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
@@ -6,6 +6,7 @@ import { of } from "rxjs";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
+import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 import {
   DAY,
   HOUR,
@@ -129,6 +130,11 @@ function myAccess(
         },
       },
       { provide: ToastService, useValue: { showToast: () => {} } },
+      // The withdrawal confirmation is declined in stories, so a click never mutates the fixture.
+      {
+        provide: AccessRequestCancelService,
+        useValue: { confirmWithdrawal: () => Promise.resolve(false) },
+      },
     ],
   });
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -40,6 +40,7 @@ import { AccessBadgeState } from "../access-state-badge/access-badge-state";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { RemainingTimePipe } from "../date/remaining-time.pipe";
+import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 
 import { MyAccessLeaseRow, MyAccessRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
@@ -93,6 +94,7 @@ export class MyRequestsTabComponent implements OnInit {
   private readonly toastService = inject(ToastService);
   private readonly logService = inject(LogService);
   private readonly dialogService = inject(DialogService);
+  private readonly cancelService = inject(AccessRequestCancelService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
 
@@ -273,12 +275,21 @@ export class MyRequestsTabComponent implements OnInit {
     );
   }
 
+  /**
+   * Withdraw a request from its row. Asks the shared confirmation — the same question the request
+   * drawer and the cipher-view banner ask — then withdraws through {@link MyAccessService}, whose
+   * optimistic patch is what keeps the row from lingering. The row stays busy across the
+   * confirmation too, so a second click cannot open a second dialog over the same request.
+   */
   protected async cancel(row: MyAccessRequestRow): Promise<void> {
     if (!this.canCancel(row) || this.isCancelling(row.id)) {
       return;
     }
     this.cancelling.update((s) => new Set([...s, row.id]));
     try {
+      if (!(await this.cancelService.confirmWithdrawal(row.status === "pending"))) {
+        return;
+      }
       await this.myAccess.cancel(row.id);
       this.toastService.showToast({
         variant: "success",

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
@@ -160,6 +160,34 @@ describe("AccessRequestCancelService", () => {
     expect(announced).toHaveBeenCalledWith(CIPHER_ID);
   });
 
+  describe("confirmWithdrawal", () => {
+    it("asks the same question the withdrawing entry points ask, and withdraws nothing itself", async () => {
+      requestsApi.getAccessRequest.mockResolvedValue(loadedRequest());
+      await service.cancelRequestById(REQUEST_ID);
+      const withdrawnOptions = dialogService.openSimpleDialog.mock.calls[0][0];
+      requestsApi.cancelAccessRequest.mockClear();
+
+      await expect(service.confirmWithdrawal(true)).resolves.toBe(true);
+
+      expect(dialogService.openSimpleDialog.mock.calls[1][0]).toEqual(withdrawnOptions);
+      expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
+    });
+
+    it("describes the approved case in its own words", async () => {
+      await service.confirmWithdrawal(false);
+
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ content: { key: "pamCancelRequestApprovedConfirm" } }),
+      );
+    });
+
+    it("reports a declined confirmation", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+
+      await expect(service.confirmWithdrawal(true)).resolves.toBe(false);
+    });
+  });
+
   describe("cancelRequestById", () => {
     it("cancels the pending request, toasts success, and announces the change", async () => {
       requestsApi.getAccessRequest.mockResolvedValue(loadedRequest());

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.spec.ts
@@ -5,7 +5,11 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 
-import type { AccessRequestId, CipherAccessStateView } from "../abstractions/access-lease";
+import type {
+  AccessRequestId,
+  AccessRequestView,
+  CipherAccessStateView,
+} from "../abstractions/access-lease";
 import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
 
 import { AccessRequestCancelService } from "./access-request-cancel.service";
@@ -22,6 +26,15 @@ function state(overrides: Partial<CipherAccessStateView> = {}): CipherAccessStat
     approvedRequest: undefined,
     ...overrides,
   } as unknown as CipherAccessStateView;
+}
+
+function loadedRequest(overrides: Partial<AccessRequestView> = {}): AccessRequestView {
+  return {
+    id: REQUEST_ID,
+    cipherId: CIPHER_ID,
+    status: "pending",
+    ...overrides,
+  } as unknown as AccessRequestView;
 }
 
 describe("AccessRequestCancelService", () => {
@@ -145,5 +158,92 @@ describe("AccessRequestCancelService", () => {
       expect.objectContaining({ variant: "error", message: "pendingStateCancelError" }),
     );
     expect(announced).toHaveBeenCalledWith(CIPHER_ID);
+  });
+
+  describe("cancelRequestById", () => {
+    it("cancels the pending request, toasts success, and announces the change", async () => {
+      requestsApi.getAccessRequest.mockResolvedValue(loadedRequest());
+      const announced = jest.spyOn(accessRefresh, "notifyAccessChanged");
+
+      await expect(service.cancelRequestById(REQUEST_ID)).resolves.toBe(true);
+
+      expect(requestsApi.cancelAccessRequest).toHaveBeenCalledWith(REQUEST_ID);
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "success", message: "pamCancelRequestCanceledToast" }),
+      );
+      expect(announced).toHaveBeenCalledWith(CIPHER_ID);
+    });
+
+    it("asks the same question the cipher-scoped entry point asks", async () => {
+      requestsApi.getAccessRequest.mockResolvedValue(loadedRequest());
+
+      await service.cancelRequestById(REQUEST_ID);
+      const pendingOptions = dialogService.openSimpleDialog.mock.calls[0][0];
+
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        state({ pendingRequest: { id: REQUEST_ID } as never }),
+      );
+      await service.cancelOutstandingRequest(CIPHER_ID);
+
+      expect(dialogService.openSimpleDialog.mock.calls[1][0]).toEqual(pendingOptions);
+    });
+
+    it("describes the approved case in the confirmation", async () => {
+      requestsApi.getAccessRequest.mockResolvedValue(loadedRequest({ status: "approved" }));
+
+      await service.cancelRequestById(REQUEST_ID);
+
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ content: { key: "pamCancelRequestApprovedConfirm" } }),
+      );
+    });
+
+    it("withdraws nothing when the confirmation is dismissed", async () => {
+      requestsApi.getAccessRequest.mockResolvedValue(loadedRequest());
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+
+      await expect(service.cancelRequestById(REQUEST_ID)).resolves.toBe(false);
+
+      expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
+      expect(toastService.showToast).not.toHaveBeenCalled();
+    });
+
+    it("leaves a request that is no longer outstanding alone", async () => {
+      // Activated since the caller rendered it: the lease, not the request, governs access now.
+      requestsApi.getAccessRequest.mockResolvedValue(
+        loadedRequest({ status: "approved", producedLeaseId: "lease-1" as never }),
+      );
+
+      await expect(service.cancelRequestById(REQUEST_ID)).resolves.toBe(false);
+
+      expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+      expect(requestsApi.cancelAccessRequest).not.toHaveBeenCalled();
+    });
+
+    it("toasts an error and still announces the change when the cancel fails", async () => {
+      requestsApi.getAccessRequest.mockResolvedValue(loadedRequest());
+      requestsApi.cancelAccessRequest.mockRejectedValue(new Error("boom"));
+      const announced = jest.spyOn(accessRefresh, "notifyAccessChanged");
+
+      await expect(service.cancelRequestById(REQUEST_ID)).resolves.toBe(false);
+
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error", message: "pendingStateCancelError" }),
+      );
+      expect(announced).toHaveBeenCalledWith(CIPHER_ID);
+    });
+
+    it("never rejects when the request cannot even be re-read", async () => {
+      requestsApi.getAccessRequest.mockRejectedValue(new Error("boom"));
+      const announced = jest.spyOn(accessRefresh, "notifyAccessChanged");
+
+      await expect(service.cancelRequestById(REQUEST_ID)).resolves.toBe(false);
+
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error", message: "pendingStateCancelError" }),
+      );
+      // No cipher to scope the signal to, so every leasing surface re-reads.
+      expect(announced).toHaveBeenCalledWith(undefined);
+    });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
@@ -16,7 +16,9 @@ import {
  * request drawer, which starts from a REQUEST — shares this flow, so the confirmation copy and the
  * withdraw semantics cannot drift apart. The remaining pages that hold a request id
  * (`MyAccessService`, `ApproverInboxService`) keep their own cancel calls, because their
- * reload and toast semantics belong to those surfaces.
+ * reload and toast semantics belong to those surfaces. The requester-facing one of those — the
+ * "My requests" list — still asks this flow's question, through {@link confirmWithdrawal}, so the
+ * confirmation stays single-sourced even where the mutation is not.
  *
  * "Outstanding" mirrors the banner's withdraw semantics: a pending request or an
  * approved-but-unactivated one — either can be withdrawn until a lease is minted, after which
@@ -81,9 +83,21 @@ export class AccessRequestCancelService {
     }
   }
 
+  /**
+   * Ask the withdrawal confirmation on behalf of a surface that owns the mutation itself — the
+   * "My requests" list, whose rows reconcile through an optimistic local patch that a shared
+   * withdrawal would turn into a full reload. Only the question is shared; the caller still
+   * performs the withdrawal and reports its outcome.
+   *
+   * @returns whether the reader confirmed.
+   */
+  async confirmWithdrawal(pending: boolean): Promise<boolean> {
+    return await this.dialogService.openSimpleDialog(cancelConfirmation(pending));
+  }
+
   /** @returns whether the request was withdrawn, as opposed to kept. */
   private async confirmAndCancel(id: AccessRequestId, pending: boolean): Promise<boolean> {
-    const confirmed = await this.dialogService.openSimpleDialog(cancelConfirmation(pending));
+    const confirmed = await this.confirmWithdrawal(pending);
     if (!confirmed) {
       return false;
     }

--- a/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/access-request-cancel.service.ts
@@ -1,15 +1,22 @@
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { DialogService, SimpleDialogOptions, ToastService } from "@bitwarden/components";
 
-import { AccessRefreshService, AccessRequestSdkService } from "..";
+import {
+  AccessRefreshService,
+  AccessRequestId,
+  AccessRequestSdkService,
+  AccessRequestView,
+} from "..";
 
 /**
- * The one place a caller's outstanding access request for a gated cipher is withdrawn. Both
- * entry points that start from a CIPHER — the cipher-view banner and the vault-row menu — share
- * this flow; the pages that already hold a request id (`MyAccessService`,
- * `AccessRequestDetailService`, `ApproverInboxService`) keep their own cancel calls, because
- * their reload and toast semantics belong to those surfaces.
+ * The one place a caller's outstanding access request is withdrawn. Every surface that offers the
+ * withdrawal — the cipher-view banner and the vault-row menu, which start from a CIPHER, and the
+ * request drawer, which starts from a REQUEST — shares this flow, so the confirmation copy and the
+ * withdraw semantics cannot drift apart. The remaining pages that hold a request id
+ * (`MyAccessService`, `ApproverInboxService`) keep their own cancel calls, because their
+ * reload and toast semantics belong to those surfaces.
  *
  * "Outstanding" mirrors the banner's withdraw semantics: a pending request or an
  * approved-but-unactivated one — either can be withdrawn until a lease is minted, after which
@@ -39,33 +46,87 @@ export class AccessRequestCancelService {
       if (request == null) {
         return;
       }
-      const contentKey =
-        state.pendingRequest != null
-          ? "pamCancelRequestPendingConfirm"
-          : "pamCancelRequestApprovedConfirm";
-      const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "pamCancelRequestTitle" },
-        content: { key: contentKey },
-        acceptButtonText: { key: "pendingStateCancelRequest" },
-        cancelButtonText: { key: "pamKeepRequest" },
-        type: "danger",
-      });
-      if (!confirmed) {
-        return;
-      }
-      await this.accessRequestSdkService.cancelAccessRequest(request.id);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamCancelRequestCanceledToast"),
-      });
+      await this.confirmAndCancel(request.id, state.pendingRequest != null);
     } catch (e) {
-      this.logService.error(e);
-      this.toastService.showToast({
-        variant: "error",
-        message: this.i18nService.t("pendingStateCancelError"),
-      });
+      this.reportFailure(e);
     } finally {
       this.accessRefreshService.notifyAccessChanged(cipherId);
     }
   }
+
+  /**
+   * Withdraw a request the caller already holds the id of, after the same confirmation
+   * {@link cancelOutstandingRequest} shows. Re-reads the request rather than trusting the status
+   * the caller rendered, for the same reason: it may have been decided or activated since, and a
+   * request that is no longer outstanding is left alone.
+   *
+   * Never rejects, and always announces the shared refresh signal. Returns whether the request was
+   * actually withdrawn, so a surface holding its own copy of the request knows to re-read it —
+   * the refresh signal reaches the cipher-scoped surfaces, not the request-scoped ones.
+   */
+  async cancelRequestById(requestId: AccessRequestId): Promise<boolean> {
+    let cipherId: string | undefined;
+    try {
+      const request = await this.accessRequestSdkService.getAccessRequest(requestId);
+      cipherId = uuidAsString(request.cipherId);
+      if (!isOutstanding(request)) {
+        return false;
+      }
+      return await this.confirmAndCancel(request.id, request.status === "pending");
+    } catch (e) {
+      this.reportFailure(e);
+      return false;
+    } finally {
+      this.accessRefreshService.notifyAccessChanged(cipherId);
+    }
+  }
+
+  /** @returns whether the request was withdrawn, as opposed to kept. */
+  private async confirmAndCancel(id: AccessRequestId, pending: boolean): Promise<boolean> {
+    const confirmed = await this.dialogService.openSimpleDialog(cancelConfirmation(pending));
+    if (!confirmed) {
+      return false;
+    }
+    await this.accessRequestSdkService.cancelAccessRequest(id);
+    this.toastService.showToast({
+      variant: "success",
+      message: this.i18nService.t("pamCancelRequestCanceledToast"),
+    });
+    return true;
+  }
+
+  private reportFailure(e: unknown): void {
+    this.logService.error(e);
+    this.toastService.showToast({
+      variant: "error",
+      message: this.i18nService.t("pendingStateCancelError"),
+    });
+  }
+}
+
+/**
+ * The confirmation every withdrawal asks. Built in one place so the two entry points cannot end up
+ * asking the reader different questions about the same action.
+ */
+function cancelConfirmation(pending: boolean): SimpleDialogOptions {
+  return {
+    title: { key: "pamCancelRequestTitle" },
+    content: {
+      key: pending ? "pamCancelRequestPendingConfirm" : "pamCancelRequestApprovedConfirm",
+    },
+    acceptButtonText: { key: "pendingStateCancelRequest" },
+    cancelButtonText: { key: "pamKeepRequest" },
+    type: "danger",
+  };
+}
+
+/**
+ * The request-scoped reading of "outstanding" — what `getCipherAccessState` reports as its
+ * `pendingRequest` / `approvedRequest`, derived from a request the caller already holds.
+ */
+function isOutstanding(request: AccessRequestView): boolean {
+  return (
+    request.status === "pending" ||
+    (request.status === "approved" && request.producedLeaseId == null)
+  );
 }

--- a/bitwarden_license/bit-web/src/app/pam/services/default-access-refresh.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/default-access-refresh.service.spec.ts
@@ -16,6 +16,13 @@ describe("DefaultAccessRefreshService", () => {
     return () => count;
   }
 
+  /** The page-level reading: every announcement, whichever cipher it names. */
+  function watchEverything(): () => number {
+    let count = 0;
+    subscriptions.push(service.accessChanged$().subscribe(() => (count += 1)));
+    return () => count;
+  }
+
   beforeEach(() => {
     push$ = new Subject<void>();
     const accessEvents: AccessEventService = {
@@ -87,6 +94,29 @@ describe("DefaultAccessRefreshService", () => {
 
     expect(cipherOne()).toBe(1);
     expect(cipherTwo()).toBe(1);
+  });
+
+  it("notifies an unscoped subscriber whichever cipher changed", () => {
+    // A page whose rows span the caller's whole vault cannot name the cipher it cares about — a
+    // request for an item it holds no row for yet still belongs on it.
+    const everything = watchEverything();
+
+    service.notifyAccessChanged("cipher-1");
+    service.notifyAccessChanged("cipher-2");
+    service.notifyAccessChanged();
+    push$.next();
+
+    expect(everything()).toBe(4);
+  });
+
+  it("gives an unscoped subscriber one emission per push, not one per cipher in flight", () => {
+    const everything = watchEverything();
+    watch("cipher-1");
+    watch("cipher-2");
+
+    push$.next();
+
+    expect(everything()).toBe(1);
   });
 
   it("does not attach to the push channel until a consumer subscribes", () => {

--- a/bitwarden_license/bit-web/src/app/pam/services/default-access-refresh.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/services/default-access-refresh.service.ts
@@ -12,7 +12,8 @@ import { AccessEventService, AccessRefreshService } from "..";
  *    nothing about which item the caller has open — so it invalidates every subscriber.
  *
  * `undefined` on the subject means "every cipher", matching {@link notifyAccessChanged}'s optional
- * parameter rather than introducing a separate sentinel value.
+ * parameter rather than introducing a separate sentinel value; `undefined` on the subscription side
+ * is its mirror — "whichever cipher changed, tell me".
  *
  * The merge happens per subscription rather than through a long-lived internal subscription, so a
  * client whose user never opens a gated item never attaches to the push channel at all, and there is
@@ -26,9 +27,9 @@ export class DefaultAccessRefreshService implements AccessRefreshService {
 
   constructor(private accessEventService: AccessEventService) {}
 
-  accessChanged$(cipherId: string): Observable<void> {
+  accessChanged$(cipherId?: string): Observable<void> {
     const local$ = this.changed$.pipe(
-      filter((changed) => changed === undefined || changed === cipherId),
+      filter((changed) => cipherId === undefined || changed === undefined || changed === cipherId),
       // Annotated: the repo builds apps without `strictNullChecks`, where a bare `undefined` widens
       // to `any` and trips `noImplicitAny` on the inferred return type.
       map((): void => undefined),


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket. From a UAT design review.

## 📔 Objective

**The drawer withdrew an access request on a single click, with no confirmation.** Every other surface that withdraws a request, the cipher-view banner and the vault-row menu, already routed through the shared confirmation in `AccessRequestCancelService`, so an already-approved request could be given up by a misclick from the drawer and nowhere else. The My requests rows had the same one-click behaviour, in both tables.

All of them now read "Cancel request", are destructive-styled, and raise the same confirmation with its existing pending-vs-approved wording. `AccessRequestCancelService` gains `cancelRequestById()` and `confirmWithdrawal()`; every entry point shares one options builder, so the dialog copy exists in one place.

Also fixes a second bug: cancelling from the drawer left the list stale until the tab was reloaded. `MyAccessService` now subscribes to `AccessRefreshService.accessChanged$()` in place of its direct `AccessEventService` subscription, so one subscription covers both server push and local mutations. Its own mutations never announce, so nothing reloads twice.

No i18n key is added, removed or changed.

## 📸 Screenshots

To follow, being re-captured against the current tip.

## Notes

- The drawer's failure toast now reads "Couldn't cancel the request." while the list rows keep "Could not cancel request." Both keys pre-exist; worth aligning.
- `DefaultPamNavBadgeService` still subscribes to `AccessEventService` directly, so the nav badge count has the same staleness. Pre-existing and out of scope here.
- The list rows show no spinner during a withdrawal. They use `[disabled]` without `[loading]`, where the drawer uses both.
