### PR TITLE
[PM-40159] Update remaining Add plan page copy under the VFO1 flag

### DIFF
--- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+++ b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
@@ -5,7 +5,9 @@
   </bit-form-field>
 </form>
 <form #form [formGroup]="formGroup" *ngIf="!nameOnly">
-  <h2>{{ "generalInformation" | i18n }}</h2>
+  @if (!vfo1Enabled()) {
+    <h2>{{ "generalInformation" | i18n }}</h2>
+  }
   <div class="tw-flex tw-w-full tw-space-x-4" *ngIf="createOrganization">
     <bit-form-field class="tw-w-1/2">
       <bit-label>{{ "organizationName" | vfo1I18n: "vaultName" }}</bit-label>

--- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/create/organization-information.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { UntypedFormControl, UntypedFormGroup } from "@angular/forms";
+import { BehaviorSubject } from "rxjs";
+
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { Vfo1TerminologyService } from "@bitwarden/vault";
+
+import { OrganizationCreateModule } from "./organization-create.module";
+import { OrganizationInformationComponent } from "./organization-information.component";
+
+describe("OrganizationInformationComponent", () => {
+  let fixture: ComponentFixture<OrganizationInformationComponent>;
+  let vfo1Enabled: boolean;
+
+  async function setup(enabled: boolean) {
+    vfo1Enabled = enabled;
+    await TestBed.configureTestingModule({
+      imports: [OrganizationCreateModule],
+      providers: [
+        {
+          provide: AccountService,
+          useValue: {
+            activeAccount$: new BehaviorSubject({ id: "user-id", email: "test@example.com" }),
+          },
+        },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+        {
+          provide: Vfo1TerminologyService,
+          useValue: { iconClass: (icon: string) => icon, enabled: () => vfo1Enabled },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OrganizationInformationComponent);
+    const component = fixture.componentInstance;
+    component.nameOnly = false;
+    component.createOrganization = true;
+    component.formGroup = new UntypedFormGroup({
+      name: new UntypedFormControl(""),
+      billingEmail: new UntypedFormControl(""),
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  it("renders the General information header when the VFO1 flag is off", async () => {
+    await setup(false);
+    expect(fixture.nativeElement.querySelector("h2")).not.toBeNull();
+  });
+
+  it("hides the General information header when the VFO1 flag is on", async () => {
+    await setup(true);
+    expect(fixture.nativeElement.querySelector("h2")).toBeNull();
+  });
+});

--- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.ts
+++ b/apps/web/src/app/admin-console/organizations/create/organization-information.component.ts
@@ -1,10 +1,11 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
-import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { Component, EventEmitter, inject, Input, OnInit, Output } from "@angular/core";
 import { UntypedFormGroup } from "@angular/forms";
 import { firstValueFrom } from "rxjs";
 
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { Vfo1TerminologyService } from "@bitwarden/vault";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -32,6 +33,8 @@ export class OrganizationInformationComponent implements OnInit {
   // FIXME(https://bitwarden.atlassian.net/browse/CL-903): Migrate to Signals
   // eslint-disable-next-line @angular-eslint/prefer-output-emitter-ref
   @Output() changedBusinessOwned = new EventEmitter<void>();
+
+  protected readonly vfo1Enabled = inject(Vfo1TerminologyService).enabled;
 
   constructor(private accountService: AccountService) {}
 

--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
+++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
@@ -34,7 +34,7 @@
       </app-org-info>
     </bit-section>
     <bit-section>
-      <h2 bitTypography="h2">{{ "chooseYourPlan" | i18n }}</h2>
+      <h2 bitTypography="h2">{{ "chooseYourPlan" | vfo1I18n: "choosePlan" }}</h2>
       <bit-radio-group formControlName="productTier" [block]="true">
         @for (selectableProduct of selectableProducts(); track $index) {
           @let pm = selectableProduct.PasswordManager;

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4964,6 +4964,9 @@
   "chooseYourPlan": {
     "message": "Choose your plan"
   },
+  "choosePlan": {
+    "message": "Choose plan"
+  },
   "users": {
     "message": "Users"
   },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-40159

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Completes the remaining "organization" to "vault" copy on the Add plan / create-organization page. Both changes are gated behind the `vfo1-foundation` flag; with the flag off the page copy is unchanged.

Changes:

- Hide the "General information" section header when the flag is on (`OrganizationInformationComponent` reads `Vfo1TerminologyService.enabled` and wraps the header in `@if (!vfo1Enabled())`).
- "Choose your plan" heading reads "Choose plan" when the flag is on, via the `vfo1I18n` pipe.

The Secrets Manager "More from Bitwarden" callout copy on this page is delivered separately by PM-41949, so it is not part of this PR.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="1305" height="941" alt="image" src="https://github.com/user-attachments/assets/46dfa5d0-175a-4722-b406-1b2f6c5d9fb2" />

