### PR TITLE
fix(pam): render the access request reason as a textarea

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -161,7 +161,7 @@
                 rows="3"
                 formControlName="reason"
                 [placeholder]="'requestAccessModalReasonPlaceholder' | i18n"
-                id="pam-cipher-view-banner_input_automatic-reason"
+                id="pam-cipher-view-banner_textarea_automatic-reason"
               ></textarea>
               <bit-hint>{{ "requestAccessModalReasonHint" | i18n }}</bit-hint>
             </bit-form-field>

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -156,13 +156,13 @@
 
             <bit-form-field>
               <bit-label>{{ "requestAccessModalReasonOptional" | i18n }}</bit-label>
-              <input
+              <textarea
                 bitInput
-                type="text"
+                rows="3"
                 formControlName="reason"
                 [placeholder]="'requestAccessModalReasonPlaceholder' | i18n"
                 id="pam-cipher-view-banner_input_automatic-reason"
-              />
+              ></textarea>
               <bit-hint>{{ "requestAccessModalReasonHint" | i18n }}</bit-hint>
             </bit-form-field>
           </form>

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -412,6 +412,18 @@ describe("CipherViewBannerComponent", () => {
       expect(component["humanForm"].getRawValue().start).not.toBe("");
     });
 
+    it("renders the automatic path's Reason field as a multi-line textarea", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      const reason = query("#pam-cipher-view-banner_textarea_automatic-reason");
+      expect(reason?.tagName).toBe("TEXTAREA");
+      expect(reason?.getAttribute("rows")).toBe("3");
+    });
+
     it("renders the human path's Reason field as a multi-line textarea", async () => {
       requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
       await create(gatedCipher());


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39643

## 📔 Objective

Renders the optional reason field on the automatic-approval branch of the inline access request form as a `<textarea rows="3">` instead of a single-line `<input type="text">`, and renames its id to the `_textarea_` convention the sibling dialogs already use.

The diff is one hunk because upstream already shipped the same change for the human-approval path under PM-42419. This PR closes the remaining half, so both branches of the bimodal form now match.

The design draws this field as a text area everywhere it appears, it is the field most likely to run long, and the approver reading it sees a `rows="3"` textarea in the decide dialog. No copy changed and no validation changed: the labels, hint and placeholder strings are untouched, and `bit-form-field` renders the error slot for an invalid touched control regardless of the underlying element.

## 📸 Screenshots
Before:
<img width="1536" height="1816" alt="01-before-automatic-reason-field" src="https://github.com/user-attachments/assets/554864f4-b95a-459c-be84-072ea77baf29" />

After:
<img width="1536" height="1908" alt="02-after-automatic-reason-field" src="https://github.com/user-attachments/assets/aace5630-c145-4aa9-97bc-3398f1f46a23" />

