### PR TITLE
fix(pam): align the request access banner copy with the design

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17615,8 +17615,11 @@
   "pamApprovedRequestBannerTitle": {
     "message": "Your access is approved — start it when you're ready"
   },
-  "pamRequestAccessBannerTitle": {
-    "message": "This item requires a lease. Request access to view or edit it."
+  "pamRequestAccessBannerBody": {
+    "message": "Credentials are masked until access is granted."
+  },
+  "pamRequestAccessBannerHeading": {
+    "message": "You can request access"
   },
   "pamRequestAccessButton": {
     "message": "Request access"

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -104,9 +104,13 @@
 } @else if (canRequestAccess()) {
   <bit-callout
     type="info"
-    [title]="'pamRequestAccessBannerTitle' | i18n"
+    [title]="'pamRequestAccessBannerHeading' | i18n"
     data-testid="cipher-view-banner-request"
   >
+    <p bitTypography="body2" class="tw-mb-3 tw-mt-0" data-testid="request-banner-body">
+      {{ "pamRequestAccessBannerBody" | i18n }}
+    </p>
+
     <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
       <app-pam-access-state-badge [state]="badge()" />
       <button

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -107,7 +107,7 @@
     [title]="'pamRequestAccessBannerHeading' | i18n"
     data-testid="cipher-view-banner-request"
   >
-    <p bitTypography="body2" class="tw-mb-3 tw-mt-0" data-testid="request-banner-body">
+    <p bitTypography="body2" class="tw-mb-3 tw-mt-0">
       {{ "pamRequestAccessBannerBody" | i18n }}
     </p>
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -223,7 +223,8 @@ describe("CipherViewBannerComponent", () => {
 
       expect(query('[data-testid="cipher-view-banner-request"]')).not.toBeNull();
       expect(query("#pam-cipher-view-banner_button_request-toggle")).not.toBeNull();
-      expect(text()).toContain("pamRequestAccessBannerTitle");
+      expect(text()).toContain("pamRequestAccessBannerHeading");
+      expect(text()).toContain("pamRequestAccessBannerBody");
     });
 
     it("offers Cancel request while a request is pending", async () => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39643

## 📔 Objective

Replaces the request-access banner's single-line title with the two-part heading and body the design specifies.

- Adds `pamRequestAccessBannerHeading` ("You can request access") and `pamRequestAccessBannerBody` ("Credentials are masked until access is granted."), and removes `pamRequestAccessBannerTitle`, which has no remaining references.
- Points the callout's `[title]` at the new heading and adds a `<p bitTypography="body2">` body line above the badge and button row.
- Updates the spec to assert both new strings render.

Copy only. The container is still a `bit-callout` after this change, while the design draws a card with a leading icon tile; that conversion is a later milestone in this stack (`pam/requests-banner-as-card`), not a gap introduced here. The `Privileged` badge, the Cancel control and the expanded request form are unchanged.

## 📸 Screenshots

<img width="1536" height="1176" alt="01-before-automatic-rule" src="https://github.com/user-attachments/assets/bf1df558-49ee-4083-ac84-2586eaf95675" />
<img width="1536" height="1240" alt="02-after-automatic-rule" src="https://github.com/user-attachments/assets/e0a77357-86b1-4e2a-a810-0ff7c93f73cd" />
<img width="1536" height="1484" alt="03-before-human-rule" src="https://github.com/user-attachments/assets/ec3c414e-08a7-41c2-811e-6c294a24a46f" />
<img width="1536" height="1552" alt="04-after-human-rule" src="https://github.com/user-attachments/assets/40f493bd-53fe-4d75-a8b1-2df7d28a3fca" />

