### PR TITLE
feat(pam): show the rule max duration and auto-approve hint before submit

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17621,6 +17621,24 @@
   "pamRequestAccessBannerHeading": {
     "message": "You can request access"
   },
+  "pamRequestAccessBannerMaxDuration": {
+    "message": "Access up to $DURATION$",
+    "placeholders": {
+      "duration": {
+        "content": "$1",
+        "example": "1 day"
+      }
+    }
+  },
+  "pamRequestAccessBannerMaxDurationAutomatic": {
+    "message": "Access up to $DURATION$, instant approval if you meet the conditions",
+    "placeholders": {
+      "duration": {
+        "content": "$1",
+        "example": "1 day"
+      }
+    }
+  },
   "pamRequestAccessButton": {
     "message": "Request access"
   },

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -111,6 +111,24 @@
       {{ "pamRequestAccessBannerBody" | i18n }}
     </p>
 
+    @if (restingRequestTerms(); as terms) {
+      <p
+        bitTypography="body2"
+        class="tw-mb-3 tw-mt-0 tw-flex tw-items-center tw-gap-2"
+        data-testid="cipher-view-banner-max-duration"
+      >
+        <bit-icon name="bwi-clock" />
+        <span>
+          {{
+            (terms.approvalMode === "automatic"
+              ? "pamRequestAccessBannerMaxDurationAutomatic"
+              : "pamRequestAccessBannerMaxDuration"
+            ) | i18n: (terms.maxSeconds | durationLong)
+          }}
+        </span>
+      </p>
+    }
+
     <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
       <app-pam-access-state-badge [state]="badge()" />
       <button

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -118,14 +118,7 @@
         data-testid="cipher-view-banner-max-duration"
       >
         <bit-icon name="bwi-clock" />
-        <span>
-          {{
-            (terms.approvalMode === "automatic"
-              ? "pamRequestAccessBannerMaxDurationAutomatic"
-              : "pamRequestAccessBannerMaxDuration"
-            ) | i18n: (terms.maxSeconds | durationLong)
-          }}
-        </span>
+        {{ terms.messageKey | i18n: (terms.maxSeconds | durationLong) }}
       </p>
     }
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -119,6 +119,10 @@ describe("CipherViewBannerComponent", () => {
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+    // The resting pre-check is only reachable once the access-state read has settled, so its
+    // resolution lands a cycle after the state it depends on.
+    await fixture.whenStable();
+    fixture.detectChanges();
   }
 
   function text(): string {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -147,8 +147,7 @@ describe("CipherViewBannerComponent", () => {
 
     requestsApi.getCipherAccessState.mockResolvedValue(accessState());
     // The resting banner pre-checks on its own to render the rule's maximum duration, so every
-    // test needs a resolved pre-check even when it never opens the form. Upstream dropped this
-    // stub when nothing pre-checked at rest; that is no longer true.
+    // test needs a resolved pre-check even when it never opens the form.
     requestsApi.preCheck.mockResolvedValue(preCheck());
     leasingErrors.isLeasingError.mockReturnValue(false);
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -146,6 +146,10 @@ describe("CipherViewBannerComponent", () => {
     toastService = mock<ToastService>();
 
     requestsApi.getCipherAccessState.mockResolvedValue(accessState());
+    // The resting banner pre-checks on its own to render the rule's maximum duration, so every
+    // test needs a resolved pre-check even when it never opens the form. Upstream dropped this
+    // stub when nothing pre-checked at rest; that is no longer true.
+    requestsApi.preCheck.mockResolvedValue(preCheck());
     leasingErrors.isLeasingError.mockReturnValue(false);
 
     // The real fan-out, not a mock: the notify-then-re-read path is the behaviour under test.

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -386,6 +386,62 @@ describe("CipherViewBannerComponent", () => {
     });
   });
 
+  describe("the rule's terms, before the form is opened", () => {
+    const MAX_DURATION = '[data-testid="cipher-view-banner-max-duration"]';
+
+    it("renders the cap alone when the rule needs an approver", async () => {
+      requestsApi.preCheck.mockResolvedValue(
+        preCheck({ approvalMode: "human", maxDurationSeconds: 4 * 3600 }),
+      );
+
+      await create(gatedCipher());
+
+      expect(query(MAX_DURATION)?.textContent?.trim()).toBe(
+        "pamRequestAccessBannerMaxDuration 4 hours",
+      );
+    });
+
+    it("renders the cap with the instant-approval clause when the rule auto-approves", async () => {
+      requestsApi.preCheck.mockResolvedValue(
+        preCheck({ approvalMode: "automatic", maxDurationSeconds: 86_400 }),
+      );
+
+      await create(gatedCipher());
+
+      expect(query(MAX_DURATION)?.textContent?.trim()).toBe(
+        "pamRequestAccessBannerMaxDurationAutomatic 1 day",
+      );
+    });
+
+    it("renders no line when the pre-check resolves no cap", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ maxDurationSeconds: undefined }));
+
+      await create(gatedCipher());
+
+      expect(query(MAX_DURATION)).toBeNull();
+      expect(query('[data-testid="cipher-view-banner-request"]')).not.toBeNull();
+    });
+
+    it("renders no line, and no error, when the pre-check fails", async () => {
+      requestsApi.preCheck.mockRejectedValue(new Error("boom"));
+
+      await create(gatedCipher());
+
+      expect(query(MAX_DURATION)).toBeNull();
+      expect(query('[data-testid="cipher-view-banner-request"]')).not.toBeNull();
+    });
+
+    it("does not pre-check a cipher whose access is already in play", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ pendingRequest: requestView() }),
+      );
+
+      await create(gatedCipher());
+
+      expect(requestsApi.preCheck).not.toHaveBeenCalled();
+    });
+  });
+
   describe("the request fold-out", () => {
     it("shapes the form from the pre-check's automatic path", async () => {
       requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.stories.ts
@@ -48,9 +48,14 @@ type AccessState = Record<string, unknown> | null;
  * are built against the real clock at render time.
  */
 function pam(
-  options: { state?: () => AccessState; mode?: "automatic" | "human"; enabled?: boolean } = {},
+  options: {
+    state?: () => AccessState;
+    mode?: "automatic" | "human";
+    enabled?: boolean;
+    maxDurationSeconds?: number;
+  } = {},
 ) {
-  const { state, mode = "automatic", enabled = true } = options;
+  const { state, mode = "automatic", enabled = true, maxDurationSeconds = 4 * 60 * 60 } = options;
   return moduleMetadata({
     imports: [CipherViewBannerComponent],
     providers: [
@@ -63,8 +68,8 @@ function pam(
             Promise.resolve({
               approvalMode: mode,
               hasActiveLease: false,
-              maxLeaseDurationSeconds: 4 * 60 * 60,
-              defaultLeaseDurationSeconds: 60 * 60,
+              maxDurationSeconds,
+              defaultDurationSeconds: 60 * 60,
             }),
           submitAccessRequest: () => Promise.resolve({}),
           activateAccessRequest: () => Promise.resolve({}),
@@ -113,16 +118,25 @@ export default {
 type Story = StoryObj<CipherViewBannerComponent>;
 
 /**
- * The resting state: the item is governed and nothing is in play, so the banner offers Request
- * access. Expanding it runs the pre-check, which here resolves the automatic path (duration only).
+ * The resting state under an auto-approving rule: the card carries the rule's cap and the
+ * instant-approval clause, and expanding it collects a duration only.
  */
 export const Privileged: Story = {
   decorators: [pam({ state: () => ({ badgeState: "privileged" }) })],
 };
 
-/** The same entry point against a rule that requires human approval: a window plus a justification. */
+/**
+ * The same entry point against a rule that requires human approval: the card carries the cap
+ * alone, and expanding it collects a window plus a justification.
+ */
 export const PrivilegedHumanApproval: Story = {
-  decorators: [pam({ state: () => ({ badgeState: "privileged" }), mode: "human" })],
+  decorators: [
+    pam({
+      state: () => ({ badgeState: "privileged" }),
+      mode: "human",
+      maxDurationSeconds: 24 * 60 * 60,
+    }),
+  ],
 };
 
 /** A request is with an approver. Request access is not offered again; the request can be cancelled. */

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -12,7 +12,17 @@ import {
 } from "@angular/core";
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
-import { catchError, combineLatest, firstValueFrom, from, map, merge, of, switchMap } from "rxjs";
+import {
+  catchError,
+  combineLatest,
+  defer,
+  firstValueFrom,
+  from,
+  map,
+  merge,
+  of,
+  switchMap,
+} from "rxjs";
 
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -25,6 +35,7 @@ import {
   CalloutModule,
   DialogService,
   FormFieldModule,
+  IconModule,
   ToastService,
   TypographyModule,
 } from "@bitwarden/components";
@@ -90,6 +101,7 @@ import {
     ButtonModule,
     CalloutModule,
     FormFieldModule,
+    IconModule,
     ReactiveFormsModule,
     TypographyModule,
     AccessStateBadgeComponent,
@@ -179,6 +191,42 @@ export class CipherViewBannerComponent implements OnInit {
       this.activeLease() == null &&
       this.approvedRequest() == null &&
       this.pendingRequest() == null,
+  );
+
+  /**
+   * The governing rule's terms for a request nobody has made yet: how long access may run, and
+   * whether it would be granted on the spot. Both come from the same side-effect-free `preCheck`
+   * the fold-out runs, because the access state read above carries neither — `CipherAccessStateView`
+   * publishes `maxExtensionDurationSeconds`, which caps extending a lease that already exists, not
+   * opening a request.
+   *
+   * Read only while the resting request-access state is on screen, so a cipher under a lease or
+   * with a request in play costs no extra round-trip. The fold-out still runs its own pre-check on
+   * open: this one is for display, and `hasActiveLease` has to be resolved against the moment of
+   * submit rather than the moment of render.
+   *
+   * Yields `null` when the cap is missing, so a rule whose bounds the server could not resolve
+   * renders no line rather than a made-up limit.
+   */
+  protected readonly restingRequestTerms = toSignal(
+    toObservable(computed(() => (this.canRequestAccess() ? this.cipher().id : null))).pipe(
+      switchMap((cipherId) =>
+        cipherId == null
+          ? of(null)
+          : defer(() => this.accessRequestSdkService.preCheck(String(cipherId))).pipe(
+              map((result) =>
+                Number.isFinite(result.maxDurationSeconds)
+                  ? { maxSeconds: result.maxDurationSeconds, approvalMode: result.approvalMode }
+                  : null,
+              ),
+              catchError((e: unknown) => {
+                this.logService.error(e);
+                return of(null);
+              }),
+            ),
+      ),
+    ),
+    { initialValue: null },
   );
 
   // Parsed once per lease change: the per-second tick would otherwise re-parse the same ISO string

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -12,17 +12,7 @@ import {
 } from "@angular/core";
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
-import {
-  catchError,
-  combineLatest,
-  defer,
-  firstValueFrom,
-  from,
-  map,
-  merge,
-  of,
-  switchMap,
-} from "rxjs";
+import { catchError, combineLatest, firstValueFrom, from, map, merge, of, switchMap } from "rxjs";
 
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -213,10 +203,16 @@ export class CipherViewBannerComponent implements OnInit {
       switchMap((cipherId) =>
         cipherId == null
           ? of(null)
-          : defer(() => this.accessRequestSdkService.preCheck(String(cipherId))).pipe(
-              map((result) =>
-                Number.isFinite(result.maxDurationSeconds)
-                  ? { maxSeconds: result.maxDurationSeconds, approvalMode: result.approvalMode }
+          : from(this.accessRequestSdkService.preCheck(String(cipherId))).pipe(
+              map(({ approvalMode, maxDurationSeconds }) =>
+                Number.isFinite(maxDurationSeconds)
+                  ? {
+                      maxSeconds: maxDurationSeconds,
+                      messageKey:
+                        approvalMode === "automatic"
+                          ? "pamRequestAccessBannerMaxDurationAutomatic"
+                          : "pamRequestAccessBannerMaxDuration",
+                    }
                   : null,
               ),
               catchError((e: unknown) => {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -186,9 +186,9 @@ export class CipherViewBannerComponent implements OnInit {
   /**
    * The governing rule's terms for a request nobody has made yet: how long access may run, and
    * whether it would be granted on the spot. Both come from the same side-effect-free `preCheck`
-   * the fold-out runs, because the access state read above carries neither — `CipherAccessStateView`
-   * publishes `maxExtensionDurationSeconds`, which caps extending a lease that already exists, not
-   * opening a request.
+   * the fold-out runs, because the access state read above carries neither. `CipherAccessStateView`
+   * publishes only `maxExtensionDurationSeconds`, which caps extending a lease that already exists
+   * rather than opening a request.
    *
    * Read only while the resting request-access state is on screen, so a cipher under a lease or
    * with a request in play costs no extra round-trip. The fold-out still runs its own pre-check on


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39644

## 📔 Objective

The resting "You can request access" card now tells the member the rule's maximum lease duration before they open the form, instead of leaving them to discover it after expanding it.

- Human approval reads "Access up to `<duration>`"; an auto-approving rule reads "Access up to `<duration>`, instant approval if you meet the conditions".
- When no finite `maxDurationSeconds` resolves, or the call fails, no line renders at all. The design has no capless variant of the sentence, and asserting a limit that does not exist would misdescribe an access restriction.

Worth weighing in review: the resting card issues its own side-effect-free `preCheck` to get the cap, so viewing a gated item costs one extra call. It is gated on `canRequestAccess()`, so it never fires for a cipher already under a lease or with a request in play, and the fold-out's own pre-check on open is untouched.

## 📸 Screenshots

<img width="1536" height="1308" alt="02-after-automatic-rule" src="https://github.com/user-attachments/assets/aa809095-ca88-472a-bf6c-f83824525337" />
<img width="1536" height="1616" alt="04-after-human-rule" src="https://github.com/user-attachments/assets/bc5feef6-6d96-4808-91a1-fee64e6318a7" />

