### PR TITLE
fix(pam): align the pending request banner with the design

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17609,8 +17609,8 @@
       }
     }
   },
-  "pamPendingBannerTitle": {
-    "message": "Your access request is awaiting approval"
+  "pamPendingRequestBannerHeading": {
+    "message": "Access request pending approval"
   },
   "pamApprovedRequestBannerTitle": {
     "message": "Your access is approved — start it when you're ready"

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -84,7 +84,7 @@
 } @else if (pendingRequest()) {
   <bit-callout
     type="warning"
-    [title]="'pamPendingBannerTitle' | i18n"
+    [title]="'pamPendingRequestBannerHeading' | i18n"
     data-testid="cipher-view-banner-pending"
   >
     <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -242,6 +242,7 @@ describe("CipherViewBannerComponent", () => {
       await create(gatedCipher());
 
       expect(query('[data-testid="cipher-view-banner-pending"]')).not.toBeNull();
+      expect(text()).toContain("pamPendingRequestBannerHeading");
       expect(query("#pam-cipher-view-banner_button_cancel")).not.toBeNull();
       expect(query("#pam-cipher-view-banner_button_request-toggle")).toBeNull();
     });


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39643

## 📔 Objective

Aligns the pending-access-request banner's heading with the design. The i18n key is renamed from `pamPendingBannerTitle` to `pamPendingRequestBannerHeading` and its message changes from "Your access request is awaiting approval" to "Access request pending approval". The template reference is updated and the pending-banner spec gains an assertion on the new text.

Scoped to the heading. The design frame also shows a "Submitted just now." body line, but that is relative time derived from the request's creation timestamp rather than a literal string, and a hardcoded "just now" would go stale the moment the banner reopens. Building it properly needs three more designer-supplied sentence forms (minute, hour, day), which were not available, so it is logged as an open copy request instead. The cancel control is untouched and no duration or expiry sentence was added.

## 📸 Screenshots

<img width="1536" height="1484" alt="01-before-pending-banner" src="https://github.com/user-attachments/assets/f606949a-c359-46b2-9c01-cc690caed739" />
<img width="1536" height="1484" alt="02-after-pending-banner" src="https://github.com/user-attachments/assets/d14b4694-646e-4772-9f93-2f323ddd24e7" />
