### PR TITLE
fix(pam): align the approved request banner with the design

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17612,8 +17612,17 @@
   "pamPendingRequestBannerHeading": {
     "message": "Access request pending approval"
   },
-  "pamApprovedRequestBannerTitle": {
-    "message": "Your access is approved — start it when you're ready"
+  "pamApprovedRequestBannerHeading": {
+    "message": "Access approved"
+  },
+  "pamApprovedRequestBannerDuration": {
+    "message": "$DURATION$ of access",
+    "placeholders": {
+      "duration": {
+        "content": "$1",
+        "example": "1 hour"
+      }
+    }
   },
   "pamRequestAccessBannerBody": {
     "message": "Credentials are masked until access is granted."

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -42,9 +42,20 @@
 } @else if (approvedRequest(); as request) {
   <bit-callout
     type="success"
-    [title]="'pamApprovedRequestBannerTitle' | i18n"
+    [title]="'pamApprovedRequestBannerHeading' | i18n"
     data-testid="cipher-view-banner-approved"
   >
+    @if (approvedDurationSeconds(); as grantedSeconds) {
+      <p
+        bitTypography="body2"
+        class="tw-mb-3 tw-mt-0 tw-flex tw-items-center tw-gap-2"
+        data-testid="cipher-view-banner-approved-duration"
+      >
+        <bit-icon name="bwi-clock" />
+        {{ "pamApprovedRequestBannerDuration" | i18n: (grantedSeconds | durationLong) }}
+      </p>
+    }
+
     <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
       <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
         <app-pam-access-state-badge [state]="badge()" />

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -285,7 +285,7 @@ describe("CipherViewBannerComponent", () => {
     });
 
     // The human-approval route resolves the window from the requester's chosen start and end,
-    // which can sit wholly in the future; the same subtraction has to hold there.
+    // which can sit wholly in the future.
     it("states the granted duration for a window that has not opened yet", async () => {
       requestsApi.getCipherAccessState.mockResolvedValue(
         accessState({ approvedRequest: requestView(grantedWindow(3 * 3600, 24 * 3600)) }),

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -52,6 +52,18 @@ function requestView(overrides: Partial<AccessRequestView> = {}): AccessRequestV
 }
 
 /**
+ * The activation window the server resolves at submit, as an override for {@link requestView}.
+ * `startsInSeconds` covers the human-approval route, whose window can open in the future.
+ */
+function grantedWindow(lengthSeconds: number, startsInSeconds = 0): Partial<AccessRequestView> {
+  const startMs = Date.now() + startsInSeconds * 1000;
+  return {
+    leaseNotBefore: new Date(startMs).toISOString(),
+    leaseNotAfter: new Date(startMs + lengthSeconds * 1000).toISOString(),
+  } as unknown as Partial<AccessRequestView>;
+}
+
+/**
  * The badge the SDK would rank for a state assembled from the parts below. Mirrored here — rather
  * than spelled out at every call site — so a fixture built from `activeLease`/`approvedRequest`/
  * `pendingRequest` stays a faithful stand-in for a real response, which always carries both the
@@ -255,8 +267,46 @@ describe("CipherViewBannerComponent", () => {
       await create(gatedCipher());
 
       expect(query('[data-testid="cipher-view-banner-approved"]')).not.toBeNull();
+      expect(text()).toContain("pamApprovedRequestBannerHeading");
       expect(query("#pam-cipher-view-banner_button_start")).not.toBeNull();
       expect(query("#pam-cipher-view-banner_button_cancel-approved")).not.toBeNull();
+    });
+
+    it("states the granted duration from the approved request's own window", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ approvedRequest: requestView(grantedWindow(3600)) }),
+      );
+
+      await create(gatedCipher());
+
+      expect(query('[data-testid="cipher-view-banner-approved-duration"]')?.textContent).toContain(
+        "pamApprovedRequestBannerDuration 1 hour",
+      );
+    });
+
+    // The human-approval route resolves the window from the requester's chosen start and end,
+    // which can sit wholly in the future; the same subtraction has to hold there.
+    it("states the granted duration for a window that has not opened yet", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ approvedRequest: requestView(grantedWindow(3 * 3600, 24 * 3600)) }),
+      );
+
+      await create(gatedCipher());
+
+      expect(query('[data-testid="cipher-view-banner-approved-duration"]')?.textContent).toContain(
+        "pamApprovedRequestBannerDuration 3 hours",
+      );
+    });
+
+    it("renders no duration line when the window does not resolve to a positive span", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ approvedRequest: requestView(grantedWindow(0)) }),
+      );
+
+      await create(gatedCipher());
+
+      expect(query('[data-testid="cipher-view-banner-approved"]')).not.toBeNull();
+      expect(query('[data-testid="cipher-view-banner-approved-duration"]')).toBeNull();
     });
 
     it("shows the countdown and End for an active lease, hiding Extend when the rule forbids it", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.stories.ts
@@ -170,6 +170,26 @@ export const ApprovedReadyToStart: Story = {
   ],
 };
 
+/**
+ * The same state reached the other way: a human approver approved a window the requester chose,
+ * which can open in the future. The granted duration is the window's length either way.
+ */
+export const ApprovedByApprover: Story = {
+  decorators: [
+    pam({
+      mode: "human",
+      state: () => ({
+        badgeState: "ready",
+        approvedRequest: accessRequest({
+          status: "approved",
+          leaseNotBefore: liveFromNow(20 * HOUR),
+          leaseNotAfter: liveFromNow(23 * HOUR),
+        }),
+      }),
+    }),
+  ],
+};
+
 /** A running lease, with the countdown ticking and the rule allowing extensions. */
 export const ActiveLease: Story = {
   args: { cipher: leasedCipher() },

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -173,9 +173,9 @@ export class CipherViewBannerComponent implements OnInit {
    * however late it is started, so a request left sitting yields less than this. The absolute
    * expiry that would say so is a separate piece of copy, not yet supplied.
    *
-   * Both routes into the approved state resolve the window at submit — an auto-approving rule from
-   * the duration the requester picked, a human approver from the window they asked for — so the
-   * same subtraction is right for both.
+   * Both routes into the approved state resolve the window at submit. An auto-approving rule
+   * resolves it from the duration the requester picked, a human approver from the window they asked
+   * for, so the same subtraction is right for both.
    *
    * Yields `null` for a window that does not resolve to a positive span, so a malformed one renders
    * no line rather than "0 minutes of access".

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -46,6 +46,7 @@ import {
   composeRequestWindow,
   defaultRequestWindow,
   requestDurationOptions,
+  requestedWindowSeconds,
 } from "..";
 import { ExtendLeaseDialogComponent } from "../access-requests/extend-lease-dialog/extend-lease-dialog.component";
 import { cipherAccessBadgeState } from "../access-state-badge/access-badge-state";
@@ -165,6 +166,28 @@ export class CipherViewBannerComponent implements OnInit {
 
   /** The unified access-state pill, so this banner reads the same as the row and the Requests page. */
   protected readonly badge = computed(() => cipherAccessBadgeState(this.state()));
+
+  /**
+   * How much access the approval granted, from the request's own activation window. This is the
+   * length of the grant, not the time still left to use it: the lease ends at `leaseNotAfter`
+   * however late it is started, so a request left sitting yields less than this. The absolute
+   * expiry that would say so is a separate piece of copy, not yet supplied.
+   *
+   * Both routes into the approved state resolve the window at submit — an auto-approving rule from
+   * the duration the requester picked, a human approver from the window they asked for — so the
+   * same subtraction is right for both.
+   *
+   * Yields `null` for a window that does not resolve to a positive span, so a malformed one renders
+   * no line rather than "0 minutes of access".
+   */
+  protected readonly approvedDurationSeconds = computed(() => {
+    const approved = this.approvedRequest();
+    if (approved == null) {
+      return null;
+    }
+    const seconds = requestedWindowSeconds(approved);
+    return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+  });
 
   /** The rule governing the active lease opted into extensions. */
   protected readonly canExtendLease = computed(() => this.state()?.extensionsAllowed === true);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42329

## 📔 Objective

Aligns the approved-request banner with the design: a short heading, plus a line stating how much access the approval granted.

- Replaces `pamApprovedRequestBannerTitle` with `pamApprovedRequestBannerHeading` ("Access approved").
- Adds `pamApprovedRequestBannerDuration` ("$DURATION$ of access"), rendered above the badge and button row.
- Adds an `approvedDurationSeconds` computed that derives the granted span from the approved request's own activation window and pipes it through `durationLong`.

The design's literal string is "1-hour of access". We deliberately ship a duration-driven placeholder instead, so the line reads "2 hours of access" and so on; hardcoding the design's example would misstate every grant that is not an hour long. A window that does not resolve to a positive span renders no line rather than "0 minutes of access". A new `ApprovedByApprover` story covers the approver route, whose window can open in the future.

## 📸 Screenshots
Before
<img width="1536" height="1176" alt="01-before-approved-banner" src="https://github.com/user-attachments/assets/0c986830-7b4e-429e-b81e-dc739c4be66f" />

After
<img width="1536" height="1240" alt="02-after-approved-banner" src="https://github.com/user-attachments/assets/e6903203-6913-47ea-bdcb-69e59e5062aa" />
