### PR TITLE
Render the access request detail as a drawer over the requests list

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
@@ -23,10 +23,14 @@ requester's leasing flow, and the approver's inbox. Gated behind `FeatureFlag.Pa
   off. Per-row CIDR validation rides on each pushed control.
 - `access-requests/` — the user-scoped "Access requests" page at `/pam`: a tabbed shell
   (`access-requests.component`) over Approvals, My requests, and History, plus the
-  shareable single-request page at `/pam/requests/:id`. `MyAccessService`,
-  `ApproverInboxService`, and `AccessNameResolverService` are provided on the SHELL
-  ROUTE, not on the component, because routed children inherit a parent route's
-  providers but not a component's — that is what lets the tabs share one load.
+  single-request drawer (`access-request-route/`) the shell opens over whichever tab is
+  showing, off a `requestId` query param. `/pam/requests/:id` survives as a redirect for
+  existing links. `MyAccessService`, `ApproverInboxService`, and
+  `AccessNameResolverService` are provided on the SHELL ROUTE, not on the component,
+  because routed children inherit a parent route's providers but not a component's —
+  that is what lets the tabs share one load. The drawer is the exception: its injector
+  parent is `DialogService`'s, never a route's, so it provides its own
+  `AccessNameResolverService` and takes its id from `DIALOG_DATA`.
 - `approvals/` — the approver side: the SDK-backed inbox data service, the decide
   dialog, the privilege check, and the route guard.
 - `cipher-view-banner/` — the requester's entry point on an open gated cipher: four

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from "@angular/core/testing";
-import { ActivatedRoute, convertToParamMap } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject, Subject, firstValueFrom } from "rxjs";
+import { Subject, firstValueFrom } from "rxjs";
 
 import {
   AccessEventService,
@@ -44,7 +43,7 @@ function leasingError(message: string): Error {
   return Object.assign(new Error(message), { name: "AccessRequestError", variant: "Api" });
 }
 
-/** Lets the route-driven fetch in the constructor settle before assertions. */
+/** Lets the fetch the service kicks off for its id settle before assertions. */
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe("AccessRequestDetailService", () => {
@@ -54,7 +53,6 @@ describe("AccessRequestDetailService", () => {
   let nameResolver: MockProxy<AccessNameResolverService>;
   let leasingErrors: MockProxy<LeasingErrorService>;
   let push$: Subject<void>;
-  let paramMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
 
   async function setup(): Promise<void> {
     TestBed.configureTestingModule({
@@ -65,10 +63,10 @@ describe("AccessRequestDetailService", () => {
         { provide: AccessNameResolverService, useValue: nameResolver },
         { provide: LeasingErrorService, useValue: leasingErrors },
         { provide: AccessEventService, useValue: { accessChanged$: () => push$.asObservable() } },
-        { provide: ActivatedRoute, useValue: { paramMap: paramMap$.asObservable() } },
       ],
     });
     service = TestBed.inject(AccessRequestDetailService);
+    service.setRequest(REQUEST_ID);
     await settle();
   }
 
@@ -78,7 +76,6 @@ describe("AccessRequestDetailService", () => {
     nameResolver = mock<AccessNameResolverService>();
     leasingErrors = mock<LeasingErrorService>();
     push$ = new Subject<void>();
-    paramMap$ = new BehaviorSubject(convertToParamMap({ id: "req-1" }));
 
     requestsApi.getAccessRequest.mockResolvedValue(request());
     // Name resolution is the resolver's own concern (and its own spec); this service only reads its maps.
@@ -87,7 +84,7 @@ describe("AccessRequestDetailService", () => {
   });
 
   describe("loading", () => {
-    it("fetches the request named by the route id", async () => {
+    it("fetches the request it is pointed at", async () => {
       await setup();
 
       expect(requestsApi.getAccessRequest).toHaveBeenCalledWith("req-1");
@@ -104,21 +101,21 @@ describe("AccessRequestDetailService", () => {
       ]);
     });
 
-    it("re-fetches when the route id changes", async () => {
+    it("re-fetches when it is pointed at another request", async () => {
       await setup();
       requestsApi.getAccessRequest.mockClear();
 
-      paramMap$.next(convertToParamMap({ id: "req-2" }));
+      service.setRequest("req-2" as unknown as AccessRequestId);
       await settle();
 
       expect(requestsApi.getAccessRequest).toHaveBeenCalledWith("req-2");
     });
 
-    it("does not re-fetch when the route re-emits the same id", async () => {
+    it("does not re-fetch when it is pointed at the same request again", async () => {
       await setup();
       requestsApi.getAccessRequest.mockClear();
 
-      paramMap$.next(convertToParamMap({ id: "req-1" }));
+      service.setRequest(REQUEST_ID);
       await settle();
 
       expect(requestsApi.getAccessRequest).not.toHaveBeenCalled();
@@ -152,7 +149,7 @@ describe("AccessRequestDetailService", () => {
       await setup();
 
       requestsApi.getAccessRequest.mockResolvedValue(request({ id: "req-2" }));
-      paramMap$.next(convertToParamMap({ id: "req-2" }));
+      service.setRequest("req-2" as unknown as AccessRequestId);
       await settle();
 
       expect(await firstValueFrom(service.loadError$)).toBeNull();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.ts
@@ -3,9 +3,9 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   BehaviorSubject,
   Observable,
+  ReplaySubject,
   combineLatest,
   distinctUntilChanged,
-  filter,
   map,
   startWith,
   switchMap,
@@ -55,7 +55,7 @@ export class AccessRequestDetailService {
   private readonly _loading$ = new BehaviorSubject<boolean>(true);
   private readonly _loadError$ = new BehaviorSubject<unknown | null>(null);
   private readonly _notFound$ = new BehaviorSubject<boolean>(false);
-  private readonly _id$ = new BehaviorSubject<AccessRequestId | null>(null);
+  private readonly _id$ = new ReplaySubject<AccessRequestId>(1);
 
   /** The loaded request; its display names come from {@link names$}. Null while loading/errored. */
   readonly request$: Observable<AccessRequestView | null> = this._request$.asObservable();
@@ -73,10 +73,7 @@ export class AccessRequestDetailService {
     // Load when the id changes, and again on every access push. `startWith` gives the push stream an
     // initial value so combineLatest emits on first paint rather than waiting for a push. fetch()
     // records failures on loadError$/notFound$ rather than throwing, so the stream never tears down.
-    const id$ = this._id$.pipe(
-      filter((id): id is AccessRequestId => id != null),
-      distinctUntilChanged(),
-    );
+    const id$ = this._id$.pipe(distinctUntilChanged());
     combineLatest([id$, this.accessEvents.accessChanged$().pipe(startWith(undefined))])
       .pipe(
         switchMap(([id]) => this.fetch(id)),

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-detail.service.ts
@@ -1,6 +1,5 @@
 import { DestroyRef, Injectable, inject } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { ActivatedRoute } from "@angular/router";
 import {
   BehaviorSubject,
   Observable,
@@ -31,16 +30,16 @@ import {
 } from "../access-name-resolver.service";
 
 /**
- * Loads and holds the single access request behind the `/pam/requests/:id` page — a shareable
- * link to one of the caller's own requests — resolving display names from local vault state and
- * owning the requester-facing mutations (cancel / activate / end lease). Approve/Deny is not
- * offered here: a requester never decides their own request (that's the deferred approver-inbox
- * flow).
+ * Loads and holds the single access request behind the request drawer — one of the caller's own
+ * requests — resolving display names from local vault state and owning the requester-facing
+ * mutations (cancel / activate / end lease). Approve/Deny is not offered here: a requester never
+ * decides their own request (that's the deferred approver-inbox flow).
  *
- * Page-scoped (provided on the route, not root), so each visit gets its own instance. Re-fetches
- * on the route id and on every server-pushed access event ({@link AccessEventService}), so an
- * approver's decision lands on an open page without a reload; mutations made here re-fetch
- * explicitly rather than waiting for their own push to come back.
+ * Drawer-scoped (provided on the drawer component, not root), so each open gets its own instance.
+ * Re-fetches on the id it is pointed at ({@link setRequest}) and on every server-pushed access
+ * event ({@link AccessEventService}), so an approver's decision lands on an open drawer without a
+ * reload; mutations made here re-fetch explicitly rather than waiting for their own push to come
+ * back.
  */
 @Injectable()
 export class AccessRequestDetailService {
@@ -49,7 +48,6 @@ export class AccessRequestDetailService {
   private readonly nameResolver = inject(AccessNameResolverService);
   private readonly leasingErrors = inject(LeasingErrorService);
   private readonly accessEvents = inject(AccessEventService);
-  private readonly route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly _request$ = new BehaviorSubject<AccessRequestView | null>(null);
@@ -57,6 +55,7 @@ export class AccessRequestDetailService {
   private readonly _loading$ = new BehaviorSubject<boolean>(true);
   private readonly _loadError$ = new BehaviorSubject<unknown | null>(null);
   private readonly _notFound$ = new BehaviorSubject<boolean>(false);
+  private readonly _id$ = new BehaviorSubject<AccessRequestId | null>(null);
 
   /** The loaded request; its display names come from {@link names$}. Null while loading/errored. */
   readonly request$: Observable<AccessRequestView | null> = this._request$.asObservable();
@@ -74,17 +73,21 @@ export class AccessRequestDetailService {
     // Load when the id changes, and again on every access push. `startWith` gives the push stream an
     // initial value so combineLatest emits on first paint rather than waiting for a push. fetch()
     // records failures on loadError$/notFound$ rather than throwing, so the stream never tears down.
-    const id$ = this.route.paramMap.pipe(
-      map((params) => params.get("id")),
-      filter((id): id is string => id != null),
+    const id$ = this._id$.pipe(
+      filter((id): id is AccessRequestId => id != null),
       distinctUntilChanged(),
     );
     combineLatest([id$, this.accessEvents.accessChanged$().pipe(startWith(undefined))])
       .pipe(
-        switchMap(([id]) => this.fetch(id as unknown as AccessRequestId)),
+        switchMap(([id]) => this.fetch(id)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  /** Point the service at a request. Re-fetches on a new id and on every access push. */
+  setRequest(id: AccessRequestId): void {
+    this._id$.next(id);
   }
 
   /** Cancel/withdraw the loaded request, then reload to surface the canceled status. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
@@ -1,222 +1,236 @@
-<app-header [title]="'pamAccessRequestTitle' | i18n"></app-header>
+<bit-dialog
+  dialogSize="large"
+  [title]="'pamAccessRequestTitle' | i18n"
+  [loading]="loading() && request() == null && !notFound() && !loadError()"
+>
+  <ng-container bitDialogContent>
+    @if (request(); as r) {
+      <bit-section>
+        <bit-section-header>
+          <h2 bitTypography="h4">{{ "pamAccessRequestDetailsTitle" | i18n }}</h2>
+        </bit-section-header>
 
-@if (loading() && request() == null && !notFound() && !loadError()) {
-  <p bitTypography="body1" class="tw-text-muted">{{ "loading" | i18n }}</p>
-} @else if (request(); as r) {
-  <bit-section>
-    <bit-section-header>
-      <h2 bitTypography="h4">{{ "pamAccessRequestDetailsTitle" | i18n }}</h2>
-    </bit-section-header>
-
-    <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-3">
-      <!-- Item -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnItem" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">
-          <div class="tw-flex tw-items-center tw-gap-3">
-            @if (cipherFor(r.cipherId); as cipher) {
-              <app-vault-icon [cipher]="cipher" />
-            } @else {
-              <bit-icon name="bwi-key" class="tw-text-muted" [fixedWidth]="true"></bit-icon>
-            }
-            <div>
-              <div>{{ cipherName() }}</div>
-              @if (collectionName(); as collection) {
-                <div class="tw-text-xs tw-text-muted">
-                  {{ "pamInboxInCollection" | i18n: collection }}
-                </div>
-              }
-            </div>
-          </div>
-        </dd>
-      </div>
-
-      <!-- Status -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnStatus" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">
-          @if (badge()?.badgeState; as state) {
-            <app-pam-access-state-badge [state]="state" />
-          } @else if (badge()?.statusBadge; as b) {
-            <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
-          }
-        </dd>
-      </div>
-
-      <!-- Requester -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamInboxRequester" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">{{ requesterDisplay() }}</dd>
-      </div>
-
-      <!-- Requested window -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnRequestedWindow" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">
-          <span [bitTooltip]="exactWindowText()">
-            @if (duration(); as d) {
-              {{ d.key | i18n: d.value }}
-            }
-            @if (start(); as s) {
-              <span class="tw-text-muted">&nbsp;·&nbsp;{{ s.key | i18n: s.value }}</span>
-            }
-          </span>
-          <div class="tw-text-xs tw-text-muted">
-            {{ r.leaseNotBefore | date: "short" }} &ndash; {{ r.leaseNotAfter | date: "short" }}
-          </div>
-        </dd>
-      </div>
-
-      <!-- Reason -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamInboxReason" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">
-          @if (reason()) {
-            {{ reason() }}
-          } @else {
-            <span class="tw-italic tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
-          }
-        </dd>
-      </div>
-
-      <!-- Submitted -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnSubmitted" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">{{ r.submittedAt | date: "medium" }}</dd>
-      </div>
-
-      <!-- Resolved -->
-      @if (r.resolvedAt) {
-        <div class="tw-flex tw-gap-4">
-          <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnResolved" | i18n }}</dt>
-          <dd class="tw-m-0 tw-flex-1">{{ r.resolvedAt | date: "medium" }}</dd>
-        </div>
-      }
-    </dl>
-  </bit-section>
-
-  <!-- Lease -->
-  @if (r.producedLeaseId) {
-    <bit-section>
-      <bit-section-header>
-        <h2 bitTypography="h4">{{ "pamAccessRequestLeaseTitle" | i18n }}</h2>
-      </bit-section-header>
-      <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-3">
-        <div class="tw-flex tw-gap-4">
-          <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnStatus" | i18n }}</dt>
-          <dd class="tw-m-0 tw-flex-1">
-            @if (leaseActive()) {
-              <span bitBadge variant="success">{{ "pamStatusActivated" | i18n }}</span>
-            } @else if (badge()?.statusBadge; as b) {
-              <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
-            }
-          </dd>
-        </div>
-        @if (showLeaseRemaining()) {
+        <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-3">
+          <!-- Item -->
           <div class="tw-flex tw-gap-4">
-            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnRemaining" | i18n }}</dt>
-            <dd class="tw-m-0 tw-flex-1">{{ r.leaseNotAfter | remainingTime: nowMs() }}</dd>
-          </div>
-        }
-      </dl>
-    </bit-section>
-  }
-
-  <!-- Decision log -->
-  @if (decisions().length > 0) {
-    <bit-section>
-      <bit-section-header>
-        <h2 bitTypography="h4">{{ "pamAccessRequestDecisionLogTitle" | i18n }}</h2>
-      </bit-section-header>
-      <ul class="tw-m-0 tw-flex tw-list-none tw-flex-col tw-gap-4 tw-p-0">
-        @for (decision of decisions(); track $index) {
-          <li class="tw-flex tw-flex-col tw-gap-1">
-            <div class="tw-flex tw-items-center tw-gap-2">
-              <span
-                bitBadge
-                [variant]="
-                  decision.outcome === 'approved'
-                    ? 'success'
-                    : decision.outcome === 'denied'
-                      ? 'danger'
-                      : 'secondary'
-                "
-              >
-                {{ decision.labelKey | i18n }}
-              </span>
-              <span>
-                @if (decision.automatic) {
-                  {{ "pamResolverAccessRule" | i18n }}
+            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnItem" | i18n }}</dt>
+            <dd class="tw-m-0 tw-flex-1">
+              <div class="tw-flex tw-items-center tw-gap-3">
+                @if (cipherFor(r.cipherId); as cipher) {
+                  <app-vault-icon [cipher]="cipher" />
                 } @else {
-                  {{ decision.who }}
+                  <bit-icon name="bwi-key" class="tw-text-muted" [fixedWidth]="true"></bit-icon>
+                }
+                <div>
+                  <div>{{ cipherName() }}</div>
+                  @if (collectionName(); as collection) {
+                    <div class="tw-text-xs tw-text-muted">
+                      {{ "pamInboxInCollection" | i18n: collection }}
+                    </div>
+                  }
+                </div>
+              </div>
+            </dd>
+          </div>
+
+          <!-- Status -->
+          <div class="tw-flex tw-gap-4">
+            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnStatus" | i18n }}</dt>
+            <dd class="tw-m-0 tw-flex-1">
+              @if (badge()?.badgeState; as state) {
+                <app-pam-access-state-badge [state]="state" />
+              } @else if (badge()?.statusBadge; as b) {
+                <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
+              }
+            </dd>
+          </div>
+
+          <!-- Requester -->
+          <div class="tw-flex tw-gap-4">
+            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamInboxRequester" | i18n }}</dt>
+            <dd class="tw-m-0 tw-flex-1">{{ requesterDisplay() }}</dd>
+          </div>
+
+          <!-- Requested window -->
+          <div class="tw-flex tw-gap-4">
+            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">
+              {{ "pamColumnRequestedWindow" | i18n }}
+            </dt>
+            <dd class="tw-m-0 tw-flex-1">
+              <span [bitTooltip]="exactWindowText()">
+                @if (duration(); as d) {
+                  {{ d.key | i18n: d.value }}
+                }
+                @if (start(); as s) {
+                  <span class="tw-text-muted">&nbsp;·&nbsp;{{ s.key | i18n: s.value }}</span>
                 }
               </span>
-              <span class="tw-text-xs tw-text-muted">{{
-                decision.decidedAt | date: "medium"
-              }}</span>
-            </div>
-            @if (decision.comment) {
-              <div class="tw-text-xs tw-text-muted">{{ decision.comment }}</div>
-            }
-          </li>
-        }
-      </ul>
-    </bit-section>
-  }
+              <div class="tw-text-xs tw-text-muted">
+                {{ r.leaseNotBefore | date: "short" }} &ndash; {{ r.leaseNotAfter | date: "short" }}
+              </div>
+            </dd>
+          </div>
 
-  <!-- Actions -->
-  <div class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-    @if (canStart()) {
-      <button
-        type="button"
-        bitButton
-        buttonType="primary"
-        id="access-request_button_start"
-        [loading]="starting()"
-        [disabled]="starting()"
-        (click)="startAccess()"
-      >
-        {{ "pamStartLeaseButton" | i18n }}
-      </button>
-      <span class="tw-text-xs tw-text-muted">
-        {{ "pamActivateWithin" | i18n: (r.leaseNotAfter | remainingTime: nowMs()) }}
-      </span>
+          <!-- Reason -->
+          <div class="tw-flex tw-gap-4">
+            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamInboxReason" | i18n }}</dt>
+            <dd class="tw-m-0 tw-flex-1">
+              @if (reason()) {
+                {{ reason() }}
+              } @else {
+                <span class="tw-italic tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
+              }
+            </dd>
+          </div>
+
+          <!-- Submitted -->
+          <div class="tw-flex tw-gap-4">
+            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnSubmitted" | i18n }}</dt>
+            <dd class="tw-m-0 tw-flex-1">{{ r.submittedAt | date: "medium" }}</dd>
+          </div>
+
+          <!-- Resolved -->
+          @if (r.resolvedAt) {
+            <div class="tw-flex tw-gap-4">
+              <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnResolved" | i18n }}</dt>
+              <dd class="tw-m-0 tw-flex-1">{{ r.resolvedAt | date: "medium" }}</dd>
+            </div>
+          }
+        </dl>
+      </bit-section>
+
+      <!-- Lease -->
+      @if (r.producedLeaseId) {
+        <bit-section>
+          <bit-section-header>
+            <h2 bitTypography="h4">{{ "pamAccessRequestLeaseTitle" | i18n }}</h2>
+          </bit-section-header>
+          <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-3">
+            <div class="tw-flex tw-gap-4">
+              <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnStatus" | i18n }}</dt>
+              <dd class="tw-m-0 tw-flex-1">
+                @if (leaseActive()) {
+                  <span bitBadge variant="success">{{ "pamStatusActivated" | i18n }}</span>
+                } @else if (badge()?.statusBadge; as b) {
+                  <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
+                }
+              </dd>
+            </div>
+            @if (showLeaseRemaining()) {
+              <div class="tw-flex tw-gap-4">
+                <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnRemaining" | i18n }}</dt>
+                <dd class="tw-m-0 tw-flex-1">{{ r.leaseNotAfter | remainingTime: nowMs() }}</dd>
+              </div>
+            }
+          </dl>
+        </bit-section>
+      }
+
+      <!-- Decision log -->
+      @if (decisions().length > 0) {
+        <bit-section>
+          <bit-section-header>
+            <h2 bitTypography="h4">{{ "pamAccessRequestDecisionLogTitle" | i18n }}</h2>
+          </bit-section-header>
+          <ul class="tw-m-0 tw-flex tw-list-none tw-flex-col tw-gap-4 tw-p-0">
+            @for (decision of decisions(); track $index) {
+              <li class="tw-flex tw-flex-col tw-gap-1">
+                <div class="tw-flex tw-items-center tw-gap-2">
+                  <span
+                    bitBadge
+                    [variant]="
+                      decision.outcome === 'approved'
+                        ? 'success'
+                        : decision.outcome === 'denied'
+                          ? 'danger'
+                          : 'secondary'
+                    "
+                  >
+                    {{ decision.labelKey | i18n }}
+                  </span>
+                  <span>
+                    @if (decision.automatic) {
+                      {{ "pamResolverAccessRule" | i18n }}
+                    } @else {
+                      {{ decision.who }}
+                    }
+                  </span>
+                  <span class="tw-text-xs tw-text-muted">{{
+                    decision.decidedAt | date: "medium"
+                  }}</span>
+                </div>
+                @if (decision.comment) {
+                  <div class="tw-text-xs tw-text-muted">{{ decision.comment }}</div>
+                }
+              </li>
+            }
+          </ul>
+        </bit-section>
+      }
+    } @else if (notFound()) {
+      <bit-no-items>
+        <span slot="title" class="tw-mt-4 tw-block">{{ "pamAccessRequestNotFound" | i18n }}</span>
+        <span slot="description">{{ "pamAccessRequestNotFoundDescription" | i18n }}</span>
+        <button
+          slot="button"
+          type="button"
+          bitButton
+          buttonType="secondary"
+          id="access-request_button_close"
+          (click)="close()"
+        >
+          {{ "close" | i18n }}
+        </button>
+      </bit-no-items>
+    } @else if (loadError()) {
+      <p bitTypography="body1" class="tw-text-muted">{{ "pamAccessRequestLoadError" | i18n }}</p>
     }
-    @if (canCancel()) {
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        id="access-request_button_cancel"
-        [loading]="cancelling()"
-        [disabled]="cancelling()"
-        (click)="cancel()"
-      >
-        {{ "cancel" | i18n }}
-      </button>
-    }
-    @if (canEndLease()) {
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        id="access-request_button_end-lease"
-        [loading]="ending()"
-        [disabled]="ending()"
-        (click)="endLease()"
-      >
-        {{ "pamEndLeaseButton" | i18n }}
-      </button>
-    }
-  </div>
-} @else if (notFound()) {
-  <bit-no-items>
-    <span slot="title" class="tw-mt-4 tw-block">{{ "pamAccessRequestNotFound" | i18n }}</span>
-    <span slot="description">{{ "pamAccessRequestNotFoundDescription" | i18n }}</span>
-    <a slot="button" bitButton buttonType="secondary" routerLink="/pam">
-      {{ "pamMyAccess" | i18n }}
-    </a>
-  </bit-no-items>
-} @else {
-  <p bitTypography="body1" class="tw-text-muted">{{ "pamAccessRequestLoadError" | i18n }}</p>
-}
+  </ng-container>
+
+  @if (hasActions() && request(); as r) {
+    <ng-container bitDialogFooter>
+      @if (canStart()) {
+        <button
+          type="button"
+          bitButton
+          buttonType="primary"
+          id="access-request_button_start"
+          [loading]="starting()"
+          [disabled]="starting()"
+          (click)="startAccess()"
+        >
+          {{ "pamStartLeaseButton" | i18n }}
+        </button>
+        <span class="tw-text-xs tw-text-muted">
+          {{ "pamActivateWithin" | i18n: (r.leaseNotAfter | remainingTime: nowMs()) }}
+        </span>
+      }
+      @if (canCancel()) {
+        <button
+          type="button"
+          bitButton
+          buttonType="secondary"
+          id="access-request_button_cancel"
+          [loading]="cancelling()"
+          [disabled]="cancelling()"
+          (click)="cancel()"
+        >
+          {{ "cancel" | i18n }}
+        </button>
+      }
+      @if (canEndLease()) {
+        <button
+          type="button"
+          bitButton
+          buttonType="secondary"
+          id="access-request_button_end-lease"
+          [loading]="ending()"
+          [disabled]="ending()"
+          (click)="endLease()"
+        >
+          {{ "pamEndLeaseButton" | i18n }}
+        </button>
+      }
+    </ng-container>
+  }
+</bit-dialog>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
@@ -1,8 +1,4 @@
-<bit-dialog
-  dialogSize="large"
-  [title]="'pamAccessRequestTitle' | i18n"
-  [loading]="loading() && request() == null && !notFound() && !loadError()"
->
+<bit-dialog dialogSize="large" [title]="'pamAccessRequestTitle' | i18n" [loading]="showLoading()">
   <ng-container bitDialogContent>
     @if (request(); as r) {
       <bit-section>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
@@ -1,19 +1,27 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { provideRouter } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
-import { DialogService, ToastService } from "@bitwarden/components";
-import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
+import {
+  DIALOG_DATA,
+  DialogModule,
+  DialogService,
+  DrawerRef,
+  ToastService,
+} from "@bitwarden/components";
 
 import type { AccessRequestView } from "../../abstractions/access-lease";
 import { automaticDecision, humanDecision, selfEndDecision } from "../../testing/decision-builders";
-import { ResolvedNames, emptyResolvedNames } from "../access-name-resolver.service";
+import {
+  AccessNameResolverService,
+  ResolvedNames,
+  emptyResolvedNames,
+} from "../access-name-resolver.service";
 
 import { AccessRequestDetailService } from "./access-request-detail.service";
 import { AccessRequestRouteComponent } from "./access-request-route.component";
@@ -50,9 +58,11 @@ describe("AccessRequestRouteComponent", () => {
     cancel: jest.Mock;
     activate: jest.Mock;
     endLease: jest.Mock;
+    setRequest: jest.Mock;
   };
   let dialogService: MockProxy<DialogService>;
   let toastService: MockProxy<ToastService>;
+  let drawerRef: { isDrawer: true; close: jest.Mock };
 
   function create(): void {
     fixture = TestBed.createComponent(AccessRequestRouteComponent);
@@ -79,7 +89,9 @@ describe("AccessRequestRouteComponent", () => {
       cancel: jest.fn().mockResolvedValue(undefined),
       activate: jest.fn().mockResolvedValue(undefined),
       endLease: jest.fn().mockResolvedValue(undefined),
+      setRequest: jest.fn(),
     };
+    drawerRef = { isDrawer: true, close: jest.fn() };
     dialogService = mock<DialogService>();
     toastService = mock<ToastService>();
     dialogService.openSimpleDialog.mockResolvedValue(true);
@@ -87,20 +99,25 @@ describe("AccessRequestRouteComponent", () => {
     await TestBed.configureTestingModule({
       imports: [AccessRequestRouteComponent, NoopAnimationsModule],
       providers: [
-        provideRouter([]),
         { provide: DialogService, useValue: dialogService },
         { provide: ToastService, useValue: toastService },
         { provide: LogService, useValue: mock<LogService>() },
+        { provide: DIALOG_DATA, useValue: { requestId: "req-1" } },
+        { provide: DrawerRef, useValue: drawerRef },
         {
           provide: I18nService,
           useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
         },
       ],
     })
-      // The detail service is provided ON the component, so it has to be swapped there; the header
-      // module pulls in page chrome this test has no interest in.
+      // The detail service and the name resolver are provided ON the component, so they have to be
+      // swapped there. `DialogModule` goes too: it provides `DialogService`, which would shadow the
+      // mock this test asserts the end-lease confirm against.
       .overrideComponent(AccessRequestRouteComponent, {
-        remove: { imports: [HeaderModule], providers: [AccessRequestDetailService] },
+        remove: {
+          imports: [DialogModule],
+          providers: [AccessRequestDetailService, AccessNameResolverService],
+        },
         add: {
           schemas: [NO_ERRORS_SCHEMA],
           providers: [{ provide: AccessRequestDetailService, useValue: detail }],
@@ -110,6 +127,12 @@ describe("AccessRequestRouteComponent", () => {
   });
 
   describe("loading states", () => {
+    it("points the detail service at the request the drawer was opened for", () => {
+      create();
+
+      expect(detail.setRequest).toHaveBeenCalledWith("req-1");
+    });
+
     it("renders the not-found state when the request is not available", () => {
       detail.request$.next(null);
       detail.notFound$.next(true);
@@ -117,6 +140,16 @@ describe("AccessRequestRouteComponent", () => {
       create();
 
       expect(text()).toContain("pamAccessRequestNotFound");
+    });
+
+    it("closes the drawer from the not-found state rather than linking nowhere", () => {
+      detail.request$.next(null);
+      detail.notFound$.next(true);
+      create();
+
+      component["close"]();
+
+      expect(drawerRef.close).toHaveBeenCalled();
     });
 
     it("toasts a load failure that is not a not-found", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.stories.ts
@@ -1,9 +1,9 @@
 import { importProvidersFrom } from "@angular/core";
-import { ActivatedRoute, RouterModule, convertToParamMap } from "@angular/router";
+import { RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
-import { EMPTY, of } from "rxjs";
+import { EMPTY } from "rxjs";
 
-import { DialogService, ToastService } from "@bitwarden/components";
+import { DIALOG_DATA, DialogService, DrawerRef, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AccessEventService } from "../../abstractions/access-event.service";
@@ -21,7 +21,6 @@ import {
   liveFromNow,
   provideStoryChangeDetection,
   provideStoryLogService,
-  provideStoryWebHeader,
   storyNames,
 } from "../../testing/story-fixtures";
 import { AccessNameResolverService } from "../access-name-resolver.service";
@@ -30,7 +29,7 @@ import { AccessRequestRouteComponent } from "./access-request-route.component";
 
 const names = storyNames();
 
-/** The 404 shape the page reads as "not found" rather than an error banner. */
+/** The 404 shape the drawer reads as "not found" rather than an error banner. */
 const NOT_FOUND = {
   name: "AccessRequestError",
   variant: "Api",
@@ -40,10 +39,10 @@ const NOT_FOUND = {
 /**
  * The component declares `providers: [AccessRequestDetailService]`, so a module-level stub of that
  * service is shadowed and the real one is always constructed. These stories therefore stub the
- * service's own dependencies and let the real page-scoped service run — which is more faithful
+ * service's own dependencies and let the real drawer-scoped service run — which is more faithful
  * anyway, since the loading/not-found/error states are its logic, not the component's.
  *
- * The page clocks its own countdown for a running lease, so windows that must still be open are
+ * The drawer clocks its own countdown for a running lease, so windows that must still be open are
  * built against the real clock inside the factory.
  */
 function detail(options: { request?: () => AccessRequestView; error?: unknown } = {}) {
@@ -73,16 +72,8 @@ function detail(options: { request?: () => AccessRequestView; error?: unknown } 
         },
       },
       { provide: AccessEventService, useValue: { accessChanged$: () => EMPTY } },
-      {
-        provide: ActivatedRoute,
-        // `data` is what the shared web header reads for its route title; without it the header
-        // throws before the page renders.
-        useValue: {
-          paramMap: of(convertToParamMap({ id: "req-1" })),
-          params: of({ id: "req-1" }),
-          data: of({}),
-        },
-      },
+      { provide: DIALOG_DATA, useValue: { requestId: "req-1" } },
+      { provide: DrawerRef, useValue: { isDrawer: true, close: () => {} } },
       { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
       { provide: ToastService, useValue: { showToast: () => {} } },
     ],
@@ -99,7 +90,6 @@ export default {
         importProvidersFrom(PreloadedEnglishI18nModule),
         importProvidersFrom(RouterModule.forRoot([])),
         provideStoryLogService(),
-        ...provideStoryWebHeader(),
       ],
     }),
   ],
@@ -179,8 +169,8 @@ export const AutoApproved: Story = {
 
 /**
  * A link to a request that no longer exists — or that is not this caller's to see. The server
- * returns 404 for both so ids cannot be probed, and the page reads that as not-found rather than
- * an error banner.
+ * returns 404 for both so ids cannot be probed, and the drawer reads that as not-found rather than
+ * an error banner. Its only way out is Close, since the list it opened over is still behind it.
  */
 export const NotFound: Story = {
   decorators: [detail({ error: NOT_FOUND })],

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -115,7 +115,7 @@ export class AccessRequestRouteComponent implements OnInit {
 
   private readonly detail = inject(AccessRequestDetailService);
   private readonly drawerRef = inject<DrawerRef<undefined>>(DrawerRef);
-  protected readonly params = inject<AccessRequestDrawerParams>(DIALOG_DATA);
+  private readonly params = inject<AccessRequestDrawerParams>(DIALOG_DATA);
   private readonly dialogService = inject(DialogService);
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
@@ -124,7 +124,7 @@ export class AccessRequestRouteComponent implements OnInit {
   private readonly ngZone = inject(NgZone);
 
   protected readonly request = toSignal(this.detail.request$, { initialValue: null });
-  protected readonly loading = toSignal(this.detail.loading$, { initialValue: true });
+  private readonly loading = toSignal(this.detail.loading$, { initialValue: true });
   protected readonly notFound = toSignal(this.detail.notFound$, { initialValue: false });
   protected readonly loadError = toSignal(this.detail.loadError$, { initialValue: null });
   private readonly cipherById = toSignal(this.detail.cipherById$, {
@@ -267,6 +267,11 @@ export class AccessRequestRouteComponent implements OnInit {
   /** Whether the drawer renders a footer at all — a terminal request offers no action. */
   protected readonly hasActions = computed(
     () => this.canStart() || this.canCancel() || this.canEndLease(),
+  );
+
+  /** The first load, before there is either a request or a terminal state to render instead. */
+  protected readonly showLoading = computed(
+    () => this.loading() && this.request() == null && !this.notFound() && !this.loadError(),
   );
 
   ngOnInit(): void {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -10,7 +10,6 @@ import {
   signal,
 } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
-import { RouterModule } from "@angular/router";
 import { filter } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
@@ -21,7 +20,10 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeComponent,
   ButtonModule,
+  DIALOG_DATA,
+  DialogModule,
   DialogService,
+  DrawerRef,
   IconModule,
   NoItemsModule,
   SectionComponent,
@@ -31,9 +33,9 @@ import {
   TypographyModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
-import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import {
+  AccessRequestId,
   AccessRequestView,
   durationLabel,
   exactWindow,
@@ -43,7 +45,7 @@ import {
 } from "../..";
 import { AccessStateBadgeComponent } from "../../access-state-badge/access-state-badge.component";
 import { RemainingTimePipe } from "../../date/remaining-time.pipe";
-import { emptyResolvedNames } from "../access-name-resolver.service";
+import { AccessNameResolverService, emptyResolvedNames } from "../access-name-resolver.service";
 import { historyDisplayStatus } from "../my-access-row";
 
 import { AccessRequestDetailService } from "./access-request-detail.service";
@@ -60,9 +62,13 @@ const DECISION_LABEL_KEYS = {
   revoked: "pamAuditKindLeaseRevoked",
 } as const;
 
+/** What the shell hands the drawer: the request to load. */
+export type AccessRequestDrawerParams = { requestId: string };
+
 /**
- * The dedicated, shareable page for one of the caller's own access requests
- * (`/pam/requests/:id`). Reached by clicking a request/lease row in "My access", or a direct link.
+ * The drawer body for one of the caller's own access requests, opened over the requests list by
+ * {@link AccessRequestsComponent} whenever the `requestId` query param names a request. Closing it
+ * leaves the reader on the tab they opened it from.
  *
  * Trimmed port of the `pam/poc` branch's `access-request-route.component`: the pass-1
  * `AccessRequestSdkService.getAccessRequest` is user-scoped (it only ever returns one of the
@@ -72,19 +78,18 @@ const DECISION_LABEL_KEYS = {
  * requester never decides their own request — that's the deferred approver-inbox flow). Only
  * Start / Cancel / End access are offered here.
  *
- * Data, name resolution, and mutations live in the page-scoped {@link AccessRequestDetailService};
+ * Data, name resolution, and mutations live in the drawer-scoped {@link AccessRequestDetailService};
  * this component owns only the view (the live countdown clock and the action affordances).
  */
 @Component({
   selector: "app-pam-access-request-route",
   templateUrl: "./access-request-route.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [AccessRequestDetailService],
+  providers: [AccessRequestDetailService, AccessNameResolverService],
   imports: [
     CommonModule,
-    RouterModule,
     I18nPipe,
-    HeaderModule,
+    DialogModule,
     AccessStateBadgeComponent,
     BadgeComponent,
     ButtonModule,
@@ -99,7 +104,18 @@ const DECISION_LABEL_KEYS = {
   ],
 })
 export class AccessRequestRouteComponent implements OnInit {
+  /** Opens the drawer over whatever list is on screen. The caller owns the `requestId` query param. */
+  static openDrawer(dialogService: DialogService, params: AccessRequestDrawerParams) {
+    return dialogService.openDrawer<
+      undefined,
+      AccessRequestDrawerParams,
+      AccessRequestRouteComponent
+    >(AccessRequestRouteComponent, { data: params });
+  }
+
   private readonly detail = inject(AccessRequestDetailService);
+  private readonly drawerRef = inject<DrawerRef<undefined>>(DrawerRef);
+  protected readonly params = inject<AccessRequestDrawerParams>(DIALOG_DATA);
   private readonly dialogService = inject(DialogService);
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
@@ -248,7 +264,14 @@ export class AccessRequestRouteComponent implements OnInit {
   /** The holder can end their own active lease early. */
   protected readonly canEndLease = computed(() => this.leaseActive());
 
+  /** Whether the drawer renders a footer at all — a terminal request offers no action. */
+  protected readonly hasActions = computed(
+    () => this.canStart() || this.canCancel() || this.canEndLease(),
+  );
+
   ngOnInit(): void {
+    this.detail.setRequest(this.params.requestId as unknown as AccessRequestId);
+
     // Keep the countdown clock outside the Angular zone so a periodic in-zone timer never blocks
     // `whenStable()` for tests/hosts; the signal write still drives change detection.
     this.ngZone.runOutsideAngular(() => {
@@ -269,6 +292,10 @@ export class AccessRequestRouteComponent implements OnInit {
           message: this.i18nService.t("pamAccessRequestLoadError"),
         });
       });
+  }
+
+  protected close(): void {
+    void this.drawerRef.close();
   }
 
   protected cipherFor(cipherIdValue: AccessRequestView["cipherId"]): CipherView | undefined {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests-routing.module.ts
@@ -1,11 +1,10 @@
-import { NgModule } from "@angular/core";
-import { RouterModule, Routes } from "@angular/router";
+import { NgModule, inject } from "@angular/core";
+import { Router, RouterModule, Routes } from "@angular/router";
 
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import { canViewApprovalsGuard } from "../approvals/can-view-approvals.guard";
 
 import { AccessNameResolverService } from "./access-name-resolver.service";
-import { AccessRequestRouteComponent } from "./access-request-route/access-request-route.component";
 import { AccessRequestsComponent } from "./access-requests.component";
 import { ApprovalsTabComponent } from "./approvals-tab.component";
 import { HistoryTabComponent } from "./history-tab.component";
@@ -42,13 +41,14 @@ const routes: Routes = [
     ],
   },
   {
-    // A shareable link to a single one of the caller's own requests/leases — every row links here.
-    // A sibling of the tabbed shell so it renders full-page; `AccessRequestRouteComponent` provides
-    // its own page-scoped detail service, sharing only `AccessNameResolverService` via this route.
+    // The email deep-link target. Kept as a redirect rather than a page so an existing link lands
+    // on the list with the request's drawer open over it — a redirect FUNCTION, because the :id has
+    // to cross from a path segment into a query param.
     path: "requests/:id",
-    component: AccessRequestRouteComponent,
-    providers: [AccessNameResolverService],
-    data: { titleId: "pamAccessRequestTitle" },
+    redirectTo: ({ params }) =>
+      inject(Router).createUrlTree(["/pam/my-requests"], {
+        queryParams: { requestId: params.id },
+      }),
   },
 ];
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.spec.ts
@@ -136,7 +136,7 @@ describe("AccessRequestsComponent", () => {
       expect(ref.close).toHaveBeenCalled();
     });
 
-    it("clears the request from the URL when the drawer closes, keeping the current tab", async () => {
+    it("closes over the drawer's entry, clearing the request but keeping the tab and history depth", async () => {
       const ref = drawerRef();
       queryParams$.next({ requestId: "req-1" });
       openDrawer.mockResolvedValue(ref);
@@ -144,12 +144,44 @@ describe("AccessRequestsComponent", () => {
 
       ref.closed.next(undefined);
 
+      // Replace, not push: the entry being written over is the drawer's own, so Back cannot reopen
+      // the request the reader just dismissed, and repeated opens cannot pile up entries.
       expect(router.navigate).toHaveBeenCalledWith([], {
         queryParams: { requestId: null },
         queryParamsHandling: "merge",
         replaceUrl: true,
       });
       expect(router.navigate.mock.calls[0][1]).not.toHaveProperty("relativeTo");
+    });
+
+    it("does not navigate when opening a request, so the list keeps its own history entry", async () => {
+      // The regression this pins: the drawer used to be opened with `replaceUrl`, which destroyed
+      // the list's entry and left Back to escape the app entirely. Opening is the row link's
+      // navigation alone — the shell only reacts to the param it lands on.
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(drawerRef());
+
+      await create();
+
+      expect(openDrawer).toHaveBeenCalledTimes(1);
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it("closes the drawer when Back pops the request out of the URL, without navigating again", async () => {
+      const ref = drawerRef();
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(ref);
+      await create();
+
+      // What browser Back does: the popped entry is the bare list, so the param simply goes away.
+      queryParams$.next({});
+      await settle();
+      ref.closed.next(undefined);
+
+      expect(ref.close).toHaveBeenCalled();
+      // Back has already moved history; writing the cleared URL again would strand the reader an
+      // entry deeper than the list they just returned to.
+      expect(router.navigate).not.toHaveBeenCalled();
     });
 
     it("ignores a superseded drawer's close, so it cannot wipe the request that replaced it", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.spec.ts
@@ -7,7 +7,7 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { DialogService, DrawerRef, ToastService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 
@@ -93,7 +93,7 @@ describe("AccessRequestsComponent", () => {
 
     it("opens the drawer for the request the query param names", async () => {
       queryParams$.next({ requestId: "req-1" });
-      openDrawer.mockResolvedValue(drawerRef() as unknown as DrawerRef<undefined>);
+      openDrawer.mockResolvedValue(drawerRef());
 
       await create();
 
@@ -103,7 +103,7 @@ describe("AccessRequestsComponent", () => {
 
     it("does not reopen when the same request is emitted again", async () => {
       queryParams$.next({ requestId: "req-1" });
-      openDrawer.mockResolvedValue(drawerRef() as unknown as DrawerRef<undefined>);
+      openDrawer.mockResolvedValue(drawerRef());
       await create();
 
       queryParams$.next({ requestId: "req-1", tab: "history" });
@@ -114,7 +114,7 @@ describe("AccessRequestsComponent", () => {
 
     it("reopens for another request — a row clicked while the drawer is showing", async () => {
       queryParams$.next({ requestId: "req-1" });
-      openDrawer.mockResolvedValue(drawerRef() as unknown as DrawerRef<undefined>);
+      openDrawer.mockResolvedValue(drawerRef());
       await create();
 
       queryParams$.next({ requestId: "req-2" });
@@ -127,7 +127,7 @@ describe("AccessRequestsComponent", () => {
     it("closes the open drawer when the query param is cleared", async () => {
       const ref = drawerRef();
       queryParams$.next({ requestId: "req-1" });
-      openDrawer.mockResolvedValue(ref as unknown as DrawerRef<undefined>);
+      openDrawer.mockResolvedValue(ref);
       await create();
 
       queryParams$.next({});
@@ -139,7 +139,7 @@ describe("AccessRequestsComponent", () => {
     it("clears the request from the URL when the drawer closes, keeping the current tab", async () => {
       const ref = drawerRef();
       queryParams$.next({ requestId: "req-1" });
-      openDrawer.mockResolvedValue(ref as unknown as DrawerRef<undefined>);
+      openDrawer.mockResolvedValue(ref);
       await create();
 
       ref.closed.next(undefined);
@@ -156,10 +156,10 @@ describe("AccessRequestsComponent", () => {
       const first = drawerRef();
       const second = drawerRef();
       queryParams$.next({ requestId: "req-1" });
-      openDrawer.mockResolvedValue(first as unknown as DrawerRef<undefined>);
+      openDrawer.mockResolvedValue(first);
       await create();
 
-      openDrawer.mockResolvedValue(second as unknown as DrawerRef<undefined>);
+      openDrawer.mockResolvedValue(second);
       queryParams$.next({ requestId: "req-2" });
       await settle();
 
@@ -171,7 +171,7 @@ describe("AccessRequestsComponent", () => {
     it("closes the drawer on destroy without writing query params onto the new route", async () => {
       const ref = drawerRef();
       queryParams$.next({ requestId: "req-1" });
-      openDrawer.mockResolvedValue(ref as unknown as DrawerRef<undefined>);
+      openDrawer.mockResolvedValue(ref);
       await create();
 
       fixture.destroy();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.spec.ts
@@ -1,0 +1,183 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Router } from "@angular/router";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, Subject, of } from "rxjs";
+
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { DialogService, DrawerRef, ToastService } from "@bitwarden/components";
+
+import { ApproverInboxService } from "../approvals/approver-inbox.service";
+
+import { AccessRequestRouteComponent } from "./access-request-route/access-request-route.component";
+import { AccessRequestsComponent } from "./access-requests.component";
+import { MyAccessService } from "./my-access.service";
+
+/** A drawer the shell can hold and close, with a `closed` the test drives by hand. */
+function drawerRef(): { closed: Subject<undefined>; close: jest.Mock } {
+  return { closed: new Subject<undefined>(), close: jest.fn().mockResolvedValue({ closed: true }) };
+}
+
+/** Lets the query-param subscription's async open settle before assertions. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("AccessRequestsComponent", () => {
+  let fixture: ComponentFixture<AccessRequestsComponent>;
+  let queryParams$: BehaviorSubject<Record<string, unknown>>;
+  let router: { navigate: jest.Mock };
+  let openDrawer: jest.SpyInstance;
+
+  async function create(): Promise<void> {
+    fixture = TestBed.createComponent(AccessRequestsComponent);
+    fixture.detectChanges();
+    await settle();
+  }
+
+  beforeEach(async () => {
+    queryParams$ = new BehaviorSubject<Record<string, unknown>>({});
+    router = { navigate: jest.fn().mockResolvedValue(true) };
+    openDrawer = jest.spyOn(AccessRequestRouteComponent, "openDrawer");
+
+    await TestBed.configureTestingModule({
+      imports: [AccessRequestsComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: { queryParams: queryParams$.asObservable() } },
+        { provide: Router, useValue: router },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: LogService, useValue: mock<LogService>() },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+        {
+          provide: OrganizationService,
+          useValue: { organizations$: () => of([{ canManageAccessRules: false }]) },
+        },
+        {
+          provide: MyAccessService,
+          useValue: {
+            pendingRows$: of([]),
+            extensionRows$: of([]),
+            leases$: of([]),
+            loadError$: of(null),
+            load: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: ApproverInboxService,
+          useValue: {
+            pendingCount$: of(0),
+            loadError$: of(null),
+            load: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    // The tab nav and the shared web header are chrome this spec has no interest in; what it pins
+    // is the shell's drawer wiring, which lives entirely in ngOnInit.
+    TestBed.overrideTemplate(AccessRequestsComponent, "");
+  });
+
+  afterEach(() => {
+    openDrawer.mockRestore();
+  });
+
+  describe("the request drawer", () => {
+    it("opens nothing when no request is named", async () => {
+      await create();
+
+      expect(openDrawer).not.toHaveBeenCalled();
+    });
+
+    it("opens the drawer for the request the query param names", async () => {
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(drawerRef() as unknown as DrawerRef<undefined>);
+
+      await create();
+
+      expect(openDrawer).toHaveBeenCalledTimes(1);
+      expect(openDrawer).toHaveBeenCalledWith(expect.anything(), { requestId: "req-1" });
+    });
+
+    it("does not reopen when the same request is emitted again", async () => {
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(drawerRef() as unknown as DrawerRef<undefined>);
+      await create();
+
+      queryParams$.next({ requestId: "req-1", tab: "history" });
+      await settle();
+
+      expect(openDrawer).toHaveBeenCalledTimes(1);
+    });
+
+    it("reopens for another request — a row clicked while the drawer is showing", async () => {
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(drawerRef() as unknown as DrawerRef<undefined>);
+      await create();
+
+      queryParams$.next({ requestId: "req-2" });
+      await settle();
+
+      expect(openDrawer).toHaveBeenCalledTimes(2);
+      expect(openDrawer).toHaveBeenLastCalledWith(expect.anything(), { requestId: "req-2" });
+    });
+
+    it("closes the open drawer when the query param is cleared", async () => {
+      const ref = drawerRef();
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(ref as unknown as DrawerRef<undefined>);
+      await create();
+
+      queryParams$.next({});
+      await settle();
+
+      expect(ref.close).toHaveBeenCalled();
+    });
+
+    it("clears the request from the URL when the drawer closes, keeping the current tab", async () => {
+      const ref = drawerRef();
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(ref as unknown as DrawerRef<undefined>);
+      await create();
+
+      ref.closed.next(undefined);
+
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        queryParams: { requestId: null },
+        queryParamsHandling: "merge",
+        replaceUrl: true,
+      });
+      expect(router.navigate.mock.calls[0][1]).not.toHaveProperty("relativeTo");
+    });
+
+    it("ignores a superseded drawer's close, so it cannot wipe the request that replaced it", async () => {
+      const first = drawerRef();
+      const second = drawerRef();
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(first as unknown as DrawerRef<undefined>);
+      await create();
+
+      openDrawer.mockResolvedValue(second as unknown as DrawerRef<undefined>);
+      queryParams$.next({ requestId: "req-2" });
+      await settle();
+
+      first.closed.next(undefined);
+
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it("closes the drawer on destroy without writing query params onto the new route", async () => {
+      const ref = drawerRef();
+      queryParams$.next({ requestId: "req-1" });
+      openDrawer.mockResolvedValue(ref as unknown as DrawerRef<undefined>);
+      await create();
+
+      fixture.destroy();
+
+      expect(ref.close).toHaveBeenCalled();
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.stories.ts
@@ -5,7 +5,7 @@ import { of } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { ToastService } from "@bitwarden/components";
+import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
@@ -61,6 +61,8 @@ function shell(options: ShellOptions = {}) {
           },
         },
         { provide: ToastService, useValue: { showToast: () => {} } },
+        // The shell opens the request drawer off the `requestId` query param; no story sets one.
+        { provide: DialogService, useValue: { openDrawer: () => Promise.resolve(undefined) } },
       ],
     }),
     applicationConfig({

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
@@ -154,12 +154,15 @@ export class AccessRequestsComponent implements OnInit {
     // Leaving /pam entirely destroys the shell but not the drawer: closeOnNavigation is off, so
     // nothing else would tear it down. Clearing drawerRef first stops the closed handler writing
     // query params onto the route the user just navigated to.
-    this.destroyRef.onDestroy(() => {
-      const ref = this.drawerRef();
-      this.drawerRef.set(undefined);
-      this.openRequestId.set(null);
-      void ref?.close();
-    });
+    this.destroyRef.onDestroy(() => void this.forgetDrawer()?.close());
+  }
+
+  /** Drop the shell's hold on the drawer and hand it back, so the caller can close it. */
+  private forgetDrawer(): DrawerRef<undefined> | undefined {
+    const ref = this.drawerRef();
+    this.drawerRef.set(undefined);
+    this.openRequestId.set(null);
+    return ref;
   }
 
   private async syncDrawer(requestId: string | null): Promise<void> {
@@ -167,10 +170,7 @@ export class AccessRequestsComponent implements OnInit {
       return;
     }
     if (requestId == null) {
-      const closing = this.drawerRef();
-      this.drawerRef.set(undefined);
-      this.openRequestId.set(null);
-      await closing?.close();
+      await this.forgetDrawer()?.close();
       return;
     }
 
@@ -190,8 +190,7 @@ export class AccessRequestsComponent implements OnInit {
       if (this.drawerRef() !== ref) {
         return;
       }
-      this.drawerRef.set(undefined);
-      this.openRequestId.set(null);
+      this.forgetDrawer();
       // No `relativeTo`: an empty command array keeps the whole current path, so closing the
       // drawer leaves the reader on the tab they opened it from.
       void this.router.navigate([], {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
@@ -51,8 +51,9 @@ import { MyAccessService } from "./my-access.service";
  *
  * The shell also owns the request drawer: a `requestId` query param names the request showing in
  * {@link AccessRequestRouteComponent}, so a row link only has to add the param and the reader stays
- * on their own tab. Closing the drawer clears the param with `replaceUrl`, which is what stops
- * browser Back walking through every request that was opened.
+ * on their own tab. Both ends of that round trip navigate with `replaceUrl` — the row links as well
+ * as the close handler — so opening and closing a request leaves the history depth unchanged and
+ * browser Back does not walk through every request that was opened.
  */
 @Component({
   selector: "pam-access-requests",

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
@@ -1,19 +1,33 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  inject,
+  signal,
+} from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
-import { RouterModule } from "@angular/router";
-import { combineLatest, filter, map, take } from "rxjs";
+import { ActivatedRoute, Router, RouterModule } from "@angular/router";
+import { combineLatest, concatMap, distinctUntilChanged, filter, map, take } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { TabsModule, ToastService, TypographyModule } from "@bitwarden/components";
+import {
+  DialogService,
+  DrawerRef,
+  TabsModule,
+  ToastService,
+  TypographyModule,
+} from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import { hasApprovalPrivileges$ } from "../approvals/approval-privileges";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 
+import { AccessRequestRouteComponent } from "./access-request-route/access-request-route.component";
 import { MyAccessService } from "./my-access.service";
 
 /**
@@ -34,6 +48,11 @@ import { MyAccessService } from "./my-access.service";
  * provided the same way and loaded the same way, but only for a caller who can actually approve:
  * hitting the approver endpoints for everyone would mean two guaranteed-empty requests per page open.
  * View concerns (the countdown clock, action gating) live in the individual tabs.
+ *
+ * The shell also owns the request drawer: a `requestId` query param names the request showing in
+ * {@link AccessRequestRouteComponent}, so a row link only has to add the param and the reader stays
+ * on their own tab. Closing the drawer clears the param with `replaceUrl`, which is what stops
+ * browser Back walking through every request that was opened.
  */
 @Component({
   selector: "pam-access-requests",
@@ -50,6 +69,13 @@ export class AccessRequestsComponent implements OnInit {
   private readonly toastService = inject(ToastService);
   private readonly logService = inject(LogService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly dialogService = inject(DialogService);
+
+  /** The drawer currently showing a request, and the id it was opened for. */
+  private readonly drawerRef = signal<DrawerRef<undefined> | undefined>(undefined);
+  private readonly openRequestId = signal<string | null>(null);
 
   /**
    * The "My requests" berry: everything the caller still holds or can act on — pending requests,
@@ -113,5 +139,66 @@ export class AccessRequestsComponent implements OnInit {
           message: this.i18nService.t("pamMyRequestsLoadError"),
         });
       });
+
+    this.route.queryParams
+      .pipe(
+        map((params) => (typeof params.requestId === "string" ? params.requestId : null)),
+        distinctUntilChanged(),
+        // concatMap, not switchMap: two rapid id changes must not interleave two opens and leave
+        // the stack describing a request the URL no longer names.
+        concatMap((requestId) => this.syncDrawer(requestId)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
+    // Leaving /pam entirely destroys the shell but not the drawer: closeOnNavigation is off, so
+    // nothing else would tear it down. Clearing drawerRef first stops the closed handler writing
+    // query params onto the route the user just navigated to.
+    this.destroyRef.onDestroy(() => {
+      const ref = this.drawerRef();
+      this.drawerRef.set(undefined);
+      this.openRequestId.set(null);
+      void ref?.close();
+    });
+  }
+
+  private async syncDrawer(requestId: string | null): Promise<void> {
+    if (requestId === this.openRequestId()) {
+      return;
+    }
+    if (requestId == null) {
+      const closing = this.drawerRef();
+      this.drawerRef.set(undefined);
+      this.openRequestId.set(null);
+      await closing?.close();
+      return;
+    }
+
+    this.openRequestId.set(requestId);
+    // openDrawer() closes whatever is on the stack first, and that drawer's `closed` fires while
+    // the new one is opening. Dropping the reference now is what makes the guard in the closed
+    // handler below reject it, so the outgoing drawer cannot wipe the id the incoming one needs.
+    this.drawerRef.set(undefined);
+    const ref = await AccessRequestRouteComponent.openDrawer(this.dialogService, { requestId });
+    if (ref == null) {
+      this.openRequestId.set(null);
+      return;
+    }
+    this.drawerRef.set(ref);
+
+    ref.closed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      if (this.drawerRef() !== ref) {
+        return;
+      }
+      this.drawerRef.set(undefined);
+      this.openRequestId.set(null);
+      // No `relativeTo`: an empty command array keeps the whole current path, so closing the
+      // drawer leaves the reader on the tab they opened it from.
+      void this.router.navigate([], {
+        queryParams: { requestId: null },
+        queryParamsHandling: "merge",
+        replaceUrl: true,
+      });
+    });
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-requests.component.ts
@@ -51,9 +51,19 @@ import { MyAccessService } from "./my-access.service";
  *
  * The shell also owns the request drawer: a `requestId` query param names the request showing in
  * {@link AccessRequestRouteComponent}, so a row link only has to add the param and the reader stays
- * on their own tab. Both ends of that round trip navigate with `replaceUrl` — the row links as well
- * as the close handler — so opening and closing a request leaves the history depth unchanged and
- * browser Back does not walk through every request that was opened.
+ * on their own tab. That param is also what makes browser Back close the drawer, so the two ends of
+ * the round trip navigate differently:
+ *  - Opening from the bare list PUSHES, leaving the list's own history entry intact behind the
+ *    drawer's. Back therefore pops back to the list, the param goes away, and {@link syncDrawer}
+ *    closes the drawer — the reader lands on the list they came from, still inside the app.
+ *  - Opening a second request while the drawer is showing REPLACES (the row links bind their
+ *    `replaceUrl` to `requestDrawerShowing()`), so at most one drawer entry ever sits above the
+ *    list and Back does not walk through every request that was opened.
+ *  - The close handler REPLACES, dropping the param from that single drawer entry rather than
+ *    stacking another. Back after an explicit close cannot reopen what was just closed.
+ *
+ * A deep link (`/pam/requests/:id`) arrives through a redirect, which never pushes an entry of its
+ * own, so Back from a cold-loaded drawer does not bounce through the redirect.
  */
 @Component({
   selector: "pam-access-requests",

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -61,6 +61,7 @@
                   [routerLink]="[]"
                   [queryParams]="{ requestId: row.id }"
                   queryParamsHandling="merge"
+                  [replaceUrl]="true"
                   >{{ row.cipherName }}</a
                 >
                 @if (row.collectionName) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -61,7 +61,7 @@
                   [routerLink]="[]"
                   [queryParams]="{ requestId: row.id }"
                   queryParamsHandling="merge"
-                  [replaceUrl]="true"
+                  [replaceUrl]="drawerShowing()"
                   >{{ row.cipherName }}</a
                 >
                 @if (row.collectionName) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -57,7 +57,12 @@
                 <app-vault-icon [cipher]="cipher" />
               }
               <div>
-                <a [routerLink]="['/pam/requests', row.id]">{{ row.cipherName }}</a>
+                <a
+                  [routerLink]="[]"
+                  [queryParams]="{ requestId: row.id }"
+                  queryParamsHandling="merge"
+                  >{{ row.cipherName }}</a
+                >
                 @if (row.collectionName) {
                   <div class="tw-text-xs tw-text-muted">
                     {{ "pamInboxInCollection" | i18n: row.collectionName }}

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -1,7 +1,8 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { provideRouter } from "@angular/router";
+import { provideRouter, RouterLink } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
@@ -243,5 +244,22 @@ describe("ApprovalsTabComponent", () => {
       expect(dialogService.open).not.toHaveBeenCalled();
       expect(inbox.decide).not.toHaveBeenCalled();
     });
+  });
+
+  function drawerLinks(): RouterLink[] {
+    return fixture.debugElement
+      .queryAll(By.directive(RouterLink))
+      .map((el) => el.injector.get(RouterLink))
+      .filter((link) => link.queryParams?.requestId != null);
+  }
+
+  it("opens a request with replaceUrl, so Back leaves the page instead of unwinding opened requests", () => {
+    inbox.inboxRows$.next([row()]);
+    create();
+
+    const links = drawerLinks();
+
+    expect(links.length).toBeGreaterThan(0);
+    expect(links.every((link) => link.replaceUrl)).toBe(true);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -2,7 +2,7 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { provideRouter, RouterLink } from "@angular/router";
+import { ActivatedRoute, Params, provideRouter, RouterLink } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
@@ -253,13 +253,29 @@ describe("ApprovalsTabComponent", () => {
       .filter((link) => link.queryParams?.requestId != null);
   }
 
-  it("opens a request with replaceUrl, so Back leaves the page instead of unwinding opened requests", () => {
+  /** Put the tab in the state it is in while a request drawer is showing over it. */
+  function showRequestDrawer(requestId: string | null): void {
+    const queryParams = TestBed.inject(ActivatedRoute).queryParams as BehaviorSubject<Params>;
+    queryParams.next(requestId == null ? {} : { requestId });
+    fixture.detectChanges();
+  }
+
+  it("pushes when a request is opened from the list, so Back has the list to return to", () => {
     inbox.inboxRows$.next([row()]);
     create();
 
     const links = drawerLinks();
 
     expect(links.length).toBeGreaterThan(0);
-    expect(links.every((link) => link.replaceUrl)).toBe(true);
+    expect(links.some((link) => link.replaceUrl)).toBe(false);
+  });
+
+  it("replaces once a drawer is showing, so Back does not unwind every request that was opened", () => {
+    inbox.inboxRows$.next([row()]);
+    create();
+
+    showRequestDrawer("req-showing");
+
+    expect(drawerLinks().every((link) => link.replaceUrl)).toBe(true);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
@@ -1,4 +1,5 @@
 import { importProvidersFrom } from "@angular/core";
+import { provideRouter } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
 
@@ -80,6 +81,8 @@ export default {
         provideStoryChangeDetection(),
         importProvidersFrom(PreloadedEnglishI18nModule),
         provideStoryLogService(),
+        // The row links are routerLinks, and their replaceUrl reads the route's query params.
+        provideRouter([]),
       ],
     }),
   ],

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -36,6 +36,8 @@ import { ApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import { DecideDialogComponent } from "../approvals/decide-dialog/decide-dialog.component";
 
+import { requestDrawerShowing } from "./request-drawer-showing";
+
 /**
  * "Approvals" tab — the requests awaiting the caller's decision, oldest first.
  *
@@ -72,6 +74,12 @@ export class ApprovalsTabComponent {
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
+
+  /**
+   * Whether a request drawer is already showing, which makes a row link replace instead of push —
+   * see {@link requestDrawerShowing}.
+   */
+  protected readonly drawerShowing = requestDrawerShowing();
 
   /** Ids currently being decided, so a second click on the same row is a no-op. */
   private readonly deciding = signal<Set<string>>(new Set());

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -51,7 +51,7 @@
                 [routerLink]="[]"
                 [queryParams]="{ requestId: row.id }"
                 queryParamsHandling="merge"
-                [replaceUrl]="true"
+                [replaceUrl]="drawerShowing()"
                 >{{ row.cipherName ?? row.cipherId }}</a
               >
               @if (row.collectionName) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -47,7 +47,12 @@
               <app-vault-icon [cipher]="cipher" />
             }
             <div>
-              <a [routerLink]="['/pam/requests', row.id]">{{ row.cipherName ?? row.cipherId }}</a>
+              <a
+                [routerLink]="[]"
+                [queryParams]="{ requestId: row.id }"
+                queryParamsHandling="merge"
+                >{{ row.cipherName ?? row.cipherId }}</a
+              >
               @if (row.collectionName) {
                 <div class="tw-text-xs tw-text-muted">
                   {{ "pamInboxInCollection" | i18n: row.collectionName }}

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -51,6 +51,7 @@
                 [routerLink]="[]"
                 [queryParams]="{ requestId: row.id }"
                 queryParamsHandling="merge"
+                [replaceUrl]="true"
                 >{{ row.cipherName ?? row.cipherId }}</a
               >
               @if (row.collectionName) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -2,7 +2,7 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { provideRouter, RouterLink } from "@angular/router";
+import { ActivatedRoute, Params, provideRouter, RouterLink } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
@@ -321,13 +321,29 @@ describe("HistoryTabComponent", () => {
       .filter((link) => link.queryParams?.requestId != null);
   }
 
-  it("opens a request with replaceUrl, so Back leaves the page instead of unwinding opened requests", () => {
+  /** Put the tab in the state it is in while a request drawer is showing over it. */
+  function showRequestDrawer(requestId: string | null): void {
+    const queryParams = TestBed.inject(ActivatedRoute).queryParams as BehaviorSubject<Params>;
+    queryParams.next(requestId == null ? {} : { requestId });
+    fixture.detectChanges();
+  }
+
+  it("pushes when a request is opened from the list, so Back has the list to return to", () => {
     myRows$.next([historyRow()]);
     create();
 
     const links = drawerLinks();
 
     expect(links.length).toBeGreaterThan(0);
-    expect(links.every((link) => link.replaceUrl)).toBe(true);
+    expect(links.some((link) => link.replaceUrl)).toBe(false);
+  });
+
+  it("replaces once a drawer is showing, so Back does not unwind every request that was opened", () => {
+    myRows$.next([historyRow()]);
+    create();
+
+    showRequestDrawer("req-showing");
+
+    expect(drawerLinks().every((link) => link.replaceUrl)).toBe(true);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -1,7 +1,8 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { provideRouter } from "@angular/router";
+import { provideRouter, RouterLink } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
@@ -311,5 +312,22 @@ describe("HistoryTabComponent", () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain("pamMyRequestsHistoryEmpty");
+  });
+
+  function drawerLinks(): RouterLink[] {
+    return fixture.debugElement
+      .queryAll(By.directive(RouterLink))
+      .map((el) => el.injector.get(RouterLink))
+      .filter((link) => link.queryParams?.requestId != null);
+  }
+
+  it("opens a request with replaceUrl, so Back leaves the page instead of unwinding opened requests", () => {
+    myRows$.next([historyRow()]);
+    create();
+
+    const links = drawerLinks();
+
+    expect(links.length).toBeGreaterThan(0);
+    expect(links.every((link) => link.replaceUrl)).toBe(true);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
@@ -1,4 +1,5 @@
 import { importProvidersFrom } from "@angular/core";
+import { provideRouter } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
 
@@ -138,6 +139,8 @@ export default {
         provideStoryChangeDetection(),
         importProvidersFrom(PreloadedEnglishI18nModule),
         provideStoryLogService(),
+        // The row links are routerLinks, and their replaceUrl reads the route's query params.
+        provideRouter([]),
       ],
     }),
   ],

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -35,6 +35,7 @@ import { RelativeTimePipe } from "../date/relative-time.pipe";
 
 import { MyAccessRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
+import { requestDrawerShowing } from "./request-drawer-showing";
 
 /** Which side of the history the table is showing. */
 const HistoryScope = Object.freeze({ Mine: "mine", Managed: "managed" } as const);
@@ -84,6 +85,12 @@ export class HistoryTabComponent {
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
+
+  /**
+   * Whether a request drawer is already showing, which makes a row link replace instead of push —
+   * see {@link requestDrawerShowing}.
+   */
+  protected readonly drawerShowing = requestDrawerShowing();
 
   protected readonly HistoryScope = HistoryScope;
   protected readonly scope = signal<HistoryScope>(HistoryScope.Mine);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -52,7 +52,7 @@
                     [routerLink]="[]"
                     [queryParams]="{ requestId: row.id }"
                     queryParamsHandling="merge"
-                    [replaceUrl]="true"
+                    [replaceUrl]="drawerShowing()"
                     >{{ row.cipherName ?? row.cipherId }}</a
                   >
                   @if (row.collectionName) {
@@ -149,7 +149,7 @@
                     [routerLink]="[]"
                     [queryParams]="{ requestId: row.id }"
                     queryParamsHandling="merge"
-                    [replaceUrl]="true"
+                    [replaceUrl]="drawerShowing()"
                     >{{ row.cipherName ?? row.cipherId }}</a
                   >
                   @if (row.collectionName) {
@@ -222,7 +222,7 @@
                     [routerLink]="[]"
                     [queryParams]="{ requestId: lease.requestId }"
                     queryParamsHandling="merge"
-                    [replaceUrl]="true"
+                    [replaceUrl]="drawerShowing()"
                     >{{ lease.cipherName ?? lease.cipherId }}</a
                   >
                   @if (lease.collectionName) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -52,6 +52,7 @@
                     [routerLink]="[]"
                     [queryParams]="{ requestId: row.id }"
                     queryParamsHandling="merge"
+                    [replaceUrl]="true"
                     >{{ row.cipherName ?? row.cipherId }}</a
                   >
                   @if (row.collectionName) {
@@ -148,6 +149,7 @@
                     [routerLink]="[]"
                     [queryParams]="{ requestId: row.id }"
                     queryParamsHandling="merge"
+                    [replaceUrl]="true"
                     >{{ row.cipherName ?? row.cipherId }}</a
                   >
                   @if (row.collectionName) {
@@ -220,6 +222,7 @@
                     [routerLink]="[]"
                     [queryParams]="{ requestId: lease.requestId }"
                     queryParamsHandling="merge"
+                    [replaceUrl]="true"
                     >{{ lease.cipherName ?? lease.cipherId }}</a
                   >
                   @if (lease.collectionName) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -48,9 +48,12 @@
                   <app-vault-icon [cipher]="cipher" />
                 }
                 <div>
-                  <a [routerLink]="['/pam/requests', row.id]">{{
-                    row.cipherName ?? row.cipherId
-                  }}</a>
+                  <a
+                    [routerLink]="[]"
+                    [queryParams]="{ requestId: row.id }"
+                    queryParamsHandling="merge"
+                    >{{ row.cipherName ?? row.cipherId }}</a
+                  >
                   @if (row.collectionName) {
                     <div class="tw-text-xs tw-text-muted">
                       {{ "pamInboxInCollection" | i18n: row.collectionName }}
@@ -141,9 +144,12 @@
                   <app-vault-icon [cipher]="cipher" />
                 }
                 <div>
-                  <a [routerLink]="['/pam/requests', row.id]">{{
-                    row.cipherName ?? row.cipherId
-                  }}</a>
+                  <a
+                    [routerLink]="[]"
+                    [queryParams]="{ requestId: row.id }"
+                    queryParamsHandling="merge"
+                    >{{ row.cipherName ?? row.cipherId }}</a
+                  >
                   @if (row.collectionName) {
                     <div class="tw-text-xs tw-text-muted">
                       {{ "pamInboxInCollection" | i18n: row.collectionName }}
@@ -210,9 +216,12 @@
                   <app-vault-icon [cipher]="cipher" />
                 }
                 <div>
-                  <a [routerLink]="['/pam/requests', lease.requestId]">{{
-                    lease.cipherName ?? lease.cipherId
-                  }}</a>
+                  <a
+                    [routerLink]="[]"
+                    [queryParams]="{ requestId: lease.requestId }"
+                    queryParamsHandling="merge"
+                    >{{ lease.cipherName ?? lease.cipherId }}</a
+                  >
                   @if (lease.collectionName) {
                     <div class="tw-text-xs tw-text-muted">
                       {{ "pamInboxInCollection" | i18n: lease.collectionName }}

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -1,7 +1,8 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { provideRouter } from "@angular/router";
+import { provideRouter, RouterLink } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
@@ -258,5 +259,24 @@ describe("MyRequestsTabComponent", () => {
       expect(query('[data-testid="my-access-pending-empty"]')).not.toBeNull();
       expect(fixture.nativeElement.textContent).toContain("pamMyRequestsPendingEmpty");
     });
+  });
+
+  function drawerLinks(): RouterLink[] {
+    return fixture.debugElement
+      .queryAll(By.directive(RouterLink))
+      .map((el) => el.injector.get(RouterLink))
+      .filter((link) => link.queryParams?.requestId != null);
+  }
+
+  it("opens a request with replaceUrl from every section, so Back leaves the page instead of unwinding opened requests", () => {
+    pendingRows$.next([requestRow({ id: "req-pending", status: "pending" })]);
+    extensionRows$.next([requestRow({ id: "req-ext", status: "pending" })]);
+    leases$.next([leaseRow()]);
+    create();
+
+    const links = drawerLinks();
+
+    expect(links).toHaveLength(3);
+    expect(links.every((link) => link.replaceUrl)).toBe(true);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -2,7 +2,7 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { provideRouter, RouterLink } from "@angular/router";
+import { ActivatedRoute, Params, provideRouter, RouterLink } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject } from "rxjs";
 
@@ -268,11 +268,34 @@ describe("MyRequestsTabComponent", () => {
       .filter((link) => link.queryParams?.requestId != null);
   }
 
-  it("opens a request with replaceUrl from every section, so Back leaves the page instead of unwinding opened requests", () => {
+  /** Put the tab in the state it is in while a request drawer is showing over it. */
+  function showRequestDrawer(requestId: string | null): void {
+    const queryParams = TestBed.inject(ActivatedRoute).queryParams as BehaviorSubject<Params>;
+    queryParams.next(requestId == null ? {} : { requestId });
+    fixture.detectChanges();
+  }
+
+  /** Every section's row link, so neither rule can be fixed on one section and missed on another. */
+  function showAllSections(): void {
     pendingRows$.next([requestRow({ id: "req-pending", status: "pending" })]);
     extensionRows$.next([requestRow({ id: "req-ext", status: "pending" })]);
     leases$.next([leaseRow()]);
     create();
+  }
+
+  it("pushes from every section when a request is opened, so Back has the list to return to", () => {
+    showAllSections();
+
+    const links = drawerLinks();
+
+    expect(links).toHaveLength(3);
+    expect(links.some((link) => link.replaceUrl)).toBe(false);
+  });
+
+  it("replaces in every section once a drawer is showing, so Back does not unwind every request that was opened", () => {
+    showAllSections();
+
+    showRequestDrawer("req-showing");
 
     const links = drawerLinks();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
@@ -1,4 +1,5 @@
 import { importProvidersFrom } from "@angular/core";
+import { provideRouter } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
 
@@ -143,6 +144,8 @@ export default {
         provideStoryChangeDetection(),
         importProvidersFrom(PreloadedEnglishI18nModule),
         provideStoryLogService(),
+        // The row links are routerLinks, and their replaceUrl reads the route's query params.
+        provideRouter([]),
       ],
     }),
   ],

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -43,6 +43,7 @@ import { RemainingTimePipe } from "../date/remaining-time.pipe";
 
 import { MyAccessLeaseRow, MyAccessRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
+import { requestDrawerShowing } from "./request-drawer-showing";
 
 /** A row carrying the id + collection fields the toolbar filters against. */
 type FilterableRow = {
@@ -94,6 +95,12 @@ export class MyRequestsTabComponent implements OnInit {
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
+
+  /**
+   * Whether a request drawer is already showing, which makes a row link replace instead of push —
+   * see {@link requestDrawerShowing}.
+   */
+  protected readonly drawerShowing = requestDrawerShowing();
 
   protected readonly cancelling = signal<Set<AccessRequestId>>(new Set());
   /** Ids of approved requests currently being activated (prevents double-click). */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/request-drawer-showing.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/request-drawer-showing.spec.ts
@@ -1,0 +1,40 @@
+import { Signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { ActivatedRoute, Params, provideRouter } from "@angular/router";
+import { BehaviorSubject } from "rxjs";
+
+import { requestDrawerShowing } from "./request-drawer-showing";
+
+describe("requestDrawerShowing", () => {
+  let queryParams: BehaviorSubject<Params>;
+  let showing: Signal<boolean>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [provideRouter([])] });
+    queryParams = TestBed.inject(ActivatedRoute).queryParams as BehaviorSubject<Params>;
+    showing = TestBed.runInInjectionContext(() => requestDrawerShowing());
+  });
+
+  it("is false on the bare list, so opening a request pushes an entry to come back to", () => {
+    expect(showing()).toBe(false);
+  });
+
+  it("is true while a request is named, so the next row opened replaces rather than stacks", () => {
+    queryParams.next({ requestId: "req-1" });
+
+    expect(showing()).toBe(true);
+  });
+
+  it("goes back to false once the request is cleared", () => {
+    queryParams.next({ requestId: "req-1" });
+    queryParams.next({});
+
+    expect(showing()).toBe(false);
+  });
+
+  it("ignores a requestId that is not a single value, matching the shell's own read of it", () => {
+    queryParams.next({ requestId: ["req-1", "req-2"] });
+
+    expect(showing()).toBe(false);
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/request-drawer-showing.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/request-drawer-showing.ts
@@ -1,0 +1,21 @@
+import { Signal, inject } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { ActivatedRoute } from "@angular/router";
+import { map } from "rxjs";
+
+/**
+ * Whether a request drawer is showing right now, read from the `requestId` query param that names
+ * it (the shell, `AccessRequestsComponent`, owns the drawer itself).
+ *
+ * A tab's row links bind this to `replaceUrl`, which is what keeps browser Back useful: opening a
+ * request from the bare list pushes, so Back has the list to return to, while swapping straight
+ * from one open request to another replaces, so at most one drawer entry ever sits above the list
+ * and Back never walks through every request the reader opened.
+ */
+export function requestDrawerShowing(): Signal<boolean> {
+  const route = inject(ActivatedRoute);
+
+  return toSignal(route.queryParams.pipe(map((params) => typeof params.requestId === "string")), {
+    initialValue: false,
+  });
+}


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket. From a UAT design review.

## 📔 Objective

Opening a request from any of the three tabs took you to a separate full page, whose content filled about the top third of the screen, with no way back except browser Back. It is now a drawer over the requests list.

`/pam/requests/:id` stops rendering a component and redirects into `/pam/my-requests?requestId=:id`, so existing deep links keep working and a cold load lands on the list with the drawer open. The tabbed shell opens and closes the drawer from that query param; the five row links across the three tabs point at the query param instead of the path. This follows the query-param-driven overlay pattern the web and desktop vaults already use. Nothing in the repo drives an overlay from a path route.

`AccessRequestDetailService` takes its id from `DIALOG_DATA` rather than `ActivatedRoute`, which is null inside a drawer.

Browser history follows three rules, so Back closes the drawer rather than leaving the app: opening from the bare list pushes an entry, opening a second request while a drawer is already showing replaces (so Back never unwinds a chain of opened requests), and closing replaces. Row links bind `[replaceUrl]` to whether a drawer is currently showing.

Closes `uat-FLW-04-fe5e3bb8`.

`uat-FLW-04-5c8129d2`, reported as a denied request showing "Canceled", did not reproduce. `status: "denied"` maps to `pamStatusDenied` and can never reach the Canceled label. No code changed.

## 📸 Screenshots

To follow, being re-captured against the current tip.

## Notes

- `npm run test:types` is red on a pre-existing `TS2531` at `access-rule-edit.component.spec.ts:249`, a file this PR does not touch, already on `pam/uat`.
- The redirect always lands on My requests, including for a request that belongs on History or Approvals.
- Each open-then-close cycle leaves one extra bare-list history entry, so Back can appear inert once per cycle before leaving PAM. Popping the entry instead would strand a cold-loaded deep link.
