### PR TITLE
Tighten the drawer's detail layout and reflow the requests list beside it

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
@@ -2,165 +2,105 @@
   <ng-container bitDialogContent>
     @if (request(); as r) {
       <bit-section>
-        <bit-section-header>
-          <h2 bitTypography="h4">{{ "pamAccessRequestDetailsTitle" | i18n }}</h2>
-        </bit-section-header>
+        <bit-item>
+          <bit-item-content [truncate]="false">
+            @if (cipherFor(r.cipherId); as cipher) {
+              <app-vault-icon slot="start" [cipher]="cipher" />
+            } @else {
+              <bit-icon slot="start" name="bwi-key" class="tw-text-muted" [fixedWidth]="true" />
+            }
 
-        <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-3">
-          <!-- Item -->
-          <div class="tw-flex tw-gap-4">
-            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnItem" | i18n }}</dt>
-            <dd class="tw-m-0 tw-flex-1">
-              <div class="tw-flex tw-items-center tw-gap-3">
-                @if (cipherFor(r.cipherId); as cipher) {
-                  <app-vault-icon [cipher]="cipher" />
-                } @else {
-                  <bit-icon name="bwi-key" class="tw-text-muted" [fixedWidth]="true"></bit-icon>
-                }
-                <div>
-                  <div>{{ cipherName() }}</div>
-                  @if (collectionName(); as collection) {
-                    <div class="tw-text-xs tw-text-muted">
-                      {{ "pamInboxInCollection" | i18n: collection }}
-                    </div>
-                  }
-                </div>
-              </div>
-            </dd>
-          </div>
+            {{ cipherName() }}
 
-          <!-- Status -->
-          <div class="tw-flex tw-gap-4">
-            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnStatus" | i18n }}</dt>
-            <dd class="tw-m-0 tw-flex-1">
+            <ng-container slot="default-trailing">
+              <span class="tw-sr-only">{{ "pamColumnStatus" | i18n }}</span>
               @if (badge()?.badgeState; as state) {
                 <app-pam-access-state-badge [state]="state" />
               } @else if (badge()?.statusBadge; as b) {
                 <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
               }
-            </dd>
-          </div>
+            </ng-container>
 
-          <!-- Requester -->
-          <div class="tw-flex tw-gap-4">
-            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamInboxRequester" | i18n }}</dt>
-            <dd class="tw-m-0 tw-flex-1">{{ requesterDisplay() }}</dd>
-          </div>
+            @if (collectionName(); as collection) {
+              <span slot="secondary">{{ "pamInboxInCollection" | i18n: collection }}</span>
+            }
+          </bit-item-content>
+        </bit-item>
+      </bit-section>
 
-          <!-- Requested window -->
-          <div class="tw-flex tw-gap-4">
-            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">
-              {{ "pamColumnRequestedWindow" | i18n }}
-            </dt>
-            <dd class="tw-m-0 tw-flex-1">
-              <span [bitTooltip]="exactWindowText()">
-                @if (duration(); as d) {
-                  {{ d.key | i18n: d.value }}
-                }
-                @if (start(); as s) {
-                  <span class="tw-text-muted">&nbsp;·&nbsp;{{ s.key | i18n: s.value }}</span>
-                }
-              </span>
-              <div class="tw-text-xs tw-text-muted">
-                {{ r.leaseNotBefore | date: "short" }} &ndash; {{ r.leaseNotAfter | date: "short" }}
-              </div>
-            </dd>
-          </div>
+      <bit-section>
+        <dl
+          class="tw-m-0 tw-grid tw-grid-cols-[minmax(0,12rem)_minmax(0,1fr)] tw-items-baseline tw-gap-x-6 tw-gap-y-4"
+        >
+          <dt class="tw-font-normal tw-text-muted">{{ "pamInboxRequester" | i18n }}</dt>
+          <dd class="tw-m-0">{{ requesterDisplay() }}</dd>
 
-          <!-- Reason -->
-          <div class="tw-flex tw-gap-4">
-            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamInboxReason" | i18n }}</dt>
-            <dd class="tw-m-0 tw-flex-1">
-              @if (reason()) {
-                {{ reason() }}
-              } @else {
-                <span class="tw-italic tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
+          <dt class="tw-font-normal tw-text-muted">{{ "pamColumnRequestedWindow" | i18n }}</dt>
+          <dd class="tw-m-0">
+            <div>
+              @if (duration(); as d) {
+                {{ d.key | i18n: d.value }}
               }
-            </dd>
-          </div>
-
-          <!-- Submitted -->
-          <div class="tw-flex tw-gap-4">
-            <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnSubmitted" | i18n }}</dt>
-            <dd class="tw-m-0 tw-flex-1">{{ r.submittedAt | date: "medium" }}</dd>
-          </div>
-
-          <!-- Resolved -->
-          @if (r.resolvedAt) {
-            <div class="tw-flex tw-gap-4">
-              <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnResolved" | i18n }}</dt>
-              <dd class="tw-m-0 tw-flex-1">{{ r.resolvedAt | date: "medium" }}</dd>
+              @if (start(); as s) {
+                <span aria-hidden="true">&nbsp;&middot;&nbsp;</span>{{ s.key | i18n: s.value }}
+              }
             </div>
+            <div bitTypography="helper" class="tw-text-muted">{{ exactWindowText() }}</div>
+          </dd>
+
+          @if (showLeaseRemaining()) {
+            <dt class="tw-font-normal tw-text-muted">{{ "pamColumnRemaining" | i18n }}</dt>
+            <dd class="tw-m-0">{{ r.leaseNotAfter | remainingTime: nowMs() }}</dd>
           }
+
+          <dt class="tw-font-normal tw-text-muted">{{ "pamColumnSubmitted" | i18n }}</dt>
+          <dd class="tw-m-0">{{ r.submittedAt | date: "medium" }}</dd>
+
+          @if (r.resolvedAt) {
+            <dt class="tw-font-normal tw-text-muted">{{ "pamColumnResolved" | i18n }}</dt>
+            <dd class="tw-m-0">{{ r.resolvedAt | date: "medium" }}</dd>
+          }
+
+          <dt class="tw-font-normal tw-text-muted">{{ "pamInboxReason" | i18n }}</dt>
+          <dd class="tw-m-0">
+            @if (reason(); as reasonGiven) {
+              {{ reasonGiven }}
+            } @else {
+              <span class="tw-italic tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
+            }
+          </dd>
         </dl>
       </bit-section>
 
-      <!-- Lease -->
-      @if (r.producedLeaseId) {
-        <bit-section>
-          <bit-section-header>
-            <h2 bitTypography="h4">{{ "pamAccessRequestLeaseTitle" | i18n }}</h2>
-          </bit-section-header>
-          <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-3">
-            <div class="tw-flex tw-gap-4">
-              <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnStatus" | i18n }}</dt>
-              <dd class="tw-m-0 tw-flex-1">
-                @if (leaseActive()) {
-                  <span bitBadge variant="success">{{ "pamStatusActivated" | i18n }}</span>
-                } @else if (badge()?.statusBadge; as b) {
-                  <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
-                }
-              </dd>
-            </div>
-            @if (showLeaseRemaining()) {
-              <div class="tw-flex tw-gap-4">
-                <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnRemaining" | i18n }}</dt>
-                <dd class="tw-m-0 tw-flex-1">{{ r.leaseNotAfter | remainingTime: nowMs() }}</dd>
-              </div>
-            }
-          </dl>
-        </bit-section>
-      }
-
-      <!-- Decision log -->
       @if (decisions().length > 0) {
         <bit-section>
           <bit-section-header>
             <h2 bitTypography="h4">{{ "pamAccessRequestDecisionLogTitle" | i18n }}</h2>
           </bit-section-header>
-          <ul class="tw-m-0 tw-flex tw-list-none tw-flex-col tw-gap-4 tw-p-0">
+          <bit-item-group>
             @for (decision of decisions(); track $index) {
-              <li class="tw-flex tw-flex-col tw-gap-1">
-                <div class="tw-flex tw-items-center tw-gap-2">
-                  <span
-                    bitBadge
-                    [variant]="
-                      decision.outcome === 'approved'
-                        ? 'success'
-                        : decision.outcome === 'denied'
-                          ? 'danger'
-                          : 'secondary'
-                    "
-                  >
-                    {{ decision.labelKey | i18n }}
-                  </span>
-                  <span>
-                    @if (decision.automatic) {
-                      {{ "pamResolverAccessRule" | i18n }}
-                    } @else {
-                      {{ decision.who }}
-                    }
-                  </span>
-                  <span class="tw-text-xs tw-text-muted">{{
-                    decision.decidedAt | date: "medium"
+              <bit-item>
+                <bit-item-content [truncate]="false">
+                  @if (decision.automatic) {
+                    {{ "pamResolverAccessRule" | i18n }}
+                  } @else {
+                    {{ decision.who }}
+                  }
+
+                  <span bitBadge slot="default-trailing" [variant]="decision.variant">{{
+                    decision.labelKey | i18n
                   }}</span>
-                </div>
-                @if (decision.comment) {
-                  <div class="tw-text-xs tw-text-muted">{{ decision.comment }}</div>
-                }
-              </li>
+
+                  <ng-container slot="secondary">
+                    <div>{{ decision.decidedAt | date: "medium" }}</div>
+                    @if (decision.comment) {
+                      <div class="tw-mt-1">{{ decision.comment }}</div>
+                    }
+                  </ng-container>
+                </bit-item-content>
+              </bit-item>
             }
-          </ul>
+          </bit-item-group>
         </bit-section>
       }
     } @else if (notFound()) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
@@ -77,30 +77,27 @@
           <bit-section-header>
             <h2 bitTypography="h4">{{ "pamAccessRequestDecisionLogTitle" | i18n }}</h2>
           </bit-section-header>
-          <bit-item-group>
+          <ol class="tw-m-0 tw-flex tw-list-none tw-flex-col tw-gap-4 tw-p-0">
             @for (decision of decisions(); track $index) {
-              <bit-item>
-                <bit-item-content [truncate]="false">
+              <li data-testid="access-request-decision">
+                <div bitTypography="body2" class="tw-font-medium">
+                  {{ decision.labelKey | i18n }}
+                </div>
+                <div bitTypography="helper" class="tw-text-muted">
                   @if (decision.automatic) {
-                    {{ "pamResolverAccessRule" | i18n }}
-                  } @else {
-                    {{ decision.who }}
+                    {{ "pamResolverAccessRule" | i18n
+                    }}<span aria-hidden="true">&nbsp;&middot;&nbsp;</span>
+                  } @else if (decision.who) {
+                    {{ decision.who }}<span aria-hidden="true">&nbsp;&middot;&nbsp;</span>
                   }
-
-                  <span bitBadge slot="default-trailing" [variant]="decision.variant">{{
-                    decision.labelKey | i18n
-                  }}</span>
-
-                  <ng-container slot="secondary">
-                    <div>{{ decision.decidedAt | date: "medium" }}</div>
-                    @if (decision.comment) {
-                      <div class="tw-mt-1">{{ decision.comment }}</div>
-                    }
-                  </ng-container>
-                </bit-item-content>
-              </bit-item>
+                  {{ decision.decidedAt | date: "medium" }}
+                </div>
+                @if (decision.comment) {
+                  <p bitTypography="body2" class="tw-mb-0 tw-mt-1">{{ decision.comment }}</p>
+                }
+              </li>
             }
-          </bit-item-group>
+          </ol>
         </bit-section>
       }
     } @else if (notFound()) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
@@ -193,6 +193,88 @@ describe("AccessRequestRouteComponent", () => {
     });
   });
 
+  describe("layout", () => {
+    function labels(): (string | undefined)[] {
+      return Array.from(fixture.nativeElement.querySelectorAll("dt")).map((label) =>
+        (label as Element).textContent?.trim(),
+      );
+    }
+
+    it("renders the gated item as its own row rather than as a value in the detail list", () => {
+      create();
+
+      expect(labels()).not.toContain("pamColumnItem");
+      expect(fixture.nativeElement.querySelector("bit-item bit-item-content")).not.toBeNull();
+    });
+
+    it("leaves no icon in a value cell, so the value column shares one left edge", () => {
+      create();
+
+      const list = fixture.nativeElement.querySelector("dl") as HTMLElement;
+      expect(list).not.toBeNull();
+      expect(list.querySelector("dd bit-icon, dd app-vault-icon")).toBeNull();
+    });
+
+    it("shows the exact requested window as text rather than only on hover", () => {
+      create();
+
+      expect(text()).toContain(component["exactWindowText"]());
+      expect(fixture.nativeElement.querySelector("[bitTooltip]")).toBeNull();
+    });
+
+    it("states the request's status once, outside the detail list", () => {
+      detail.request$.next(request({ status: "denied", resolvedAt: PAST }));
+
+      create();
+
+      expect(labels()).not.toContain("pamColumnStatus");
+    });
+
+    it("keeps the live countdown in the detail list rather than in a section of its own", () => {
+      detail.request$.next(
+        request({ status: "approved", producedLeaseId: "lease-1", producedLeaseStatus: "active" }),
+      );
+
+      create();
+
+      expect(labels()).toContain("pamColumnRemaining");
+    });
+
+    it("drops the countdown row once the lease is no longer live", () => {
+      detail.request$.next(
+        request({ status: "approved", producedLeaseId: "lease-1", producedLeaseStatus: "expired" }),
+      );
+
+      create();
+
+      expect(labels()).not.toContain("pamColumnRemaining");
+    });
+
+    it("contains a decision's comment within its own log entry", () => {
+      detail.request$.next(
+        request({
+          status: "denied",
+          decisions: [
+            humanDecision({
+              id: "approver-1",
+              name: "Ada",
+              verdict: "deny",
+              comment: "Use the read replica instead.",
+            }),
+          ],
+        }),
+      );
+
+      create();
+
+      const entry = fixture.nativeElement.querySelector("bit-item-group bit-item") as HTMLElement;
+      expect(entry).not.toBeNull();
+      expect(entry.textContent).toContain("Ada");
+      expect(entry.textContent).toContain("pamStatusDenied");
+      expect(entry.textContent).toContain("Use the read replica instead.");
+    });
+  });
+
   describe("the decision log", () => {
     it("credits the access rule for an automatic decision", () => {
       detail.request$.next(request({ status: "approved", decisions: [automaticDecision()] }));
@@ -263,6 +345,9 @@ describe("AccessRequestRouteComponent", () => {
 
       const decisions = component["decisions"]();
       expect(decisions[1].labelKey).toBe("pamAuditKindLeaseEndedByHolder");
+      // Neutral, not danger: a holder closing their own lease is not a denial.
+      expect(decisions[1].variant).toBe("subtle");
+      expect(decisions[0].variant).toBe("success");
       expect(text()).not.toContain("pamStatusDenied");
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
@@ -267,7 +267,9 @@ describe("AccessRequestRouteComponent", () => {
 
       create();
 
-      const entry = fixture.nativeElement.querySelector("bit-item-group bit-item") as HTMLElement;
+      const entry = fixture.nativeElement.querySelector(
+        '[data-testid="access-request-decision"]',
+      ) as HTMLElement;
       expect(entry).not.toBeNull();
       expect(entry.textContent).toContain("Ada");
       expect(entry.textContent).toContain("pamStatusDenied");
@@ -345,9 +347,7 @@ describe("AccessRequestRouteComponent", () => {
 
       const decisions = component["decisions"]();
       expect(decisions[1].labelKey).toBe("pamAuditKindLeaseEndedByHolder");
-      // Neutral, not danger: a holder closing their own lease is not a denial.
-      expect(decisions[1].variant).toBe("subtle");
-      expect(decisions[0].variant).toBe("success");
+      expect(decisions[0].labelKey).toBe("pamStatusApproved");
       expect(text()).not.toContain("pamStatusDenied");
     });
 
@@ -365,6 +365,50 @@ describe("AccessRequestRouteComponent", () => {
       create();
 
       expect(component["decisions"]()[1].labelKey).toBe("pamAuditKindLeaseRevoked");
+    });
+
+    it("leads an entry with its verdict and demotes the actor to the supporting line", () => {
+      detail.request$.next(
+        request({
+          status: "approved",
+          decisions: [humanDecision({ id: "approver-1", name: "Ada" })],
+        }),
+      );
+
+      create();
+
+      const entry = fixture.nativeElement.querySelector(
+        '[data-testid="access-request-decision"]',
+      ) as HTMLElement;
+      const lines = Array.from(entry.children) as HTMLElement[];
+      const verdict = lines.findIndex((line) => line.textContent?.includes("pamStatusApproved"));
+      const actor = lines.findIndex((line) => line.textContent?.includes("Ada"));
+
+      expect(verdict).toBe(0);
+      expect(actor).toBeGreaterThan(verdict);
+      expect(lines[verdict].className).not.toContain("tw-text-muted");
+      expect(lines[actor].className).toContain("tw-text-muted");
+    });
+
+    it("spends no badge on a log entry, leaving the header pill as the drawer's only status badge", () => {
+      detail.request$.next(
+        request({
+          status: "approved",
+          producedLeaseId: "lease-1",
+          producedLeaseStatus: "revoked",
+          decisions: [automaticDecision(), selfEndDecision("user-1")],
+        }),
+      );
+
+      create();
+
+      const entries = fixture.nativeElement.querySelectorAll(
+        '[data-testid="access-request-decision"]',
+      ) as NodeListOf<HTMLElement>;
+
+      expect(entries).toHaveLength(2);
+      entries.forEach((entry) => expect(entry.querySelector("[bitBadge]")).toBeNull());
+      expect(fixture.nativeElement.querySelectorAll("[bitBadge]")).toHaveLength(1);
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.stories.ts
@@ -151,6 +151,35 @@ export const Denied: Story = {
   ],
 };
 
+/**
+ * The widest content the detail layout has to absorb: a long free-text reason, and a decision log
+ * carrying more than one entry — here an approval that was later pulled back by an operator.
+ */
+export const LongReasonAndMultipleDecisions: Story = {
+  decorators: [
+    detail({
+      request: () =>
+        accessRequest({
+          status: "approved",
+          resolvedAt: fromNow(-35 * MINUTE),
+          producedLeaseId: "lease-3",
+          producedLeaseStatus: "revoked",
+          reason:
+            "Paging on the checkout latency spike. I need the primary to compare its slow-query log against the read replica, and the replica lag is already well outside the window we can reason about.",
+          decisions: [
+            decision({ comment: "Approved for the incident window." }),
+            decision({
+              decider: { human: { id: "operator-9", name: "Ops on-call" } },
+              verdict: "deny",
+              comment: "Incident closed, pulling access back.",
+              decidedAt: fromNow(-5 * MINUTE),
+            }),
+          ],
+        }),
+    }),
+  ],
+};
+
 /** Auto-approved by the rule: the decision log credits the rule rather than a person. */
 export const AutoApproved: Story = {
   decorators: [

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -19,7 +19,6 @@ import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.se
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeComponent,
-  BadgeVariant,
   ButtonModule,
   DIALOG_DATA,
   DialogModule,
@@ -52,17 +51,20 @@ import { historyDisplayStatus } from "../my-access-row";
 import { AccessRequestDetailService } from "./access-request-detail.service";
 
 /**
- * Copy and badge colour for a decision-log entry's outcome. A Deny recorded on a request that did
- * not end Denied is the lease ending (self-end or operator revoke), not a denial — mirroring the
- * historical-status derivation in `../my-access-row`. A lease ending is neither good news nor bad,
- * so it takes the neutral badge rather than the denial's danger colour.
+ * Copy for a decision-log entry's outcome. A Deny recorded on a request that did not end Denied is
+ * the lease ending (self-end or operator revoke), not a denial — mirroring the historical-status
+ * derivation in `../my-access-row`.
+ *
+ * The log carries no badge of its own: the drawer states the request's outcome once, in the header
+ * pill, and each log entry leads with its verdict as the entry's own title. That keeps a single
+ * badge scale in the panel instead of one weight per verdict colour.
  */
-const DECISION_BADGES = {
-  approved: { labelKey: "pamStatusApproved", variant: "success" },
-  denied: { labelKey: "pamStatusDenied", variant: "danger" },
-  endedByHolder: { labelKey: "pamAuditKindLeaseEndedByHolder", variant: "subtle" },
-  revoked: { labelKey: "pamAuditKindLeaseRevoked", variant: "subtle" },
-} as const satisfies Record<string, { labelKey: string; variant: BadgeVariant }>;
+const DECISION_LABELS = {
+  approved: "pamStatusApproved",
+  denied: "pamStatusDenied",
+  endedByHolder: "pamAuditKindLeaseEndedByHolder",
+  revoked: "pamAuditKindLeaseRevoked",
+} as const satisfies Record<string, string>;
 
 /** What the shell hands the drawer: the request to load. */
 export type AccessRequestDrawerParams = { requestId: string };
@@ -216,8 +218,7 @@ export class AccessRequestRouteComponent implements OnInit {
           approver?.email ||
           (approver?.id == null ? "" : uuidAsString(approver.id)),
         outcome,
-        labelKey: DECISION_BADGES[outcome].labelKey,
-        variant: DECISION_BADGES[outcome].variant as BadgeVariant,
+        labelKey: DECISION_LABELS[outcome],
         comment: decision.comment,
         decidedAt: decision.decidedAt,
       };

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -19,17 +19,18 @@ import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.se
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeComponent,
+  BadgeVariant,
   ButtonModule,
   DIALOG_DATA,
   DialogModule,
   DialogService,
   DrawerRef,
   IconModule,
+  ItemModule,
   NoItemsModule,
   SectionComponent,
   SectionHeaderComponent,
   ToastService,
-  TooltipDirective,
   TypographyModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -51,16 +52,17 @@ import { historyDisplayStatus } from "../my-access-row";
 import { AccessRequestDetailService } from "./access-request-detail.service";
 
 /**
- * i18n keys for a decision-log entry's outcome. A Deny recorded on a request that did not end
- * Denied is the lease ending (self-end or operator revoke), not a denial — mirroring the
- * historical-status derivation in `../my-access-row`.
+ * Copy and badge colour for a decision-log entry's outcome. A Deny recorded on a request that did
+ * not end Denied is the lease ending (self-end or operator revoke), not a denial — mirroring the
+ * historical-status derivation in `../my-access-row`. A lease ending is neither good news nor bad,
+ * so it takes the neutral badge rather than the denial's danger colour.
  */
-const DECISION_LABEL_KEYS = {
-  approved: "pamStatusApproved",
-  denied: "pamStatusDenied",
-  endedByHolder: "pamAuditKindLeaseEndedByHolder",
-  revoked: "pamAuditKindLeaseRevoked",
-} as const;
+const DECISION_BADGES = {
+  approved: { labelKey: "pamStatusApproved", variant: "success" },
+  denied: { labelKey: "pamStatusDenied", variant: "danger" },
+  endedByHolder: { labelKey: "pamAuditKindLeaseEndedByHolder", variant: "subtle" },
+  revoked: { labelKey: "pamAuditKindLeaseRevoked", variant: "subtle" },
+} as const satisfies Record<string, { labelKey: string; variant: BadgeVariant }>;
 
 /** What the shell hands the drawer: the request to load. */
 export type AccessRequestDrawerParams = { requestId: string };
@@ -95,10 +97,10 @@ export type AccessRequestDrawerParams = { requestId: string };
     ButtonModule,
     IconModule,
     IconComponent,
+    ItemModule,
     NoItemsModule,
     SectionComponent,
     SectionHeaderComponent,
-    TooltipDirective,
     TypographyModule,
     RemainingTimePipe,
   ],
@@ -214,7 +216,8 @@ export class AccessRequestRouteComponent implements OnInit {
           approver?.email ||
           (approver?.id == null ? "" : uuidAsString(approver.id)),
         outcome,
-        labelKey: DECISION_LABEL_KEYS[outcome],
+        labelKey: DECISION_BADGES[outcome].labelKey,
+        variant: DECISION_BADGES[outcome].variant as BadgeVariant,
         comment: decision.comment,
         decidedAt: decision.decidedAt,
       };

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -40,10 +40,17 @@
       <ng-container header>
         <tr>
           <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-          <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
-          <th bitCell>{{ "pamInboxWindow" | i18n }}</th>
-          <th bitCell>{{ "pamInboxReason" | i18n }}</th>
-          <th bitCell bitSortable="submittedAtMs" default="asc">
+          <th bitCell bitSortable="requester" class="tw-hidden @lg:tw-table-cell">
+            {{ "pamInboxRequester" | i18n }}
+          </th>
+          <th bitCell class="tw-hidden @2xl:tw-table-cell">{{ "pamInboxWindow" | i18n }}</th>
+          <th bitCell class="tw-hidden @4xl:tw-table-cell">{{ "pamInboxReason" | i18n }}</th>
+          <th
+            bitCell
+            bitSortable="submittedAtMs"
+            default="asc"
+            class="tw-hidden @3xl:tw-table-cell"
+          >
             {{ "pamColumnSubmitted" | i18n }}
           </th>
           <th bitCell>{{ "pamColumnActions" | i18n }}</th>
@@ -72,19 +79,19 @@
               </div>
             </div>
           </td>
-          <td bitCell>
+          <td bitCell class="tw-hidden @lg:tw-table-cell">
             <div>{{ row.requester }}</div>
             @if (row.requesterEmail && row.requesterEmail !== row.requester) {
               <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
             }
           </td>
-          <td bitCell>
+          <td bitCell class="tw-hidden @2xl:tw-table-cell">
             <span class="tw-whitespace-nowrap" [title]="row.exactWindow">
               {{ row.duration.key | i18n: row.duration.value }},
               {{ row.relativeStart.key | i18n: row.relativeStart.value }}
             </span>
           </td>
-          <td bitCell>
+          <td bitCell class="tw-hidden @4xl:tw-table-cell">
             @if (row.reason) {
               <div class="tw-line-clamp-2 tw-max-w-xs tw-break-words" [title]="row.reason">
                 {{ row.reason }}
@@ -93,13 +100,13 @@
               <span class="tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
             }
           </td>
-          <td bitCell>
+          <td bitCell class="tw-hidden @3xl:tw-table-cell">
             <span class="tw-whitespace-nowrap" [title]="row.request.submittedAt | date: 'medium'">
               {{ row.elapsed.key | i18n: row.elapsed.value }}
             </span>
           </td>
           <td bitCell>
-            <div class="tw-flex tw-gap-2">
+            <div class="tw-flex tw-flex-col tw-gap-2 @sm:tw-flex-row">
               <button
                 type="button"
                 bitButton

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -14,6 +14,7 @@ import { DialogService, ToastService } from "@bitwarden/components";
 import type { AccessRequestView } from "../abstractions/access-lease";
 import { ApprovalRow, toApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
+import { tableColumnVisibility } from "../testing/table-columns";
 
 import { emptyResolvedNames } from "./access-name-resolver.service";
 import { ApprovalsTabComponent } from "./approvals-tab.component";
@@ -243,6 +244,20 @@ describe("ApprovalsTabComponent", () => {
 
       expect(dialogService.open).not.toHaveBeenCalled();
       expect(inbox.decide).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reflowing beside the drawer", () => {
+    it("sheds its secondary columns as the pane narrows, keeping the item and the decision buttons", () => {
+      inbox.inboxRows$.next([row()]);
+      create();
+
+      const [table] = tableColumnVisibility(fixture.nativeElement);
+
+      expect(table).toEqual({
+        header: [null, "@lg", "@2xl", "@4xl", "@3xl", null],
+        body: [null, "@lg", "@2xl", "@4xl", "@3xl", null],
+      });
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -27,9 +27,11 @@
       <tr>
         <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
         <th bitCell bitSortable="status">{{ "pamColumnStatus" | i18n }}</th>
-        <th bitCell>{{ "pamColumnResolver" | i18n }}</th>
-        <th bitCell>{{ "pamColumnComment" | i18n }}</th>
-        <th bitCell bitSortable="resolvedAt" default="desc">{{ "pamColumnResolved" | i18n }}</th>
+        <th bitCell class="tw-hidden @2xl:tw-table-cell">{{ "pamColumnResolver" | i18n }}</th>
+        <th bitCell class="tw-hidden @3xl:tw-table-cell">{{ "pamColumnComment" | i18n }}</th>
+        <th bitCell bitSortable="resolvedAt" default="desc" class="tw-hidden @lg:tw-table-cell">
+          {{ "pamColumnResolved" | i18n }}
+        </th>
         @if (showingManaged()) {
           <th bitCell>{{ "pamColumnActions" | i18n }}</th>
         }
@@ -90,21 +92,23 @@
             </span>
           }
         </td>
-        <td bitCell>
+        <td bitCell class="tw-hidden @2xl:tw-table-cell">
           @if (row.resolverLabelKey) {
             {{ row.resolverLabelKey | i18n }}
           } @else {
             {{ row.resolverName }}
           }
         </td>
-        <td bitCell>
+        <td bitCell class="tw-hidden @3xl:tw-table-cell">
           @if (row.approverComment) {
-            {{ row.approverComment }}
+            <div class="tw-line-clamp-2 tw-max-w-xs tw-break-words" [title]="row.approverComment">
+              {{ row.approverComment }}
+            </div>
           } @else {
             <span class="tw-text-muted">&mdash;</span>
           }
         </td>
-        <td bitCell>
+        <td bitCell class="tw-hidden @lg:tw-table-cell">
           @if (row.resolvedAt) {
             <span class="tw-whitespace-nowrap" [title]="row.resolvedAt | date: 'medium'">
               {{ row.resolvedAt | relativeTime }}

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -12,6 +12,7 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
+import { tableColumnVisibility } from "../testing/table-columns";
 
 import { HistoryTabComponent } from "./history-tab.component";
 import { MyAccessRequestRow } from "./my-access-row";
@@ -312,6 +313,32 @@ describe("HistoryTabComponent", () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain("pamMyRequestsHistoryEmpty");
+  });
+
+  describe("reflowing beside the drawer", () => {
+    it("keeps the item and the status badge, dropping the comment first and the resolved date last", () => {
+      myRows$.next([historyRow()]);
+      create();
+
+      const [table] = tableColumnVisibility(fixture.nativeElement);
+
+      expect(table).toEqual({
+        header: [null, null, "@2xl", "@3xl", "@lg"],
+        body: [null, null, "@2xl", "@3xl", "@lg"],
+      });
+    });
+
+    it("never hides the managed scope's actions column", () => {
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      create();
+      showManaged();
+
+      const [table] = tableColumnVisibility(fixture.nativeElement);
+
+      expect(table.header).toHaveLength(6);
+      expect(table.header[5]).toBeNull();
+      expect(table.body).toEqual(table.header);
+    });
   });
 
   function drawerLinks(): RouterLink[] {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -27,8 +27,15 @@
         <ng-container header>
           <tr>
             <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-            <th bitCell>{{ "pamColumnRequestedWindow" | i18n }}</th>
-            <th bitCell bitSortable="submittedAt" default="desc">
+            <th bitCell class="tw-hidden @lg:tw-table-cell">
+              {{ "pamColumnRequestedWindow" | i18n }}
+            </th>
+            <th
+              bitCell
+              bitSortable="submittedAt"
+              default="desc"
+              class="tw-hidden @2xl:tw-table-cell"
+            >
               {{ "pamColumnSubmitted" | i18n }}
             </th>
             <th bitCell class="tw-w-32">
@@ -63,7 +70,7 @@
                 </div>
               </div>
             </td>
-            <td bitCell>
+            <td bitCell class="tw-hidden @lg:tw-table-cell">
               @if (startsNow(row)) {
                 {{ "pamWindowUntil" | i18n: (row.leaseNotAfter | date: "short") }}
               } @else {
@@ -71,9 +78,11 @@
                 {{ row.leaseNotAfter | date: "short" }}
               }
             </td>
-            <td bitCell>{{ row.submittedAt | date: "short" }}</td>
+            <td bitCell class="tw-hidden @2xl:tw-table-cell">
+              {{ row.submittedAt | date: "short" }}
+            </td>
             <td bitCell>
-              <div class="tw-flex tw-items-start tw-gap-2">
+              <div class="tw-flex tw-flex-col tw-items-start tw-gap-2 @sm:tw-flex-row">
                 @if (canStart(row)) {
                   <div class="tw-flex tw-flex-col tw-items-start tw-gap-1">
                     <button
@@ -124,8 +133,15 @@
         <ng-container header>
           <tr>
             <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-            <th bitCell>{{ "pamColumnRequestedWindow" | i18n }}</th>
-            <th bitCell bitSortable="submittedAt" default="desc">
+            <th bitCell class="tw-hidden @lg:tw-table-cell">
+              {{ "pamColumnRequestedWindow" | i18n }}
+            </th>
+            <th
+              bitCell
+              bitSortable="submittedAt"
+              default="desc"
+              class="tw-hidden @2xl:tw-table-cell"
+            >
               {{ "pamColumnSubmitted" | i18n }}
             </th>
             <th bitCell class="tw-w-32">
@@ -160,11 +176,13 @@
                 </div>
               </div>
             </td>
-            <td bitCell>
+            <td bitCell class="tw-hidden @lg:tw-table-cell">
               {{ row.leaseNotBefore | date: "short" }} &ndash;
               {{ row.leaseNotAfter | date: "short" }}
             </td>
-            <td bitCell>{{ row.submittedAt | date: "short" }}</td>
+            <td bitCell class="tw-hidden @2xl:tw-table-cell">
+              {{ row.submittedAt | date: "short" }}
+            </td>
             <td bitCell>
               @if (canCancel(row)) {
                 <button
@@ -199,8 +217,10 @@
         <ng-container header>
           <tr>
             <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-            <th bitCell>{{ "pamColumnWindow" | i18n }}</th>
-            <th bitCell bitSortable="notAfter" default="asc">{{ "pamColumnRemaining" | i18n }}</th>
+            <th bitCell class="tw-hidden @2xl:tw-table-cell">{{ "pamColumnWindow" | i18n }}</th>
+            <th bitCell bitSortable="notAfter" default="asc" class="tw-hidden @sm:tw-table-cell">
+              {{ "pamColumnRemaining" | i18n }}
+            </th>
             <th bitCell class="tw-w-32">
               <span class="tw-sr-only">{{ "pamColumnActions" | i18n }}</span>
             </th>
@@ -248,10 +268,10 @@
                 </div>
               </div>
             </td>
-            <td bitCell>
+            <td bitCell class="tw-hidden @2xl:tw-table-cell">
               {{ lease.notBefore | date: "short" }} &ndash; {{ lease.notAfter | date: "short" }}
             </td>
-            <td bitCell>
+            <td bitCell class="tw-hidden @sm:tw-table-cell">
               <app-pam-access-state-badge [state]="leaseBadgeState(lease.id)" />
             </td>
             <td bitCell>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -11,6 +11,8 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
+import { tableColumnVisibility } from "../testing/table-columns";
+
 import { MyAccessLeaseRow, MyAccessRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
 import { MyRequestsTabComponent } from "./my-requests-tab.component";
@@ -258,6 +260,43 @@ describe("MyRequestsTabComponent", () => {
 
       expect(query('[data-testid="my-access-pending-empty"]')).not.toBeNull();
       expect(fixture.nativeElement.textContent).toContain("pamMyRequestsPendingEmpty");
+    });
+  });
+
+  describe("reflowing beside the drawer", () => {
+    function everyTable() {
+      pendingRows$.next([requestRow({ id: "req-pending", status: "pending" })]);
+      extensionRows$.next([requestRow({ id: "req-ext", status: "pending" })]);
+      leases$.next([leaseRow()]);
+      create();
+      return tableColumnVisibility(fixture.nativeElement);
+    }
+
+    it("keeps the item and actions columns at every container width", () => {
+      const tables = everyTable();
+
+      expect(tables).toHaveLength(3);
+      for (const { header, body } of tables) {
+        expect(header[0]).toBeNull();
+        expect(header[header.length - 1]).toBeNull();
+        expect(body[0]).toBeNull();
+        expect(body[body.length - 1]).toBeNull();
+      }
+    });
+
+    it("hides a header and its cells at the same container width, so no row shifts a column", () => {
+      for (const { header, body } of everyTable()) {
+        expect(body).toEqual(header);
+      }
+    });
+
+    it("drops the submitted date before the requested window, which is the narrower loss", () => {
+      const [pending] = everyTable();
+
+      expect(pending).toEqual({
+        header: [null, "@lg", "@2xl", null],
+        body: [null, "@lg", "@2xl", null],
+      });
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/testing/table-columns.ts
+++ b/bitwarden_license/bit-web/src/app/pam/testing/table-columns.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers for asserting how a `bit-table` reflows as its container narrows.
+ *
+ * The requests tables live inside `bit-layout`'s main content area, which is a container-query
+ * root, so their secondary columns fall away on the width of the *pane* rather than the viewport —
+ * the drawer takes half the pane while the viewport stays wide. jsdom has no layout, so a spec can
+ * only assert the declared ladder: that a hidden column names the container width that brings it
+ * back, and that a header and its body cells hide together.
+ */
+
+/** The container-query variant a column reappears at (e.g. `@2xl`), or null when it always shows. */
+export type ColumnVisibility = string | null;
+
+const HIDDEN = /(^|\s)tw-hidden(\s|$)/;
+const SHOWN_AT = /(@[^\s:]+):tw-table-cell/;
+
+/** Read one cell's declared visibility, rejecting a column that hides with no way back. */
+export function columnVisibility(cell: Element): ColumnVisibility {
+  const classes = cell.getAttribute("class") ?? "";
+  if (!HIDDEN.test(classes)) {
+    return null;
+  }
+  const shownAt = SHOWN_AT.exec(classes);
+  if (shownAt == null) {
+    throw new Error(`A hidden column names no container width that restores it: "${classes}"`);
+  }
+  return shownAt[1];
+}
+
+/** Every table's header row and first body row, read column by column. */
+export function tableColumnVisibility(
+  root: Element,
+): { header: ColumnVisibility[]; body: ColumnVisibility[] }[] {
+  return Array.from(root.querySelectorAll("table"), (table) => {
+    const firstRow = table.querySelector("tbody tr");
+    if (firstRow == null) {
+      throw new Error("A table under test rendered no rows, so its columns cannot be compared");
+    }
+    return {
+      header: Array.from(table.querySelectorAll("thead th"), columnVisibility),
+      body: Array.from(firstRow.children, columnVisibility),
+    };
+  });
+}


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket. From a UAT design review.

## 📔 Objective

Two layout fixes on top of the drawer.

**The drawer body.** The subject row becomes a `bit-item`, so no `<dd>` holds an icon and the detail list keeps a single left edge; the details are a real `<dl>` grid. Removes a duplicate Status row, two headings that repeated the drawer's own title, and the decision-log badges, so the drawer now spends exactly one badge. Each log entry is led by its verdict instead of by the actor. The exact access window was tooltip-only, so unreachable by keyboard and invisible on touch; it is now a visible line.

**The list beside the drawer.** With the drawer open the list pane narrows but the viewport does not, so viewport breakpoints never fire and the tables grew horizontal and vertical scrollbars instead of reflowing. Columns now drop on *container* width via `@tailwindcss/container-queries`, resolving against `bit-layout`'s existing `tw-@container`. Item and actions never hide. 13 of 24 columns gated across 5 tables.

The scrollbars had two causes, both fixed at source rather than capped: the accordion's `tw-max-h-80 tw-overflow-y-auto` forces a horizontal bar on any overflowing child, and History's Comment cell needed clamping. Nothing under `libs/` is touched.

## 📸 Screenshots

To follow, being re-captured against the current tip.

## Notes

- Removing the two headings orphans `pamAccessRequestDetailsTitle` and `pamAccessRequestLeaseTitle`. Left in place pending confirmation; `test-locales` does not fail on orphans.
- The header pill "Revoked" and the log's "Lease revoked" overlap in wording. Designer's call, unchanged here.
- The column ladder is deliberately non-monotonic: Reason returns at `@4xl` despite preceding Submitted in DOM order, being the widest cell.
