### PR TITLE
feat(pam): render the access request banner as a card

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -12,7 +12,7 @@
           {{ "pamActiveLeaseBannerTitle" | i18n: leaseRemainingLabel() }}
         </h3>
 
-        <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+        <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
           <span bitTypography="body2" data-testid="active-lease-ends-at">
             {{ "pamWindowUntil" | i18n: (lease.notAfter | date: "short") }}
           </span>
@@ -62,7 +62,7 @@
           </p>
         }
 
-        <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+        <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
           <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
             <app-pam-access-state-badge [state]="badge()" />
             <span bitTypography="body2" data-testid="approved-access-window">
@@ -107,7 +107,7 @@
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
         <h3 bitTypography="h5" noMargin>{{ "pamPendingRequestBannerHeading" | i18n }}</h3>
 
-        <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+        <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
           <app-pam-access-state-badge [state]="badge()" />
           <button
             type="button"
@@ -145,7 +145,7 @@
           </p>
         }
 
-        <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+        <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
           <app-pam-access-state-badge [state]="badge()" />
           <button
             type="button"

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -162,138 +162,142 @@
     </div>
 
     @if (requestFormExpanded()) {
-      <hr class="tw-my-4 tw-border-t tw-border-border-base" />
+      <div class="tw-text-fg-body">
+        <hr class="tw-my-4 tw-border-t tw-border-border-base" />
 
-      @if (loadingRequestForm()) {
-        <p bitTypography="body2" class="tw-m-0">{{ "loading" | i18n }}</p>
-      } @else if (requestMode() !== null) {
-        <p bitTypography="body2" class="tw-mb-4 tw-mt-0 tw-text-fg-body">
-          @if (requestMode() === "automatic") {
-            {{ "requestAccessModalAutomaticDescription" | i18n }}
-          } @else {
-            {{ "requestAccessModalHumanDescription" | i18n }}
-          }
-        </p>
-
-        @if (requestMode() === "automatic") {
-          <form [formGroup]="automaticForm" class="tw-flex tw-flex-col tw-gap-4">
-            <bit-form-field>
-              <bit-label>{{ "requestAccessModalDuration" | i18n }}</bit-label>
-              <select
-                bitInput
-                formControlName="durationSeconds"
-                id="pam-cipher-view-banner_select_duration"
-              >
-                @for (option of durationOptions(); track option.seconds) {
-                  <option [value]="option.seconds">
-                    {{
-                      option.labelKey ? (option.labelKey | i18n) : (option.seconds | durationShort)
-                    }}
-                  </option>
-                }
-              </select>
-            </bit-form-field>
-
-            <bit-form-field>
-              <bit-label>{{ "requestAccessModalReasonOptional" | i18n }}</bit-label>
-              <textarea
-                bitInput
-                rows="3"
-                formControlName="reason"
-                [placeholder]="'requestAccessModalReasonPlaceholder' | i18n"
-                id="pam-cipher-view-banner_textarea_automatic-reason"
-              ></textarea>
-              <bit-hint>{{ "requestAccessModalReasonHint" | i18n }}</bit-hint>
-            </bit-form-field>
-          </form>
-        } @else {
-          <form [formGroup]="humanForm" class="tw-flex tw-flex-col tw-gap-4">
-            <bit-form-field>
-              <bit-label>{{ "requestAccessModalDate" | i18n }}</bit-label>
-              <input
-                bitInput
-                type="date"
-                formControlName="date"
-                id="pam-cipher-view-banner_input_date"
-              />
-            </bit-form-field>
-
-            <div class="tw-grid tw-grid-cols-2 tw-gap-3">
-              <bit-form-field>
-                <bit-label>{{ "requestAccessModalStart" | i18n }}</bit-label>
-                <input
-                  bitInput
-                  type="time"
-                  formControlName="start"
-                  id="pam-cipher-view-banner_input_start"
-                />
-              </bit-form-field>
-              <bit-form-field>
-                <bit-label>{{ "requestAccessModalEnd" | i18n }}</bit-label>
-                <input
-                  bitInput
-                  type="time"
-                  formControlName="end"
-                  id="pam-cipher-view-banner_input_end"
-                />
-              </bit-form-field>
-            </div>
-
-            @if (windowEndBeforeStart()) {
-              <p
-                bitTypography="helper"
-                class="tw-text-danger"
-                data-testid="window-end-before-start"
-              >
-                {{ "requestAccessModalEndBeforeStart" | i18n }}
-              </p>
-            } @else if (windowExceedsMax()) {
-              <p bitTypography="helper" class="tw-text-danger" data-testid="window-exceeds-max">
-                {{
-                  "requestAccessModalWindowExceedsMax" | i18n: (maxWindowSeconds() | durationLong)
-                }}
-              </p>
+        @if (loadingRequestForm()) {
+          <p bitTypography="body2" class="tw-m-0">{{ "loading" | i18n }}</p>
+        } @else if (requestMode() !== null) {
+          <p bitTypography="body2" class="tw-mb-4 tw-mt-0">
+            @if (requestMode() === "automatic") {
+              {{ "requestAccessModalAutomaticDescription" | i18n }}
+            } @else {
+              {{ "requestAccessModalHumanDescription" | i18n }}
             }
+          </p>
 
-            <bit-form-field>
-              <bit-label>{{ "requestAccessModalReasonRequired" | i18n }}</bit-label>
-              <textarea
-                bitInput
-                rows="3"
-                formControlName="reason"
-                [placeholder]="'requestAccessModalReasonPlaceholder' | i18n"
-                id="pam-cipher-view-banner_textarea_human-reason"
-              ></textarea>
-              <bit-hint>{{ "requestAccessModalReasonHint" | i18n }}</bit-hint>
-            </bit-form-field>
-          </form>
+          @if (requestMode() === "automatic") {
+            <form [formGroup]="automaticForm" class="tw-flex tw-flex-col tw-gap-4">
+              <bit-form-field>
+                <bit-label>{{ "requestAccessModalDuration" | i18n }}</bit-label>
+                <select
+                  bitInput
+                  formControlName="durationSeconds"
+                  id="pam-cipher-view-banner_select_duration"
+                >
+                  @for (option of durationOptions(); track option.seconds) {
+                    <option [value]="option.seconds">
+                      {{
+                        option.labelKey
+                          ? (option.labelKey | i18n)
+                          : (option.seconds | durationShort)
+                      }}
+                    </option>
+                  }
+                </select>
+              </bit-form-field>
+
+              <bit-form-field>
+                <bit-label>{{ "requestAccessModalReasonOptional" | i18n }}</bit-label>
+                <textarea
+                  bitInput
+                  rows="3"
+                  formControlName="reason"
+                  [placeholder]="'requestAccessModalReasonPlaceholder' | i18n"
+                  id="pam-cipher-view-banner_textarea_automatic-reason"
+                ></textarea>
+                <bit-hint>{{ "requestAccessModalReasonHint" | i18n }}</bit-hint>
+              </bit-form-field>
+            </form>
+          } @else {
+            <form [formGroup]="humanForm" class="tw-flex tw-flex-col tw-gap-4">
+              <bit-form-field>
+                <bit-label>{{ "requestAccessModalDate" | i18n }}</bit-label>
+                <input
+                  bitInput
+                  type="date"
+                  formControlName="date"
+                  id="pam-cipher-view-banner_input_date"
+                />
+              </bit-form-field>
+
+              <div class="tw-grid tw-grid-cols-2 tw-gap-3">
+                <bit-form-field>
+                  <bit-label>{{ "requestAccessModalStart" | i18n }}</bit-label>
+                  <input
+                    bitInput
+                    type="time"
+                    formControlName="start"
+                    id="pam-cipher-view-banner_input_start"
+                  />
+                </bit-form-field>
+                <bit-form-field>
+                  <bit-label>{{ "requestAccessModalEnd" | i18n }}</bit-label>
+                  <input
+                    bitInput
+                    type="time"
+                    formControlName="end"
+                    id="pam-cipher-view-banner_input_end"
+                  />
+                </bit-form-field>
+              </div>
+
+              @if (windowEndBeforeStart()) {
+                <p
+                  bitTypography="helper"
+                  class="tw-text-danger"
+                  data-testid="window-end-before-start"
+                >
+                  {{ "requestAccessModalEndBeforeStart" | i18n }}
+                </p>
+              } @else if (windowExceedsMax()) {
+                <p bitTypography="helper" class="tw-text-danger" data-testid="window-exceeds-max">
+                  {{
+                    "requestAccessModalWindowExceedsMax" | i18n: (maxWindowSeconds() | durationLong)
+                  }}
+                </p>
+              }
+
+              <bit-form-field>
+                <bit-label>{{ "requestAccessModalReasonRequired" | i18n }}</bit-label>
+                <textarea
+                  bitInput
+                  rows="3"
+                  formControlName="reason"
+                  [placeholder]="'requestAccessModalReasonPlaceholder' | i18n"
+                  id="pam-cipher-view-banner_textarea_human-reason"
+                ></textarea>
+                <bit-hint>{{ "requestAccessModalReasonHint" | i18n }}</bit-hint>
+              </bit-form-field>
+            </form>
+          }
         }
-      }
 
-      @if (requestError(); as error) {
-        <p
-          bitTypography="helper"
-          class="tw-mb-0 tw-mt-3 tw-text-danger"
-          data-testid="request-error"
-        >
-          {{ error }}
-        </p>
-      }
-
-      @if (requestMode() !== null) {
-        <div class="tw-mt-4 tw-flex tw-justify-end">
-          <button
-            type="button"
-            bitButton
-            buttonType="primary"
-            size="small"
-            [bitAction]="submitRequest"
-            id="pam-cipher-view-banner_button_request-submit"
+        @if (requestError(); as error) {
+          <p
+            bitTypography="helper"
+            class="tw-mb-0 tw-mt-3 tw-text-danger"
+            data-testid="request-error"
           >
-            {{ "requestAccessModalSubmit" | i18n }}
-          </button>
-        </div>
-      }
+            {{ error }}
+          </p>
+        }
+
+        @if (requestMode() !== null) {
+          <div class="tw-mt-4 tw-flex tw-justify-end">
+            <button
+              type="button"
+              bitButton
+              buttonType="primary"
+              size="small"
+              [bitAction]="submitRequest"
+              id="pam-cipher-view-banner_button_request-submit"
+            >
+              {{ "requestAccessModalSubmit" | i18n }}
+            </button>
+          </div>
+        }
+      </div>
     }
   </bit-card>
 }

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -1,11 +1,7 @@
 @if (activeLease(); as lease) {
   <bit-card class="tw-mb-4" data-testid="cipher-view-banner-active">
     <div class="tw-flex tw-items-start tw-gap-4">
-      <div
-        class="tw-flex tw-size-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-bg-bg-accent-primary-medium tw-border-border-accent-primary-soft tw-text-fg-accent-primary"
-      >
-        <bit-icon name="bwi-clock" />
-      </div>
+      <bit-icon-tile icon="bwi-clock" variant="teal" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
         <!--
           No access-state badge here: the heading already carries the live countdown, and the badge's
@@ -51,11 +47,7 @@
 } @else if (approvedRequest(); as request) {
   <bit-card class="tw-mb-4" data-testid="cipher-view-banner-approved">
     <div class="tw-flex tw-items-start tw-gap-4">
-      <div
-        class="tw-flex tw-size-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-bg-bg-success-medium tw-border-border-success-soft tw-text-fg-success"
-      >
-        <bit-icon name="bwi-check-circle" />
-      </div>
+      <bit-icon-tile icon="bwi-check-circle" variant="success" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
         <h3 bitTypography="h5" noMargin>{{ "pamApprovedRequestBannerHeading" | i18n }}</h3>
 
@@ -111,11 +103,7 @@
 } @else if (pendingRequest()) {
   <bit-card class="tw-mb-4" data-testid="cipher-view-banner-pending">
     <div class="tw-flex tw-items-start tw-gap-4">
-      <div
-        class="tw-flex tw-size-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-bg-bg-warning-medium tw-border-border-warning-soft tw-text-fg-warning"
-      >
-        <bit-icon name="bwi-clock" />
-      </div>
+      <bit-icon-tile icon="bwi-clock" variant="warning" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
         <h3 bitTypography="h5" noMargin>{{ "pamPendingRequestBannerHeading" | i18n }}</h3>
 
@@ -138,11 +126,7 @@
 } @else if (canRequestAccess()) {
   <bit-card class="tw-mb-4" data-testid="cipher-view-banner-request">
     <div class="tw-flex tw-items-start tw-gap-4">
-      <div
-        class="tw-flex tw-size-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-bg-bg-brand-soft tw-border-border-brand-soft tw-text-fg-brand"
-      >
-        <bit-icon name="bwi-key" />
-      </div>
+      <bit-icon-tile icon="bwi-key" variant="primary" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
         <h3 bitTypography="h5" noMargin>{{ "pamRequestAccessBannerHeading" | i18n }}</h3>
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -1,159 +1,189 @@
 @if (activeLease(); as lease) {
-  <bit-callout
-    type="success"
-    [title]="'pamActiveLeaseBannerTitle' | i18n: leaseRemainingLabel()"
-    data-testid="cipher-view-banner-active"
-  >
-    <!--
-      No access-state badge here: the title already carries the live countdown, and the badge's
-      "N left" / "Ending soon" pill would render a second copy of the same clock. The other three
-      states have no countdown in their title, so they show the shared pill.
-    -->
-    <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
-      <span bitTypography="body2" data-testid="active-lease-ends-at">
-        {{ "pamWindowUntil" | i18n: (lease.notAfter | date: "short") }}
-      </span>
-      <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-        @if (canExtendLease()) {
+  <bit-card class="tw-mb-4" data-testid="cipher-view-banner-active">
+    <div class="tw-flex tw-items-start tw-gap-4">
+      <div
+        class="tw-flex tw-size-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-bg-bg-accent-primary-medium tw-border-border-accent-primary-soft tw-text-fg-accent-primary"
+      >
+        <bit-icon name="bwi-clock" />
+      </div>
+      <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
+        <!--
+          No access-state badge here: the heading already carries the live countdown, and the badge's
+          "N left" / "Ending soon" pill would render a second copy of the same clock. The other three
+          states have no countdown in their heading, so they show the shared pill.
+        -->
+        <h3 bitTypography="h5" noMargin>
+          {{ "pamActiveLeaseBannerTitle" | i18n: leaseRemainingLabel() }}
+        </h3>
+
+        <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+          <span bitTypography="body2" data-testid="active-lease-ends-at">
+            {{ "pamWindowUntil" | i18n: (lease.notAfter | date: "short") }}
+          </span>
+          <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+            @if (canExtendLease()) {
+              <button
+                type="button"
+                bitButton
+                buttonType="secondary"
+                size="small"
+                [bitAction]="extendLease"
+                id="pam-cipher-view-banner_button_extend"
+              >
+                {{ "pamExtendLeaseButton" | i18n }}
+              </button>
+            }
+            <button
+              type="button"
+              bitButton
+              buttonType="danger"
+              size="small"
+              [bitAction]="endLease"
+              id="pam-cipher-view-banner_button_end"
+            >
+              {{ "pamEndLeaseButton" | i18n }}
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </bit-card>
+} @else if (approvedRequest(); as request) {
+  <bit-card class="tw-mb-4" data-testid="cipher-view-banner-approved">
+    <div class="tw-flex tw-items-start tw-gap-4">
+      <div
+        class="tw-flex tw-size-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-bg-bg-success-medium tw-border-border-success-soft tw-text-fg-success"
+      >
+        <bit-icon name="bwi-check-circle" />
+      </div>
+      <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
+        <h3 bitTypography="h5" noMargin>{{ "pamApprovedRequestBannerHeading" | i18n }}</h3>
+
+        @if (approvedDurationSeconds(); as grantedSeconds) {
+          <p
+            bitTypography="body2"
+            class="tw-m-0 tw-flex tw-items-center tw-gap-2"
+            data-testid="cipher-view-banner-approved-duration"
+          >
+            <bit-icon name="bwi-clock" />
+            {{ "pamApprovedRequestBannerDuration" | i18n: (grantedSeconds | durationLong) }}
+          </p>
+        }
+
+        <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+          <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+            <app-pam-access-state-badge [state]="badge()" />
+            <span bitTypography="body2" data-testid="approved-access-window">
+              @if (approvedRequestStartsNow()) {
+                {{ "pamWindowUntil" | i18n: (request.leaseNotAfter | date: "short") }}
+              } @else {
+                {{ request.leaseNotBefore | date: "short" }} &ndash;
+                {{ request.leaseNotAfter | date: "short" }}
+              }
+            </span>
+          </span>
+          <span class="tw-flex tw-items-center tw-gap-2">
+            <button
+              type="button"
+              bitButton
+              buttonType="primary"
+              size="small"
+              [bitAction]="activateRequest"
+              id="pam-cipher-view-banner_button_start"
+            >
+              {{ "pamStartLeaseButton" | i18n }}
+            </button>
+            <button
+              type="button"
+              bitButton
+              buttonType="secondary"
+              size="small"
+              [bitAction]="cancelRequest"
+              id="pam-cipher-view-banner_button_cancel-approved"
+            >
+              {{ "pendingStateCancelRequest" | i18n }}
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </bit-card>
+} @else if (pendingRequest()) {
+  <bit-card class="tw-mb-4" data-testid="cipher-view-banner-pending">
+    <div class="tw-flex tw-items-start tw-gap-4">
+      <div
+        class="tw-flex tw-size-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-bg-bg-warning-medium tw-border-border-warning-soft tw-text-fg-warning"
+      >
+        <bit-icon name="bwi-clock" />
+      </div>
+      <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
+        <h3 bitTypography="h5" noMargin>{{ "pamPendingRequestBannerHeading" | i18n }}</h3>
+
+        <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+          <app-pam-access-state-badge [state]="badge()" />
           <button
             type="button"
             bitButton
             buttonType="secondary"
             size="small"
-            [bitAction]="extendLease"
-            id="pam-cipher-view-banner_button_extend"
+            [bitAction]="cancelRequest"
+            id="pam-cipher-view-banner_button_cancel"
           >
-            {{ "pamExtendLeaseButton" | i18n }}
+            {{ "pendingStateCancelRequest" | i18n }}
           </button>
-        }
-        <button
-          type="button"
-          bitButton
-          buttonType="danger"
-          size="small"
-          [bitAction]="endLease"
-          id="pam-cipher-view-banner_button_end"
-        >
-          {{ "pamEndLeaseButton" | i18n }}
-        </button>
-      </span>
+        </div>
+      </div>
     </div>
-  </bit-callout>
-} @else if (approvedRequest(); as request) {
-  <bit-callout
-    type="success"
-    [title]="'pamApprovedRequestBannerHeading' | i18n"
-    data-testid="cipher-view-banner-approved"
-  >
-    @if (approvedDurationSeconds(); as grantedSeconds) {
-      <p
-        bitTypography="body2"
-        class="tw-mb-3 tw-mt-0 tw-flex tw-items-center tw-gap-2"
-        data-testid="cipher-view-banner-approved-duration"
-      >
-        <bit-icon name="bwi-clock" />
-        {{ "pamApprovedRequestBannerDuration" | i18n: (grantedSeconds | durationLong) }}
-      </p>
-    }
-
-    <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
-      <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-        <app-pam-access-state-badge [state]="badge()" />
-        <span bitTypography="body2" data-testid="approved-access-window">
-          @if (approvedRequestStartsNow()) {
-            {{ "pamWindowUntil" | i18n: (request.leaseNotAfter | date: "short") }}
-          } @else {
-            {{ request.leaseNotBefore | date: "short" }} &ndash;
-            {{ request.leaseNotAfter | date: "short" }}
-          }
-        </span>
-      </span>
-      <span class="tw-flex tw-items-center tw-gap-2">
-        <button
-          type="button"
-          bitButton
-          buttonType="primary"
-          size="small"
-          [bitAction]="activateRequest"
-          id="pam-cipher-view-banner_button_start"
-        >
-          {{ "pamStartLeaseButton" | i18n }}
-        </button>
-        <button
-          type="button"
-          bitButton
-          buttonType="secondary"
-          size="small"
-          [bitAction]="cancelRequest"
-          id="pam-cipher-view-banner_button_cancel-approved"
-        >
-          {{ "pendingStateCancelRequest" | i18n }}
-        </button>
-      </span>
-    </div>
-  </bit-callout>
-} @else if (pendingRequest()) {
-  <bit-callout
-    type="warning"
-    [title]="'pamPendingRequestBannerHeading' | i18n"
-    data-testid="cipher-view-banner-pending"
-  >
-    <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
-      <app-pam-access-state-badge [state]="badge()" />
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        size="small"
-        [bitAction]="cancelRequest"
-        id="pam-cipher-view-banner_button_cancel"
-      >
-        {{ "pendingStateCancelRequest" | i18n }}
-      </button>
-    </div>
-  </bit-callout>
+  </bit-card>
 } @else if (canRequestAccess()) {
-  <bit-callout
-    type="info"
-    [title]="'pamRequestAccessBannerHeading' | i18n"
-    data-testid="cipher-view-banner-request"
-  >
-    <p bitTypography="body2" class="tw-mb-3 tw-mt-0">
-      {{ "pamRequestAccessBannerBody" | i18n }}
-    </p>
-
-    @if (restingRequestTerms(); as terms) {
-      <p
-        bitTypography="body2"
-        class="tw-mb-3 tw-mt-0 tw-flex tw-items-center tw-gap-2"
-        data-testid="cipher-view-banner-max-duration"
+  <bit-card class="tw-mb-4" data-testid="cipher-view-banner-request">
+    <div class="tw-flex tw-items-start tw-gap-4">
+      <div
+        class="tw-flex tw-size-8 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-bg-bg-brand-soft tw-border-border-brand-soft tw-text-fg-brand"
       >
-        <bit-icon name="bwi-clock" />
-        {{ terms.messageKey | i18n: (terms.maxSeconds | durationLong) }}
-      </p>
-    }
+        <bit-icon name="bwi-key" />
+      </div>
+      <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
+        <h3 bitTypography="h5" noMargin>{{ "pamRequestAccessBannerHeading" | i18n }}</h3>
 
-    <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
-      <app-pam-access-state-badge [state]="badge()" />
-      <button
-        type="button"
-        bitButton
-        buttonType="primary"
-        size="small"
-        (click)="toggleRequestForm()"
-        id="pam-cipher-view-banner_button_request-toggle"
-      >
-        {{ (requestFormExpanded() ? "cancel" : "pamRequestAccessButton") | i18n }}
-      </button>
+        <p bitTypography="body2" class="tw-m-0">
+          {{ "pamRequestAccessBannerBody" | i18n }}
+        </p>
+
+        @if (restingRequestTerms(); as terms) {
+          <p
+            bitTypography="body2"
+            class="tw-m-0 tw-flex tw-items-center tw-gap-2"
+            data-testid="cipher-view-banner-max-duration"
+          >
+            <bit-icon name="bwi-clock" />
+            {{ terms.messageKey | i18n: (terms.maxSeconds | durationLong) }}
+          </p>
+        }
+
+        <div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+          <app-pam-access-state-badge [state]="badge()" />
+          <button
+            type="button"
+            bitButton
+            buttonType="primary"
+            size="small"
+            (click)="toggleRequestForm()"
+            id="pam-cipher-view-banner_button_request-toggle"
+          >
+            {{ (requestFormExpanded() ? "cancel" : "pamRequestAccessButton") | i18n }}
+          </button>
+        </div>
+      </div>
     </div>
 
     @if (requestFormExpanded()) {
-      <hr class="tw-my-3 tw-border-t tw-border-border-brand-soft" />
+      <hr class="tw-my-4 tw-border-t tw-border-border-base" />
 
       @if (loadingRequestForm()) {
         <p bitTypography="body2" class="tw-m-0">{{ "loading" | i18n }}</p>
       } @else if (requestMode() !== null) {
-        <p bitTypography="body2" class="tw-mb-4 tw-mt-0">
+        <p bitTypography="body2" class="tw-mb-4 tw-mt-0 tw-text-fg-body">
           @if (requestMode() === "automatic") {
             {{ "requestAccessModalAutomaticDescription" | i18n }}
           } @else {
@@ -281,5 +311,5 @@
         </div>
       }
     }
-  </bit-callout>
+  </bit-card>
 }

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -1,66 +1,72 @@
 @if (activeLease(); as lease) {
   <bit-card class="tw-mb-4" data-testid="cipher-view-banner-active">
     <div class="tw-flex tw-items-start tw-gap-4">
-      <bit-icon-tile icon="bwi-clock" variant="teal" />
+      <bit-icon-tile icon="bwi-clock" variant="teal" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
         <!--
           No access-state badge here: the heading already carries the live countdown, and the badge's
           "N left" / "Ending soon" pill would render a second copy of the same clock. The other three
           states have no countdown in their heading, so they show the shared pill.
         -->
-        <h3 bitTypography="h5" noMargin>
-          {{ "pamActiveLeaseBannerTitle" | i18n: leaseRemainingLabel() }}
-        </h3>
-
-        <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
-          <span bitTypography="body2" data-testid="active-lease-ends-at">
+        <div class="tw-flex tw-flex-col">
+          <h3 bitTypography="h5" noMargin>
+            {{ "pamActiveLeaseBannerTitle" | i18n: leaseRemainingLabel() }}
+          </h3>
+          <span
+            bitTypography="helper"
+            class="tw-text-fg-body-subtle"
+            data-testid="active-lease-ends-at"
+          >
             {{ "pamWindowUntil" | i18n: (lease.notAfter | date: "short") }}
           </span>
-          <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-            @if (canExtendLease()) {
-              <button
-                type="button"
-                bitButton
-                buttonType="secondary"
-                size="small"
-                [bitAction]="extendLease"
-                id="pam-cipher-view-banner_button_extend"
-              >
-                {{ "pamExtendLeaseButton" | i18n }}
-              </button>
-            }
+        </div>
+
+        <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+          @if (canExtendLease()) {
             <button
               type="button"
               bitButton
-              buttonType="danger"
+              buttonType="secondary"
               size="small"
-              [bitAction]="endLease"
-              id="pam-cipher-view-banner_button_end"
+              [bitAction]="extendLease"
+              id="pam-cipher-view-banner_button_extend"
             >
-              {{ "pamEndLeaseButton" | i18n }}
+              {{ "pamExtendLeaseButton" | i18n }}
             </button>
-          </span>
-        </div>
+          }
+          <button
+            type="button"
+            bitButton
+            buttonType="danger"
+            size="small"
+            [bitAction]="endLease"
+            id="pam-cipher-view-banner_button_end"
+          >
+            {{ "pamEndLeaseButton" | i18n }}
+          </button>
+        </span>
       </div>
     </div>
   </bit-card>
 } @else if (approvedRequest(); as request) {
   <bit-card class="tw-mb-4" data-testid="cipher-view-banner-approved">
     <div class="tw-flex tw-items-start tw-gap-4">
-      <bit-icon-tile icon="bwi-check-circle" variant="success" />
+      <bit-icon-tile icon="bwi-check-circle" variant="success" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
-        <h3 bitTypography="h5" noMargin>{{ "pamApprovedRequestBannerHeading" | i18n }}</h3>
+        <div class="tw-flex tw-flex-col">
+          <h3 bitTypography="h5" noMargin>{{ "pamApprovedRequestBannerHeading" | i18n }}</h3>
 
-        @if (approvedDurationSeconds(); as grantedSeconds) {
-          <p
-            bitTypography="body2"
-            class="tw-m-0 tw-flex tw-items-center tw-gap-2"
-            data-testid="cipher-view-banner-approved-duration"
-          >
-            <bit-icon name="bwi-clock" />
-            {{ "pamApprovedRequestBannerDuration" | i18n: (grantedSeconds | durationLong) }}
-          </p>
-        }
+          @if (approvedDurationSeconds(); as grantedSeconds) {
+            <p
+              bitTypography="helper"
+              class="tw-m-0 tw-flex tw-items-center tw-gap-2 tw-text-fg-body-subtle"
+              data-testid="cipher-view-banner-approved-duration"
+            >
+              <bit-icon name="bwi-clock" />
+              {{ "pamApprovedRequestBannerDuration" | i18n: (grantedSeconds | durationLong) }}
+            </p>
+          }
+        </div>
 
         <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
           <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
@@ -103,7 +109,7 @@
 } @else if (pendingRequest()) {
   <bit-card class="tw-mb-4" data-testid="cipher-view-banner-pending">
     <div class="tw-flex tw-items-start tw-gap-4">
-      <bit-icon-tile icon="bwi-clock" variant="warning" />
+      <bit-icon-tile icon="bwi-clock" variant="warning" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
         <h3 bitTypography="h5" noMargin>{{ "pamPendingRequestBannerHeading" | i18n }}</h3>
 
@@ -126,13 +132,15 @@
 } @else if (canRequestAccess()) {
   <bit-card class="tw-mb-4" data-testid="cipher-view-banner-request">
     <div class="tw-flex tw-items-start tw-gap-4">
-      <bit-icon-tile icon="bwi-key" variant="primary" />
+      <bit-icon-tile icon="bwi-key" variant="primary" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
-        <h3 bitTypography="h5" noMargin>{{ "pamRequestAccessBannerHeading" | i18n }}</h3>
+        <div class="tw-flex tw-flex-col">
+          <h3 bitTypography="h5" noMargin>{{ "pamRequestAccessBannerHeading" | i18n }}</h3>
 
-        <p bitTypography="body2" class="tw-m-0">
-          {{ "pamRequestAccessBannerBody" | i18n }}
-        </p>
+          <p bitTypography="helper" class="tw-m-0 tw-text-fg-body-subtle">
+            {{ "pamRequestAccessBannerBody" | i18n }}
+          </p>
+        </div>
 
         @if (restingRequestTerms(); as terms) {
           <p

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -445,49 +445,43 @@ describe("CipherViewBannerComponent", () => {
   });
 
   describe("the card container", () => {
-    // Each state is the same card in a different mood, so the tile's glyph is the only thing that
-    // distinguishes them structurally.
-    const cases: ReadonlyArray<[string, () => void, string, string]> = [
-      ["resting request-access", () => {}, "cipher-view-banner-request", "bwi-key"],
-      [
-        "pending request",
-        () =>
-          requestsApi.getCipherAccessState.mockResolvedValue(
-            accessState({ pendingRequest: requestView() }),
-          ),
-        "cipher-view-banner-pending",
-        "bwi-clock",
-      ],
-      [
-        "approved request",
-        () =>
-          requestsApi.getCipherAccessState.mockResolvedValue(
-            accessState({ approvedRequest: requestView() }),
-          ),
-        "cipher-view-banner-approved",
-        "bwi-check-circle",
-      ],
-      [
-        "active lease",
-        () =>
-          requestsApi.getCipherAccessState.mockResolvedValue(
-            accessState({ activeLease: leaseView() }),
-          ),
-        "cipher-view-banner-active",
-        "bwi-clock",
-      ],
+    const cases: ReadonlyArray<{
+      name: string;
+      state: Partial<CipherAccessStateView>;
+      testId: string;
+      glyph: string;
+    }> = [
+      { name: "resting request-access", state: {}, testId: "request", glyph: "bwi-key" },
+      {
+        name: "pending request",
+        state: { pendingRequest: requestView() },
+        testId: "pending",
+        glyph: "bwi-clock",
+      },
+      {
+        name: "approved request",
+        state: { approvedRequest: requestView() },
+        testId: "approved",
+        glyph: "bwi-check-circle",
+      },
+      {
+        name: "active lease",
+        state: { activeLease: leaseView() },
+        testId: "active",
+        glyph: "bwi-clock",
+      },
     ];
 
     it.each(cases)(
-      "renders %s as a card with an icon tile",
-      async (_name, arrange, testId, glyph) => {
-        arrange();
+      "renders $name as a card with an icon tile",
+      async ({ state, testId, glyph }) => {
+        requestsApi.getCipherAccessState.mockResolvedValue(accessState(state));
 
         await create(gatedCipher());
 
-        const card = query(`bit-card[data-testid="${testId}"]`);
+        const card = query(`bit-card[data-testid="cipher-view-banner-${testId}"]`);
         expect(card).not.toBeNull();
-        expect(card?.querySelector(`bit-icon.${glyph}`)).not.toBeNull();
+        expect(card?.querySelector(`bit-icon-tile i.${glyph}`)).not.toBeNull();
       },
     );
   });

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -208,7 +208,7 @@ describe("CipherViewBannerComponent", () => {
       await create(gatedCipher({ partial: false }));
 
       expect(requestsApi.getCipherAccessState).not.toHaveBeenCalled();
-      expect(query("bit-callout")).toBeNull();
+      expect(query("bit-card")).toBeNull();
     });
 
     it("renders nothing when the PAM feature flag is off", async () => {
@@ -217,7 +217,7 @@ describe("CipherViewBannerComponent", () => {
       await create(gatedCipher());
 
       expect(requestsApi.getCipherAccessState).not.toHaveBeenCalled();
-      expect(query("bit-callout")).toBeNull();
+      expect(query("bit-card")).toBeNull();
     });
 
     it("reads access state for a leaseGated cipher whose partial data is gone", async () => {
@@ -232,7 +232,7 @@ describe("CipherViewBannerComponent", () => {
 
       await create(gatedCipher());
 
-      expect(query("bit-callout")).toBeNull();
+      expect(query("bit-card")).toBeNull();
     });
   });
 
@@ -442,6 +442,54 @@ describe("CipherViewBannerComponent", () => {
         until(ENDS_AT),
       );
     });
+  });
+
+  describe("the card container", () => {
+    // Each state is the same card in a different mood, so the tile's glyph is the only thing that
+    // distinguishes them structurally.
+    const cases: ReadonlyArray<[string, () => void, string, string]> = [
+      ["resting request-access", () => {}, "cipher-view-banner-request", "bwi-key"],
+      [
+        "pending request",
+        () =>
+          requestsApi.getCipherAccessState.mockResolvedValue(
+            accessState({ pendingRequest: requestView() }),
+          ),
+        "cipher-view-banner-pending",
+        "bwi-clock",
+      ],
+      [
+        "approved request",
+        () =>
+          requestsApi.getCipherAccessState.mockResolvedValue(
+            accessState({ approvedRequest: requestView() }),
+          ),
+        "cipher-view-banner-approved",
+        "bwi-check-circle",
+      ],
+      [
+        "active lease",
+        () =>
+          requestsApi.getCipherAccessState.mockResolvedValue(
+            accessState({ activeLease: leaseView() }),
+          ),
+        "cipher-view-banner-active",
+        "bwi-clock",
+      ],
+    ];
+
+    it.each(cases)(
+      "renders %s as a card with an icon tile",
+      async (_name, arrange, testId, glyph) => {
+        arrange();
+
+        await create(gatedCipher());
+
+        const card = query(`bit-card[data-testid="${testId}"]`);
+        expect(card).not.toBeNull();
+        expect(card?.querySelector(`bit-icon.${glyph}`)).not.toBeNull();
+      },
+    );
   });
 
   describe("the rule's terms, before the form is opened", () => {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -22,7 +22,7 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   AsyncActionsModule,
   ButtonModule,
-  CalloutModule,
+  CardComponent,
   DialogService,
   FormFieldModule,
   IconModule,
@@ -90,7 +90,7 @@ import {
   imports: [
     AsyncActionsModule,
     ButtonModule,
-    CalloutModule,
+    CardComponent,
     FormFieldModule,
     IconModule,
     ReactiveFormsModule,

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -26,6 +26,7 @@ import {
   DialogService,
   FormFieldModule,
   IconModule,
+  IconTileComponent,
   ToastService,
   TypographyModule,
 } from "@bitwarden/components";
@@ -93,6 +94,7 @@ import {
     CardComponent,
     FormFieldModule,
     IconModule,
+    IconTileComponent,
     ReactiveFormsModule,
     TypographyModule,
     AccessStateBadgeComponent,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39643

## 📔 Objective

Replaces `bit-callout` with `bit-card` as the container for all four access-request banner states (resting, pending, approved, active lease), matching the design's card treatment.

- Each state renders a `<bit-card>` with a leading 24px `<bit-icon-tile size="sm">` beside a text column: key/primary when resting, clock/warning when pending, check-circle/success when approved, clock/teal under an active lease.
- The heading each state passed as the callout's `[title]` becomes an in-body `<h3 bitTypography="h5" noMargin>`. Note that `bit-callout` wrapped that title in an `<aside>` landmark with `aria-labelledby`; the card has neither, so the banner is no longer a landmark. Visible text treatment is unchanged.
- The request form stays inside the card, below an `<hr>`, rather than moving to a separate section.

Known deviation: the design calls for an 8px corner radius, and `bit-card` inherits a fixed 12px from `libs/components`, which this milestone is scoped away from editing. Logged in `DECISIONS.md`.

## 📸 Screenshots

Before:
<img width="1536" height="1308" alt="01-before-automatic-rule" src="https://github.com/user-attachments/assets/3366581d-9150-4969-9933-a8dfb1c52df6" />
After:
<img width="1536" height="1388" alt="02-after-automatic-rule" src="https://github.com/user-attachments/assets/c2bd9715-db2e-40a8-acbb-eba928053c35" />
Before:
<img width="1536" height="1616" alt="03-before-human-rule" src="https://github.com/user-attachments/assets/dc16682b-a0fd-471d-847a-0a73d1765a47" />
After:
<img width="1536" height="1700" alt="04-after-human-rule" src="https://github.com/user-attachments/assets/d1445db3-fecf-4b6d-84c6-97732d4db5d5" />



