### PR TITLE
feat(vault): order the gated cipher view to match the design

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -1,5 +1,5 @@
 @if (activeLease(); as lease) {
-  <bit-card class="tw-mb-4" data-testid="cipher-view-banner-active">
+  <bit-card class="tw-mb-5 bit-compact:tw-mb-4" data-testid="cipher-view-banner-active">
     <div class="tw-flex tw-items-start tw-gap-4">
       <bit-icon-tile icon="bwi-clock" variant="teal" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
@@ -49,7 +49,7 @@
     </div>
   </bit-card>
 } @else if (approvedRequest(); as request) {
-  <bit-card class="tw-mb-4" data-testid="cipher-view-banner-approved">
+  <bit-card class="tw-mb-5 bit-compact:tw-mb-4" data-testid="cipher-view-banner-approved">
     <div class="tw-flex tw-items-start tw-gap-4">
       <bit-icon-tile icon="bwi-check-circle" variant="success" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
@@ -107,7 +107,7 @@
     </div>
   </bit-card>
 } @else if (pendingRequest()) {
-  <bit-card class="tw-mb-4" data-testid="cipher-view-banner-pending">
+  <bit-card class="tw-mb-5 bit-compact:tw-mb-4" data-testid="cipher-view-banner-pending">
     <div class="tw-flex tw-items-start tw-gap-4">
       <bit-icon-tile icon="bwi-clock" variant="warning" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
@@ -130,7 +130,7 @@
     </div>
   </bit-card>
 } @else if (canRequestAccess()) {
-  <bit-card class="tw-mb-4" data-testid="cipher-view-banner-request">
+  <bit-card class="tw-mb-5 bit-compact:tw-mb-4" data-testid="cipher-view-banner-request">
     <div class="tw-flex tw-items-start tw-gap-4">
       <bit-icon-tile icon="bwi-key" variant="primary" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
@@ -45,7 +45,7 @@ import {
 import { CipherViewBannerComponent } from "./cipher-view-banner.component";
 
 /**
- * The composed cipher view, rather than the banner on its own — this is where the card ORDER is
+ * The composed cipher view, rather than the banner on its own. This is where the card ORDER is
  * visible, and the order is the only thing these stories exist to show: identity, then access, then
  * Autofill options, then Item history.
  *
@@ -86,7 +86,7 @@ function provideStoryCipherView() {
   return [
     // Only the PAM flag is on. `VFO1Foundation` and `PM32016RemoveAtRiskCallout` are read by the
     // cipher view and its item-details child, and blanket-enabling every flag would silently swap
-    // the terminology and drop the at-risk callout — neither of which these stories are about.
+    // the terminology and drop the at-risk callout, neither of which these stories are about.
     {
       provide: ConfigService,
       useValue: { getFeatureFlag$: (flag: FeatureFlag) => of(flag === FeatureFlag.Pam) },
@@ -124,7 +124,6 @@ function provideStoryCipherView() {
   ];
 }
 
-/** Binds the real banner to the token, over an access state built at render time. */
 function gated(state: () => Record<string, unknown>) {
   return moduleMetadata({
     imports: [CipherViewBannerComponent],
@@ -206,7 +205,7 @@ export const Pending: Story = {
   ],
 };
 
-/** Approved but not yet started — the tallest of the three access cards. */
+/** Approved but not yet started: the tallest of the three access cards. */
 export const Approved: Story = {
   decorators: [
     gated(() => ({

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
@@ -54,39 +54,28 @@ import { CipherViewBannerComponent } from "./cipher-view-banner.component";
  * untouched; that story is the ungoverned item, with no `CIPHER_VIEW_BANNER` bound at all.
  */
 
+function loginCipher(id: string, name: string, uri: string): CipherView {
+  const cipher = new CipherView();
+  cipher.id = id;
+  cipher.name = name;
+  cipher.type = CipherType.Login;
+  cipher.login.uris = [Object.assign(new LoginUriView(), { uri })];
+  return cipher;
+}
+
 /** A governed item, still unrevealed: `partial` is what marks it, and it carries no credentials. */
 function gatedCipher(): CipherView {
-  const cipher = new CipherView();
-  cipher.id = "cipher-1";
-  cipher.name = "Prod database";
-  cipher.type = CipherType.Login;
+  const cipher = loginCipher("cipher-1", "Prod database", "https://db.example.com");
   cipher.organizationId = "org-1";
   cipher.partial = true;
-  cipher.login.uris = [Object.assign(new LoginUriView(), { uri: "https://db.example.com" })];
   return cipher;
 }
 
 function ordinaryCipher(): CipherView {
-  const cipher = new CipherView();
-  cipher.id = "cipher-9";
-  cipher.name = "Example account";
-  cipher.type = CipherType.Login;
+  const cipher = loginCipher("cipher-9", "Example account", "https://example.com");
   cipher.login.username = "ada.lovelace";
   cipher.login.password = "correct-horse-battery-staple";
-  cipher.login.uris = [Object.assign(new LoginUriView(), { uri: "https://example.com" })];
   return cipher;
-}
-
-/**
- * Only the PAM flag is on. `VFO1Foundation` and `PM32016RemoveAtRiskCallout` are read by the cipher
- * view and its item-details child, and blanket-enabling every flag would silently swap the
- * terminology and drop the at-risk callout — neither of which these stories are about.
- */
-function stubConfigService() {
-  return {
-    provide: ConfigService,
-    useValue: { getFeatureFlag$: (flag: FeatureFlag) => of(flag === FeatureFlag.Pam) },
-  };
 }
 
 /**
@@ -95,7 +84,13 @@ function stubConfigService() {
  */
 function provideStoryCipherView() {
   return [
-    stubConfigService(),
+    // Only the PAM flag is on. `VFO1Foundation` and `PM32016RemoveAtRiskCallout` are read by the
+    // cipher view and its item-details child, and blanket-enabling every flag would silently swap
+    // the terminology and drop the at-risk callout — neither of which these stories are about.
+    {
+      provide: ConfigService,
+      useValue: { getFeatureFlag$: (flag: FeatureFlag) => of(flag === FeatureFlag.Pam) },
+    },
     provideRouter([]),
     DatePipe,
     {
@@ -129,10 +124,8 @@ function provideStoryCipherView() {
   ];
 }
 
-type AccessState = Record<string, unknown> | null;
-
 /** Binds the real banner to the token, over an access state built at render time. */
-function gated(state: () => AccessState) {
+function gated(state: () => Record<string, unknown>) {
   return moduleMetadata({
     imports: [CipherViewBannerComponent],
     providers: [

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
@@ -1,0 +1,236 @@
+import { DatePipe } from "@angular/common";
+import { importProvidersFrom } from "@angular/core";
+import { provideRouter } from "@angular/router";
+import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
+import { EMPTY, of } from "rxjs";
+
+import { CollectionService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
+import { EventCollectionService } from "@bitwarden/common/dirt/event-logs";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { EnvironmentService } from "@bitwarden/common/platform/abstractions/environment.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { ChangeLoginPasswordService } from "@bitwarden/common/vault/abstractions/change-login-password.service";
+import { CipherRiskService } from "@bitwarden/common/vault/abstractions/cipher-risk.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
+import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
+import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault-settings/vault-settings.service";
+import { ViewPasswordHistoryService } from "@bitwarden/common/vault/abstractions/view-password-history.service";
+import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
+import { TaskService } from "@bitwarden/common/vault/tasks";
+import { DialogService, ToastService } from "@bitwarden/components";
+import { CipherViewComponent, CIPHER_VIEW_BANNER } from "@bitwarden/vault";
+import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
+
+import { AccessLeaseSdkService } from "../abstractions/access-lease-sdk.service";
+import { AccessRefreshService } from "../abstractions/access-refresh.service";
+import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
+import { LeasingErrorService } from "../abstractions/leasing-error.service";
+import { AccessRequestCancelService } from "../services/access-request-cancel.service";
+import {
+  HOUR,
+  accessRequest,
+  liveFromNow,
+  provideStoryChangeDetection,
+  provideStoryLogService,
+} from "../testing/story-fixtures";
+
+import { CipherViewBannerComponent } from "./cipher-view-banner.component";
+
+/**
+ * The composed cipher view, rather than the banner on its own — this is where the card ORDER is
+ * visible, and the order is the only thing these stories exist to show: identity, then access, then
+ * Autofill options, then Item history.
+ *
+ * {@link OrdinaryLogin} is the load-bearing one. `cipher-view.component.html` renders every vault
+ * item in the product, so a change to where the banner outlet sits has to leave an ungoverned item
+ * untouched; that story is the ungoverned item, with no `CIPHER_VIEW_BANNER` bound at all.
+ */
+
+/** A governed item, still unrevealed: `partial` is what marks it, and it carries no credentials. */
+function gatedCipher(): CipherView {
+  const cipher = new CipherView();
+  cipher.id = "cipher-1";
+  cipher.name = "Prod database";
+  cipher.type = CipherType.Login;
+  cipher.organizationId = "org-1";
+  cipher.partial = true;
+  cipher.login.uris = [Object.assign(new LoginUriView(), { uri: "https://db.example.com" })];
+  return cipher;
+}
+
+function ordinaryCipher(): CipherView {
+  const cipher = new CipherView();
+  cipher.id = "cipher-9";
+  cipher.name = "Example account";
+  cipher.type = CipherType.Login;
+  cipher.login.username = "ada.lovelace";
+  cipher.login.password = "correct-horse-battery-staple";
+  cipher.login.uris = [Object.assign(new LoginUriView(), { uri: "https://example.com" })];
+  return cipher;
+}
+
+/**
+ * Only the PAM flag is on. `VFO1Foundation` and `PM32016RemoveAtRiskCallout` are read by the cipher
+ * view and its item-details child, and blanket-enabling every flag would silently swap the
+ * terminology and drop the at-risk callout — neither of which these stories are about.
+ */
+function stubConfigService() {
+  return {
+    provide: ConfigService,
+    useValue: { getFeatureFlag$: (flag: FeatureFlag) => of(flag === FeatureFlag.Pam) },
+  };
+}
+
+/**
+ * Everything `CipherViewComponent` and its section children inject. Root injector, because
+ * `Vfo1TerminologyService` is `providedIn: "root"` and resolves its own `ConfigService` there.
+ */
+function provideStoryCipherView() {
+  return [
+    stubConfigService(),
+    provideRouter([]),
+    DatePipe,
+    {
+      provide: EnvironmentService,
+      useValue: { environment$: of({ getIconsUrl: () => "https://icons.bitwarden.net" }) },
+    },
+    { provide: DomainSettingsService, useValue: { showFavicons$: of(true) } },
+    { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+    { provide: OrganizationService, useValue: { organizations$: () => of([]) } },
+    { provide: CollectionService, useValue: { decryptedCollections$: () => of([]) } },
+    { provide: FolderService, useValue: { getDecrypted$: () => of(undefined) } },
+    { provide: TaskService, useValue: { pendingTasks$: () => of([]) } },
+    { provide: PlatformUtilsService, useValue: { launchUri: () => {} } },
+    {
+      provide: ChangeLoginPasswordService,
+      useValue: { getChangePasswordUrl: () => Promise.resolve(undefined) },
+    },
+    { provide: CipherService, useValue: { ciphers$: () => of({}) } },
+    {
+      provide: CipherRiskService,
+      useValue: { computeCipherRiskForUser: () => Promise.resolve(undefined) },
+    },
+    {
+      provide: BillingAccountProfileStateService,
+      useValue: { hasPremiumFromAnySource$: () => of(true) },
+    },
+    { provide: VaultSettingsService, useValue: { showAtRiskPasswordNotifications$: of(false) } },
+    { provide: ViewPasswordHistoryService, useValue: { viewPasswordHistory: () => {} } },
+    { provide: PremiumUpgradePromptService, useValue: { promptForPremium: () => {} } },
+    { provide: EventCollectionService, useValue: { collect: () => Promise.resolve() } },
+  ];
+}
+
+type AccessState = Record<string, unknown> | null;
+
+/** Binds the real banner to the token, over an access state built at render time. */
+function gated(state: () => AccessState) {
+  return moduleMetadata({
+    imports: [CipherViewBannerComponent],
+    providers: [
+      { provide: CIPHER_VIEW_BANNER, useValue: CipherViewBannerComponent },
+      {
+        provide: AccessRequestSdkService,
+        useValue: {
+          getCipherAccessState: () => Promise.resolve(state()),
+          preCheck: () =>
+            Promise.resolve({
+              approvalMode: "automatic",
+              hasActiveLease: false,
+              maxDurationSeconds: 4 * 60 * 60,
+              defaultDurationSeconds: 60 * 60,
+            }),
+          submitAccessRequest: () => Promise.resolve({}),
+          activateAccessRequest: () => Promise.resolve({}),
+        },
+      },
+      {
+        provide: AccessLeaseSdkService,
+        useValue: { extendLease: () => Promise.resolve({}), endLease: () => Promise.resolve() },
+      },
+      {
+        provide: AccessRefreshService,
+        useValue: { accessChanged$: () => EMPTY, notifyAccessChanged: () => {} },
+      },
+      {
+        provide: AccessRequestCancelService,
+        useValue: { cancelOutstandingRequest: () => Promise.resolve() },
+      },
+      { provide: LeasingErrorService, useValue: { isLeasingError: () => false } },
+      {
+        provide: DialogService,
+        useValue: {
+          openSimpleDialog: () => Promise.resolve(false),
+          open: () => ({ closed: of(undefined) }),
+        },
+      },
+      { provide: ToastService, useValue: { showToast: () => {} } },
+    ],
+  });
+}
+
+export default {
+  title: "Web/PAM/Gated Cipher View",
+  component: CipherViewComponent,
+  decorators: [
+    applicationConfig({
+      providers: [
+        provideStoryChangeDetection(),
+        importProvidersFrom(PreloadedEnglishI18nModule),
+        provideStoryLogService(),
+        ...provideStoryCipherView(),
+      ],
+    }),
+  ],
+  args: { cipher: gatedCipher() },
+} as Meta<CipherViewComponent>;
+
+type Story = StoryObj<CipherViewComponent>;
+
+/** The resting state: the access card sits under the item's identity, above Autofill options. */
+export const RequestAccess: Story = {
+  decorators: [gated(() => ({ badgeState: "privileged" }))],
+};
+
+/** A request is with an approver. The card grows, and the cards under it keep their places. */
+export const Pending: Story = {
+  decorators: [
+    gated(() => ({
+      badgeState: "pending",
+      pendingRequest: accessRequest({
+        leaseNotBefore: liveFromNow(0),
+        leaseNotAfter: liveFromNow(HOUR),
+      }),
+    })),
+  ],
+};
+
+/** Approved but not yet started — the tallest of the three access cards. */
+export const Approved: Story = {
+  decorators: [
+    gated(() => ({
+      badgeState: "ready",
+      approvedRequest: accessRequest({
+        status: "approved",
+        leaseNotBefore: liveFromNow(0),
+        leaseNotAfter: liveFromNow(2 * HOUR),
+      }),
+    })),
+  ],
+};
+
+/**
+ * An ungoverned login with no banner bound. The card order here must be identical to what it was
+ * before the outlet moved: identity, credentials, Autofill options, Item history.
+ */
+export const OrdinaryLogin: Story = {
+  args: { cipher: ordinaryCipher() },
+};

--- a/libs/vault/src/cipher-view/cipher-view.component.html
+++ b/libs/vault/src/cipher-view/cipher-view.component.html
@@ -1,15 +1,4 @@
 @if (!!cipher()) {
-  @if (bannerComponent) {
-    <ng-container
-      *ngComponentOutlet="
-        bannerComponent;
-        inputs: {
-          cipher: cipher(),
-        }
-      "
-    />
-  }
-
   @if (cardIsExpired()) {
     <bit-callout type="info" [title]="'cardExpiredTitle' | i18n">
       {{ "cardExpiredMessage" | i18n }}
@@ -60,6 +49,17 @@
   >
     <ng-content select="[slot=button]"></ng-content>
   </app-item-details-v2>
+
+  @if (bannerComponent) {
+    <ng-container
+      *ngComponentOutlet="
+        bannerComponent;
+        inputs: {
+          cipher: cipher(),
+        }
+      "
+    />
+  }
 
   <!-- LOGIN CREDENTIALS -->
   @if (hasLogin()) {

--- a/libs/vault/src/cipher-view/cipher-view.component.spec.ts
+++ b/libs/vault/src/cipher-view/cipher-view.component.spec.ts
@@ -7,6 +7,7 @@ import { BehaviorSubject } from "rxjs";
 
 // eslint-disable-next-line no-restricted-imports
 import { CollectionService } from "@bitwarden/admin-console/common";
+import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService, Account } from "@bitwarden/common/auth/abstractions/account.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
@@ -23,6 +24,7 @@ import { VaultSettingsService } from "@bitwarden/common/vault/abstractions/vault
 import { ViewPasswordHistoryService } from "@bitwarden/common/vault/abstractions/view-password-history.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { TaskService } from "@bitwarden/common/vault/tasks";
 
 import { CIPHER_VIEW_BANNER } from "../tokens/cipher-view-banner.token";
@@ -226,6 +228,123 @@ describe("CipherViewComponent", () => {
       expect(banner).not.toBeNull();
       const instance = banner.componentInstance as TestBannerComponent;
       expect(instance.cipher()).toBe(cipher);
+    });
+  });
+
+  describe("card order in the real template", () => {
+    async function setupRealTemplate(provideBanner: boolean): Promise<void> {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [CipherViewComponent],
+        providers: [
+          { provide: AccountService, useValue: mockAccountService },
+          { provide: OrganizationService, useValue: mockOrganizationService },
+          { provide: CollectionService, useValue: mockCollectionService },
+          { provide: FolderService, useValue: mockFolderService },
+          { provide: TaskService, useValue: mockTaskService },
+          { provide: PlatformUtilsService, useValue: mockPlatformUtilsService },
+          { provide: ChangeLoginPasswordService, useValue: mockChangeLoginPasswordService },
+          { provide: CipherService, useValue: mockCipherService },
+          { provide: ViewPasswordHistoryService, useValue: mockViewPasswordHistoryService },
+          { provide: I18nService, useValue: mockI18nService },
+          { provide: LogService, useValue: mockLogService },
+          { provide: CipherRiskService, useValue: mockCipherRiskService },
+          {
+            provide: BillingAccountProfileStateService,
+            useValue: mockBillingAccountProfileStateService,
+          },
+          { provide: VaultSettingsService, useValue: mockVaultSettingsService },
+          { provide: ConfigService, useValue: mockConfigService },
+          ...(provideBanner
+            ? [{ provide: CIPHER_VIEW_BANNER, useValue: TestBannerComponent }]
+            : []),
+        ],
+        schemas: [NO_ERRORS_SCHEMA],
+      })
+        // `schemas` has to ride on the component's own metadata, not on the TestBed module: this is
+        // a standalone component, and a standalone component resolves schemas from its definition.
+        .overrideComponent(CipherViewComponent, {
+          set: {
+            imports: [CommonModule, JslibModule, TestBannerComponent],
+            schemas: [NO_ERRORS_SCHEMA],
+          },
+        })
+        .compileComponents();
+
+      fixture = TestBed.createComponent(CipherViewComponent);
+      component = fixture.componentInstance;
+    }
+
+    function loginCipher(): CipherView {
+      const cipher = new CipherView();
+      cipher.id = "cipher-id";
+      cipher.name = "Test Login";
+      cipher.type = CipherType.Login;
+      cipher.login.username = "ada";
+      cipher.login.uris = [{ uri: "https://example.com" } as LoginUriView];
+      return cipher;
+    }
+
+    const SECTIONS = [
+      "bit-callout",
+      "app-item-details-v2",
+      "test-cipher-view-banner",
+      "app-login-credentials-view",
+      "app-autofill-options-view",
+      "app-item-history-v2",
+    ].join(",");
+
+    function renderedSections(): string[] {
+      return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll(SECTIONS)).map(
+        (element) => element.tagName.toLowerCase(),
+      );
+    }
+
+    it("renders the gated banner between the item details and the login credentials", async () => {
+      await setupRealTemplate(true);
+      fixture.componentRef.setInput("cipher", loginCipher());
+      fixture.detectChanges();
+
+      expect(renderedSections()).toEqual([
+        "app-item-details-v2",
+        "test-cipher-view-banner",
+        "app-login-credentials-view",
+        "app-autofill-options-view",
+        "app-item-history-v2",
+      ]);
+    });
+
+    it("renders no banner and an unchanged order for an ordinary cipher", async () => {
+      await setupRealTemplate(false);
+      fixture.componentRef.setInput("cipher", loginCipher());
+      fixture.detectChanges();
+
+      expect(renderedSections()).toEqual([
+        "app-item-details-v2",
+        "app-login-credentials-view",
+        "app-autofill-options-view",
+        "app-item-history-v2",
+      ]);
+    });
+
+    it("keeps the general vault callouts above the item details", async () => {
+      await setupRealTemplate(true);
+      const cipher = new CipherView();
+      cipher.id = "cipher-id";
+      cipher.name = "Expired card";
+      cipher.type = CipherType.Card;
+      cipher.card.cardholderName = "Ada Lovelace";
+      cipher.card.expMonth = "1";
+      cipher.card.expYear = "2020";
+      fixture.componentRef.setInput("cipher", cipher);
+      fixture.detectChanges();
+
+      expect(renderedSections()).toEqual([
+        "bit-callout",
+        "app-item-details-v2",
+        "test-cipher-view-banner",
+        "app-item-history-v2",
+      ]);
     });
   });
 

--- a/libs/vault/src/cipher-view/cipher-view.component.ts
+++ b/libs/vault/src/cipher-view/cipher-view.component.ts
@@ -87,8 +87,8 @@ export class CipherViewComponent {
   readonly cipher = input.required<CipherView>();
 
   /**
-   * Optional host-provided banner rendered above the cipher's details. Only the web
-   * vault provides one today (privileged-access gating); elsewhere this is null and
+   * Optional host-provided banner rendered directly below the cipher's details. Only the
+   * web vault provides one today (privileged-access gating); elsewhere this is null and
    * nothing renders. See {@link CIPHER_VIEW_BANNER}.
    */
   protected readonly bannerComponent: Type<unknown> | null = inject(CIPHER_VIEW_BANNER, {

--- a/libs/vault/src/tokens/cipher-view-banner.token.ts
+++ b/libs/vault/src/tokens/cipher-view-banner.token.ts
@@ -3,7 +3,7 @@ import { Type } from "@angular/core";
 import { SafeInjectionToken } from "@bitwarden/ui-common";
 
 /**
- * Optional banner rendered at the top of the cipher view. Hosts that surface a
+ * Optional banner rendered directly below the cipher view's item details. Hosts that surface a
  * privileged-access feature (currently the web vault) provide the banner component
  * class through this token; platforms without it (browser, desktop, emergency access)
  * leave it unprovided, so the cipher view injects `null` and renders nothing.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39643

## 📔 Objective

Moves the PAM access-request banner outlet in the composed cipher view so it renders directly below the item's identity card instead of above everything, matching the design's card order for a governed item: identity, access card, Autofill options, Item history.

This template renders every vault item, so the negative case deserves the hardest look: an ordinary login provides no banner and its section order is byte-identical to before. A new `describe("card order in the real template")` suite renders the real `CipherViewComponent` template and asserts DOM order for a gated login, an ordinary login, and an expired card (whose callout still sits above the item details).

Also updates the now-false doc comments on `bannerComponent` and the `CIPHER_VIEW_BANNER` token, adds a `gated-cipher-view.stories.ts` composing the real view with the real banner, and widens the banner's bottom margin to `tw-mb-5 bit-compact:tw-mb-4`.

## 📸 Screenshots

<img width="1536" height="1340" alt="02-after-gated-item" src="https://github.com/user-attachments/assets/05dba6ac-b4db-4402-8cc3-6008536ee675" />
