### PR TITLE
feat(vault): show the access state badge on the item details card

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
@@ -36,8 +36,8 @@ requester's leasing flow, and the approver's inbox. Gated behind `FeatureFlag.Pa
   name row. The hosts differ only in how they refresh — the item-details one re-reads on
   `AccessRefreshService` so it cannot contradict the banner below it, the row one reads
   once so a list of gated rows does not carry a subscription each. Which badge to show is
-  NOT decided here: the SDK ranks
-  the three states into `CipherAccessStateView.badgeState`, and `cipherAccessBadgeState()`
+  NOT decided here: the SDK ranks the three states into
+  `CipherAccessStateView.badgeState`, and `cipherAccessBadgeState()`
   only adapts that onto the presentation model (a `kind` discriminant, a parsed `Date`).
   Add a state by teaching the SDK, not by re-ranking the parts client-side.
 - `collection-access-rule-callout/` — names the rules governing a collection, inside the

--- a/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
@@ -35,7 +35,9 @@ requester's leasing flow, and the approver's inbox. Gated behind `FeatureFlag.Pa
   access-state pill, and the two hosts that render it: a vault row, and the open item's
   name row. The hosts differ only in how they refresh — the item-details one re-reads on
   `AccessRefreshService` so it cannot contradict the banner below it, the row one reads
-  once so a list of gated rows does not carry a subscription each. Which badge to show is
+  once so a list of gated rows does not carry a subscription each. The item-details host
+  also drops the `active` state, because the banner heading under it already runs that
+  countdown on its own timer. Which badge to show is
   NOT decided here: the SDK ranks the three states into
   `CipherAccessStateView.badgeState`, and `cipherAccessBadgeState()`
   only adapts that onto the presentation model (a `kind` discriminant, a parsed `Date`).

--- a/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
@@ -31,8 +31,12 @@ requester's leasing flow, and the approver's inbox. Gated behind `FeatureFlag.Pa
   dialog, the privilege check, and the route guard.
 - `cipher-view-banner/` — the requester's entry point on an open gated cipher: four
   states off `cipher_access_state()`, with an inline request form.
-- `access-state-badge/`, `vault-row-lease-badge/` — the one access-state pill, and the
-  vault-row host that renders it. Which badge to show is NOT decided here: the SDK ranks
+- `access-state-badge/`, `vault-row-lease-badge/`, `item-details-state-badge/` — the one
+  access-state pill, and the two hosts that render it: a vault row, and the open item's
+  name row. The hosts differ only in how they refresh — the item-details one re-reads on
+  `AccessRefreshService` so it cannot contradict the banner below it, the row one reads
+  once so a list of gated rows does not carry a subscription each. Which badge to show is
+  NOT decided here: the SDK ranks
   the three states into `CipherAccessStateView.badgeState`, and `cipherAccessBadgeState()`
   only adapts that onto the presentation model (a `kind` discriminant, a parsed `Date`).
   Add a state by teaching the SDK, not by re-ranking the parts client-side.
@@ -123,7 +127,8 @@ several subjects describing different moments.
 
 PAM reaches non-commercial code only through injection tokens, each injected
 `{ optional: true }` on the OSS side so an unprovided token is inert. `provide-pam.ts`
-binds them all: `CIPHER_VIEW_BANNER`, `GATED_CIPHER_RELOADER` (both `libs/vault`),
+binds them all: `CIPHER_VIEW_BANNER`, `GATED_CIPHER_RELOADER`, `ITEM_DETAILS_STATE_BADGE`
+(all `libs/vault`),
 `VAULT_ROW_LEASE_BADGE` (one badge component for both cipher and collection rows —
 collection rows show the "Privileged" pill via the shared per-org
 `GovernedCollectionsService` lookup), `COLLECTION_ACCESS_RULE_CALLOUT`, `PamNavBadgeService`, and

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -3,11 +3,6 @@
     <div class="tw-flex tw-items-start tw-gap-4">
       <bit-icon-tile icon="bwi-clock" variant="teal" size="sm" />
       <div class="tw-flex tw-min-w-0 tw-grow tw-flex-col tw-gap-2 tw-text-fg-body">
-        <!--
-          No access-state badge here: the heading already carries the live countdown, and the badge's
-          "N left" / "Ending soon" pill would render a second copy of the same clock. The other three
-          states have no countdown in their heading, so they show the shared pill.
-        -->
         <div class="tw-flex tw-flex-col">
           <h3 bitTypography="h5" noMargin>
             {{ "pamActiveLeaseBannerTitle" | i18n: leaseRemainingLabel() }}
@@ -69,16 +64,13 @@
         </div>
 
         <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
-          <span class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-            <app-pam-access-state-badge [state]="badge()" />
-            <span bitTypography="body2" data-testid="approved-access-window">
-              @if (approvedRequestStartsNow()) {
-                {{ "pamWindowUntil" | i18n: (request.leaseNotAfter | date: "short") }}
-              } @else {
-                {{ request.leaseNotBefore | date: "short" }} &ndash;
-                {{ request.leaseNotAfter | date: "short" }}
-              }
-            </span>
+          <span bitTypography="body2" data-testid="approved-access-window">
+            @if (approvedRequestStartsNow()) {
+              {{ "pamWindowUntil" | i18n: (request.leaseNotAfter | date: "short") }}
+            } @else {
+              {{ request.leaseNotBefore | date: "short" }} &ndash;
+              {{ request.leaseNotAfter | date: "short" }}
+            }
           </span>
           <span class="tw-flex tw-items-center tw-gap-2">
             <button
@@ -114,7 +106,6 @@
         <h3 bitTypography="h5" noMargin>{{ "pamPendingRequestBannerHeading" | i18n }}</h3>
 
         <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
-          <app-pam-access-state-badge [state]="badge()" />
           <button
             type="button"
             bitButton
@@ -154,7 +145,6 @@
         }
 
         <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
-          <app-pam-access-state-badge [state]="badge()" />
           <button
             type="button"
             bitButton

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -53,6 +53,7 @@ import { ExtendLeaseDialogComponent } from "../access-requests/extend-lease-dial
 import { DurationLongPipe } from "../date/duration-long.pipe";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { formatRemaining } from "../date/format-remaining";
+import { isGovernedCipher } from "../helpers/governed-cipher";
 import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 
 import {
@@ -127,9 +128,8 @@ export class CipherViewBannerComponent implements OnInit {
   /**
    * The caller's access state for the open cipher, re-read on every access change.
    *
-   * Reads only for a PAM-governed cipher — the flag is on and the cipher is either still gated
-   * (`partial`) or already served under a lease (`leaseGated`). Without that guard a plain cipher
-   * open would fire a PAM request for every item in the vault.
+   * Reads only for a PAM-governed cipher, per {@link isGovernedCipher}, and only while the flag
+   * is on.
    *
    * The re-read trigger is {@link AccessRefreshService}, shared with the gated-cipher reloader, so
    * starting access here also reveals the credential in the item behind this banner.
@@ -137,7 +137,7 @@ export class CipherViewBannerComponent implements OnInit {
   protected readonly state = toSignal(
     combineLatest([toObservable(this.cipher), this.enabled$]).pipe(
       switchMap(([cipher, enabled]) => {
-        if (!enabled || cipher.id == null || !(cipher.partial || cipher.leaseGated === true)) {
+        if (!enabled || cipher.id == null || !isGovernedCipher(cipher)) {
           return of(null);
         }
         const cipherId = String(cipher.id);

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -50,8 +50,6 @@ import {
   requestedWindowSeconds,
 } from "..";
 import { ExtendLeaseDialogComponent } from "../access-requests/extend-lease-dialog/extend-lease-dialog.component";
-import { cipherAccessBadgeState } from "../access-state-badge/access-badge-state";
-import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationLongPipe } from "../date/duration-long.pipe";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { formatRemaining } from "../date/format-remaining";
@@ -97,7 +95,6 @@ import {
     IconTileComponent,
     ReactiveFormsModule,
     TypographyModule,
-    AccessStateBadgeComponent,
     DatePipe,
     DurationLongPipe,
     DurationShortPipe,
@@ -165,9 +162,6 @@ export class CipherViewBannerComponent implements OnInit {
   protected readonly activeLease = computed(() => this.state()?.activeLease);
   protected readonly approvedRequest = computed(() => this.state()?.approvedRequest);
   protected readonly pendingRequest = computed(() => this.state()?.pendingRequest);
-
-  /** The unified access-state pill, so this banner reads the same as the row and the Requests page. */
-  protected readonly badge = computed(() => cipherAccessBadgeState(this.state()));
 
   /**
    * How much access the approval granted, from the request's own activation window. This is the

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
@@ -209,17 +209,19 @@ export const RequestAccess: Story = {
   decorators: [gated(() => ({ badgeState: "privileged" }))],
 };
 
+function pendingState() {
+  return {
+    badgeState: "pending",
+    pendingRequest: accessRequest({
+      leaseNotBefore: liveFromNow(0),
+      leaseNotAfter: liveFromNow(HOUR),
+    }),
+  };
+}
+
 /** A request is with an approver: "Pending approval" on the name row, Cancel request in the card. */
 export const Pending: Story = {
-  decorators: [
-    gated(() => ({
-      badgeState: "pending",
-      pendingRequest: accessRequest({
-        leaseNotBefore: liveFromNow(0),
-        leaseNotAfter: liveFromNow(HOUR),
-      }),
-    })),
-  ],
+  decorators: [gated(pendingState)],
 };
 
 /** Approved but not yet started: "Ready to use" on the name row, the tallest of the access cards. */
@@ -242,15 +244,7 @@ export const Approved: Story = {
  */
 export const LongNameWithBadge: Story = {
   args: { cipher: longNameGatedCipher() },
-  decorators: [
-    gated(() => ({
-      badgeState: "pending",
-      pendingRequest: accessRequest({
-        leaseNotBefore: liveFromNow(0),
-        leaseNotAfter: liveFromNow(HOUR),
-      }),
-    })),
-  ],
+  decorators: [gated(pendingState)],
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
@@ -117,6 +117,14 @@ function provideStoryCipherView() {
     { provide: TaskService, useValue: { pendingTasks$: () => of([]) } },
     { provide: PlatformUtilsService, useValue: { launchUri: () => {} } },
     {
+      provide: DialogService,
+      useValue: {
+        openSimpleDialog: () => Promise.resolve(false),
+        open: () => ({ closed: of(undefined) }),
+      },
+    },
+    { provide: ToastService, useValue: { showToast: () => {} } },
+    {
       provide: ChangeLoginPasswordService,
       useValue: { getChangePasswordUrl: () => Promise.resolve(undefined) },
     },
@@ -176,14 +184,6 @@ function gated(state: () => Record<string, unknown>) {
         useValue: { cancelOutstandingRequest: () => Promise.resolve() },
       },
       { provide: LeasingErrorService, useValue: { isLeasingError: () => false } },
-      {
-        provide: DialogService,
-        useValue: {
-          openSimpleDialog: () => Promise.resolve(false),
-          open: () => ({ closed: of(undefined) }),
-        },
-      },
-      { provide: ToastService, useValue: { showToast: () => {} } },
     ],
   });
 }

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
@@ -139,6 +139,8 @@ function provideStoryCipherView() {
 /**
  * Binds the real banner and the real name-row badge to their tokens, over one access state built at
  * render time — the two seams read the same state, so a story showing them disagreeing is a bug.
+ * There is no active-lease story because that state badges only in the banner heading; see
+ * `ItemDetailsStateBadgeComponent` for why.
  */
 function gated(state: () => Record<string, unknown>) {
   return moduleMetadata({

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
@@ -26,13 +26,18 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LoginUriView } from "@bitwarden/common/vault/models/view/login-uri.view";
 import { TaskService } from "@bitwarden/common/vault/tasks";
 import { DialogService, ToastService } from "@bitwarden/components";
-import { CipherViewComponent, CIPHER_VIEW_BANNER } from "@bitwarden/vault";
+import {
+  CipherViewComponent,
+  CIPHER_VIEW_BANNER,
+  ITEM_DETAILS_STATE_BADGE,
+} from "@bitwarden/vault";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AccessLeaseSdkService } from "../abstractions/access-lease-sdk.service";
 import { AccessRefreshService } from "../abstractions/access-refresh.service";
 import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
 import { LeasingErrorService } from "../abstractions/leasing-error.service";
+import { ItemDetailsStateBadgeComponent } from "../item-details-state-badge/item-details-state-badge.component";
 import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 import {
   HOUR,
@@ -45,13 +50,14 @@ import {
 import { CipherViewBannerComponent } from "./cipher-view-banner.component";
 
 /**
- * The composed cipher view, rather than the banner on its own. This is where the card ORDER is
- * visible, and the order is the only thing these stories exist to show: identity, then access, then
- * Autofill options, then Item history.
+ * The composed cipher view, rather than the banner on its own — this is where the card ORDER and
+ * the name-row badge are visible, and those are the only things these stories exist to show:
+ * the state badge opposite the item name, then identity, access, Autofill options, Item history.
  *
- * {@link OrdinaryLogin} is the load-bearing one. `cipher-view.component.html` renders every vault
- * item in the product, so a change to where the banner outlet sits has to leave an ungoverned item
- * untouched; that story is the ungoverned item, with no `CIPHER_VIEW_BANNER` bound at all.
+ * {@link OrdinaryLogin} is the load-bearing one. `cipher-view.component.html` and
+ * `item-details-v2.component.html` render every vault item in the product, so neither the banner
+ * outlet nor the badge outlet may leave a mark on an ungoverned item; that story is the ungoverned
+ * item, with neither `CIPHER_VIEW_BANNER` nor `ITEM_DETAILS_STATE_BADGE` bound at all.
  */
 
 function loginCipher(id: string, name: string, uri: string): CipherView {
@@ -68,6 +74,12 @@ function gatedCipher(): CipherView {
   const cipher = loginCipher("cipher-1", "Prod database", "https://db.example.com");
   cipher.organizationId = "org-1";
   cipher.partial = true;
+  return cipher;
+}
+
+function longNameGatedCipher(): CipherView {
+  const cipher = gatedCipher();
+  cipher.name = "production-eu-west-1-postgres-primary-readwrite-credentials-rotated-quarterly";
   return cipher;
 }
 
@@ -124,11 +136,16 @@ function provideStoryCipherView() {
   ];
 }
 
+/**
+ * Binds the real banner and the real name-row badge to their tokens, over one access state built at
+ * render time — the two seams read the same state, so a story showing them disagreeing is a bug.
+ */
 function gated(state: () => Record<string, unknown>) {
   return moduleMetadata({
-    imports: [CipherViewBannerComponent],
+    imports: [CipherViewBannerComponent, ItemDetailsStateBadgeComponent],
     providers: [
       { provide: CIPHER_VIEW_BANNER, useValue: CipherViewBannerComponent },
+      { provide: ITEM_DETAILS_STATE_BADGE, useValue: ItemDetailsStateBadgeComponent },
       {
         provide: AccessRequestSdkService,
         useValue: {
@@ -187,12 +204,12 @@ export default {
 
 type Story = StoryObj<CipherViewComponent>;
 
-/** The resting state: the access card sits under the item's identity, above Autofill options. */
+/** The resting state: the "Privileged" badge on the name row, the access card under the identity. */
 export const RequestAccess: Story = {
   decorators: [gated(() => ({ badgeState: "privileged" }))],
 };
 
-/** A request is with an approver. The card grows, and the cards under it keep their places. */
+/** A request is with an approver: "Pending approval" on the name row, Cancel request in the card. */
 export const Pending: Story = {
   decorators: [
     gated(() => ({
@@ -205,7 +222,7 @@ export const Pending: Story = {
   ],
 };
 
-/** Approved but not yet started: the tallest of the three access cards. */
+/** Approved but not yet started: "Ready to use" on the name row, the tallest of the access cards. */
 export const Approved: Story = {
   decorators: [
     gated(() => ({
@@ -220,8 +237,26 @@ export const Approved: Story = {
 };
 
 /**
- * An ungoverned login with no banner bound. The card order here must be identical to what it was
- * before the outlet moved: identity, credentials, Autofill options, Item history.
+ * The narrow-width case the name row has to survive: the name is `tw-break-all tw-line-clamp-2` and
+ * now shares its row with a badge that must not be squeezed. Pending is the longest label.
+ */
+export const LongNameWithBadge: Story = {
+  args: { cipher: longNameGatedCipher() },
+  decorators: [
+    gated(() => ({
+      badgeState: "pending",
+      pendingRequest: accessRequest({
+        leaseNotBefore: liveFromNow(0),
+        leaseNotAfter: liveFromNow(HOUR),
+      }),
+    })),
+  ],
+};
+
+/**
+ * An ungoverned login with neither seam bound — the name row carries no badge and the card order is
+ * identical to what it was before either outlet existed: identity, credentials, Autofill options,
+ * Item history.
  */
 export const OrdinaryLogin: Story = {
   args: { cipher: ordinaryCipher() },

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/gated-cipher-view.stories.ts
@@ -50,7 +50,7 @@ import {
 import { CipherViewBannerComponent } from "./cipher-view-banner.component";
 
 /**
- * The composed cipher view, rather than the banner on its own — this is where the card ORDER and
+ * The composed cipher view, rather than the banner on its own. This is where the card ORDER and
  * the name-row badge are visible, and those are the only things these stories exist to show:
  * the state badge opposite the item name, then identity, access, Autofill options, Item history.
  *
@@ -146,7 +146,7 @@ function provideStoryCipherView() {
 
 /**
  * Binds the real banner and the real name-row badge to their tokens, over one access state built at
- * render time — the two seams read the same state, so a story showing them disagreeing is a bug.
+ * render time. The two seams read the same state, so a story showing them disagreeing is a bug.
  * There is no active-lease story because that state badges only in the banner heading; see
  * `ItemDetailsStateBadgeComponent` for why.
  */
@@ -250,7 +250,7 @@ export const LongNameWithBadge: Story = {
 };
 
 /**
- * An ungoverned login with neither seam bound — the name row carries no badge and the card order is
+ * An ungoverned login with neither seam bound. The name row carries no badge and the card order is
  * identical to what it was before either outlet existed: identity, credentials, Autofill options,
  * Item history.
  */

--- a/bitwarden_license/bit-web/src/app/pam/helpers/governed-cipher.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/governed-cipher.spec.ts
@@ -1,0 +1,16 @@
+import { isGovernedCipher } from "./governed-cipher";
+
+describe("isGovernedCipher", () => {
+  it("governs a still-gated cipher", () => {
+    expect(isGovernedCipher({ partial: true })).toBe(true);
+  });
+
+  it("governs a full cipher revealed under a lease", () => {
+    expect(isGovernedCipher({ partial: false, leaseGated: true })).toBe(true);
+  });
+
+  it("does not govern a plain cipher", () => {
+    expect(isGovernedCipher({ partial: false })).toBe(false);
+    expect(isGovernedCipher({ partial: false, leaseGated: false })).toBe(false);
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/helpers/governed-cipher.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/governed-cipher.ts
@@ -1,0 +1,13 @@
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+/**
+ * Whether PAM governs this cipher: the server still has it gated (`partial`), or it was already
+ * revealed under a lease (`leaseGated`, stamped client-side once the lease lands).
+ *
+ * One home for the rule, because every gating surface on the open item guards on it and they must
+ * agree. The cipher view and the item-details card render for EVERY vault item in the product, so
+ * without the guard opening any plain item would fire a PAM read.
+ */
+export function isGovernedCipher(cipher: Pick<CipherView, "partial" | "leaseGated">): boolean {
+  return cipher.partial || cipher.leaseGated === true;
+}

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.html
@@ -1,0 +1,1 @@
+<app-pam-access-state-badge [state]="badge()" />

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.html
@@ -1,1 +1,5 @@
-<app-pam-access-state-badge [state]="badge()" />
+@if (badge()) {
+  <div class="tw-ml-2 tw-mt-2" data-testid="item-details-state-badge">
+    <app-pam-access-state-badge [state]="badge()" />
+  </div>
+}

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.spec.ts
@@ -1,0 +1,127 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BehaviorSubject, Subject } from "rxjs";
+
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import type { CipherAccessStateView } from "@bitwarden/sdk-internal";
+
+import { AccessRefreshService } from "../abstractions/access-refresh.service";
+import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
+
+import { ItemDetailsStateBadgeComponent } from "./item-details-state-badge.component";
+
+describe("ItemDetailsStateBadgeComponent", () => {
+  let fixture: ComponentFixture<ItemDetailsStateBadgeComponent>;
+  let component: ItemDetailsStateBadgeComponent;
+  let enabled$: BehaviorSubject<boolean>;
+  let accessChanged$: Subject<void>;
+  let accessRequestSdkService: {
+    getCipherAccessState: jest.Mock<Promise<CipherAccessStateView>, [string]>;
+  };
+
+  function create(cipher: CipherView): void {
+    fixture = TestBed.createComponent(ItemDetailsStateBadgeComponent);
+    fixture.componentRef.setInput("cipher", cipher);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  async function settle(): Promise<void> {
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function gatedCipher(): CipherView {
+    const cipher = new CipherView();
+    cipher.id = "cipher-1";
+    cipher.partial = true;
+    return cipher;
+  }
+
+  beforeEach(() => {
+    enabled$ = new BehaviorSubject<boolean>(true);
+    accessChanged$ = new Subject<void>();
+    accessRequestSdkService = { getCipherAccessState: jest.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [ItemDetailsStateBadgeComponent],
+      providers: [
+        { provide: ConfigService, useValue: { getFeatureFlag$: () => enabled$ } },
+        { provide: AccessRequestSdkService, useValue: accessRequestSdkService },
+        {
+          provide: AccessRefreshService,
+          useValue: { accessChanged$: () => accessChanged$, notifyAccessChanged: () => {} },
+        },
+        { provide: LogService, useValue: { error: jest.fn() } },
+        {
+          provide: I18nService,
+          useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ") },
+        },
+      ],
+    });
+  });
+
+  it("renders nothing for an ungoverned cipher, and reads no access state", async () => {
+    const cipher = new CipherView();
+    cipher.id = "cipher-9";
+    cipher.partial = false;
+
+    create(cipher);
+    await settle();
+
+    expect(component["badge"]()).toBeNull();
+    expect(fixture.nativeElement.textContent.trim()).toBe("");
+    expect(accessRequestSdkService.getCipherAccessState).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when the PAM flag is off, even for a gated cipher", async () => {
+    enabled$.next(false);
+
+    create(gatedCipher());
+    await settle();
+
+    expect(component["badge"]()).toBeNull();
+    expect(accessRequestSdkService.getCipherAccessState).not.toHaveBeenCalled();
+  });
+
+  it("renders the resting privileged pill for a gated cipher", async () => {
+    accessRequestSdkService.getCipherAccessState.mockResolvedValue({
+      badgeState: "privileged",
+    } as unknown as CipherAccessStateView);
+
+    create(gatedCipher());
+    await settle();
+
+    expect(component["badge"]()?.kind).toBe("privileged");
+    expect(
+      fixture.nativeElement.querySelector("[data-testid='access-state-badge-privileged']"),
+    ).not.toBeNull();
+  });
+
+  it("reads the state again when access changes, so it cannot contradict the card below", async () => {
+    accessRequestSdkService.getCipherAccessState
+      .mockResolvedValueOnce({ badgeState: "pending" } as unknown as CipherAccessStateView)
+      .mockResolvedValueOnce({ badgeState: "privileged" } as unknown as CipherAccessStateView);
+
+    create(gatedCipher());
+    await settle();
+    expect(component["badge"]()?.kind).toBe("pending");
+
+    accessChanged$.next();
+    await settle();
+
+    expect(component["badge"]()?.kind).toBe("privileged");
+    expect(accessRequestSdkService.getCipherAccessState).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders nothing when the access-state read fails", async () => {
+    accessRequestSdkService.getCipherAccessState.mockRejectedValue(new Error("boom"));
+
+    create(gatedCipher());
+    await settle();
+
+    expect(component["badge"]()).toBeNull();
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.spec.ts
@@ -73,6 +73,9 @@ describe("ItemDetailsStateBadgeComponent", () => {
 
     expect(component["badge"]()).toBeNull();
     expect(fixture.nativeElement.textContent.trim()).toBe("");
+    expect(
+      fixture.nativeElement.querySelector("[data-testid='item-details-state-badge']"),
+    ).toBeNull();
     expect(accessRequestSdkService.getCipherAccessState).not.toHaveBeenCalled();
   });
 
@@ -98,6 +101,9 @@ describe("ItemDetailsStateBadgeComponent", () => {
     expect(
       fixture.nativeElement.querySelector("[data-testid='access-state-badge-privileged']"),
     ).not.toBeNull();
+    expect(
+      fixture.nativeElement.querySelector("[data-testid='item-details-state-badge']"),
+    ).not.toBeNull();
   });
 
   it("reads the state again when access changes, so it cannot contradict the card below", async () => {
@@ -114,6 +120,20 @@ describe("ItemDetailsStateBadgeComponent", () => {
 
     expect(component["badge"]()?.kind).toBe("privileged");
     expect(accessRequestSdkService.getCipherAccessState).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders nothing for an active lease, so the banner heading is the only countdown", async () => {
+    accessRequestSdkService.getCipherAccessState.mockResolvedValue({
+      badgeState: { active: { expiresAt: new Date(Date.now() + 12 * 60 * 1000).toISOString() } },
+    } as unknown as CipherAccessStateView);
+
+    create(gatedCipher());
+    await settle();
+
+    expect(component["badge"]()).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector("[data-testid='item-details-state-badge']"),
+    ).toBeNull();
   });
 
   it("renders nothing when the access-state read fails", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
@@ -14,7 +14,7 @@ import { AccessStateBadgeComponent } from "../access-state-badge/access-state-ba
 import { isGovernedCipher } from "../helpers/governed-cipher";
 
 /**
- * Binds `ITEM_DETAILS_STATE_BADGE` for the open item — the access-state pill on the item-details
+ * Binds `ITEM_DETAILS_STATE_BADGE` for the open item: the access-state pill on the item-details
  * card's name row. Encapsulates every PAM dependency so `libs/vault` stays PAM-free: pass the open
  * `cipher`, get the shared badge (or nothing) back. The recipe, copy and countdown live in
  * {@link AccessStateBadgeComponent}, so this reads the same as the vault row and the Requests page.
@@ -27,13 +27,13 @@ import { isGovernedCipher } from "../helpers/governed-cipher";
  *
  * The item-details card renders for EVERY vault item, so an ungoverned cipher must cost nothing:
  * {@link isGovernedCipher} keeps a plain item from firing a PAM read, and a null state renders no
- * element — not even the spacing wrapper, which lives here rather than in `libs/vault` so an
+ * element, not even the spacing wrapper. That wrapper lives here rather than in `libs/vault` so an
  * ungoverned item gets no empty flex child on its name row.
  *
  * An ACTIVE lease deliberately shows no pill here. The cipher-view banner heading directly below
  * carries the same countdown from its own interval (`cipher-view-banner.component.ts:122,329`), and
- * two independent one-second timers drift apart across a minute boundary — one reading "12m left"
- * while the other reads "11m left", and under five minutes the pill escalating to the danger
+ * two independent one-second timers drift apart across a minute boundary. One reads "12m left"
+ * while the other reads "11m left", and under five minutes the pill escalates to the danger
  * "Ending soon" wording while the heading stays neutral. The other four states have no countdown in
  * the banner, so they badge normally.
  */
@@ -67,8 +67,8 @@ export class ItemDetailsStateBadgeComponent {
             map(cipherAccessBadgeState),
             map((badge) => (badge?.kind === "active" ? null : badge)),
             catchError((e: unknown) => {
-              // An unreadable access state renders no pill rather than an error — the item itself is
-              // still useful, and the banner below behaves the same way.
+              // An unreadable access state renders no pill rather than an error: the item itself
+              // is still useful, and the banner below behaves the same way.
               this.logService.error(e);
               return of(null);
             }),

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
@@ -31,11 +31,11 @@ import { isGovernedCipher } from "../helpers/governed-cipher";
  * ungoverned item gets no empty flex child on its name row.
  *
  * An ACTIVE lease deliberately shows no pill here. The cipher-view banner heading directly below
- * carries the same countdown from its own interval (`cipher-view-banner.component.ts:122,329`), and
- * two independent one-second timers drift apart across a minute boundary. One reads "12m left"
- * while the other reads "11m left", and under five minutes the pill escalates to the danger
- * "Ending soon" wording while the heading stays neutral. The other four states have no countdown in
- * the banner, so they badge normally.
+ * carries the same countdown from its own interval (`cipher-view-banner.component.ts`,
+ * `nowMs` / `leaseRemainingLabel`), and two independent one-second timers drift apart across a
+ * minute boundary. One reads "12m left" while the other reads "11m left", and under five minutes
+ * the pill escalates to the danger "Ending soon" wording while the heading stays neutral. The
+ * other four states have no countdown in the banner, so they badge normally.
  */
 @Component({
   selector: "app-pam-item-details-state-badge",

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
@@ -11,6 +11,7 @@ import { AccessRefreshService } from "../abstractions/access-refresh.service";
 import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
 import { AccessBadgeState, cipherAccessBadgeState } from "../access-state-badge/access-badge-state";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
+import { isGovernedCipher } from "../helpers/governed-cipher";
 
 /**
  * Binds `ITEM_DETAILS_STATE_BADGE` for the open item — the access-state pill on the item-details
@@ -25,7 +26,8 @@ import { AccessStateBadgeComponent } from "../access-state-badge/access-state-ba
  * once per gated row for a state nobody is acting on, which is why the row host reads once instead.
  *
  * The item-details card renders for EVERY vault item, so an ungoverned cipher must cost nothing:
- * the guard below keeps a plain item from firing a PAM read, and a null state renders no element.
+ * {@link isGovernedCipher} keeps a plain item from firing a PAM read, and a null state renders no
+ * element.
  */
 @Component({
   selector: "app-pam-item-details-state-badge",
@@ -46,12 +48,7 @@ export class ItemDetailsStateBadgeComponent {
     this.configService.getFeatureFlag$(FeatureFlag.Pam),
   ]).pipe(
     switchMap(([cipher, enabled]) => {
-      if (
-        !enabled ||
-        cipher == null ||
-        cipher.id == null ||
-        !(cipher.partial || cipher.leaseGated === true)
-      ) {
+      if (!enabled || cipher == null || cipher.id == null || !isGovernedCipher(cipher)) {
         return of(null);
       }
       const cipherId = String(cipher.id);

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
@@ -1,0 +1,75 @@
+import { ChangeDetectionStrategy, Component, inject, input } from "@angular/core";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
+import { catchError, combineLatest, from, map, merge, Observable, of, switchMap } from "rxjs";
+
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+
+import { AccessRefreshService } from "../abstractions/access-refresh.service";
+import { AccessRequestSdkService } from "../abstractions/access-request-sdk.service";
+import { AccessBadgeState, cipherAccessBadgeState } from "../access-state-badge/access-badge-state";
+import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
+
+/**
+ * Binds `ITEM_DETAILS_STATE_BADGE` for the open item — the access-state pill on the item-details
+ * card's name row. Encapsulates every PAM dependency so `libs/vault` stays PAM-free: pass the open
+ * `cipher`, get the shared badge (or nothing) back. The recipe, copy and countdown live in
+ * {@link AccessStateBadgeComponent}, so this reads the same as the vault row and the Requests page.
+ *
+ * Separate from `VaultRowLeaseBadgeComponent` because the refresh semantics differ, not because the
+ * pill does. This one re-reads on {@link AccessRefreshService}, the same signal the cipher-view
+ * banner and the gated-cipher reloader use, so withdrawing a request or starting a lease from the
+ * card below cannot leave a contradicting pill above it. A vault list would pay that subscription
+ * once per gated row for a state nobody is acting on, which is why the row host reads once instead.
+ *
+ * The item-details card renders for EVERY vault item, so an ungoverned cipher must cost nothing:
+ * the guard below keeps a plain item from firing a PAM read, and a null state renders no element.
+ */
+@Component({
+  selector: "app-pam-item-details-state-badge",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [AccessStateBadgeComponent],
+  templateUrl: "./item-details-state-badge.component.html",
+})
+export class ItemDetailsStateBadgeComponent {
+  readonly cipher = input<CipherView | null>(null);
+
+  private readonly configService = inject(ConfigService);
+  private readonly accessRequestSdkService = inject(AccessRequestSdkService);
+  private readonly accessRefreshService = inject(AccessRefreshService);
+  private readonly logService = inject(LogService);
+
+  private readonly state$: Observable<AccessBadgeState | null> = combineLatest([
+    toObservable(this.cipher),
+    this.configService.getFeatureFlag$(FeatureFlag.Pam),
+  ]).pipe(
+    switchMap(([cipher, enabled]) => {
+      if (
+        !enabled ||
+        cipher == null ||
+        cipher.id == null ||
+        !(cipher.partial || cipher.leaseGated === true)
+      ) {
+        return of(null);
+      }
+      const cipherId = String(cipher.id);
+      return merge(of(undefined), this.accessRefreshService.accessChanged$(cipherId)).pipe(
+        switchMap(() =>
+          from(this.accessRequestSdkService.getCipherAccessState(cipherId)).pipe(
+            map(cipherAccessBadgeState),
+            catchError((e: unknown) => {
+              // An unreadable access state renders no pill rather than an error — the item itself is
+              // still useful, and the banner below behaves the same way.
+              this.logService.error(e);
+              return of(null);
+            }),
+          ),
+        ),
+      );
+    }),
+  );
+
+  protected readonly badge = toSignal(this.state$, { initialValue: null });
+}

--- a/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/item-details-state-badge/item-details-state-badge.component.ts
@@ -27,12 +27,21 @@ import { isGovernedCipher } from "../helpers/governed-cipher";
  *
  * The item-details card renders for EVERY vault item, so an ungoverned cipher must cost nothing:
  * {@link isGovernedCipher} keeps a plain item from firing a PAM read, and a null state renders no
- * element.
+ * element — not even the spacing wrapper, which lives here rather than in `libs/vault` so an
+ * ungoverned item gets no empty flex child on its name row.
+ *
+ * An ACTIVE lease deliberately shows no pill here. The cipher-view banner heading directly below
+ * carries the same countdown from its own interval (`cipher-view-banner.component.ts:122,329`), and
+ * two independent one-second timers drift apart across a minute boundary — one reading "12m left"
+ * while the other reads "11m left", and under five minutes the pill escalating to the danger
+ * "Ending soon" wording while the heading stays neutral. The other four states have no countdown in
+ * the banner, so they badge normally.
  */
 @Component({
   selector: "app-pam-item-details-state-badge",
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [AccessStateBadgeComponent],
+  host: { class: "tw-shrink-0" },
   templateUrl: "./item-details-state-badge.component.html",
 })
 export class ItemDetailsStateBadgeComponent {
@@ -56,6 +65,7 @@ export class ItemDetailsStateBadgeComponent {
         switchMap(() =>
           from(this.accessRequestSdkService.getCipherAccessState(cipherId)).pipe(
             map(cipherAccessBadgeState),
+            map((badge) => (badge?.kind === "active" ? null : badge)),
             catchError((e: unknown) => {
               // An unreadable access state renders no pill rather than an error — the item itself is
               // still useful, and the banner below behaves the same way.

--- a/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
+++ b/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
@@ -7,7 +7,11 @@ import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.serv
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { SafeProvider, safeProvider } from "@bitwarden/ui-common";
-import { CIPHER_VIEW_BANNER, GATED_CIPHER_RELOADER } from "@bitwarden/vault";
+import {
+  CIPHER_VIEW_BANNER,
+  GATED_CIPHER_RELOADER,
+  ITEM_DETAILS_STATE_BADGE,
+} from "@bitwarden/vault";
 import { COLLECTION_ACCESS_RULE_CALLOUT } from "@bitwarden/web-vault/app/admin-console/organizations/shared/components/collection-dialog/collection-access-rule-callout.token";
 import { PamNavBadgeService } from "@bitwarden/web-vault/app/pam/pam-nav-badge.service";
 import { VaultRowAccessActionsService } from "@bitwarden/web-vault/app/vault/components/vault-items/vault-row-access-actions.service";
@@ -19,6 +23,7 @@ import { DefaultCidrValidationService } from "./access-rules/access-rule-edit/ip
 import { ApprovalPrivilegeService } from "./approvals/approval-privilege.service";
 import { CipherViewBannerComponent } from "./cipher-view-banner/cipher-view-banner.component";
 import { CollectionAccessRuleCalloutComponent } from "./collection-access-rule-callout/collection-access-rule-callout.component";
+import { ItemDetailsStateBadgeComponent } from "./item-details-state-badge/item-details-state-badge.component";
 import { AccessLeasesSdkService } from "./services/access-leases-sdk.service";
 import { AccessRequestCancelService } from "./services/access-request-cancel.service";
 import { AccessRequestsSdkService } from "./services/access-requests-sdk.service";
@@ -60,11 +65,12 @@ import {
  *
  * Also fills the OSS seams PAM owns, each injected `{ optional: true }` on the OSS
  * side so an unprovided token stays inert: `CIPHER_VIEW_BANNER` (the requester's
- * leasing entry point on an open cipher) and `VAULT_ROW_LEASE_BADGE` (the per-row
- * access-state pill, on cipher AND collection rows — collection rows show the
+ * leasing entry point on an open cipher), `ITEM_DETAILS_STATE_BADGE` (the access-state
+ * pill on the open item's name row) and `VAULT_ROW_LEASE_BADGE` (the same pill per row,
+ * on cipher AND collection rows — collection rows show the
  * "Privileged" pill straight off the collection's server-derived
  * `hasEnabledAccessRule`),
- * both component classes, plus `GATED_CIPHER_RELOADER` (the
+ * all three component classes, plus `GATED_CIPHER_RELOADER` (the
  * observable that reveals a gated cipher in place once a lease covers it),
  * `COLLECTION_ACCESS_RULE_CALLOUT` (the governing-rule notice in the collection
  * edit dialog), `PamNavBadgeService` (the nav badge count), and
@@ -136,6 +142,10 @@ export function providePam(): SafeProvider[] {
     safeProvider({
       provide: CIPHER_VIEW_BANNER,
       useValue: CipherViewBannerComponent,
+    }),
+    safeProvider({
+      provide: ITEM_DETAILS_STATE_BADGE,
+      useValue: ItemDetailsStateBadgeComponent,
     }),
     safeProvider({
       provide: AccessEventService,

--- a/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
+++ b/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
@@ -67,11 +67,10 @@ import {
  * side so an unprovided token stays inert: `CIPHER_VIEW_BANNER` (the requester's
  * leasing entry point on an open cipher), `ITEM_DETAILS_STATE_BADGE` (the access-state
  * pill on the open item's name row) and `VAULT_ROW_LEASE_BADGE` (the same pill per row,
- * on cipher AND collection rows — collection rows show the
- * "Privileged" pill straight off the collection's server-derived
- * `hasEnabledAccessRule`),
- * all three component classes, plus `GATED_CIPHER_RELOADER` (the
- * observable that reveals a gated cipher in place once a lease covers it),
+ * on cipher AND collection rows — collection rows show the "Privileged" pill straight
+ * off the collection's server-derived `hasEnabledAccessRule`), all three component
+ * classes, plus `GATED_CIPHER_RELOADER` (the observable that reveals a gated cipher in
+ * place once a lease covers it),
  * `COLLECTION_ACCESS_RULE_CALLOUT` (the governing-rule notice in the collection
  * edit dialog), `PamNavBadgeService` (the nav badge count), and
  * `VaultRowAccessActionsService` (withdrawing a gated row's outstanding access

--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
@@ -18,16 +18,14 @@
         {{ cipher().name }}
       </h2>
       @if (stateBadgeComponent) {
-        <div class="tw-ml-2 tw-mt-2 tw-shrink-0" data-testid="item-details-state-badge">
-          <ng-container
-            *ngComponentOutlet="
-              stateBadgeComponent;
-              inputs: {
-                cipher: cipher(),
-              }
-            "
-          />
-        </div>
+        <ng-container
+          *ngComponentOutlet="
+            stateBadgeComponent;
+            inputs: {
+              cipher: cipher(),
+            }
+          "
+        />
       }
     </div>
     <ng-container>

--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.html
@@ -12,11 +12,23 @@
       </div>
       <h2
         bitTypography="h4"
-        class="tw-ml-2 tw-mt-2 tw-select-auto tw-flex-1 tw-break-all tw-line-clamp-2"
+        class="tw-ml-2 tw-mt-2 tw-select-auto tw-flex-1 tw-min-w-0 tw-break-all tw-line-clamp-2"
         data-testid="item-name"
       >
         {{ cipher().name }}
       </h2>
+      @if (stateBadgeComponent) {
+        <div class="tw-ml-2 tw-mt-2 tw-shrink-0" data-testid="item-details-state-badge">
+          <ng-container
+            *ngComponentOutlet="
+              stateBadgeComponent;
+              inputs: {
+                cipher: cipher(),
+              }
+            "
+          />
+        </div>
+      }
     </div>
     <ng-container>
       <div class="tw-flex tw-flex-col tw-mt-2 md:tw-flex-row md:tw-flex-wrap">

--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.spec.ts
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.spec.ts
@@ -1,4 +1,11 @@
-import { ComponentRef, signal, WritableSignal } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ComponentRef,
+  input,
+  signal,
+  WritableSignal,
+} from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { of } from "rxjs";
@@ -14,8 +21,18 @@ import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 
 import { Vfo1TerminologyService } from "../../services/vfo1-terminology.service";
+import { ITEM_DETAILS_STATE_BADGE } from "../../tokens/item-details-state-badge.token";
 
 import { ItemDetailsV2Component } from "./item-details-v2.component";
+
+@Component({
+  selector: "app-stub-state-badge",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<span data-testid="stub-state-badge">{{ cipher()?.name }}</span>`,
+})
+class StubStateBadgeComponent {
+  readonly cipher = input<CipherView | null>(null);
+}
 
 describe("ItemDetailsV2Component", () => {
   let component: ItemDetailsV2Component;
@@ -183,5 +200,56 @@ describe("ItemDetailsV2Component", () => {
 
       expect(personalVaultChip).toBeUndefined();
     });
+  });
+});
+
+describe("ItemDetailsV2Component state badge seam", () => {
+  const cipher = { id: "cipher1", name: "cipher name", collectionIds: [] } as unknown as CipherView;
+
+  async function render(badge: typeof StubStateBadgeComponent | null) {
+    await TestBed.configureTestingModule({
+      imports: [ItemDetailsV2Component],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: { t: (key: string, p1?: string) => (p1 ? `${key} ${p1}` : key) },
+        },
+        { provide: ConfigService, useValue: { getFeatureFlag$: () => of(false) } },
+        {
+          provide: EnvironmentService,
+          useValue: { environment$: of({ getIconsUrl: () => "https://icons.example.com" }) },
+        },
+        { provide: DomainSettingsService, useValue: { showFavicons$: of(true) } },
+        { provide: Vfo1TerminologyService, useFactory: () => ({ enabled: signal(false) }) },
+        ...(badge == null ? [] : [{ provide: ITEM_DETAILS_STATE_BADGE, useValue: badge }]),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(ItemDetailsV2Component);
+    fixture.componentRef.setInput("cipher", cipher);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it("renders no badge element at all when no host provides the token", async () => {
+    const fixture = await render(null);
+
+    expect(
+      fixture.debugElement.query(By.css('[data-testid="item-details-state-badge"]')),
+    ).toBeNull();
+  });
+
+  it("renders the provided badge on the name row, after the item name", async () => {
+    const fixture = await render(StubStateBadgeComponent);
+
+    const badge = fixture.debugElement.query(By.css('[data-testid="stub-state-badge"]'));
+    expect(badge).not.toBeNull();
+    expect(badge.nativeElement.textContent.trim()).toBe(cipher.name);
+
+    const nameRow = fixture.debugElement.query(By.css('[data-testid="item-name"]')).nativeElement
+      .parentElement;
+    expect(nameRow.querySelector('[data-testid="item-details-state-badge"]')).not.toBeNull();
   });
 });

--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.spec.ts
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.spec.ts
@@ -233,12 +233,17 @@ describe("ItemDetailsV2Component state badge seam", () => {
 
   afterEach(() => TestBed.resetTestingModule());
 
-  it("renders no badge element at all when no host provides the token", async () => {
+  function nameRow(fixture: ComponentFixture<ItemDetailsV2Component>): HTMLElement {
+    return fixture.debugElement.query(By.css('[data-testid="item-name"]')).nativeElement
+      .parentElement;
+  }
+
+  it("adds nothing to the name row when no host provides the token", async () => {
     const fixture = await render(null);
 
-    expect(
-      fixture.debugElement.query(By.css('[data-testid="item-details-state-badge"]')),
-    ).toBeNull();
+    const row = nameRow(fixture);
+    expect(fixture.debugElement.query(By.css("app-stub-state-badge"))).toBeNull();
+    expect(row.lastElementChild).toBe(row.querySelector('[data-testid="item-name"]'));
   });
 
   it("renders the provided badge on the name row, after the item name", async () => {
@@ -248,8 +253,7 @@ describe("ItemDetailsV2Component state badge seam", () => {
     expect(badge).not.toBeNull();
     expect(badge.nativeElement.textContent.trim()).toBe(cipher.name);
 
-    const nameRow = fixture.debugElement.query(By.css('[data-testid="item-name"]')).nativeElement
-      .parentElement;
-    expect(nameRow.querySelector('[data-testid="item-details-state-badge"]')).not.toBeNull();
+    const row = nameRow(fixture);
+    expect(row.lastElementChild?.contains(badge.nativeElement)).toBe(true);
   });
 });

--- a/libs/vault/src/cipher-view/item-details/item-details-v2.component.ts
+++ b/libs/vault/src/cipher-view/item-details/item-details-v2.component.ts
@@ -1,7 +1,7 @@
 // FIXME: Update this file to be type safe and remove this and next line
 // @ts-strict-ignore
 import { CommonModule } from "@angular/common";
-import { Component, computed, inject, input, signal } from "@angular/core";
+import { Component, Type, computed, inject, input, signal } from "@angular/core";
 // This import has been flagged as unallowed for this class. It may be involved in a circular dependency loop.
 import { toSignal } from "@angular/core/rxjs-interop";
 import { fromEvent, map, startWith } from "rxjs";
@@ -25,6 +25,7 @@ import {
 import { OrgIconDirective } from "../../components/org-icon.directive";
 import { Vfo1I18nPipe } from "../../pipes/vfo1-i18n.pipe";
 import { Vfo1TerminologyService } from "../../services/vfo1-terminology.service";
+import { ITEM_DETAILS_STATE_BADGE } from "../../tokens/item-details-state-badge.token";
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -45,6 +46,15 @@ import { Vfo1TerminologyService } from "../../services/vfo1-terminology.service"
 export class ItemDetailsV2Component {
   private readonly vfo1TerminologyService = inject(Vfo1TerminologyService);
   protected readonly vfo1Enabled = this.vfo1TerminologyService.enabled;
+
+  /**
+   * Optional host-provided badge rendered on the item name row. Only the web vault provides one
+   * today (privileged-access state); elsewhere this is null and nothing renders.
+   * See {@link ITEM_DETAILS_STATE_BADGE}.
+   */
+  protected readonly stateBadgeComponent: Type<unknown> | null = inject(ITEM_DETAILS_STATE_BADGE, {
+    optional: true,
+  });
 
   readonly hideOwner = input<boolean>(false);
   readonly cipher = input.required<CipherView>();

--- a/libs/vault/src/index.ts
+++ b/libs/vault/src/index.ts
@@ -116,6 +116,7 @@ export {
 
 export { CIPHER_VIEW_BANNER } from "./tokens/cipher-view-banner.token";
 export { GATED_CIPHER_RELOADER } from "./tokens/gated-cipher-reloader.token";
+export { ITEM_DETAILS_STATE_BADGE } from "./tokens/item-details-state-badge.token";
 export type { GatedCipherReloader } from "./tokens/gated-cipher-reloader.token";
 
 export { VaultBatchBarService, VaultBatchBarConfig } from "./services/vault-batch-bar.service";

--- a/libs/vault/src/tokens/item-details-state-badge.token.ts
+++ b/libs/vault/src/tokens/item-details-state-badge.token.ts
@@ -1,0 +1,24 @@
+import { Type } from "@angular/core";
+
+import { SafeInjectionToken } from "@bitwarden/ui-common";
+
+/**
+ * Optional state badge rendered on the item-details card's NAME ROW, right-aligned opposite the
+ * item name. Hosts that surface a privileged-access feature (currently the web vault) provide the
+ * badge component class; platforms without it leave the token unprovided, so `item-details-v2`
+ * injects `null` and the card renders exactly as it did before.
+ *
+ * Distinct from {@link CIPHER_VIEW_BANNER}, which carries the access CARD below the details, and
+ * from the web vault's own `VAULT_ROW_LEASE_BADGE`, which carries the same pill into the vault
+ * LIST. That one cannot be reused here: it lives in `apps/web`, and `libs/vault` may not import an
+ * app. Its contract is also list-shaped — it drives a "Controlled access" column and accepts a
+ * collection as well as a cipher — where this one is scoped to the open item.
+ *
+ * The token holds the component CLASS — `item-details-v2` renders it with `NgComponentOutlet`,
+ * passing the `cipher` as a single input — so `libs/vault` needs no dependency on the feature
+ * library that implements the badge. The card renders for EVERY vault item, so an implementation
+ * must render nothing for an item it does not govern.
+ */
+export const ITEM_DETAILS_STATE_BADGE = new SafeInjectionToken<Type<unknown>>(
+  "ItemDetailsStateBadge",
+);

--- a/libs/vault/src/tokens/item-details-state-badge.token.ts
+++ b/libs/vault/src/tokens/item-details-state-badge.token.ts
@@ -17,7 +17,9 @@ import { SafeInjectionToken } from "@bitwarden/ui-common";
  * The token holds the component CLASS — `item-details-v2` renders it with `NgComponentOutlet`,
  * passing the `cipher` as a single input — so `libs/vault` needs no dependency on the feature
  * library that implements the badge. The card renders for EVERY vault item, so an implementation
- * must render nothing for an item it does not govern.
+ * must render nothing for an item it does not govern, and it owns its own spacing: the card wraps
+ * the outlet in no element of its own, so a badge-less item leaves no empty flex child, and no
+ * margin, on the name row.
  */
 export const ITEM_DETAILS_STATE_BADGE = new SafeInjectionToken<Type<unknown>>(
   "ItemDetailsStateBadge",

--- a/libs/vault/src/tokens/item-details-state-badge.token.ts
+++ b/libs/vault/src/tokens/item-details-state-badge.token.ts
@@ -4,22 +4,7 @@ import { SafeInjectionToken } from "@bitwarden/ui-common";
 
 /**
  * Optional state badge rendered on the item-details card's NAME ROW, right-aligned opposite the
- * item name. Hosts that surface a privileged-access feature (currently the web vault) provide the
- * badge component class; platforms without it leave the token unprovided, so `item-details-v2`
- * injects `null` and the card renders exactly as it did before.
- *
- * Distinct from {@link CIPHER_VIEW_BANNER}, which carries the access CARD below the details, and
- * from the web vault's own `VAULT_ROW_LEASE_BADGE`, which carries the same pill into the vault
- * LIST. That one cannot be reused here: it lives in `apps/web`, and `libs/vault` may not import an
- * app. Its contract is also list-shaped, driving a "Controlled access" column and accepting a
- * collection as well as a cipher, where this one is scoped to the open item.
- *
- * The token holds the component CLASS, rendered by `item-details-v2` with `NgComponentOutlet` and
- * passed the `cipher` as a single input, so `libs/vault` needs no dependency on the feature
- * library that implements the badge. The card renders for EVERY vault item, so an implementation
- * must render nothing for an item it does not govern, and it owns its own spacing: the card wraps
- * the outlet in no element of its own, so a badge-less item leaves no empty flex child, and no
- * margin, on the name row.
+ * item name.
  */
 export const ITEM_DETAILS_STATE_BADGE = new SafeInjectionToken<Type<unknown>>(
   "ItemDetailsStateBadge",

--- a/libs/vault/src/tokens/item-details-state-badge.token.ts
+++ b/libs/vault/src/tokens/item-details-state-badge.token.ts
@@ -11,11 +11,11 @@ import { SafeInjectionToken } from "@bitwarden/ui-common";
  * Distinct from {@link CIPHER_VIEW_BANNER}, which carries the access CARD below the details, and
  * from the web vault's own `VAULT_ROW_LEASE_BADGE`, which carries the same pill into the vault
  * LIST. That one cannot be reused here: it lives in `apps/web`, and `libs/vault` may not import an
- * app. Its contract is also list-shaped — it drives a "Controlled access" column and accepts a
- * collection as well as a cipher — where this one is scoped to the open item.
+ * app. Its contract is also list-shaped, driving a "Controlled access" column and accepting a
+ * collection as well as a cipher, where this one is scoped to the open item.
  *
- * The token holds the component CLASS — `item-details-v2` renders it with `NgComponentOutlet`,
- * passing the `cipher` as a single input — so `libs/vault` needs no dependency on the feature
+ * The token holds the component CLASS, rendered by `item-details-v2` with `NgComponentOutlet` and
+ * passed the `cipher` as a single input, so `libs/vault` needs no dependency on the feature
  * library that implements the badge. The card renders for EVERY vault item, so an implementation
  * must render nothing for an item it does not govern, and it owns its own spacing: the card wraps
  * the outlet in no element of its own, so a badge-less item leaves no empty flex child, and no


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42329

## 📔 Objective

Moves the PAM access-state pill (`Privileged` / `Pending approval` / `Ready to use`) out of the access card and onto the item-details name row, right-aligned opposite the item name, where every design frame puts it. It is removed from the card in the same commit, so it renders exactly once.

The item-details card is OSS and `libs/vault` may not import `bitwarden_license`, so the badge arrives through a new injection token, `ITEM_DETAILS_STATE_BADGE`. Neither existing seam fits: `CIPHER_VIEW_BANNER` carries the whole access card, and `VAULT_ROW_LEASE_BADGE` lives in `apps/web` with a list-shaped contract that would drag the "Controlled access" column down with it. A thin host wraps the shared `AccessStateBadgeComponent` and merges `accessChanged$`, so the pill updates when a requester cancels rather than going stale.

This touches a template every vault item renders. With no PAM provider bound the seam renders nothing, which the `ordinary-login` story asserts.

## 📸 Screenshots

<img width="1536" height="1332" alt="02-after-gated-item" src="https://github.com/user-attachments/assets/f9b87d21-84f3-423b-a673-535abad9f0f7" />
