### PR TITLE
ci: Fix not reporting test results on push and workflow_dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,9 @@ jobs:
 
       - name: Report test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !cancelled() }}
+        # This will skip the job if it's a pull request from a fork, because that won't have permission to upload test results.
+        # PRs from the repository and all other events are OK.
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && !cancelled()
         with:
           name: Test Results - ${{ matrix.test-group.name }}
           path: ${{ matrix.test-group.junit }}


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Ports bitwarden/directory-connector#921 to this repo.

Test results are only uploaded to GitHub if `github.event.pull_request.head.repo.full_name == github.repository`. The intention of that conditional is to skip PRs from forks. However, when the `Testing` workflow triggers for other events (`push` and `workflow_dispatch`), `github.event.pull_request` is undefined and the "Report test results" step is incorrectly skipped — so test results are never reported on pushes to `main`/`rc\`/`hotfix-rc-*`.

This adds an explicit allowlist of \`push\` and \`workflow_dispatch\` events, which do not pose the same fork-permission concerns since triggering them generally requires write permissions in the repo.