### PR TITLE
key service flaky cipherDecryptionKeys$ tests

### DIFF
--- a/libs/key-management/src/key.service.spec.ts
+++ b/libs/key-management/src/key.service.spec.ts
@@ -18,7 +18,6 @@ import { USER_ENCRYPTED_PROVIDER_KEYS } from "@bitwarden/common/platform/service
 import { USER_EVER_HAD_USER_KEY } from "@bitwarden/common/platform/services/key-state/user-key.state";
 import { UserKeyDefinition } from "@bitwarden/common/platform/state";
 import {
-  awaitAsync,
   makeEncString,
   makeStaticByteArray,
   makeSymmetricCryptoKey,
@@ -39,6 +38,7 @@ import {
   SymmetricCryptoKey,
   UnsignedPublicKey,
 } from "@bitwarden/legacy-crypto";
+import { WrappedAccountCryptographicState } from "@bitwarden/sdk-internal";
 
 import { BiometricsService } from "./biometrics/biometric.service";
 import { DefaultKeyService } from "./key.service";
@@ -88,6 +88,7 @@ describe("keyService", () => {
   };
 
   afterEach(() => {
+    jest.useRealTimers();
     jest.resetAllMocks();
   });
 
@@ -247,7 +248,7 @@ describe("keyService", () => {
       // Initial state: both set
       const accountStateSubject = new BehaviorSubject({
         V1: { private_key: mockEncryptedPrivateKey },
-      });
+      } as WrappedAccountCryptographicState | null);
       accountCryptographicStateService.accountCryptographicState$.mockReturnValue(
         accountStateSubject.asObservable(),
       );
@@ -281,6 +282,17 @@ describe("keyService", () => {
       accountCryptographicStateService.accountCryptographicState$.mockReturnValue(
         accountStateSubject.asObservable(),
       );
+
+      encryptService.unwrapDecapsulationKey.mockImplementation((encryptedPrivateKey, userKey) => {
+        return Promise.resolve(fakePrivateKeyDecryption(encryptedPrivateKey, userKey));
+      });
+      encryptService.unwrapSymmetricKey.mockImplementation((encryptedPrivateKey, userKey) => {
+        return Promise.resolve(new SymmetricCryptoKey(new Uint8Array(64)));
+      });
+
+      encryptService.decapsulateKeyUnsigned.mockImplementation((data, privateKey) => {
+        return Promise.resolve(new SymmetricCryptoKey(fakeOrgKeyDecryption(data, privateKey)));
+      });
     });
 
     function fakePrivateKeyDecryption(encryptedPrivateKey: EncString, key: SymmetricCryptoKey) {
@@ -338,17 +350,6 @@ describe("keyService", () => {
         );
         providerKeysState.nextState(keys.providerKeys!);
       }
-
-      encryptService.unwrapDecapsulationKey.mockImplementation((encryptedPrivateKey, userKey) => {
-        return Promise.resolve(fakePrivateKeyDecryption(encryptedPrivateKey, userKey));
-      });
-      encryptService.unwrapSymmetricKey.mockImplementation((encryptedPrivateKey, userKey) => {
-        return Promise.resolve(new SymmetricCryptoKey(new Uint8Array(64)));
-      });
-
-      encryptService.decapsulateKeyUnsigned.mockImplementation((data, privateKey) => {
-        return Promise.resolve(new SymmetricCryptoKey(fakeOrgKeyDecryption(data, privateKey)));
-      });
     }
 
     it("returns decryption keys when there are no org or provider keys set", async () => {
@@ -440,19 +441,22 @@ describe("keyService", () => {
     });
 
     it("returns a stream that pays attention to updates of all data", async () => {
+      jest.useFakeTimers();
+
       // Start listening until there have been 6 emissions
       const promise = lastValueFrom(
         keyService.cipherDecryptionKeys$(mockUserId).pipe(bufferCount(6), take(1)),
       );
 
       // User has their UserKey set
-      const initialUserKey = makeSymmetricCryptoKey<UserKey>(64);
+      const initialUserKey = makeSymmetricCryptoKey<UserKey>(64, 0);
       updateKeys({
         userKey: initialUserKey,
       });
 
-      // Because switchMap is a little to good at its job
-      await awaitAsync();
+      // Let the decryption chain settle before the next push, otherwise the outer switchMap
+      // unsubscribes it and the emission never arrives
+      await jest.advanceTimersByTimeAsync(0);
 
       // User has their private key set
       const initialPrivateKey = makeEncString("userPrivateKey");
@@ -460,16 +464,14 @@ describe("keyService", () => {
         encryptedPrivateKey: initialPrivateKey,
       });
 
-      // Because switchMap is a little to good at its job
-      await awaitAsync();
+      await jest.advanceTimersByTimeAsync(0);
 
       // Current architecture requires that provider keys are set before org keys
       updateKeys({
         providerKeys: {},
       });
 
-      // Because switchMap is a little to good at its job
-      await awaitAsync();
+      await jest.advanceTimersByTimeAsync(0);
 
       // User has their org keys set
       updateKeys({
@@ -478,8 +480,10 @@ describe("keyService", () => {
         },
       });
 
+      await jest.advanceTimersByTimeAsync(0);
+
       // Out of band user key update
-      const updatedUserKey = makeSymmetricCryptoKey<UserKey>(64);
+      const updatedUserKey = makeSymmetricCryptoKey<UserKey>(64, 1);
       updateKeys({
         userKey: updatedUserKey,
       });
@@ -531,12 +535,15 @@ describe("keyService", () => {
       makeUserKey: boolean;
     };
 
-    function setupKeys({ makeMasterKey, makeUserKey }: SetupKeysParams): [UserKey, MasterKey] {
+    function setupKeys({
+      makeMasterKey,
+      makeUserKey,
+    }: SetupKeysParams): [UserKey | null, MasterKey | null] {
       const userKeyState = stateProvider.singleUser.getFake(mockUserId, USER_KEY);
-      const fakeMasterKey = makeMasterKey ? makeSymmetricCryptoKey<MasterKey>(64) : null;
+      const fakeMasterKey = makeMasterKey ? makeSymmetricCryptoKey<MasterKey>(64, 0) : null;
       masterPasswordService.masterKeySubject.next(fakeMasterKey);
       userKeyState.nextState(null);
-      const fakeUserKey = makeUserKey ? makeSymmetricCryptoKey<UserKey>(64) : null;
+      const fakeUserKey = makeUserKey ? makeSymmetricCryptoKey<UserKey>(64, 1) : null;
       userKeyState.nextState(fakeUserKey);
       return [fakeUserKey, fakeMasterKey];
     }
@@ -579,8 +586,8 @@ describe("keyService", () => {
     beforeEach(() => {
       mockUserPrivateKey = makeStaticByteArray(64, 1);
       mockProviderKeys = {
-        ["provider1" as ProviderId]: makeSymmetricCryptoKey<ProviderKey>(64),
-        ["provider2" as ProviderId]: makeSymmetricCryptoKey<ProviderKey>(64),
+        ["provider1" as ProviderId]: makeSymmetricCryptoKey<ProviderKey>(64, 0),
+        ["provider2" as ProviderId]: makeSymmetricCryptoKey<ProviderKey>(64, 1),
       };
     });
 

--- a/libs/key-management/src/key.service.spec.ts
+++ b/libs/key-management/src/key.service.spec.ts
@@ -275,10 +275,10 @@ describe("keyService", () => {
   });
 
   describe("cipherDecryptionKeys$", () => {
-    let accountStateSubject: BehaviorSubject<any>;
+    let accountStateSubject: BehaviorSubject<WrappedAccountCryptographicState | null>;
 
     beforeEach(() => {
-      accountStateSubject = new BehaviorSubject(null);
+      accountStateSubject = new BehaviorSubject<WrappedAccountCryptographicState | null>(null);
       accountCryptographicStateService.accountCryptographicState$.mockReturnValue(
         accountStateSubject.asObservable(),
       );
@@ -286,8 +286,10 @@ describe("keyService", () => {
       encryptService.unwrapDecapsulationKey.mockImplementation((encryptedPrivateKey, userKey) => {
         return Promise.resolve(fakePrivateKeyDecryption(encryptedPrivateKey, userKey));
       });
-      encryptService.unwrapSymmetricKey.mockImplementation((encryptedPrivateKey, userKey) => {
-        return Promise.resolve(new SymmetricCryptoKey(new Uint8Array(64)));
+      encryptService.unwrapSymmetricKey.mockImplementation((encryptedOrgKey, providerKey) => {
+        return Promise.resolve(
+          new SymmetricCryptoKey(fakeOrgKeyDecryption(encryptedOrgKey, providerKey.toEncoded())),
+        );
       });
 
       encryptService.decapsulateKeyUnsigned.mockImplementation((data, privateKey) => {
@@ -438,6 +440,7 @@ describe("keyService", () => {
       const org2Key = decryptionKeys!.orgKeys![org2Id];
       expect(org2Key).not.toBeNull();
       expect(org2Key.toEncoded()).toHaveLength(64);
+      expect(org2Key.keyB64).toContain("provider1Key");
     });
 
     it("returns a stream that pays attention to updates of all data", async () => {
@@ -515,7 +518,7 @@ describe("keyService", () => {
       expect(emittedValues[4]).toEqual({
         userKey: initialUserKey,
         orgKeys: {
-          [org1Id]: expect.anything(),
+          [org1Id]: expect.objectContaining({ keyB64: expect.stringContaining("org1Key") }),
         },
       });
 
@@ -523,9 +526,15 @@ describe("keyService", () => {
       expect(emittedValues[5]).toEqual({
         userKey: updatedUserKey,
         orgKeys: {
-          [org1Id]: expect.anything(),
+          [org1Id]: expect.objectContaining({ keyB64: expect.stringContaining("org1Key") }),
         },
       });
+
+      // The org key is decrypted with the user key, so the out of band update must produce a new
+      // org key rather than replaying the one decrypted with the previous user key
+      expect(emittedValues[5]!.orgKeys![org1Id].keyB64).not.toEqual(
+        emittedValues[4]!.orgKeys![org1Id].keyB64,
+      );
     });
   });
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Fixes flaky test that i have seen failing at least 3 times this week:
```
FAIL libs/key-management/src/key.service.spec.ts
 - keyService › cipherDecryptionKeys$ › returns a stream that pays attention to updates of all data
```

Root cause: unreliable rxjs pipe processing in tests (1 ms sleep).
Replaced with jest fake timers, should reliably process the rxjs `cipherDecryptionKeys` pipe now.
Other fixes / observations:
- fixed TS test types
- `mockImplementation` performed once during the test run
- several generated symmetric keys were identical to each other, but should differ in practise
- updated test assertions to expect value, not just "any"

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
