### PR TITLE
[PM-42470] Add cooldown to user key id backfill migration

### DIFF
--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -1176,6 +1176,7 @@ export class ServiceContainer {
       new CliUserKeyRotationService(),
       this.cipherService,
       this.sdkService,
+      this.stateProvider,
     );
   }
 

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -603,6 +603,7 @@ const safeProviders: SafeProvider[] = [
       UserKeyRotationServiceAbstraction,
       CipherServiceAbstraction,
       SdkService,
+      StateProvider,
     ],
   }),
   safeProvider({

--- a/libs/common/src/key-management/encrypted-migrator/default-encrypted-migrator.spec.ts
+++ b/libs/common/src/key-management/encrypted-migrator/default-encrypted-migrator.spec.ts
@@ -14,6 +14,7 @@ import { ClientType } from "../../enums";
 import { ConfigService } from "../../platform/abstractions/config/config.service";
 import { PlatformUtilsService } from "../../platform/abstractions/platform-utils.service";
 import { SdkService } from "../../platform/abstractions/sdk/sdk.service";
+import { StateProvider } from "../../platform/state";
 import { SyncService } from "../../platform/sync";
 import { UserId } from "../../types/guid";
 import { CipherService } from "../../vault/abstractions/cipher.service";
@@ -33,6 +34,7 @@ jest.mock("./migrations/user-key-id-backfill-migration");
 
 describe("EncryptedMigrator", () => {
   const mockKdfConfigService = mock<KdfConfigService>();
+  const mockStateProvider = mock<StateProvider>();
   const mockLogService = mock<LogService>();
   const configService = mock<ConfigService>();
   const masterPasswordService = mock<InternalMasterPasswordServiceAbstraction>();
@@ -94,6 +96,7 @@ describe("EncryptedMigrator", () => {
       mockUserKeyRotationService,
       mockCipherService,
       mockSdkService,
+      mockStateProvider,
     );
   });
 

--- a/libs/common/src/key-management/encrypted-migrator/default-encrypted-migrator.ts
+++ b/libs/common/src/key-management/encrypted-migrator/default-encrypted-migrator.ts
@@ -13,6 +13,7 @@ import { ClientType } from "../../enums";
 import { ConfigService } from "../../platform/abstractions/config/config.service";
 import { PlatformUtilsService } from "../../platform/abstractions/platform-utils.service";
 import { SdkService } from "../../platform/abstractions/sdk/sdk.service";
+import { StateProvider } from "../../platform/state";
 import { SyncService } from "../../platform/sync";
 import { UserId } from "../../types/guid";
 import { CipherService } from "../../vault/abstractions/cipher.service";
@@ -42,12 +43,13 @@ export class DefaultEncryptedMigrator implements EncryptedMigrator {
     userKeyRotationService: UserKeyRotationServiceAbstraction,
     cipherService: CipherService,
     sdkService: SdkService,
+    stateProvider: StateProvider,
   ) {
     // Register migrations here
 
     this.migrations.push({
       name: "User Key Id Backfill Migration",
-      migration: new UserKeyIdBackfillMigration(sdkService, syncService, logService),
+      migration: new UserKeyIdBackfillMigration(sdkService, syncService, stateProvider, logService),
     });
 
     this.migrations.push({

--- a/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.spec.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.spec.ts
@@ -24,6 +24,18 @@ describe("UserKeyIdBackfillMigration", () => {
   const mockUserId = "00000000-0000-0000-0000-000000000000" as UserId;
   const HOUR_MS = 1000 * 60 * 60;
 
+  /**
+   * Fabricates the shape the SDK produces for a `KeyIdBackfillError`. The name and variant
+   * fields are what `isKeyIdBackfillError` uses to identify the error.
+   */
+  const makeBackfillError = (variant: string, message: string): Error => {
+    const error = new Error(message);
+    error.name = "KeyIdBackfillError";
+    (error as Error & { variant: string }).variant = variant;
+
+    return error;
+  };
+
   // SDK reference chain: sdk.take() -> ref.value.user_crypto_management().user_key_id_backfill()
   const needsBackfill = jest.fn();
   const backfill = jest.fn();
@@ -148,7 +160,9 @@ describe("UserKeyIdBackfillMigration", () => {
 
     it("starts the cooldown when the server rejects the backfill", async () => {
       // e.g. a server too old to know the backfill endpoint answers with a 404
-      backfill.mockRejectedValue(new Error("404 Not Found"));
+      backfill.mockRejectedValue(
+        makeBackfillError("Api", "error in response: status code 404 Not Found: {}"),
+      );
 
       await expect(sut.runMigrations(mockUserId)).rejects.toThrow("404 Not Found");
 
@@ -156,6 +170,19 @@ describe("UserKeyIdBackfillMigration", () => {
         stateProvider.getUser(mockUserId, USER_KEY_ID_BACKFILL_COOLDOWN).state$,
       );
       expect(cooldown).not.toBeNull();
+    });
+
+    it("does not start the cooldown when the backfill fails locally", async () => {
+      backfill.mockRejectedValue(
+        makeBackfillError("UserKeyNotAvailable", "user key is not available"),
+      );
+
+      await expect(sut.runMigrations(mockUserId)).rejects.toThrow("user key is not available");
+
+      const cooldown = await firstValueFrom(
+        stateProvider.getUser(mockUserId, USER_KEY_ID_BACKFILL_COOLDOWN).state$,
+      );
+      expect(cooldown).toBeNull();
     });
 
     it("does not start the cooldown when the backfill succeeds", async () => {

--- a/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.spec.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.spec.ts
@@ -1,22 +1,28 @@
 import { mock } from "jest-mock-extended";
-import { of } from "rxjs";
+import { firstValueFrom, of } from "rxjs";
 
 import { LogService } from "@bitwarden/logging";
 
+import { FakeStateProvider, mockAccountServiceWith } from "../../../../spec";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
 import { SyncService } from "../../../platform/sync";
 import { UserId } from "../../../types/guid";
 
-import { UserKeyIdBackfillMigration } from "./user-key-id-backfill-migration";
+import {
+  USER_KEY_ID_BACKFILL_COOLDOWN,
+  UserKeyIdBackfillMigration,
+} from "./user-key-id-backfill-migration";
 
 describe("UserKeyIdBackfillMigration", () => {
   const mockSdkService = mock<SdkService>();
   const mockSyncService = mock<SyncService>();
   const mockLogService = mock<LogService>();
 
+  let stateProvider: FakeStateProvider;
   let sut: UserKeyIdBackfillMigration;
 
   const mockUserId = "00000000-0000-0000-0000-000000000000" as UserId;
+  const HOUR_MS = 1000 * 60 * 60;
 
   // SDK reference chain: sdk.take() -> ref.value.user_crypto_management().user_key_id_backfill()
   const needsBackfill = jest.fn();
@@ -39,7 +45,14 @@ describe("UserKeyIdBackfillMigration", () => {
 
     mockSdkService.userClient$ = jest.fn(() => of(mockSdk)) as any;
 
-    sut = new UserKeyIdBackfillMigration(mockSdkService, mockSyncService, mockLogService);
+    stateProvider = new FakeStateProvider(mockAccountServiceWith(mockUserId));
+
+    sut = new UserKeyIdBackfillMigration(
+      mockSdkService,
+      mockSyncService,
+      stateProvider,
+      mockLogService,
+    );
   });
 
   describe("needsMigration", () => {
@@ -75,6 +88,34 @@ describe("UserKeyIdBackfillMigration", () => {
       expect(mockSyncService.fullSync).toHaveBeenCalledWith(false);
     });
 
+    it("returns 'noMigrationNeeded' without syncing while a failed attempt is in cooldown", async () => {
+      needsBackfill.mockResolvedValue(true);
+      await stateProvider.setUserState(
+        USER_KEY_ID_BACKFILL_COOLDOWN,
+        new Date(new Date().getTime() - 1 * HOUR_MS),
+        mockUserId,
+      );
+
+      const result = await sut.needsMigration(mockUserId);
+
+      expect(result).toBe("noMigrationNeeded");
+      expect(mockSyncService.fullSync).not.toHaveBeenCalled();
+      expect(needsBackfill).not.toHaveBeenCalled();
+    });
+
+    it("returns 'needsMigration' once the cooldown of a failed attempt has expired", async () => {
+      needsBackfill.mockResolvedValue(true);
+      await stateProvider.setUserState(
+        USER_KEY_ID_BACKFILL_COOLDOWN,
+        new Date(new Date().getTime() - 25 * HOUR_MS),
+        mockUserId,
+      );
+
+      const result = await sut.needsMigration(mockUserId);
+
+      expect(result).toBe("needsMigration");
+    });
+
     it("returns 'noMigrationNeeded' when the SDK cannot evaluate the backfill", async () => {
       // e.g. the account is locked, so the user key is not in the key store
       needsBackfill.mockRejectedValue(new Error("User key is not available in key store"));
@@ -103,6 +144,29 @@ describe("UserKeyIdBackfillMigration", () => {
       await expect(sut.runMigrations(mockUserId)).rejects.toThrow(
         "API call failed during user key id backfill",
       );
+    });
+
+    it("starts the cooldown when the server rejects the backfill", async () => {
+      // e.g. a server too old to know the backfill endpoint answers with a 404
+      backfill.mockRejectedValue(new Error("404 Not Found"));
+
+      await expect(sut.runMigrations(mockUserId)).rejects.toThrow("404 Not Found");
+
+      const cooldown = await firstValueFrom(
+        stateProvider.getUser(mockUserId, USER_KEY_ID_BACKFILL_COOLDOWN).state$,
+      );
+      expect(cooldown).not.toBeNull();
+    });
+
+    it("does not start the cooldown when the backfill succeeds", async () => {
+      backfill.mockResolvedValue(undefined);
+
+      await sut.runMigrations(mockUserId);
+
+      const cooldown = await firstValueFrom(
+        stateProvider.getUser(mockUserId, USER_KEY_ID_BACKFILL_COOLDOWN).state$,
+      );
+      expect(cooldown).toBeNull();
     });
   });
 });

--- a/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.ts
@@ -1,12 +1,36 @@
+import { firstValueFrom } from "rxjs";
+
 import { LogService } from "@bitwarden/logging";
 
 import { assertNonNullish } from "../../../auth/utils";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
+import {
+  ENCRYPTED_MIGRATION_DISK,
+  StateProvider,
+  UserKeyDefinition,
+} from "../../../platform/state";
 import { SyncService } from "../../../platform/sync";
 import { UserId } from "../../../types/guid";
 import { withPasswordManagerSdk } from "../../utils";
 
 import { EncryptedMigration, MigrationRequirement } from "./encrypted-migration";
+
+/**
+ * Timestamp of the last failed backfill attempt. Servers older than the one introducing the
+ * backfill endpoint answer with a 404, which would otherwise make the migration retry on every
+ * scheduler tick.
+ */
+export const USER_KEY_ID_BACKFILL_COOLDOWN = new UserKeyDefinition<Date>(
+  ENCRYPTED_MIGRATION_DISK,
+  "userKeyIdBackfillCooldown",
+  {
+    deserializer: (obj: string) => (obj != null ? new Date(obj) : null),
+    clearOn: [],
+  },
+);
+
+const COOLDOWN_HOURS = 24;
+const MS_PER_HOUR = 1000 * 60 * 60;
 
 /**
  * @internal
@@ -19,6 +43,7 @@ export class UserKeyIdBackfillMigration implements EncryptedMigration {
   constructor(
     private readonly sdkService: SdkService,
     private readonly syncService: SyncService,
+    private readonly stateProvider: StateProvider,
     private readonly logService: LogService,
   ) {}
 
@@ -26,15 +51,31 @@ export class UserKeyIdBackfillMigration implements EncryptedMigration {
     assertNonNullish(userId, "userId");
 
     this.logService.info(`[UserKeyIdBackfillMigration] Recording the user key id for ${userId}`);
-    await withPasswordManagerSdk(userId, this.sdkService, async (sdk) => {
-      await sdk.user_crypto_management().user_key_id_backfill();
-    });
+    try {
+      await withPasswordManagerSdk(userId, this.sdkService, async (sdk) => {
+        await sdk.user_crypto_management().user_key_id_backfill();
+      });
+    } catch (error) {
+      // The server may not support the backfill endpoint at all; back off instead of retrying
+      // on every scheduler tick.
+      await this.startCooldown(userId);
+      throw error;
+    }
   }
 
   async needsMigration(userId: UserId): Promise<MigrationRequirement> {
     assertNonNullish(userId, "userId");
 
     try {
+      // Checked before anything else: the sync below re-triggers the scheduler, so a failing
+      // migration would otherwise loop.
+      if (await this.isInCooldown(userId)) {
+        this.logService.info(
+          `[UserKeyIdBackfillMigration] Skipping migration for user ${userId}; a previous attempt failed less than ${COOLDOWN_HOURS} hours ago`,
+        );
+        return "noMigrationNeeded";
+      }
+
       if (!(await this.needsBackfill(userId))) {
         return "noMigrationNeeded";
       }
@@ -68,5 +109,22 @@ export class UserKeyIdBackfillMigration implements EncryptedMigration {
       this.sdkService,
       async (sdk) => await sdk.user_crypto_management().user_key_id_needs_backfill(),
     );
+  }
+
+  private async isInCooldown(userId: UserId): Promise<boolean> {
+    const failedAt = await firstValueFrom(
+      this.stateProvider.getUser(userId, USER_KEY_ID_BACKFILL_COOLDOWN).state$,
+    );
+    if (failedAt == null) {
+      return false;
+    }
+
+    const hoursSinceFailure = (new Date().getTime() - failedAt.getTime()) / MS_PER_HOUR;
+
+    return hoursSinceFailure < COOLDOWN_HOURS;
+  }
+
+  private async startCooldown(userId: UserId): Promise<void> {
+    await this.stateProvider.setUserState(USER_KEY_ID_BACKFILL_COOLDOWN, new Date(), userId);
   }
 }

--- a/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.ts
@@ -1,6 +1,7 @@
 import { firstValueFrom } from "rxjs";
 
 import { LogService } from "@bitwarden/logging";
+import { isKeyIdBackfillError } from "@bitwarden/sdk-internal";
 
 import { assertNonNullish } from "../../../auth/utils";
 import { SdkService } from "../../../platform/abstractions/sdk/sdk.service";
@@ -16,9 +17,9 @@ import { withPasswordManagerSdk } from "../../utils";
 import { EncryptedMigration, MigrationRequirement } from "./encrypted-migration";
 
 /**
- * Timestamp of the last failed backfill attempt. Servers older than the one introducing the
- * backfill endpoint answer with a 404, which would otherwise make the migration retry on every
- * scheduler tick.
+ * Timestamp of the last backfill attempt that failed against the server. Servers older than the
+ * one introducing the backfill endpoint answer with a 404, which would otherwise make the
+ * migration retry on every scheduler tick.
  */
 export const USER_KEY_ID_BACKFILL_COOLDOWN = new UserKeyDefinition<Date>(
   ENCRYPTED_MIGRATION_DISK,
@@ -56,9 +57,13 @@ export class UserKeyIdBackfillMigration implements EncryptedMigration {
         await sdk.user_crypto_management().user_key_id_backfill();
       });
     } catch (error) {
-      // The server may not support the backfill endpoint at all; back off instead of retrying
-      // on every scheduler tick.
-      await this.startCooldown(userId);
+      // Only server-side failures back off: the server may not support the backfill endpoint at
+      // all, which would otherwise be retried on every scheduler tick. The remaining variants
+      // (`UserKeyNotAvailable`, `NoKeyId`, `StateBridgeNotRegistered`) are local conditions that
+      // resolve on their own.
+      if (isKeyIdBackfillError(error) && error.variant === "Api") {
+        await this.startCooldown(userId);
+      }
       throw error;
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42470

## 📔 Objective

Stop the user key id backfill migration from looping against servers that do not have the backfill endpoint (self hosted outdated).

### Where the loop comes from

`UserKeyIdBackfillMigration.needsMigration()` runs `syncService.fullSync(false)` to check whether another client already performed the backfill. `DefaultSyncService.fullSync` writes `setLastSync(now)` unconditionally, including on the "no sync needed" path. `DefaultEncryptedMigrationsSchedulerService` triggers off `combineLatest([authStatusFor$, lastSync$, url$])`, so that write re-triggers the scheduler:

```
lastSync$ emits
  -> runMigrationsIfNeeded
    -> needsMigration -> fullSync(false) -> setLastSync(now)
      -> lastSync$ emits ...
```

Normally this terminates after one successful backfill, since `user_key_id_needs_backfill()` then returns false and `needsMigration` returns early before the sync. On an old server the backfill call 404s, the flag stays true, and the cycle repeats as fast as the network allows. The `isMigrating` / `isRunningMigration` guards do not help: `concatMap` serializes the passes, so both are already cleared by the time the next emission arrives.

We introduce a simple 24 hour cooldown which fixes the bug.

## 📸 Screenshots

n/a

