### PR TITLE
[PM-41001] Create scaffold for libs/managed-settings lib

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,6 +117,7 @@ libs/platform                     @bitwarden/team-platform-dev
 libs/storage-core                 @bitwarden/team-platform-dev
 libs/logging                      @bitwarden/team-platform-dev
 libs/logging-angular              @bitwarden/team-platform-dev
+libs/managed-settings             @bitwarden/team-platform-dev
 libs/storage-test-utils           @bitwarden/team-platform-dev
 libs/messaging                    @bitwarden/team-platform-dev
 libs/serialization                @bitwarden/team-platform-dev

--- a/jest.config.js
+++ b/jest.config.js
@@ -70,6 +70,7 @@ module.exports = {
     "<rootDir>/libs/pam/jest.config.js",
     "<rootDir>/libs/storybook/jest.config.js",
     "<rootDir>/libs/legacy-crypto/jest.config.js",
+    "<rootDir>/libs/managed-settings/jest.config.js",
   ],
 
   // Workaround for a memory leak that crashes tests in CI:

--- a/libs/managed-settings/README.md
+++ b/libs/managed-settings/README.md
@@ -1,0 +1,5 @@
+# managed-settings
+
+Owned by: platform
+
+Administrator-forced client settings acquired from operating system device-management (UEM/MDM) channels

--- a/libs/managed-settings/eslint.config.mjs
+++ b/libs/managed-settings/eslint.config.mjs
@@ -1,0 +1,3 @@
+import baseConfig from "../../eslint.config.mjs";
+
+export default [...baseConfig];

--- a/libs/managed-settings/jest.config.js
+++ b/libs/managed-settings/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  displayName: "managed-settings",
+  preset: "../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }],
+  },
+  moduleFileExtensions: ["ts", "js", "html"],
+  coverageDirectory: "../../coverage/libs/managed-settings",
+};

--- a/libs/managed-settings/package.json
+++ b/libs/managed-settings/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@bitwarden/managed-settings",
+  "version": "0.0.1",
+  "description": "Administrator-forced client settings acquired from operating system device-management (UEM/MDM) channels",
+  "private": true,
+  "type": "commonjs",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "license": "GPL-3.0",
+  "author": "platform"
+}

--- a/libs/managed-settings/project.json
+++ b/libs/managed-settings/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "managed-settings",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/managed-settings/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/managed-settings",
+        "main": "libs/managed-settings/src/index.ts",
+        "tsConfig": "libs/managed-settings/tsconfig.lib.json",
+        "assets": ["libs/managed-settings/*.md"],
+        "rootDir": "libs/managed-settings/src"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/managed-settings/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/managed-settings/jest.config.js"
+      }
+    }
+  }
+}

--- a/libs/managed-settings/src/managed-settings.spec.ts
+++ b/libs/managed-settings/src/managed-settings.spec.ts
@@ -1,0 +1,7 @@
+describe("managed-settings", () => {
+  // Placeholder test until the library exports something. Replace with real
+  // coverage as the managed settings library grows.
+  it("should work", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/libs/managed-settings/tsconfig.eslint.json
+++ b/libs/managed-settings/tsconfig.eslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": ["src/**/*.ts", "src/**/*.js"],
+  "exclude": ["**/build", "**/dist"]
+}

--- a/libs/managed-settings/tsconfig.json
+++ b/libs/managed-settings/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/managed-settings/tsconfig.lib.json
+++ b/libs/managed-settings/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.js", "src/**/*.spec.ts"]
+}

--- a/libs/managed-settings/tsconfig.spec.json
+++ b/libs/managed-settings/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -357,6 +357,11 @@
       "version": "0.0.1",
       "license": "GPL-3.0"
     },
+    "libs/managed-settings": {
+      "name": "@bitwarden/managed-settings",
+      "version": "0.0.1",
+      "license": "GPL-3.0"
+    },
     "libs/messaging": {
       "name": "@bitwarden/messaging",
       "version": "0.0.1",
@@ -4914,6 +4919,10 @@
     },
     "node_modules/@bitwarden/logging-angular": {
       "resolved": "libs/logging-angular",
+      "link": true
+    },
+    "node_modules/@bitwarden/managed-settings": {
+      "resolved": "libs/managed-settings",
       "link": true
     },
     "node_modules/@bitwarden/messaging": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -79,7 +79,8 @@
       "@bitwarden/vault-export-ui": ["./libs/tools/export-vault-ui/src"],
       "@bitwarden/web-vault/*": ["./apps/web/src/*"],
       "@bitwarden/pam": ["./libs/pam/src/index.ts"],
-      "@bitwarden/storybook": ["./libs/storybook/src/index.ts"]
+      "@bitwarden/storybook": ["./libs/storybook/src/index.ts"],
+      "@bitwarden/managed-settings": ["./libs/managed-settings/src/index.ts"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41001

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Create the scaffold for the `managed-settings`-lib located under `libs/*` using the [bitwarden-nx plugin for generating libraries](https://github.com/bitwarden/clients/blob/main/libs/nx-plugin/docs/using-the-basic-lib-generator.md).

This will be the future place for adding capabilities of reading/storing managed settings provided via MDM/UEM tooling.

**This is only the scaffold and does not contain any business logic**