### PR TITLE
Add more support for DDG browser

### DIFF
--- a/apps/browser/src/platform/actions/browser-actions.service.ts
+++ b/apps/browser/src/platform/actions/browser-actions.service.ts
@@ -18,6 +18,7 @@ export class BrowserActionsService implements ActionsService {
     try {
       switch (deviceType) {
         case DeviceType.FirefoxExtension:
+        case DeviceType.DuckDuckGoExtension:
         case DeviceType.ChromeExtension: {
           const browserAction = BrowserApi.getBrowserAction();
 

--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -1108,6 +1108,25 @@ describe("BrowserApi", () => {
 
       expect(BrowserApi.getBrowserClientVendor(window)).toBe(expected);
     });
+
+    // A DuckDuckGo extension implies the Windows (WebView2) build, which is Chromium.
+    it("returns Chrome for DuckDuckGoExtension device", () => {
+      jest
+        .spyOn(BrowserPlatformUtilsService, "getDevice")
+        .mockReturnValue(DeviceType.DuckDuckGoExtension);
+
+      expect(BrowserApi.getBrowserClientVendor(window)).toBe(BrowserClientVendors.Chrome);
+    });
+
+    // DuckDuckGoBrowser spans both the Windows Chromium build and the WebKit macOS build, so
+    // it must not be assumed Chromium.
+    it("returns Unknown for DuckDuckGoBrowser device", () => {
+      jest
+        .spyOn(BrowserPlatformUtilsService, "getDevice")
+        .mockReturnValue(DeviceType.DuckDuckGoBrowser);
+
+      expect(BrowserApi.getBrowserClientVendor(window)).toBe(BrowserClientVendors.Unknown);
+    });
   });
 
   describe("registerContentScriptsMv2", () => {

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -222,8 +222,13 @@ export class BrowserApi {
     const device = BrowserPlatformUtilsService.getDevice(clientWindow);
 
     switch (device) {
+      // DuckDuckGoExtension implies the Windows (WebView2) build, since detection relies on
+      // userAgentData, which only Chromium exposes. That build uses the Chrome Web Store and
+      // Chromium's settings URIs. DuckDuckGoBrowser is deliberately absent: it spans both the
+      // Windows Chromium build and the WebKit-based macOS build, so it cannot be mapped here.
       case DeviceType.ChromeExtension:
       case DeviceType.ChromeBrowser:
+      case DeviceType.DuckDuckGoExtension:
         return BrowserClientVendors.Chrome;
       case DeviceType.OperaExtension:
       case DeviceType.OperaBrowser:

--- a/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.spec.ts
+++ b/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.spec.ts
@@ -53,6 +53,13 @@ describe("Browser Utils Service", () => {
       });
     });
 
+    const setUserAgentData = (userAgentData: unknown) => {
+      Object.defineProperty(navigator, "userAgentData", {
+        configurable: true,
+        value: userAgentData,
+      });
+    };
+
     beforeEach(() => {
       (window as any).matchMedia = jest.fn().mockReturnValueOnce({});
     });
@@ -60,6 +67,7 @@ describe("Browser Utils Service", () => {
     afterEach(() => {
       window.matchMedia = undefined;
       (BrowserPlatformUtilsService as any).deviceCache = null;
+      delete (navigator as any).userAgentData;
     });
 
     it("should detect chrome", () => {
@@ -119,6 +127,65 @@ describe("Browser Utils Service", () => {
       });
 
       expect(browserPlatformUtilsService.getDevice()).toBe(DeviceType.VivaldiExtension);
+    });
+
+    it("should detect duckduckgo from the userAgentData brand list", () => {
+      // DuckDuckGo's Chromium build masquerades as Edge in its user agent, so the brand
+      // list is the only signal that distinguishes it.
+      Object.defineProperty(navigator, "userAgent", {
+        configurable: true,
+        value:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.0.0",
+      });
+      setUserAgentData({
+        brands: [
+          { brand: "Not=A?Brand", version: "99" },
+          { brand: "DuckDuckGo", version: "151" },
+          { brand: "Chromium", version: "151" },
+        ],
+      });
+
+      expect(browserPlatformUtilsService.getDevice()).toBe(DeviceType.DuckDuckGoExtension);
+      expect(browserPlatformUtilsService.isDuckDuckGo()).toBe(true);
+    });
+
+    it("should still detect chrome when the brand list has no DuckDuckGo entry", () => {
+      Object.defineProperty(navigator, "userAgent", {
+        configurable: true,
+        value:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+      });
+      setUserAgentData({
+        brands: [
+          { brand: "Not=A?Brand", version: "99" },
+          { brand: "Chromium", version: "135" },
+          { brand: "Google Chrome", version: "135" },
+        ],
+      });
+
+      expect(browserPlatformUtilsService.getDevice()).toBe(DeviceType.ChromeExtension);
+    });
+
+    it("should fall back to user agent detection when userAgentData is unavailable", () => {
+      Object.defineProperty(navigator, "userAgent", {
+        configurable: true,
+        value:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+      });
+      setUserAgentData(undefined);
+
+      expect(browserPlatformUtilsService.getDevice()).toBe(DeviceType.ChromeExtension);
+    });
+
+    it("should not throw when userAgentData is present without a brand list", () => {
+      Object.defineProperty(navigator, "userAgent", {
+        configurable: true,
+        value:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+      });
+      setUserAgentData({});
+
+      expect(browserPlatformUtilsService.getDevice()).toBe(DeviceType.ChromeExtension);
     });
 
     it("returns a previously determined device using a cached value", () => {
@@ -369,6 +436,7 @@ describe("Browser Utils Service", () => {
       DeviceType.EdgeExtension,
       DeviceType.OperaExtension,
       DeviceType.VivaldiExtension,
+      DeviceType.DuckDuckGoExtension,
     ];
 
     const nonChromiumDevices: DeviceType[] = [

--- a/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
+++ b/apps/browser/src/platform/services/platform-utils/browser-platform-utils.service.ts
@@ -6,6 +6,7 @@ import {
   ClipboardOptions,
   PlatformUtilsService,
 } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { hasUserAgentBrand } from "@bitwarden/common/platform/misc/user-agent-data";
 
 import { SafariApp } from "../../../browser/safariApp";
 import { BrowserApi } from "../../browser/browser-api";
@@ -32,6 +33,11 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
     // the list we hope to catch all by the most generic clients they could be on.
     if (BrowserPlatformUtilsService.isFirefox()) {
       this.deviceCache = DeviceType.FirefoxExtension;
+    } else if (BrowserPlatformUtilsService.isDuckDuckGo()) {
+      // Must precede the Edge and Chrome checks: DuckDuckGo's Chromium build carries an
+      // "Edg/" suffix in its user agent and lists "Chromium" among its brands, so both of
+      // those checks would otherwise claim it first.
+      this.deviceCache = DeviceType.DuckDuckGoExtension;
     } else if (BrowserPlatformUtilsService.isOpera(globalContext)) {
       this.deviceCache = DeviceType.OperaExtension;
     } else if (BrowserPlatformUtilsService.isEdge()) {
@@ -107,6 +113,14 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
     return this.getDevice() === DeviceType.VivaldiExtension;
   }
 
+  private static isDuckDuckGo(): boolean {
+    return hasUserAgentBrand("DuckDuckGo");
+  }
+
+  isDuckDuckGo(): boolean {
+    return this.getDevice() === DeviceType.DuckDuckGoExtension;
+  }
+
   private static isSafari(globalContext: Window | ServiceWorkerGlobalScope): boolean {
     // Opera masquerades as Safari, so make sure we're not there first
     return (
@@ -124,7 +138,13 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
   }
 
   isChromium(): boolean {
-    return this.isChrome() || this.isEdge() || this.isOpera() || this.isVivaldi();
+    // DuckDuckGo is Chromium (WebView2) on Windows but WebKit on macOS, so it is not
+    // Chromium in general. It is safe to treat unconditionally here because detection relies
+    // on userAgentData, which only Chromium exposes — so DuckDuckGoExtension can only ever
+    // be the Windows build. Revisit if a user-agent-based fallback is ever added above.
+    return (
+      this.isChrome() || this.isEdge() || this.isOpera() || this.isVivaldi() || this.isDuckDuckGo()
+    );
   }
 
   /**
@@ -328,6 +348,8 @@ export abstract class BrowserPlatformUtilsService implements PlatformUtilsServic
         return "Vivaldi Extension";
       case DeviceType.SafariExtension:
         return "Safari Extension";
+      case DeviceType.DuckDuckGoExtension:
+        return "DuckDuckGo Extension";
       default:
         return "Unknown Browser Extension";
     }

--- a/apps/browser/src/tools/popup/guards/file-picker-popout.guard.ts
+++ b/apps/browser/src/tools/popup/guards/file-picker-popout.guard.ts
@@ -58,6 +58,8 @@ export function filePickerPopoutGuard(): CanActivateFn {
     // Chromium on Linux/Mac: needs sidebar OR popout for file picker access
     // All Chromium-based browsers (Chrome, Edge, Opera, Vivaldi)
     // Brave intentionally reports itself as Chrome for compatibility
+    // DuckDuckGo is deliberately absent: it is only Chromium (WebView2) on Windows, where
+    // no popout is required, and its macOS build is WebKit rather than Chromium.
     const isChromiumBased = [
       DeviceType.ChromeExtension,
       DeviceType.EdgeExtension,

--- a/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
+++ b/apps/browser/src/tools/popup/settings/about-page/about-page-v2.component.ts
@@ -28,6 +28,8 @@ const RateUrls = {
   [DeviceType.VivaldiExtension]:
     "https://chromewebstore.google.com/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb/reviews",
   [DeviceType.SafariExtension]: "https://apps.apple.com/app/bitwarden/id1352778147",
+  [DeviceType.DuckDuckGoExtension]:
+    "https://chromewebstore.google.com/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb/reviews",
 };
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush

--- a/apps/web/src/app/core/web-platform-utils.service.spec.ts
+++ b/apps/web/src/app/core/web-platform-utils.service.spec.ts
@@ -138,27 +138,67 @@ describe("Web Platform Utils Service", () => {
       });
     };
 
+    const setUserAgentData = (userAgentData?: unknown) => {
+      Object.defineProperty(navigator, "userAgentData", {
+        value: userAgentData,
+        configurable: true,
+      });
+    };
+
     afterEach(() => {
       // Reset to original after each test
       setUserAgent(originalUserAgent);
+      delete (navigator as any).userAgentData;
     });
 
     const testData: {
       userAgent: string;
       expectedDevice: DeviceType;
       windowProps?: Record<string, any>;
+      userAgentData?: unknown;
     }[] = [
       {
-        // DuckDuckGo macoOS browser v1.13
+        // DuckDuckGo macoOS browser v1.13. The macOS build is WebKit-based and exposes no
+        // userAgentData, so the Ddg user agent suffix is the only available signal.
         userAgent:
           "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Safari/605.1.15 Ddg/18.3.1",
         expectedDevice: DeviceType.DuckDuckGoBrowser,
       },
-      // DuckDuckGo Windows browser v0.109.7, which does not present the Ddg suffix and is therefore detected as Edge
       {
+        // DuckDuckGo Windows browser v0.109.7. Its user agent carries an Edg/ suffix and no
+        // Ddg suffix, so the userAgentData brand list is what distinguishes it from Edge.
         userAgent:
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.0.0",
+        userAgentData: {
+          brands: [
+            { brand: "Not=A?Brand", version: "99" },
+            { brand: "DuckDuckGo", version: "151" },
+            { brand: "Chromium", version: "151" },
+          ],
+        },
+        expectedDevice: DeviceType.DuckDuckGoBrowser,
+      },
+      {
+        // Regression guard: a brand list without a DuckDuckGo entry must not be claimed by
+        // the DuckDuckGo check, even though it also contains Chromium.
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.0.0",
+        userAgentData: {
+          brands: [
+            { brand: "Not=A?Brand", version: "99" },
+            { brand: "Chromium", version: "135" },
+            { brand: "Microsoft Edge", version: "135" },
+          ],
+        },
         expectedDevice: DeviceType.EdgeBrowser,
+      },
+      {
+        // Regression guard: userAgentData present but without a brand list must not throw.
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+        userAgentData: {},
+        expectedDevice: DeviceType.ChromeBrowser,
+        windowProps: { chrome: {} },
       },
       {
         userAgent:
@@ -195,8 +235,9 @@ describe("Web Platform Utils Service", () => {
 
     test.each(testData)(
       "returns $expectedDevice for User-Agent: $userAgent",
-      ({ userAgent, expectedDevice, windowProps }) => {
+      ({ userAgent, expectedDevice, windowProps, userAgentData }) => {
         setUserAgent(userAgent);
+        setUserAgentData(userAgentData);
         setWindowProperties(windowProps);
         const result = webPlatformUtilsService.getDevice();
         expect(result).toBe(expectedDevice);
@@ -205,6 +246,15 @@ describe("Web Platform Utils Service", () => {
   });
 
   describe("isChromium", () => {
+    const originalUserAgent = navigator.userAgent;
+
+    const setUserAgent = (userAgent: string) => {
+      Object.defineProperty(navigator, "userAgent", {
+        value: userAgent,
+        configurable: true,
+      });
+    };
+
     const chromiumDevices = [
       DeviceType.ChromeBrowser,
       DeviceType.EdgeBrowser,
@@ -216,12 +266,12 @@ describe("Web Platform Utils Service", () => {
       DeviceType.FirefoxBrowser,
       DeviceType.SafariBrowser,
       DeviceType.IEBrowser,
-      DeviceType.DuckDuckGoBrowser,
       DeviceType.UnknownBrowser,
     ];
 
     afterEach(() => {
       jest.restoreAllMocks();
+      setUserAgent(originalUserAgent);
     });
 
     test.each(chromiumDevices)("returns true when getDevice() is %s", (deviceType) => {
@@ -231,6 +281,30 @@ describe("Web Platform Utils Service", () => {
 
     test.each(nonChromiumDevices)("returns false when getDevice() is %s", (deviceType) => {
       jest.spyOn(webPlatformUtilsService, "getDevice").mockReturnValue(deviceType);
+      expect(webPlatformUtilsService.isChromium()).toBe(false);
+    });
+
+    // DuckDuckGo is the one browser whose engine depends on the platform: Chromium on
+    // Windows, WebKit on macOS.
+    it("returns true for DuckDuckGo on Windows", () => {
+      jest
+        .spyOn(webPlatformUtilsService, "getDevice")
+        .mockReturnValue(DeviceType.DuckDuckGoBrowser);
+      setUserAgent(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.0.0",
+      );
+
+      expect(webPlatformUtilsService.isChromium()).toBe(true);
+    });
+
+    it("returns false for DuckDuckGo on macOS", () => {
+      jest
+        .spyOn(webPlatformUtilsService, "getDevice")
+        .mockReturnValue(DeviceType.DuckDuckGoBrowser);
+      setUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.3.1 Safari/605.1.15 Ddg/18.3.1",
+      );
+
       expect(webPlatformUtilsService.isChromium()).toBe(false);
     });
   });

--- a/apps/web/src/app/core/web-platform-utils.service.ts
+++ b/apps/web/src/app/core/web-platform-utils.service.ts
@@ -7,6 +7,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { hasUserAgentBrand } from "@bitwarden/common/platform/misc/user-agent-data";
 
 @Injectable()
 export class WebPlatformUtilsService implements PlatformUtilsService {
@@ -28,19 +29,23 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
       navigator.userAgent.indexOf(" Gecko/") !== -1
     ) {
       this.browserCache = DeviceType.FirefoxBrowser;
+    } else if (
+      // DuckDuckGo advertises itself in two different ways depending on the platform, and
+      // both must be checked before the Chromium brands below:
+      //  - Its Chromium builds report a "DuckDuckGo" brand alongside "Chromium", and their
+      //    user agent carries an "Edg/" suffix that would otherwise match Edge.
+      //  - Its macOS build is WebKit-based, exposes no userAgentData, and instead appends a
+      //    "Ddg" suffix to the user agent.
+      hasUserAgentBrand("DuckDuckGo") ||
+      navigator.userAgent.indexOf("Ddg") !== -1
+    ) {
+      this.browserCache = DeviceType.DuckDuckGoBrowser;
     } else if (navigator.userAgent.indexOf(" OPR/") >= 0) {
       this.browserCache = DeviceType.OperaBrowser;
     } else if (navigator.userAgent.indexOf(" Edg/") !== -1) {
       this.browserCache = DeviceType.EdgeBrowser;
     } else if (navigator.userAgent.indexOf(" Vivaldi/") !== -1) {
       this.browserCache = DeviceType.VivaldiBrowser;
-    } else if (
-      // We are only detecting DuckDuckGo browser on macOS currently, as
-      // it is not presenting the Ddg suffix on Windows. DuckDuckGo users
-      // on Windows will be detected as Edge.
-      navigator.userAgent.indexOf("Ddg") !== -1
-    ) {
-      this.browserCache = DeviceType.DuckDuckGoBrowser;
     } else if (
       navigator.userAgent.indexOf(" Safari/") !== -1 &&
       navigator.userAgent.indexOf("Chrome") === -1
@@ -90,8 +95,25 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
     return this.getDevice() === DeviceType.SafariBrowser;
   }
 
+  isDuckDuckGo(): boolean {
+    return this.getDevice() === DeviceType.DuckDuckGoBrowser;
+  }
+
+  private isWindows(): boolean {
+    return navigator.userAgent.indexOf("Windows") !== -1;
+  }
+
   isChromium(): boolean {
-    return this.isChrome() || this.isEdge() || this.isOpera() || this.isVivaldi();
+    // DuckDuckGo ships a Chromium engine on Windows but a WebKit engine on macOS, so it is
+    // the one browser where this answer depends on the platform. Revisit if DuckDuckGo ever
+    // ships a Chromium build on another platform.
+    return (
+      this.isChrome() ||
+      this.isEdge() ||
+      this.isOpera() ||
+      this.isVivaldi() ||
+      (this.isDuckDuckGo() && this.isWindows())
+    );
   }
 
   isWebKit(): boolean {

--- a/apps/web/src/app/dirt/event-logs/services/event.service.ts
+++ b/apps/web/src/app/dirt/event-logs/services/event.service.ts
@@ -1379,6 +1379,8 @@ export class EventService {
         return ["bwi-puzzle", this.i18nService.t("extension") + " - Vivaldi"];
       case DeviceType.SafariExtension:
         return ["bwi-puzzle", this.i18nService.t("extension") + " - Safari"];
+      case DeviceType.DuckDuckGoExtension:
+        return ["bwi-puzzle", this.i18nService.t("extension") + " - DuckDuckGo"];
       case DeviceType.WindowsDesktop:
         return ["bwi-desktop", this.i18nService.t("desktop") + " - Windows"];
       case DeviceType.MacOsDesktop:

--- a/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt-install.component.ts
+++ b/apps/web/src/app/vault/components/browser-extension-prompt/browser-extension-prompt-install.component.ts
@@ -23,6 +23,8 @@ const WebStoreUrls: Partial<Record<DeviceType, string>> = {
     "https://addons.opera.com/extensions/details/bitwarden-free-password-manager/",
   [DeviceType.EdgeBrowser]:
     "https://microsoftedge.microsoft.com/addons/detail/jbkfoedolllekgbhcbcoahefnbanhhlh",
+  // DuckDuckGoBrowser is intentionally absent: only its Windows (Chromium) build can install
+  // Chrome Web Store extensions, and this map carries no platform information.
 };
 
 // FIXME(https://bitwarden.atlassian.net/browse/CL-764): Migrate to OnPush

--- a/libs/common/src/enums/device-type.enum.ts
+++ b/libs/common/src/enums/device-type.enum.ts
@@ -28,6 +28,7 @@ export enum DeviceType {
   MacOsCLI = 24,
   LinuxCLI = 25,
   DuckDuckGoBrowser = 26,
+  DuckDuckGoExtension = 27,
 }
 
 /**
@@ -49,6 +50,7 @@ export const DeviceTypeMetadata: Record<DeviceType, DeviceTypeMetadata> = {
   [DeviceType.EdgeExtension]: { category: "extension", platform: "Edge" },
   [DeviceType.VivaldiExtension]: { category: "extension", platform: "Vivaldi" },
   [DeviceType.SafariExtension]: { category: "extension", platform: "Safari" },
+  [DeviceType.DuckDuckGoExtension]: { category: "extension", platform: "DuckDuckGo" },
   [DeviceType.ChromeBrowser]: { category: "webApp", platform: "Chrome" },
   [DeviceType.FirefoxBrowser]: { category: "webApp", platform: "Firefox" },
   [DeviceType.OperaBrowser]: { category: "webApp", platform: "Opera" },

--- a/libs/common/src/platform/misc/user-agent-data.spec.ts
+++ b/libs/common/src/platform/misc/user-agent-data.spec.ts
@@ -1,0 +1,62 @@
+import { hasUserAgentBrand } from "./user-agent-data";
+
+describe("hasUserAgentBrand", () => {
+  const setUserAgentData = (userAgentData: unknown) => {
+    Object.defineProperty(globalThis.navigator, "userAgentData", {
+      value: userAgentData,
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    delete (globalThis.navigator as any).userAgentData;
+  });
+
+  it("returns true when the brand is present", () => {
+    setUserAgentData({
+      brands: [
+        { brand: "Not=A?Brand", version: "99" },
+        { brand: "DuckDuckGo", version: "151" },
+        { brand: "Chromium", version: "151" },
+      ],
+    });
+
+    expect(hasUserAgentBrand("DuckDuckGo")).toBe(true);
+  });
+
+  it("returns false when the brand is absent", () => {
+    setUserAgentData({
+      brands: [
+        { brand: "Not=A?Brand", version: "99" },
+        { brand: "Chromium", version: "135" },
+        { brand: "Google Chrome", version: "135" },
+      ],
+    });
+
+    expect(hasUserAgentBrand("DuckDuckGo")).toBe(false);
+  });
+
+  it("matches the brand exactly rather than as a substring", () => {
+    setUserAgentData({ brands: [{ brand: "DuckDuckGoBrowser", version: "151" }] });
+
+    expect(hasUserAgentBrand("DuckDuckGo")).toBe(false);
+  });
+
+  it("returns false when userAgentData is undefined", () => {
+    setUserAgentData(undefined);
+
+    expect(hasUserAgentBrand("DuckDuckGo")).toBe(false);
+  });
+
+  it("returns false when userAgentData has no brand list", () => {
+    setUserAgentData({});
+
+    expect(hasUserAgentBrand("DuckDuckGo")).toBe(false);
+  });
+
+  it("returns false when the brand list is empty", () => {
+    setUserAgentData({ brands: [] });
+
+    expect(hasUserAgentBrand("DuckDuckGo")).toBe(false);
+  });
+});

--- a/libs/common/src/platform/misc/user-agent-data.ts
+++ b/libs/common/src/platform/misc/user-agent-data.ts
@@ -1,0 +1,43 @@
+/**
+ * A single entry of the low-entropy brand list exposed by the User-Agent Client Hints API.
+ *
+ * The list always contains a randomized "GREASE" entry (e.g. `Not=A?Brand`) alongside the
+ * real brands, so callers must look for the brand they care about rather than assuming a
+ * position in the list.
+ */
+interface UserAgentBrand {
+  brand: string;
+  version: string;
+}
+
+/**
+ * The subset of `NavigatorUAData` we rely on. TypeScript's `dom` lib does not declare
+ * `navigator.userAgentData`, so we describe just the low-entropy surface here instead of
+ * augmenting the global `Navigator` type.
+ */
+interface UserAgentData {
+  brands?: UserAgentBrand[];
+}
+
+/**
+ * Returns true when the current browser reports the given brand in
+ * `navigator.userAgentData.brands`.
+ *
+ * `brands` is the *low-entropy* portion of the User-Agent Client Hints API, which means it
+ * is available synchronously — no `getHighEntropyValues()` call, and therefore no need to
+ * make callers async.
+ *
+ * The API is Chromium-only, is gated to secure contexts, and is absent in Firefox and
+ * Safari, so every access is guarded and this returns false wherever it is unavailable.
+ *
+ * @param brand The brand to look for, matched exactly (e.g. `"DuckDuckGo"`).
+ */
+export function hasUserAgentBrand(brand: string): boolean {
+  // `navigator` is a `WorkerNavigator` in the extension's service worker context, which
+  // also implements `userAgentData`.
+  const userAgentData: UserAgentData | undefined = (
+    globalThis.navigator as Navigator & { userAgentData?: UserAgentData }
+  )?.userAgentData;
+
+  return userAgentData?.brands?.some((b) => b.brand === brand) ?? false;
+}

--- a/libs/common/src/vault/utils/get-web-store-url.ts
+++ b/libs/common/src/vault/utils/get-web-store-url.ts
@@ -6,6 +6,9 @@ import { DeviceType } from "../../enums";
  */
 export const getWebStoreUrl = (deviceType: DeviceType): string => {
   switch (deviceType) {
+    // DuckDuckGoBrowser is intentionally not mapped: only its Windows (Chromium) build can
+    // install Chrome Web Store extensions, and this signature carries no platform
+    // information, so it falls through to the generic download page.
     case DeviceType.ChromeBrowser:
       return "https://chromewebstore.google.com/detail/bitwarden-password-manage/nngceckbapebfimnlniiiahkandclblb";
     case DeviceType.FirefoxBrowser:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42510

## 📔 Objective

Report DuckDuckGo as its own device type instead of mislabeling it as Chrome.

DuckDuckGo now identifies itself via a `DuckDuckGo` entry in `navigator.userAgentData.brands`
(and the equivalent `sec-ch-ua` header). Previously it fell through to the generic Chrome
check, so DDG users showed up as `ChromeBrowser` / `ChromeExtension` in device lists,
new-device-login emails, 2FA emails, and TDE login-approval prompts.

📓 Note that this is the first time we're using `userAgentData.brands` to control `DeviceType`, which is why this changeset is larger than just adding a new type.

Changes:

- Adds `DuckDuckGoExtension = 27` to `DeviceType`, matching `DeviceType.cs` in `bitwarden/server`.
  `DuckDuckGoBrowser = 26` already existed.
- Adds a shared `hasUserAgentBrand()` helper in `libs/common`. Brand matching uses the
  low-entropy `brands` list, which is synchronous, so `getDevice()` stays synchronous. Access
  is guarded, since `userAgentData` is Chromium-only and secure-context-gated.
- Detects DDG in the browser extension, and adds the brand signal to the web vault alongside
  the existing `Ddg` user-agent check. This fixes DDG-on-Windows in the web vault, which was
  previously reported as Edge (its user agent carries an `Edg/` suffix and no `Ddg` suffix).
  In both clients the DDG check must run before the Edge and Chrome checks for that reason.
- Updates the call sites where DDG-as-Chrome was load-bearing, so reclassifying it isn't a net
  regression. Most importantly the extension's popup would otherwise stop opening, since
  `openPopup()` switches on device type and would have fallen through to its default branch.

See https://github.com/bitwarden/server/pull/8259 for corresponding `server` PR.

### Platform caveat

DuckDuckGo is Chromium (WebView2) on Windows but WebKit (WKWebView) on macOS, so it is not
Chromium in general. Anything keyed on `DuckDuckGoBrowser` — which spans both builds — is left
deliberately unmapped, including the Chrome Web Store links, which a macOS DDG user cannot use.
Web's `isChromium()` returns true for DDG only on Windows. Values keyed on
`DuckDuckGoExtension` are safe to treat as Chromium, because detection depends on
`userAgentData`, which only Chromium exposes.

### Known gap (pre-existing, needs an SDK release)

`toSdkDevice()` is unchanged: `SdkDeviceType` comes from `@bitwarden/sdk-internal` and has no
DuckDuckGo variant, so both members fall through to `"SDK"`. `DuckDuckGoBrowser` already had
this problem before this PR.
