### PR TITLE
fix(key-management): Clear key id backfill cooldown on logout

### DIFF
--- a/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.ts
+++ b/libs/common/src/key-management/encrypted-migrator/migrations/user-key-id-backfill-migration.ts
@@ -26,7 +26,7 @@ export const USER_KEY_ID_BACKFILL_COOLDOWN = new UserKeyDefinition<Date>(
   "userKeyIdBackfillCooldown",
   {
     deserializer: (obj: string) => (obj != null ? new Date(obj) : null),
-    clearOn: [],
+    clearOn: ["logout"],
   },
 );
 


### PR DESCRIPTION
## 🎟️ Tracking

n/a

## 📔 Objective

Clear `USER_KEY_ID_BACKFILL_COOLDOWN` on logout. The cooldown timestamp previously persisted, so an account that hit a server-side backfill failure stayed in cooldown across a fresh login.

## 📸 Screenshots

n/a
