### PR TITLE
[PM-42522] Fix bw serve/unlock crashing when the server is unreachable but the vault is synced

### DIFF
--- a/apps/cli/src/key-management/commands/unlock.command.ts
+++ b/apps/cli/src/key-management/commands/unlock.command.ts
@@ -71,7 +71,15 @@ export class UnlockCommand {
       }
     }
 
-    await this.encryptedMigrator.runMigrations(userId, password);
+    try {
+      await this.encryptedMigrator.runMigrations(userId, password);
+    } catch (e) {
+      // Migrations are best-effort background bookkeeping (e.g. informing the server of a key
+      // id, bumping a KDF setting) that run opportunistically after an unlock. A failure here -
+      // most commonly the server being unreachable - must not make an otherwise-successful
+      // unlock get reported back as a failure.
+      this.logService.warning(`[UnlockCommand] Skipping migrations after unlock: ${e.message}`);
+    }
 
     return this.successResponse();
   }

--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -75,7 +75,19 @@ class JsTokenProvider implements TokenProvider {
       return undefined;
     }
 
-    return await this.apiService.getActiveBearerToken(this.userId);
+    try {
+      return await this.apiService.getActiveBearerToken(this.userId);
+    } catch {
+      // The SDK's Rust-side TokenProvider currently panics (WASM `unreachable` trap, killing the
+      // whole process) if this promise rejects, instead of treating a failed lookup as a
+      // recoverable "no token" case - see crates/bitwarden-wasm-internal/src/platform
+      // /token_provider.rs upstream. Most commonly this happens when a token refresh attempt
+      // fails because the server is unreachable. Falling back to `undefined` here - already a
+      // supported return value, per the branch above - avoids ever handing the SDK a rejected
+      // promise, so operations that don't actually need a live token (e.g. local vault
+      // unlock/decrypt) keep working.
+      return undefined;
+    }
   }
 }
 

--- a/libs/common/src/platform/services/sdk/register-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/register-sdk.service.ts
@@ -50,7 +50,19 @@ class JsTokenProvider implements TokenProvider {
       return undefined;
     }
 
-    return await this.apiService.getActiveBearerToken(this.userId);
+    try {
+      return await this.apiService.getActiveBearerToken(this.userId);
+    } catch {
+      // The SDK's Rust-side TokenProvider currently panics (WASM `unreachable` trap, killing the
+      // whole process) if this promise rejects, instead of treating a failed lookup as a
+      // recoverable "no token" case - see crates/bitwarden-wasm-internal/src/platform
+      // /token_provider.rs upstream. Most commonly this happens when a token refresh attempt
+      // fails because the server is unreachable. Falling back to `undefined` here - already a
+      // supported return value, per the branch above - avoids ever handing the SDK a rejected
+      // promise, so operations that don't actually need a live token (e.g. local vault
+      // unlock/decrypt) keep working.
+      return undefined;
+    }
   }
 }
 

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -1492,9 +1492,16 @@ export class ApiService implements ApiServiceAbstraction {
     if (this.refreshTokenPromise[userId] === undefined) {
       // TODO: Have different promise for each user
       this.refreshTokenPromise[userId] = this.internalRefreshToken(userId);
-      void this.refreshTokenPromise[userId].finally(() => {
-        delete this.refreshTokenPromise[userId];
-      });
+      // `.finally()` returns a new derived promise that rejects too if the original
+      // does. Without a handler on that derived promise, a failed refresh (e.g. the
+      // identity server being unreachable) becomes an unhandled promise rejection,
+      // which crashes the whole process. Callers still see the rejection normally
+      // via the returned `this.refreshTokenPromise[userId]` below.
+      void this.refreshTokenPromise[userId]
+        .finally(() => {
+          delete this.refreshTokenPromise[userId];
+        })
+        .catch(() => {});
     }
     return this.refreshTokenPromise[userId];
   }


### PR DESCRIPTION
## 🎟️ Tracking

Relates to #20195 and #18373.

## 📔 Objective

`bw serve` (and `bw unlock`) crash the entire Node process instead of failing cleanly when the configured server is unreachable but a vault is already synced locally - e.g. a self-hosted instance that's only reachable via a VPN the user isn't currently on. This directly causes the symptoms reported in #20195 and #18373: `bw` commands die with a raw connection error instead of using the already-cached local vault.

Traced this to three separate, compounding bugs, all triggered by the same root condition (an authenticated request - most commonly an access token refresh - failing because the server can't be reached):

1. **`libs/common/src/services/api.service.ts`** - `refreshToken()` caches the in-flight refresh promise and separately calls `.finally()` on it to clear that cache, discarding the *derived* promise `.finally()` returns with `void`. That derived promise also rejects when the original does, and since nothing observes it, a failed refresh produces an **unhandled promise rejection that crashes the whole process** (Node's default `--unhandled-rejections=throw` behavior) - not just the one request that triggered it.

2. **`libs/common/src/platform/services/sdk/register-sdk.service.ts`** and **`default-sdk.service.ts`** (two otherwise-identical `JsTokenProvider` implementations) - even after fixing (1), the *real* returned promise from `refreshToken()` still rejects as intended, and that rejection reaches the SDK's Rust-side `TokenProvider` via `get_access_token()`. The SDK currently treats a rejected token lookup as fatal and panics with a WASM `unreachable` trap (`crates/bitwarden-wasm-internal/src/platform/token_provider.rs`), which again kills the whole process. `get_access_token()` already treats `undefined` as a normal, supported return value (used when there's no active user), so this falls back to `undefined` on a failed lookup instead of ever handing the SDK a rejected promise.

3. **`apps/cli/src/key-management/commands/unlock.command.ts`** - even after (1) and (2), a successful unlock still calls `encryptedMigrator.runMigrations()` unguarded afterward. Migrations are best-effort background bookkeeping (e.g. informing the server of a key id) that can legitimately fail offline; an unguarded failure there was making `bw serve`'s `/unlock` report `500` for an unlock that had already succeeded.

Verified end-to-end against a real self-hosted instance made unreachable on purpose (server unroutable, expired access token): before these changes, `bw serve` crashed outright on `/unlock`; after all three, unlock succeeds normally against the already-synced local vault, with the migration failure logged and skipped rather than failing the response. Confirmed with a cold start the next day (fully expired token, VPN never connected) as well.

This is complementary to the cooldown added in #22682 for `UserKeyIdBackfillMigration` - that change still `throw`s on the first failure (by design, so the cooldown gets recorded), so (3) is still needed for that first failure not to fail an otherwise-successful unlock; (1) and (2) are unrelated files/bugs it doesn't touch.

Tested with `npm run lint`, `npm run test:types`, and `npm test` scoped to the touched files plus `libs/common/src/key-management/encrypted-migrator` - all pass except 3 pre-existing failures in `api.service.spec.ts` (a Windows path-separator issue in the test harness, confirmed present identically on unmodified `main`, unrelated to this change).

Given this touches the unlock/token-refresh path adjacent to the crypto boundary, flagging for `@bitwarden/team-key-management-dev` awareness per the repo's contributing guidelines, even though no encryption logic itself is added or changed.

**Disclosure:** investigated and implemented with AI pair-programming assistance (Claude Code) - the root-cause tracing, fixes, and the end-to-end verification against a real offline scenario described above were all actually run and confirmed, not just generated.

## 📸 Screenshots

N/A - CLI-only backend fix, no UI changes.
