### PR TITLE
[PM-42527] Filter autofill inline menu ciphers while typing and rank username matches on password fields

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -48,6 +48,8 @@ export type FocusedFieldData = {
   showPasskeys?: boolean;
   focusedFieldForm?: string;
   focusedFieldOpid?: string;
+  isPasswordField?: boolean;
+  detectedUsername?: string;
 };
 
 export type InlineMenuElementPosition = {
@@ -155,6 +157,7 @@ export type OverlayBackgroundExtensionMessage = {
   focusedFieldData?: FocusedFieldData;
   allFieldsRect?: AutofillField[];
   isOpeningFullInlineMenu?: boolean;
+  filterValue?: string;
   styles?: Partial<CSSStyleDeclaration>;
   data?: LockedVaultPendingNotificationsData;
   iframeSrc?: string;
@@ -245,6 +248,7 @@ export type OverlayBackgroundExtensionMessageHandlers = {
   triggerAutofillOverlayReposition: ({ sender }: BackgroundSenderParam) => void;
   checkIsInlineMenuCiphersPopulated: ({ sender }: BackgroundSenderParam) => void;
   updateFocusedFieldData: ({ message, sender }: BackgroundOnMessageHandlerParams) => void;
+  updateInlineMenuListFilter: ({ message, sender }: BackgroundOnMessageHandlerParams) => void;
   updateIsFieldCurrentlyFocused: ({ message, sender }: BackgroundOnMessageHandlerParams) => void;
   checkIsFieldCurrentlyFocused: () => boolean;
   updateIsFieldCurrentlyFilling: ({ message }: BackgroundMessageParam) => void;

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -2166,6 +2166,152 @@ describe("OverlayBackground", () => {
       });
     });
 
+    describe("updateInlineMenuListFilter message handler", () => {
+      const tab = createChromeTabMock({ id: 2 });
+      const sender = mock<chrome.runtime.MessageSender>({ tab, frameId: 0 });
+      let filterLoginCipher1: CipherView;
+      let filterLoginCipher2: CipherView;
+
+      beforeEach(async () => {
+        activeAccountStatusMock$.next(AuthenticationStatus.Unlocked);
+        await initOverlayElementPorts();
+        filterLoginCipher1 = mock<CipherView>({
+          id: "id-1",
+          name: "Example Site",
+          type: CipherType.Login,
+          login: { username: "tomkaio@example.com", uri: "https://example.com" },
+        });
+        filterLoginCipher2 = mock<CipherView>({
+          id: "id-2",
+          name: "Example Site",
+          type: CipherType.Login,
+          login: { username: "alice@example.com", uri: "https://example.com" },
+        });
+        overlayBackground["inlineMenuCiphers"] = new Map([
+          ["inline-menu-cipher-0", filterLoginCipher1],
+          ["inline-menu-cipher-1", filterLoginCipher2],
+        ]);
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          tabId: tab.id,
+          frameId: sender.frameId,
+        });
+      });
+
+      it("filters the inline menu list ciphers by a substring match of the typed value", async () => {
+        sendMockExtensionMessage(
+          { command: "updateInlineMenuListFilter", filterValue: "tom" },
+          sender,
+        );
+        await flushPromises();
+
+        expect(listPortSpy.postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            command: "updateAutofillInlineMenuListCiphers",
+            ciphers: [
+              expect.objectContaining({
+                login: expect.objectContaining({ username: "tomkaio@example.com" }),
+              }),
+            ],
+          }),
+        );
+      });
+
+      it("skips updating the list when the sender frame does not contain the focused field", async () => {
+        const otherSender = mock<chrome.runtime.MessageSender>({
+          tab: createChromeTabMock({ id: 3 }),
+          frameId: 0,
+        });
+
+        sendMockExtensionMessage(
+          { command: "updateInlineMenuListFilter", filterValue: "tom" },
+          otherSender,
+        );
+        await flushPromises();
+
+        expect(listPortSpy.postMessage).not.toHaveBeenCalledWith(
+          expect.objectContaining({ command: "updateAutofillInlineMenuListCiphers" }),
+        );
+      });
+
+      it("ranks the cipher matching the tab's captured username first on a password field", async () => {
+        sendMockExtensionMessage(
+          { command: "updateInlineMenuListFilter", filterValue: "alice@example.com" },
+          sender,
+        );
+        await flushPromises();
+
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          tabId: tab.id,
+          frameId: sender.frameId,
+          isPasswordField: true,
+        });
+        const cipherData = await overlayBackground["getInlineMenuCipherData"]();
+
+        expect(cipherData[0].login?.username).toBe("alice@example.com");
+        expect(cipherData[1].login?.username).toBe("tomkaio@example.com");
+      });
+
+      it("prefers the username detected within the page over the tab's captured username", async () => {
+        sendMockExtensionMessage(
+          { command: "updateInlineMenuListFilter", filterValue: "alice@example.com" },
+          sender,
+        );
+        await flushPromises();
+
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          tabId: tab.id,
+          frameId: sender.frameId,
+          isPasswordField: true,
+          detectedUsername: "tomkaio@example.com",
+        });
+        const cipherData = await overlayBackground["getInlineMenuCipherData"]();
+
+        expect(cipherData[0].login?.username).toBe("tomkaio@example.com");
+        expect(cipherData[1].login?.username).toBe("alice@example.com");
+      });
+
+      it("does not apply the typed filter while a password field is focused", async () => {
+        sendMockExtensionMessage(
+          { command: "updateInlineMenuListFilter", filterValue: "tom" },
+          sender,
+        );
+        await flushPromises();
+
+        overlayBackground["focusedFieldData"] = createFocusedFieldDataMock({
+          tabId: tab.id,
+          frameId: sender.frameId,
+          isPasswordField: true,
+        });
+        const cipherData = await overlayBackground["getInlineMenuCipherData"]();
+
+        expect(cipherData).toHaveLength(2);
+      });
+
+      it("resets the typed filter when a different field is focused", async () => {
+        sendMockExtensionMessage(
+          { command: "updateInlineMenuListFilter", filterValue: "tom" },
+          sender,
+        );
+        await flushPromises();
+        expect(overlayBackground["inlineMenuListFilterValue"]).toBe("tom");
+
+        sendMockExtensionMessage(
+          {
+            command: "updateFocusedFieldData",
+            focusedFieldData: createFocusedFieldDataMock({
+              tabId: tab.id,
+              frameId: sender.frameId,
+              focusedFieldOpid: "different-field-opid",
+            }),
+          },
+          sender,
+        );
+        await flushPromises();
+
+        expect(overlayBackground["inlineMenuListFilterValue"]).toBe("");
+      });
+    });
+
     describe("updateFocusedFieldData message handler", () => {
       it("sends a message to the sender frame to unset the most recently focused field data when the currently focused field does not belong to the sender", async () => {
         const tab = createChromeTabMock({ id: 2 });

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -155,6 +155,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
   private currentInlineMenuCiphersCount: number = 0;
   private currentAddNewItemData: CurrentAddNewItemData | null = null;
   private focusedFieldData: FocusedFieldData | null = null;
+  private inlineMenuListFilterValue: string = "";
+  private capturedUsernameByTab: Record<number, string> = {};
   private allFieldData: AutofillField[] = [];
   private isFieldCurrentlyFocused: boolean = false;
   private isFieldCurrentlyFilling: boolean = false;
@@ -177,6 +179,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     checkIsInlineMenuCiphersPopulated: ({ sender }) =>
       this.checkIsInlineMenuCiphersPopulated(sender),
     updateFocusedFieldData: ({ message, sender }) => this.setFocusedFieldData(message, sender),
+    updateInlineMenuListFilter: ({ message, sender }) =>
+      this.updateInlineMenuListFilter(message, sender),
     updateIsFieldCurrentlyFocused: ({ message, sender }) =>
       this.updateIsFieldCurrentlyFocused(message, sender),
     checkIsFieldCurrentlyFocused: () => this.checkIsFieldCurrentlyFocused(),
@@ -403,6 +407,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
 
     this.clearGeneratedPassword$.next();
     this.focusedFieldData = null;
+    this.inlineMenuListFilterValue = "";
   }
 
   /**
@@ -513,6 +518,116 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     if (refocusField) {
       await BrowserApi.tabSendMessage(currentTab, { command: "focusMostRecentlyFocusedField" });
     }
+  }
+
+  /**
+   * Handles a typed value within a login username field. Stores the value as the active
+   * inline menu list filter and as the tab's captured username, then rebuilds the list
+   * so it only presents ciphers matching the typed value. The captured username persists
+   * across page navigation within the tab, allowing multi-step login pages to rank the
+   * matching cipher at the top of the list on the password step.
+   *
+   * @param message - The extension message containing the typed filter value
+   * @param sender - The sender of the extension message
+   */
+  private async updateInlineMenuListFilter(
+    { filterValue }: OverlayBackgroundExtensionMessage,
+    sender: chrome.runtime.MessageSender,
+  ) {
+    if (!sender.tab || !this.senderFrameHasFocusedField(sender)) {
+      return;
+    }
+
+    this.inlineMenuListFilterValue = filterValue ?? "";
+
+    const tabId = sender.tab.id;
+    if (tabId !== null && tabId !== undefined) {
+      const capturedUsername = this.inlineMenuListFilterValue.trim();
+      if (capturedUsername) {
+        this.capturedUsernameByTab[tabId] = capturedUsername;
+      } else {
+        delete this.capturedUsernameByTab[tabId];
+      }
+    }
+
+    await this.updateInlineMenuListCiphers(sender.tab);
+  }
+
+  /**
+   * Gets the active inline menu list filter. The filter only applies while the focused
+   * field is a field the user types a username into; password fields ignore it.
+   */
+  private getInlineMenuListFilter(): string {
+    if (this.focusedFieldData?.isPasswordField) {
+      return "";
+    }
+
+    return this.inlineMenuListFilterValue.trim().toLowerCase();
+  }
+
+  /**
+   * Identifies whether the cipher matches the inline menu list filter through a
+   * case-insensitive substring match against its name or login username.
+   *
+   * @param cipher - The cipher to check against the filter
+   * @param filter - The lowercased filter value
+   */
+  private cipherMatchesInlineMenuListFilter(cipher: CipherView, filter: string): boolean {
+    if (cipher.name?.toLowerCase().includes(filter)) {
+      return true;
+    }
+
+    return !!cipher.login?.username?.toLowerCase().includes(filter);
+  }
+
+  /**
+   * Gets the username hint for a focused password field. Prefers the username detected
+   * within the page itself, falling back to the username most recently typed within the
+   * tab (e.g. on the previous step of a multi-step login page).
+   */
+  private getFocusedFieldUsernameHint(): string {
+    if (
+      !this.focusedFieldData?.isPasswordField ||
+      !this.focusedFieldMatchesFillType(CipherType.Login)
+    ) {
+      return "";
+    }
+
+    const detectedUsername = this.focusedFieldData.detectedUsername?.trim();
+    if (detectedUsername) {
+      return detectedUsername.toLowerCase();
+    }
+
+    const tabId = this.focusedFieldData.tabId;
+    const capturedUsername =
+      tabId !== null && tabId !== undefined ? this.capturedUsernameByTab[tabId] : undefined;
+    return capturedUsername ? capturedUsername.toLowerCase() : "";
+  }
+
+  /**
+   * Ranks how well a cipher's login username matches the username hint. Lower ranks sort
+   * earlier: exact matches first, partial matches second, all other ciphers last.
+   *
+   * @param cipher - The cipher to rank
+   * @param usernameHint - The lowercased username hint
+   */
+  private getUsernameHintMatchRank(cipher: CipherView, usernameHint: string): number {
+    if (cipher.type !== CipherType.Login) {
+      return 2;
+    }
+
+    const username = cipher.login?.username?.toLowerCase();
+    if (!username) {
+      return 2;
+    }
+    if (username === usernameHint) {
+      return 0;
+    }
+    if (username.includes(usernameHint) || usernameHint.includes(username)) {
+      return 1;
+    }
+
+    return 2;
   }
 
   /**
@@ -714,8 +829,23 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     }
     const passkeysEnabled = await firstValueFrom(this.vaultSettingsService.enablePasskeys$);
 
+    const usernameHint = this.getFocusedFieldUsernameHint();
+    if (usernameHint) {
+      // Stable sort preserves the last-used ordering within each match rank.
+      inlineMenuCiphersArray = [...inlineMenuCiphersArray].sort(
+        ([, cipherA], [, cipherB]) =>
+          this.getUsernameHintMatchRank(cipherA, usernameHint) -
+          this.getUsernameHintMatchRank(cipherB, usernameHint),
+      );
+    }
+    const listFilter = this.getInlineMenuListFilter();
+
     for (let cipherIndex = 0; cipherIndex < inlineMenuCiphersArray.length; cipherIndex++) {
       const [inlineMenuCipherId, cipher] = inlineMenuCiphersArray[cipherIndex];
+
+      if (listFilter && !this.cipherMatchesInlineMenuListFilter(cipher, listFilter)) {
+        continue;
+      }
 
       switch (cipher.type) {
         case CipherType.Card:
@@ -1435,6 +1565,13 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     if (!cipher) {
       return;
     }
+
+    // Remember the filled username for the tab so that a subsequent password-only
+    // step within a multi-step login flow ranks this cipher at the top of the list.
+    if (tabId !== undefined && cipher.type === CipherType.Login && cipher.login?.username) {
+      this.capturedUsernameByTab[tabId] = cipher.login.username;
+    }
+
     if (usePasskey && cipher.login?.hasFido2Credentials) {
       const credentialId = cipher.login.fido2Credentials[0]?.credentialId;
       if (credentialId) {
@@ -2060,6 +2197,14 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     };
     this.allFieldData = allFieldsRect ?? [];
     this.isFieldCurrentlyFocused = true;
+
+    if (
+      previousFocusedFieldData?.focusedFieldOpid !== focusedFieldData.focusedFieldOpid ||
+      previousFocusedFieldData?.tabId !== sender.tab.id ||
+      previousFocusedFieldData?.frameId !== frameId
+    ) {
+      this.inlineMenuListFilterValue = "";
+    }
 
     if (this.shouldUpdatePasswordGeneratorMenuOnFieldFocus()) {
       this.updateInlineMenuGeneratedPasswordOnFocus(sender.tab).catch((error) =>
@@ -3331,7 +3476,19 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     BrowserApi.messageListener("overlay.background", this.handleExtensionMessage);
     BrowserApi.addListener(chrome.webNavigation.onCommitted, this.handleWebNavigationOnCommitted);
     BrowserApi.addListener(chrome.runtime.onConnect, this.handlePortOnConnect);
+    BrowserApi.addListener(chrome.tabs.onRemoved, this.handleTabOnRemoved);
   }
+
+  /**
+   * Clears tab-scoped state when a tab is removed. The captured username is intentionally
+   * kept across page navigation within a tab so that multi-step login pages can rank the
+   * matching cipher first; it is only released once the tab closes.
+   *
+   * @param tabId - The id of the removed tab
+   */
+  private handleTabOnRemoved = (tabId: number) => {
+    delete this.capturedUsernameByTab[tabId];
+  };
 
   /**
    * Handles extension messages sent to the extension background.

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -528,7 +528,7 @@ describe("AutofillOverlayContentService", () => {
           );
         });
 
-        it("Closes the inline menu list and does not re-open the inline menu if the field has a value", async () => {
+        it("updates the inline menu list filter with the typed value on a login username field", async () => {
           (autofillFieldElement as HTMLInputElement).value = "test";
 
           await autofillOverlayContentService.setupOverlayListeners(
@@ -539,11 +539,46 @@ describe("AutofillOverlayContentService", () => {
           autofillFieldElement.dispatchEvent(new Event("input"));
           await flushPromises();
 
+          expect(sendExtensionMessageSpy).toHaveBeenCalledWith("updateInlineMenuListFilter", {
+            filterValue: "test",
+          });
+          expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("closeAutofillInlineMenu", {
+            overlayElement: AutofillOverlayElement.List,
+            forceCloseInlineMenu: true,
+          });
+          expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("openAutofillInlineMenu");
+        });
+
+        it("closes the inline menu list and does not re-open the inline menu if a password field has a value", async () => {
+          const passwordFieldElement = document.getElementById(
+            "password-field",
+          ) as ElementWithOpId<FormFieldElement>;
+          (passwordFieldElement as HTMLInputElement).value = "test";
+          const passwordFieldData = createAutofillFieldMock({
+            opid: "password-field",
+            form: "validFormId",
+            elementNumber: 2,
+            autoCompleteType: "current-password",
+            type: "password",
+          });
+
+          await autofillOverlayContentService.setupOverlayListeners(
+            passwordFieldElement,
+            passwordFieldData,
+            pageDetailsMock,
+          );
+          passwordFieldElement.dispatchEvent(new Event("input"));
+          await flushPromises();
+
           expect(sendExtensionMessageSpy).toHaveBeenCalledWith("closeAutofillInlineMenu", {
             overlayElement: AutofillOverlayElement.List,
             forceCloseInlineMenu: true,
           });
           expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith("openAutofillInlineMenu");
+          expect(sendExtensionMessageSpy).not.toHaveBeenCalledWith(
+            "updateInlineMenuListFilter",
+            expect.any(Object),
+          );
         });
 
         it("opens the inline menu if the field does not have a value", async () => {

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -37,6 +37,7 @@ import {
   currentlyInSandboxedIframe,
   debounce,
   elementIsFillableFormField,
+  elementIsInputElement,
   elementIsSelectElement,
   getAttributeBoolean,
   isReadonlyOrDisabledFormFieldElement,
@@ -850,7 +851,9 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
   /**
    * Triggers when the form field element receives an input event. This method will
    * store the modified form element data for use when the user attempts to add a new
-   * vault item. It also acts to remove the inline menu list while the user is typing.
+   * vault item. Typing within a login username field filters the inline menu list to
+   * ciphers matching the typed value; typing in any other field removes the inline
+   * menu list.
    *
    * @param formFieldElement - The form field element that triggered the input event.
    */
@@ -867,6 +870,17 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       return;
     }
 
+    if (this.isFilterableLoginUsernameField(formFieldElement)) {
+      await this.sendExtensionMessage("updateInlineMenuListFilter", {
+        filterValue: formFieldElement.value ?? "",
+      });
+
+      if (!formFieldElement.value) {
+        await this.sendExtensionMessage("openAutofillInlineMenu");
+      }
+      return;
+    }
+
     await this.sendExtensionMessage("closeAutofillInlineMenu", {
       overlayElement: AutofillOverlayElement.List,
       forceCloseInlineMenu: true,
@@ -876,6 +890,105 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       await this.sendExtensionMessage("openAutofillInlineMenu");
     }
   }
+
+  /**
+   * Identifies whether typing in the field should filter the inline menu list of login
+   * ciphers rather than close it. This applies to username fields on login forms, where
+   * the typed value narrows the list to ciphers containing that value.
+   *
+   * @param formFieldElement - The form field element that triggered the input event.
+   */
+  private isFilterableLoginUsernameField(
+    formFieldElement: ElementWithOpId<FillableFormFieldElement>,
+  ): boolean {
+    if (this.elementIsPasswordField(formFieldElement)) {
+      return false;
+    }
+
+    const autofillFieldData = this.formFieldElements.get(formFieldElement);
+    return autofillFieldData?.inlineMenuFillType === CipherType.Login;
+  }
+
+  /**
+   * Identifies whether the form field element is a password input.
+   *
+   * @param formFieldElement - The form field element to check.
+   */
+  private elementIsPasswordField(formFieldElement: FormFieldElement): boolean {
+    return elementIsInputElement(formFieldElement) && formFieldElement.type === "password";
+  }
+
+  /**
+   * Attempts to detect the username associated with a focused password field. Multi-step
+   * login pages often carry the username entered on a previous step in a hidden or
+   * pre-filled input on the password step. The detected value lets the inline menu
+   * surface the matching login cipher at the top of the list.
+   */
+  private getDetectedUsernameFromPage(): string {
+    const userFilledUsername =
+      this.userFilledFields?.[AutofillFieldQualifier.username]?.value?.trim();
+    if (userFilledUsername) {
+      return userFilledUsername;
+    }
+
+    let detectedUsername = "";
+    let detectedRank = Number.MAX_SAFE_INTEGER;
+    const inputElements = globalThis.document.querySelectorAll("input");
+    for (let index = 0; index < inputElements.length; index++) {
+      const inputElement = inputElements[index];
+      const value = inputElement.value?.trim();
+      if (!value || inputElement === this.mostRecentlyFocusedField) {
+        continue;
+      }
+
+      const rank = this.getUsernameCandidateRank(inputElement);
+      if (rank !== null && rank < detectedRank) {
+        detectedRank = rank;
+        detectedUsername = value;
+      }
+    }
+
+    return detectedUsername;
+  }
+
+  /**
+   * Ranks an input element as a candidate for holding the page's username value.
+   * Lower ranks indicate stronger candidates; `null` disqualifies the element.
+   *
+   * @param inputElement - The input element to rank.
+   */
+  private getUsernameCandidateRank(inputElement: HTMLInputElement): number | null {
+    const type = (inputElement.getAttribute("type") || "text").toLowerCase();
+    if (!AutofillOverlayContentService.usernameCandidateInputTypes.has(type)) {
+      return null;
+    }
+
+    const autocomplete = inputElement.getAttribute("autocomplete")?.toLowerCase() || "";
+    if (autocomplete.includes("username") || autocomplete.includes("email")) {
+      return 0;
+    }
+
+    if (type === "email") {
+      return 1;
+    }
+
+    const identifier = `${inputElement.name || ""} ${inputElement.id || ""}`.toLowerCase();
+    if (AutofillOverlayContentService.usernameCandidateKeywords.test(identifier)) {
+      return type === "hidden" ? 2 : 3;
+    }
+
+    return null;
+  }
+
+  private static readonly usernameCandidateInputTypes = new Set([
+    "text",
+    "email",
+    "tel",
+    "hidden",
+    "search",
+  ]);
+
+  private static readonly usernameCandidateKeywords = /user|email|login|account|identifier/;
 
   /**
    * Stores the modified form element data for use when the user attempts to add a new
@@ -1078,6 +1191,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
     const { width, height, top, left } =
       await this.getMostRecentlyFocusedFieldRects(formFieldElement);
     const autofillFieldData = this.formFieldElements.get(formFieldElement);
+    const isPasswordField = this.elementIsPasswordField(formFieldElement);
 
     this.focusedFieldData = {
       focusedFieldStyles: { paddingRight, paddingLeft },
@@ -1087,6 +1201,8 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
       accountCreationFieldType: autofillFieldData?.accountCreationFieldType,
       focusedFieldForm: autofillFieldData?.form ?? undefined,
       focusedFieldOpid: autofillFieldData?.opid,
+      isPasswordField,
+      detectedUsername: isPasswordField ? this.getDetectedUsernameFromPage() : undefined,
     };
 
     const allFields = this.formFieldElements;


### PR DESCRIPTION
## 🎟️ Tracking

Community feature request (open since Jan 2024): https://community.bitwarden.com/t/inline-autofill-menu-ability-to-filter-items-by-typing-searching/63417
Related requests: https://community.bitwarden.com/t/search-in-autofill-suggestions/68032

## 📔 Objective

Typing in a login username field previously closed the autofill inline menu list, leaving no way to narrow a long list of logins down to a specific account. On multi-step login pages (username on one page, password on the next), the password step gave no indication of which cipher matched the username entered on the previous step.

This PR (browser extension only):

- **Type-to-filter:** typing in a login username field now live-filters the inline menu list via a case-insensitive substring match on cipher name and login username, instead of closing the list. Clearing the field restores the full list. Password fields keep the existing close-on-type behavior.
- **Username-hint ranking:** when a password field is focused, ciphers whose login username matches a username hint are ranked to the top (exact matches, then partial matches, preserving last-used order within each group). The hint is detected from the page (`autocomplete="username"`, email inputs, hidden username fields common on multi-step login pages), falling back to the username most recently typed or autofilled within the tab. The tab-captured value lives only in the service worker, is kept across same-tab navigation, and is released when the tab closes — nothing is persisted or logged.

Message flow: the content script sends a new `updateInlineMenuListFilter` extension message (debounced by the existing input handler); the background filters/reorders in `buildInlineMenuCiphers` and re-posts through the existing `updateAutofillInlineMenuListCiphers` port message, so the list UI required no changes.

Covered by new unit tests in `overlay.background.spec.ts` (filter matching, sender validation, hint ranking, hint precedence, filter reset on focus change) and `autofill-overlay-content.service.spec.ts` (filter message on username input, unchanged password-field behavior).

## 📸 Screenshots

<img width="528" height="600" alt="image" src="https://github.com/user-attachments/assets/d89e5514-ad70-4937-b8f4-6a8ac6b18df7" />
<img width="566" height="560" alt="image" src="https://github.com/user-attachments/assets/01a5a866-12b4-4b55-8f25-35998d3d6e96" />

