### PR TITLE
[PM-42528] Add close affordances to the autofill inline menu

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/overlay.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/overlay.background.ts
@@ -175,7 +175,8 @@ export type OverlayPortCommand =
   | "updateColorScheme"
   | "unlockVault"
   | "refreshGeneratedPassword"
-  | "fillGeneratedPassword";
+  | "fillGeneratedPassword"
+  | "forceCloseAutofillInlineMenu";
 
 export type OverlayPortMessage = {
   command: OverlayPortCommand;
@@ -317,6 +318,7 @@ export type InlineMenuListPortMessageHandlers = {
   refreshGeneratedPassword: () => Promise<void>;
   fillGeneratedPassword: ({ port }: PortConnectionParam) => Promise<void>;
   refreshOverlayCiphers: () => Promise<void>;
+  forceCloseAutofillInlineMenu: ({ port }: PortConnectionParam) => void;
 };
 
 export interface OverlayBackground {

--- a/apps/browser/src/autofill/background/overlay.background.spec.ts
+++ b/apps/browser/src/autofill/background/overlay.background.spec.ts
@@ -3321,6 +3321,25 @@ describe("OverlayBackground", () => {
           { frameId: 0 },
         );
       });
+
+      it("closes the inline menu list when it is already visible", async () => {
+        overlayBackground["isInlineMenuListVisible"] = true;
+
+        sendPortMessage(buttonMessageConnectorSpy, {
+          command: "autofillInlineMenuButtonClicked",
+          portKey,
+        });
+        await flushPromises();
+
+        expect(tabsSendMessageSpy).toHaveBeenCalledWith(
+          sender.tab,
+          {
+            command: "closeAutofillInlineMenu",
+            overlayElement: AutofillOverlayElement.List,
+          },
+          { frameId: 0 },
+        );
+      });
     });
     describe("handles menu position when input is focused", () => {
       it("sets button and menu width and position when non-multi-input totp field is focused", async () => {
@@ -3604,6 +3623,22 @@ describe("OverlayBackground", () => {
         await flushPromises();
 
         expect(openUnlockPopoutSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe("forceCloseAutofillInlineMenu message handler", () => {
+      it("force closes the inline menu", async () => {
+        sendPortMessage(listMessageConnectorSpy, {
+          command: "forceCloseAutofillInlineMenu",
+          portKey,
+        });
+        await flushPromises();
+
+        expect(tabsSendMessageSpy).toHaveBeenCalledWith(
+          listMessageConnectorSpy.sender.tab,
+          { command: "closeAutofillInlineMenu", overlayElement: undefined },
+          { frameId: 0 },
+        );
       });
     });
 

--- a/apps/browser/src/autofill/background/overlay.background.ts
+++ b/apps/browser/src/autofill/background/overlay.background.ts
@@ -245,6 +245,8 @@ export class OverlayBackground implements OverlayBackgroundInterface {
     refreshGeneratedPassword: () => this.updateGeneratedPassword(true),
     fillGeneratedPassword: ({ port }) => this.fillGeneratedPassword(port),
     refreshOverlayCiphers: () => this.updateOverlayCiphers(false),
+    forceCloseAutofillInlineMenu: ({ port }) =>
+      this.closeInlineMenu(port.sender, { forceCloseInlineMenu: true }),
   };
 
   constructor(
@@ -2520,9 +2522,21 @@ export class OverlayBackground implements OverlayBackgroundInterface {
       return;
     }
 
-    if (port.sender) {
-      await this.openInlineMenu(port.sender, true);
+    if (!port.sender) {
+      return;
     }
+
+    // Toggle behavior: clicking the button while the list is open closes the
+    // list, allowing the user to dismiss it when it covers page content.
+    if (this.isInlineMenuListVisible) {
+      this.closeInlineMenu(port.sender, {
+        forceCloseInlineMenu: true,
+        overlayElement: AutofillOverlayElement.List,
+      });
+      return;
+    }
+
+    await this.openInlineMenu(port.sender, true);
   }
 
   /**
@@ -2609,6 +2623,7 @@ export class OverlayBackground implements OverlayBackgroundInterface {
         "addNewVaultItem",
         "authenticating",
         "cardNumberEndsWith",
+        "close",
         "fillCredentialsFor",
         "fillGeneratedPassword",
         "fillVerificationCode",

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/__snapshots__/autofill-inline-menu-list.spec.ts.snap
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/__snapshots__/autofill-inline-menu-list.spec.ts.snap
@@ -5,6 +5,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList creates the build sav
   class="inline-menu-list-container theme_light"
 >
   <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
     class="inline-menu-list-button-container"
   >
     <button
@@ -20,6 +44,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the inline menu with 
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <div
     class="no-items inline-menu-list-message"
   >
@@ -57,6 +105,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the inline menu with 
   class="inline-menu-list-container theme_light"
 >
   <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
     class="no-items inline-menu-list-message"
   >
     noItemsToShow
@@ -92,6 +164,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the inline menu with 
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <div
     class="no-items inline-menu-list-message"
   >
@@ -129,6 +225,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the inline menu with 
   class="inline-menu-list-container theme_light"
 >
   <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
     class="no-items inline-menu-list-message"
   >
     noItemsToShow
@@ -164,6 +284,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the list of ciphers f
 <div
   class="inline-menu-list-container theme_light inline-menu-list-container--with-new-item-button"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <ul
     class="inline-menu-list-actions"
     role="list"
@@ -282,6 +426,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the list of ciphers f
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <ul
     class="inline-menu-list-actions"
     role="list"
@@ -677,6 +845,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the list of ciphers f
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <ul
     class="inline-menu-list-actions"
     role="list"
@@ -794,6 +986,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the list of ciphers f
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <ul
     class="inline-menu-list-actions"
     role="list"
@@ -1189,6 +1405,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the list of ciphers f
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <ul
     class="inline-menu-list-actions"
     role="list"
@@ -1584,6 +1824,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the list of ciphers f
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <ul
     class="inline-menu-list-actions"
     role="list"
@@ -2038,6 +2302,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the list of ciphers f
   class="inline-menu-list-container theme_light"
 >
   <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
     class="passkey-authenticating-loader"
   >
     <svg
@@ -2075,6 +2363,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the list of ciphers f
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <ul
     class="inline-menu-list-actions"
     role="list"
@@ -2311,6 +2623,30 @@ exports[`AutofillInlineMenuList initAutofillInlineMenuList the locked inline men
 <div
   class="inline-menu-list-container theme_light"
 >
+  <div
+    class="inline-menu-list-close-row"
+  >
+    <button
+      aria-label=""
+      class="inline-menu-list-close-button"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="12"
+        viewBox="0 0 16 16"
+        width="12"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"
+          fill="#1B2029"
+        />
+      </svg>
+    </button>
+  </div>
   <div
     class="locked-inline-menu inline-menu-list-message"
     id="locked-inline-menu-description"

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.spec.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.spec.ts
@@ -1234,6 +1234,22 @@ describe("AutofillInlineMenuList", () => {
       });
     });
 
+    describe("close button", () => {
+      it("posts a message to force close the inline menu when clicked", () => {
+        postWindowMessage(createInitAutofillInlineMenuListMessageMock({ portKey }));
+
+        const closeButton = autofillInlineMenuList["inlineMenuListContainer"].querySelector(
+          ".inline-menu-list-close-button",
+        ) as HTMLButtonElement;
+        closeButton.dispatchEvent(new Event("click"));
+
+        expect(globalThis.parent.postMessage).toHaveBeenCalledWith(
+          { command: "forceCloseAutofillInlineMenu", portKey, token: "test-token" },
+          expectedOrigin,
+        );
+      });
+    });
+
     describe("blur event", () => {
       it("posts a message to the parent window indicating that the inline menu has lost focus", () => {
         postWindowMessage(createInitAutofillInlineMenuListMessageMock({ portKey }));

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/autofill-inline-menu-list.ts
@@ -12,6 +12,7 @@ import { InlineMenuFillType } from "../../../../enums/autofill-overlay.enum";
 import { buildSvgDomElement, specialCharacterToKeyMap, throttle } from "../../../../utils";
 import { EventSecurity } from "../../../../utils/event-security";
 import {
+  closeIcon,
   creditCardIcon,
   globeIcon,
   idCardIcon,
@@ -122,6 +123,7 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
     if (!showAnimations) {
       this.inlineMenuListContainer.classList.add("no-animations");
     }
+    this.inlineMenuListContainer.appendChild(this.buildCloseButtonRow());
     this.resizeObserver.observe(this.inlineMenuListContainer);
 
     this.shadowDom.append(linkElement, this.inlineMenuListContainer);
@@ -571,7 +573,9 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
   }
 
   /**
-   * Clears and resets the inline menu list container.
+   * Clears and resets the inline menu list container. The close button row is
+   * re-appended so that every view presented within the container retains the
+   * ability to dismiss the inline menu.
    */
   private resetInlineMenuContainer() {
     if (this.inlineMenuListContainer) {
@@ -579,8 +583,37 @@ export class AutofillInlineMenuList extends AutofillInlineMenuPageElement {
       this.inlineMenuListContainer.classList.remove(
         "inline-menu-list-container--with-new-item-button",
       );
+      this.inlineMenuListContainer.appendChild(this.buildCloseButtonRow());
     }
   }
+
+  /**
+   * Builds a row containing a close button that allows the user to dismiss the
+   * inline menu, e.g. when it covers page content they need to see. Dismissal is
+   * also available through the Escape key.
+   */
+  private buildCloseButtonRow(): HTMLDivElement {
+    const closeButton = globalThis.document.createElement("button");
+    closeButton.type = "button";
+    closeButton.tabIndex = -1;
+    closeButton.classList.add("inline-menu-list-close-button");
+    closeButton.setAttribute("aria-label", this.getTranslation("close"));
+    closeButton.append(buildSvgDomElement(closeIcon));
+    closeButton.addEventListener(EVENTS.CLICK, this.handleCloseButtonClick);
+
+    const closeButtonRow = globalThis.document.createElement("div");
+    closeButtonRow.classList.add("inline-menu-list-close-row");
+    closeButtonRow.appendChild(closeButton);
+
+    return closeButtonRow;
+  }
+
+  /**
+   * Handles clicks on the close button, triggering a forced closure of the inline menu.
+   */
+  private handleCloseButtonClick = () => {
+    this.postMessageToParent({ command: "forceCloseAutofillInlineMenu" });
+  };
 
   /**
    * Inline menu view that is presented when no ciphers are found for a given page.

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/list/list.scss
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/list/list.scss
@@ -34,6 +34,47 @@ body * {
   pointer-events: auto;
 }
 
+.inline-menu-list-close-row {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  padding: 0.2rem 0.2rem 0;
+}
+
+.inline-menu-list-close-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 0.4rem;
+  padding: 0.3rem;
+  margin: 0;
+  cursor: pointer;
+  line-height: 0;
+
+  &:hover {
+    @include themify($themes) {
+      background: themed("backgroundOffsetColor");
+    }
+  }
+
+  &:focus:focus-visible {
+    outline-width: 0.2rem;
+    outline-style: solid;
+
+    @include themify($themes) {
+      outline-color: themed("focusOutlineColor");
+    }
+  }
+
+  svg path {
+    @include themify($themes) {
+      fill: themed("mutedTextColor") !important;
+    }
+  }
+}
+
 .inline-menu-list-message {
   font-size: 1.4rem;
   line-height: 1.5;

--- a/apps/browser/src/autofill/overlay/inline-menu/pages/menu-container/autofill-inline-menu-container.ts
+++ b/apps/browser/src/autofill/overlay/inline-menu/pages/menu-container/autofill-inline-menu-container.ts
@@ -20,6 +20,7 @@ const ALLOWED_BG_COMMANDS = new Set<string>([
   "checkInlineMenuButtonFocused",
   "fillAutofillInlineMenuCipher",
   "fillGeneratedPassword",
+  "forceCloseAutofillInlineMenu",
   "redirectAutofillInlineMenuFocusOut",
   "refreshGeneratedPassword",
   "refreshOverlayCiphers",

--- a/apps/browser/src/autofill/utils/svg-icons.ts
+++ b/apps/browser/src/autofill/utils/svg-icons.ts
@@ -16,6 +16,9 @@ export const idCardIcon =
 export const lockIcon =
   '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="#1B2029" d="M10 10a.75.75 0 0 0-.75-.75h-2.5a.75.75 0 0 0 0 1.5h2.5A.75.75 0 0 0 10 10Z"/><path fill="#1B2029" fill-rule="evenodd" d="M4 4a4 4 0 0 1 7.153-2.462.75.75 0 1 1-1.182.924A2.5 2.5 0 0 0 5.5 4v1H13a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h1V4ZM3 6.5a.5.5 0 0 0-.5.5v6a.5.5 0 0 0 .5.5h10a.5.5 0 0 0 .5-.5V7a.5.5 0 0 0-.5-.5H3Z" clip-rule="evenodd"/></svg>';
 
+export const closeIcon =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 16 16"><path fill="#1B2029" d="M2.22 2.22a.75.75 0 0 1 1.06 0L8 6.94l4.72-4.72a.75.75 0 1 1 1.06 1.06L9.06 8l4.72 4.72a.75.75 0 1 1-1.06 1.06L8 9.06l-4.72 4.72a.75.75 0 0 1-1.06-1.06L6.94 8 2.22 3.28a.75.75 0 0 1 0-1.06Z"/></svg>';
+
 export const plusIcon =
   '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="#1B2029" d="M8 1.006a.75.75 0 0 1 .75.75V7.25h5.517a.75.75 0 0 1 0 1.5H8.75v5.537a.75.75 0 0 1-1.5 0V8.75H1.746a.75.75 0 1 1 0-1.5H7.25V1.756a.75.75 0 0 1 .75-.75Z"/></svg>';
 


### PR DESCRIPTION
## 🎟️ Tracking

Prior request: https://github.com/bitwarden/clients/issues/11632 (users asked for a close button when the inline menu blocks the site's own autofill; closed without the feature)
Community forum topic: _link will be added shortly._

## 📔 Objective

The inline menu list can cover page content the user needs to see, and there was no visible way to dismiss it while the field stayed focused (Escape works but is not discoverable; clicking the shield re-opened the list).

This PR (browser extension only):

- Adds a **close button** row at the top of the inline menu list, present on every list view (it is re-appended by `resetInlineMenuContainer`, so suggestions, locked, save-login, and generator views all get it). Clicking it force-closes the inline menu; clicking the field or the shield brings it back.
- Makes the **inline menu button a toggle**: clicking it while the list is open closes the list instead of re-opening it.
- Escape-key dismissal is unchanged.

Plumbing: the list iframe posts a new `forceCloseAutofillInlineMenu` port command (added to the menu container's `ALLOWED_BG_COMMANDS` allowlist and the port command types) which the overlay background routes to the existing `closeInlineMenu` logic. The button reuses the existing `close` i18n key and a new ✕ SVG icon consistent with the existing icon set; styles follow the list's `themify` pattern for light/dark themes.

Covered by new unit tests (close-button click posts the force-close command; background handler closes the menu; shield click closes the list when visible) and regenerated DOM snapshots.

## 📸 Screenshots

<img width="528" height="600" alt="image" src="https://github.com/user-attachments/assets/bd8c22f7-96b7-43a0-a6ff-6b789e49b058" />
