### PR TITLE
maintain maximized state when clicking dock icon

### DIFF
--- a/apps/desktop/src/main/tray.main.ts
+++ b/apps/desktop/src/main/tray.main.ts
@@ -141,9 +141,6 @@ export class TrayMain {
       await this.windowMain.createWindow();
       this.windowMain.win.show();
     } else {
-      if (this.windowMain.win.isMinimized()) {
-        this.windowMain.win.restore();
-      }
       this.windowMain.show();
       this.windowMain.win.focus();
     }

--- a/apps/desktop/src/main/window.main.spec.ts
+++ b/apps/desktop/src/main/window.main.spec.ts
@@ -154,6 +154,20 @@ describe("WindowMain", () => {
       // Assert
       expect(mockWin.maximize).not.toHaveBeenCalled();
     });
+
+    it("calls maximize() when the window is minimized and stored isMaximized is true", () => {
+      // Arrange — minimized window is not visible
+      const mockWin = mock<BrowserWindow>();
+      mockWin.isVisible.mockReturnValue(false);
+      sut.win = mockWin;
+      (sut as any).windowStates["mainWindowSize"] = { isMaximized: true };
+
+      // Act
+      sut.show();
+
+      // Assert
+      expect(mockWin.maximize).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("updateWindowState", () => {

--- a/apps/desktop/src/main/window.main.spec.ts
+++ b/apps/desktop/src/main/window.main.spec.ts
@@ -2,7 +2,9 @@ import * as fs from "fs";
 import { pathToFileURL } from "node:url";
 import * as path from "path";
 
+import { BrowserWindow } from "electron";
 import { mock } from "jest-mock-extended";
+import { BehaviorSubject } from "rxjs";
 
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
@@ -106,6 +108,96 @@ describe("WindowMain", () => {
 
     it("returns false for an unparseable string without throwing", () => {
       expect(isLocalBundleUrl("not a url")).toBe(false);
+    });
+  });
+
+  describe("show", () => {
+    let sut: WindowMain;
+
+    beforeEach(() => {
+      sut = new WindowMain(
+        mock<BiometricStateService>(),
+        mock<LogService>(),
+        mock<AbstractStorageService>(),
+        mock<DesktopSettingsService>(),
+        mock<SafeShell>(),
+        null,
+        () => {},
+        null,
+      );
+    });
+
+    it("calls maximize() when the window is already visible and stored isMaximized is true", () => {
+      // Arrange
+      const mockWin = mock<BrowserWindow>();
+      mockWin.isVisible.mockReturnValue(true);
+      sut.win = mockWin;
+      (sut as any).windowStates["mainWindowSize"] = { isMaximized: true };
+
+      // Act
+      sut.show();
+
+      // Assert
+      expect(mockWin.maximize).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT call maximize() when stored isMaximized is false", () => {
+      // Arrange
+      const mockWin = mock<BrowserWindow>();
+      mockWin.isVisible.mockReturnValue(false);
+      sut.win = mockWin;
+      (sut as any).windowStates["mainWindowSize"] = { isMaximized: false };
+
+      // Act
+      sut.show();
+
+      // Assert
+      expect(mockWin.maximize).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateWindowState", () => {
+    let sut: WindowMain;
+    let desktopSettingsService: ReturnType<typeof mock<DesktopSettingsService>>;
+
+    beforeEach(() => {
+      desktopSettingsService = mock<DesktopSettingsService>();
+      // updateWindowState reads modalMode$ via firstValueFrom; provide a non-modal value.
+      desktopSettingsService.modalMode$ = new BehaviorSubject({
+        isModalModeActive: false,
+        showTrafficButtons: false,
+        modalPosition: undefined,
+      });
+
+      sut = new WindowMain(
+        mock<BiometricStateService>(),
+        mock<LogService>(),
+        mock<AbstractStorageService>(),
+        desktopSettingsService,
+        mock<SafeShell>(),
+        null,
+        () => {},
+        null,
+      );
+    });
+
+    it("does NOT overwrite a stored isMaximized:true to false when the window is minimized", async () => {
+      // Arrange
+      const mockWin = mock<BrowserWindow>();
+      mockWin.isDestroyed.mockReturnValue(false);
+      mockWin.isMinimized.mockReturnValue(true);
+      mockWin.isMaximized.mockReturnValue(false);
+      mockWin.isFullScreen.mockReturnValue(false);
+      mockWin.getBounds.mockReturnValue({ x: 0, y: 0, width: 800, height: 600 });
+
+      // Pre-seed the stored state as maximized (set before the window was minimized)
+      (sut as any).windowStates["mainWindowSize"] = { isMaximized: true };
+
+      // Act
+      await (sut as any).updateWindowState("mainWindowSize", mockWin);
+
+      // Assert
+      expect((sut as any).windowStates["mainWindowSize"].isMaximized).toBe(true);
     });
   });
 });

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -327,8 +327,17 @@ export class WindowMain {
   /// Show the window with main window styles
   show() {
     if (this.win != null) {
-      applyMainWindowStyles(this.win, this.windowStates[mainWindowSizeKey]);
+      if (!this.win.isVisible()) {
+        applyMainWindowStyles(this.win, this.windowStates[mainWindowSizeKey]);
+        this.restoreMaximizedState();
+      }
       this.win.show();
+    }
+  }
+
+  private restoreMaximizedState() {
+    if (this.win != null && this.windowStates[mainWindowSizeKey]?.isMaximized) {
+      this.win.maximize();
     }
   }
 
@@ -489,9 +498,7 @@ export class WindowMain {
       await this.desktopSettingsService.setWindow(this.windowStates[mainWindowSizeKey]);
     });
 
-    if (this.windowStates[mainWindowSizeKey].isMaximized) {
-      this.win.maximize();
-    }
+    this.restoreMaximizedState();
 
     if (show) {
       this.win.show();

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -670,8 +670,15 @@ export class WindowMain {
         }
       }
 
-      // We treat fullscreen as maximized (would be even better to store isFullscreen as its own flag).
-      this.windowStates[configKey].isMaximized = win.isMaximized() || win.isFullScreen();
+      //. A minimized window reports isMaximized() === false; skip the write
+      // so we don't clobber the real maximized state before it can be
+      // restored on the next show. It might be better to early exit this
+      // function if win.isMinimized, but I've limited the condition to just
+      // this line for PM-41034
+      if (!win.isMinimized()) {
+        // We treat fullscreen as maximized (would be even better to store isFullscreen as its own flag)
+        this.windowStates[configKey].isMaximized = win.isMaximized() || win.isFullScreen();
+      }
       this.windowStates[configKey].displayBounds = screen.getDisplayMatching(bounds).bounds;
 
       // Maybe store these as well?

--- a/apps/desktop/src/main/window.main.ts
+++ b/apps/desktop/src/main/window.main.ts
@@ -329,8 +329,8 @@ export class WindowMain {
     if (this.win != null) {
       if (!this.win.isVisible()) {
         applyMainWindowStyles(this.win, this.windowStates[mainWindowSizeKey]);
-        this.restoreMaximizedState();
       }
+      this.restoreMaximizedState();
       this.win.show();
     }
   }

--- a/apps/desktop/src/platform/popup-modal-styles.ts
+++ b/apps/desktop/src/platform/popup-modal-styles.ts
@@ -61,10 +61,8 @@ export function applyMainWindowStyles(window: BrowserWindow, existingWindowState
   window.setResizable(true);
   window.setAlwaysOnTop(false);
 
-  // We're currently not recovering the maximized state, mostly due to conflicts with hiding the window.
-  // window.setFullScreen(existingWindowState.isMaximized);
-
-  // if (existingWindowState.isMaximized) {
-  //   window.maximize();
-  // }
+  // Maximized state is intentionally NOT restored here: this helper is also
+  // called immediately before hide() on the modal-mode exit path, where
+  // maximize()+hide() conflict. Callers that show the window (see WindowMain.show
+  // and createWindow) re-apply maximize() themselves after calling this.
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41034
Fixes https://github.com/bitwarden/clients/issues/22087

Originally this was implemented as https://github.com/bitwarden/clients/pull/22199, but I did something cursed during a merge and that PR did not survive. 

## 📔 Objective

Fix a bug involving the logic that focuses the desktop app's window not respecting if the latest window size was maximized.

## 📸 Screenshots

First video is me recreating the issue against the latest prod artifacts. Second video is from this branch, showing the bug resolved. Ignore the fact that I have to blow up my desktop to click the dock, I have the dock disabled and did that as a workaround for testing.


https://github.com/user-attachments/assets/cf8b9c9f-224d-427e-a966-6860e11c5043


https://github.com/user-attachments/assets/1ef372d6-1bcb-452c-aa04-3535343dd685