### PR TITLE
Auth/PM-42267 - SSO Error Handling Improvement - Add no-seats-available error to sso-login-failed component

### DIFF
--- a/apps/web/src/app/auth/sso/get-sso-login-failed-ui.func.ts
+++ b/apps/web/src/app/auth/sso/get-sso-login-failed-ui.func.ts
@@ -1,6 +1,6 @@
 import { Params } from "@angular/router";
 
-import { TwoFactorAuthEmailIcon } from "@bitwarden/assets/svg";
+import { TwoFactorAuthEmailIcon, TwoFactorTimeoutIcon } from "@bitwarden/assets/svg";
 
 import { SsoLoginFailedErrorKind } from "./sso-login-failed-error-kind.type";
 import { SsoLoginFailedUi } from "./sso-login-failed-ui.type";
@@ -26,6 +26,14 @@ export function getSsoLoginFailedUi(
           key: "ssoStagedOrgUserDirectInviteEmailSent",
           placeholders: [qParams.organizationName ?? ""],
         },
+      };
+    case SsoLoginFailedErrorKind.NoSeatsAvailable:
+      return {
+        anonLayoutData: {
+          pageTitle: { key: "openOrgInviteAcceptFailedTitle" },
+          pageIcon: TwoFactorTimeoutIcon,
+        },
+        bodyMessage: { key: "ssoNoSeatsAvailableMessage" },
       };
   }
 }

--- a/apps/web/src/app/auth/sso/get-sso-login-failed-ui.func.ts
+++ b/apps/web/src/app/auth/sso/get-sso-login-failed-ui.func.ts
@@ -30,7 +30,7 @@ export function getSsoLoginFailedUi(
     case SsoLoginFailedErrorKind.NoSeatsAvailable:
       return {
         anonLayoutData: {
-          pageTitle: { key: "openOrgInviteAcceptFailedTitle" },
+          pageTitle: { key: "cannotAcceptInvitation" },
           pageIcon: TwoFactorTimeoutIcon,
         },
         bodyMessage: { key: "ssoNoSeatsAvailableMessage" },

--- a/apps/web/src/app/auth/sso/sso-login-failed-error-kind.type.ts
+++ b/apps/web/src/app/auth/sso/sso-login-failed-error-kind.type.ts
@@ -4,6 +4,7 @@
  */
 export const SsoLoginFailedErrorKind = Object.freeze({
   StagedOrgUserDirectInviteSent: "staged-org-user-direct-invite-sent",
+  NoSeatsAvailable: "no-seats-available",
 } as const);
 
 export type SsoLoginFailedErrorKind =

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -7426,6 +7426,9 @@
       }
     }
   },
+  "ssoNoSeatsAvailableMessage": {
+    "message": "This organization is not able to accept new members at the moment. Contact your admin for assistance."
+  },
   "inviteSentToEmail": {
     "message": "Invite sent to email"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -6841,7 +6841,7 @@
   "openOrgInviteAcceptFailed": {
     "message": "Unable to accept invitation. Ask an organization admin to send a new invitation link."
   },
-  "openOrgInviteAcceptFailedTitle": {
+  "cannotAcceptInvitation": {
     "message": "Cannot accept invitation"
   },
   "openOrgInviteAcceptAlreadyMember": {

--- a/libs/angular/src/auth/organization-invite/get-open-org-invite-accept-error-ui.func.ts
+++ b/libs/angular/src/auth/organization-invite/get-open-org-invite-accept-error-ui.func.ts
@@ -25,7 +25,7 @@ export function getOpenOrgInviteAcceptErrorUi(
     labelI18nKey: "goToVault",
     navigateTo: "/",
   };
-  const pageTitle = { key: "openOrgInviteAcceptFailedTitle" };
+  const pageTitle = { key: "cannotAcceptInvitation" };
   switch (kind) {
     case "link-not-found":
       return {

--- a/libs/angular/src/auth/organization-invite/get-open-org-invite-status-error-ui.func.ts
+++ b/libs/angular/src/auth/organization-invite/get-open-org-invite-status-error-ui.func.ts
@@ -29,7 +29,7 @@ export function getOpenOrgInviteStatusErrorUi(
     case "not-found":
       return {
         anonLayoutData: {
-          pageTitle: { key: "openOrgInviteAcceptFailedTitle" },
+          pageTitle: { key: "cannotAcceptInvitation" },
           pageIcon: TwoFactorTimeoutIcon,
         },
         bodyMessageI18nKey: "openOrgInviteLinkNoLongerValid",
@@ -42,7 +42,7 @@ export function getOpenOrgInviteStatusErrorUi(
       // distinct semantic condition even if the copy overlaps.
       return {
         anonLayoutData: {
-          pageTitle: { key: "openOrgInviteAcceptFailedTitle" },
+          pageTitle: { key: "cannotAcceptInvitation" },
           pageIcon: AccountWarning,
         },
         bodyMessageI18nKey: "openOrgInviteLinkNoLongerValid",
@@ -51,7 +51,7 @@ export function getOpenOrgInviteStatusErrorUi(
     case "no-seats":
       return {
         anonLayoutData: {
-          pageTitle: { key: "openOrgInviteAcceptFailedTitle" },
+          pageTitle: { key: "cannotAcceptInvitation" },
           pageIcon: AccountWarning,
         },
         bodyMessageI18nKey: "openOrgInviteNoSeatsMessage",
@@ -60,7 +60,7 @@ export function getOpenOrgInviteStatusErrorUi(
     case "unexpected":
       return {
         anonLayoutData: {
-          pageTitle: { key: "openOrgInviteAcceptFailedTitle" },
+          pageTitle: { key: "cannotAcceptInvitation" },
           pageIcon: ReportBreach,
         },
         bodyMessageI18nKey: "openOrgInviteStatusUnexpectedErrorMessage",


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-42267
Server PR:  https://github.com/bitwarden/server/pull/8261

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Adds a `no-seats-available` variant to `SsoLoginFailedComponent`, rendered when the server refuses SSO due to no available seats and no autoscale headroom.

## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/e72c79de-61a8-482b-bd6b-fb8a73b6f376
