### PR TITLE
[PM-42465] Fix batch bar Clear not unchecking vault 

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.spec.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.spec.ts
@@ -2,6 +2,7 @@ import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { mock } from "jest-mock-extended";
+import { EMPTY } from "rxjs";
 
 import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -101,7 +102,7 @@ describe("VaultListTableComponent", () => {
       await setup([
         {
           provide: VaultBatchBarService,
-          useValue: { selection: mockSelection },
+          useValue: { selection: mockSelection, cleared$: EMPTY },
         },
       ]);
     });

--- a/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, output } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  viewChild,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
@@ -41,6 +50,14 @@ export class VaultListTableComponent<C extends CipherViewLike> {
   private readonly batchBarService = inject<VaultBatchBarService<C>>(VaultBatchBarService, {
     optional: true,
   });
+
+  private readonly vaultItemsTable = viewChild(VaultItemsTableComponent);
+
+  constructor() {
+    this.batchBarService?.cleared$.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.vaultItemsTable()?.clearSelection();
+    });
+  }
 
   readonly ciphers = input.required<C[]>();
   readonly folders = input<FolderView[]>([]);

--- a/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.html
+++ b/libs/vault/src/components/vault-batch-bar/vault-batch-action.component.html
@@ -4,10 +4,7 @@
   <main>, whose `contain: strict` establishes a containing block that traps `position: fixed`.
 -->
 <ng-template #barPortal>
-  <bit-bulk-actions-bar
-    [selectedCount]="service.selectedCount()"
-    (clear)="service.selection.clear()"
-  >
+  <bit-bulk-actions-bar [selectedCount]="service.selectedCount()" (clear)="service.clear()">
     @for (action of primaryActions(); track action.label) {
       <bit-bulk-action [action]="action.action" [icon]="action.icon" [label]="action.label" />
     }

--- a/libs/vault/src/components/vault-items-table/vault-items-table.component.ts
+++ b/libs/vault/src/components/vault-items-table/vault-items-table.component.ts
@@ -559,6 +559,11 @@ export class VaultItemsTableComponent<C extends CipherViewLike> {
    */
   private readonly tableComponent = viewChild(BitTableV2Component);
 
+  /** Clear the table's internal row selection (called when the batch bar "Clear" fires). */
+  clearSelection(): void {
+    this.tableComponent()?.selectionModel()?.clear();
+  }
+
   /**
    * The live search term. Cast because a view query erases the table's generics, so its
    * `filterValues()` comes back as an untyped record.

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -382,7 +382,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
         takeUntilDestroyed(),
       )
       .subscribe(() => {
-        this.selection.clear();
+        this.clear();
       });
   }
 
@@ -429,7 +429,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
         variant: "success",
         message: this.i18nService.t(successKey),
       });
-      this.selection.clear();
+      this.clear();
       this._completed$.next();
     } catch (e) {
       this.logService.error("Error archiving ciphers", e);
@@ -458,7 +458,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
           ciphers.length === 1 ? "itemUnarchivedToast" : "bulkUnarchiveItems",
         ),
       });
-      this.selection.clear();
+      this.clear();
       this._completed$.next();
     } catch (e) {
       this.logService.error("Error unarchiving ciphers", e);
@@ -544,7 +544,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
       }
 
       this.toastService.showToast({ variant: "success", message: toastMessage });
-      this.selection.clear();
+      this.clear();
       this._completed$.next();
     } catch (e) {
       this.logService.error("Error restoring ciphers", e);
@@ -632,7 +632,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
     });
 
     if (result === BulkDeleteDialogResult.Deleted) {
-      this.selection.clear();
+      this.clear();
       this._completed$.next();
     }
   }
@@ -660,7 +660,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
 
     const result = await lastValueFrom(dialog.closed);
     if (result === BulkMoveDialogResult.Moved) {
-      this.selection.clear();
+      this.clear();
       this._completed$.next();
     }
   }
@@ -735,7 +735,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
     });
 
     if (result === AssignCollectionsResult.Saved) {
-      this.selection.clear();
+      this.clear();
       this._completed$.next();
     }
   }
@@ -771,7 +771,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
     });
 
     if (result === BulkEditCollectionAccessResult.Saved) {
-      this.selection.clear();
+      this.clear();
       this._completed$.next();
     }
   }

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -146,7 +146,7 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   readonly selection = new SelectionModel<VaultItem<C>>(true, [], true, compareVaultItems);
 
   private readonly _cleared$ = new Subject<void>();
-  /** Emits when "Clear" is explicitly clicked in the batch bar. */
+  /** Emits whenever the selection is cleared via {@link clear} — the "Clear" button, a filter change, or a completed bulk action. */
   readonly cleared$ = this._cleared$.asObservable();
 
   private readonly _completed$ = new Subject<void>();

--- a/libs/vault/src/services/vault-batch-bar.service.ts
+++ b/libs/vault/src/services/vault-batch-bar.service.ts
@@ -145,6 +145,10 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   /** The Angular CDK selection model. Add, remove, or clear items directly. */
   readonly selection = new SelectionModel<VaultItem<C>>(true, [], true, compareVaultItems);
 
+  private readonly _cleared$ = new Subject<void>();
+  /** Emits when "Clear" is explicitly clicked in the batch bar. */
+  readonly cleared$ = this._cleared$.asObservable();
+
   private readonly _completed$ = new Subject<void>();
   /** Emits once after each successful bulk action. Subscribe to trigger a list refresh. */
   readonly completed$ = this._completed$.asObservable();
@@ -385,6 +389,12 @@ export class VaultBatchBarService<C extends CipherViewLike> {
   /** Update the vault context. Call in `ngOnChanges` or when configuration values change so permission signals stay current. */
   setConfig(config: VaultBatchBarConfig): void {
     this.config.set(config);
+  }
+
+  /** Clear the selection and notify subscribers (e.g. the table component) to uncheck rows. */
+  clear(): void {
+    this.selection.clear();
+    this._cleared$.next();
   }
 
   /** Archive the selected ciphers after confirmation. No-op if reprompt is cancelled. */


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42465](https://bitwarden.atlassian.net/browse/PM-42465)

## 📔 Objective

Under `vfo1-foundation`, the desktop vault renders the batch bar through a CDK overlay portal, which breaks the DI ancestor chain. This meant clicking "Clear" could not reach `BitTableV2Component`'s internal `TableSelectionModel`, so row checkboxes stayed checked even after the bar dismissed.

**Fix:** Added a `cleared$` stream to `VaultBatchBarService`. The batch bar now calls `service.clear()` (instead of `service.selection.clear()` directly), which clears the CDK selection model and emits on `cleared$`. `VaultListTableComponent` subscribes and forwards the signal to `VaultItemsTableComponent.clearSelection()`.

## 📸 Screenshots


<video src="https://github.com/user-attachments/assets/c4b7d81c-6929-4120-9d25-6500e65bc757" />


[PM-42465]: https://bitwarden.atlassian.net/browse/PM-42465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ