### PR TITLE
fix(pam): surface the server's reason when starting access fails

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17401,6 +17401,33 @@
   "pamStartLeaseError": {
     "message": "Couldn't start access."
   },
+  "pamStartLeaseErrorWindowNotStarted": {
+    "message": "The approved access window has not started yet."
+  },
+  "pamStartLeaseErrorWindowEnded": {
+    "message": "The approved access window has already ended."
+  },
+  "pamStartLeaseErrorNotApproved": {
+    "message": "This request has not been approved yet."
+  },
+  "pamStartLeaseErrorNoLongerActivatable": {
+    "message": "This request can no longer be activated."
+  },
+  "pamStartLeaseErrorAlreadyUsed": {
+    "message": "This request's access has already been used and is no longer active."
+  },
+  "pamStartLeaseErrorSingleActiveLease": {
+    "message": "Another active lease exists for this item. Try again once it ends."
+  },
+  "pamStartLeaseErrorNetworkNotPermitted": {
+    "message": "Access to this item is not permitted from your current network."
+  },
+  "pamStartLeaseErrorTimeNotPermitted": {
+    "message": "Access to this item is not permitted at this time."
+  },
+  "pamStartLeaseErrorNotPermitted": {
+    "message": "Access to this item is not permitted right now."
+  },
   "pamMyRequestsCanceledToast": {
     "message": "Request canceled"
   },

--- a/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
+++ b/bitwarden_license/bit-web/src/app/pam/CLAUDE.md
@@ -98,7 +98,10 @@ the next bump. The SDK splits its own failures per client —
 `AccessRequestError` (request/activate/cancel), `ApprovalError` (decide) and `AccessLeaseError`
 (read/extend/end). `abstractions/access-lease.ts` unions them as `LeasingError`, detected
 through the injectable `LeasingErrorService` seam so consumers never import the wasm guards.
-All three carry an `Api` variant holding the server's message.
+All three carry an `Api` variant holding the server's message. That variant's payload is the whole
+serialized response, so `abstractions/api-error.ts` owns the one `apiErrorBodyMessage()` decode of
+the `ErrorResponseModel` body — use it rather than re-parsing; what a miss means (generic copy, or
+the raw string) stays with the caller.
 
 A rejected access-request submit is interpreted by
 `helpers/request-access-error.ts`. Three of the server's messages mean the caller already

--- a/bitwarden_license/bit-web/src/app/pam/abstractions/access-rule.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/abstractions/access-rule.spec.ts
@@ -43,6 +43,14 @@ describe("accessRuleErrorMessage", () => {
       ).toBe("A rule with that name already exists.");
     });
 
+    it("extracts it even when the transport appended content after the body", () => {
+      expect(
+        accessRuleErrorMessage(
+          wrap('{"message":"A rule with that name already exists."} (request id 8f2c)'),
+        ),
+      ).toBe("A rule with that name already exists.");
+    });
+
     it("returns undefined when the body has no usable message", () => {
       expect(accessRuleErrorMessage(wrap('{"message":""}'))).toBeUndefined();
       expect(accessRuleErrorMessage(wrap('{"validationErrors":{}}'))).toBeUndefined();

--- a/bitwarden_license/bit-web/src/app/pam/abstractions/access-rule.ts
+++ b/bitwarden_license/bit-web/src/app/pam/abstractions/access-rule.ts
@@ -1,5 +1,7 @@
 import type { AccessCondition, AccessRuleError } from "@bitwarden/sdk-internal";
 
+import { apiErrorBodyMessage } from "./api-error";
+
 // `export type` is REQUIRED (not `export`) — these are type-only re-exports of the
 // wasm SDK's shapes. Because they carry no runtime value, this line is erased by the
 // compiler, so jest never resolves the wasm package while running this directory's unit tests.
@@ -84,35 +86,16 @@ function isAccessRuleError(e: unknown): e is AccessRuleError {
  * The toastable message carried by the SDK's `AccessRuleError`, or `undefined` when
  * `e` isn't that shape — callers fall back to a generic error message in that case.
  *
- * The `Api` variant needs unwrapping first: the SDK stringifies the whole failed
- * response as `error in response: status code 400 Bad Request: {…ErrorResponseModel
- * JSON…}`, so the human-readable server message (`"A rule with that name already
- * exists."`, …) is buried inside a JSON body. Surface that inner message; when there
- * is no parsable body (network failures, serde errors) return `undefined` so callers
- * use their generic fallback rather than toasting the raw wrapper.
+ * The `Api` variant needs unwrapping first through {@link apiErrorBodyMessage}, which digs the
+ * server's sentence (`"A rule with that name already exists."`, …) out of the serialized response
+ * body. When there is no parsable body (network failures, serde errors) return `undefined` so
+ * callers use their generic fallback rather than toasting the raw wrapper.
  */
 export function accessRuleErrorMessage(e: unknown): string | undefined {
   if (!isAccessRuleError(e)) {
     return undefined;
   }
   return e.variant === "Api" ? apiErrorBodyMessage(e.message) : e.message;
-}
-
-/** Extract the server's `message` field from an `Api`-variant error string, if present. */
-function apiErrorBodyMessage(message: string): string | undefined {
-  const bodyStart = message.indexOf("{");
-  if (bodyStart === -1) {
-    return undefined;
-  }
-  try {
-    const body: unknown = JSON.parse(message.slice(bodyStart));
-    const serverMessage = (body as { message?: unknown }).message;
-    return typeof serverMessage === "string" && serverMessage.length > 0
-      ? serverMessage
-      : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/abstractions/api-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/abstractions/api-error.spec.ts
@@ -1,0 +1,40 @@
+import { apiErrorBodyMessage } from "./api-error";
+
+describe("apiErrorBodyMessage", () => {
+  const wrap = (body: string) => `error in response: status code 400 Bad Request: ${body}`;
+
+  it("extracts the server message from the embedded ErrorResponseModel body", () => {
+    expect(apiErrorBodyMessage(wrap('{"message":"A rule with that name already exists."}'))).toBe(
+      "A rule with that name already exists.",
+    );
+  });
+
+  it("extracts the message when the transport appended content after the body", () => {
+    expect(
+      apiErrorBodyMessage(`${wrap('{"message":"The approved access window has already ended."}')}
+       (request id 8f2c)`),
+    ).toBe("The approved access window has already ended.");
+  });
+
+  it("keeps the last brace of a nested body", () => {
+    expect(
+      apiErrorBodyMessage(wrap('{"message":"Bad input.","validationErrors":{"name":[]}}')),
+    ).toBe("Bad input.");
+  });
+
+  it("returns undefined when the body has no usable message", () => {
+    expect(apiErrorBodyMessage(wrap('{"message":""}'))).toBeUndefined();
+    expect(apiErrorBodyMessage(wrap('{"validationErrors":{}}'))).toBeUndefined();
+    expect(apiErrorBodyMessage(wrap('{"message":42}'))).toBeUndefined();
+  });
+
+  it("returns undefined when there is no JSON body (network/serde failures)", () => {
+    expect(apiErrorBodyMessage("error in reqwest: timed out")).toBeUndefined();
+    expect(apiErrorBodyMessage(wrap("not json"))).toBeUndefined();
+    expect(apiErrorBodyMessage("")).toBeUndefined();
+  });
+
+  it("returns undefined when the closing brace precedes the opening one", () => {
+    expect(apiErrorBodyMessage('} {"message":"never closed"')).toBeUndefined();
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/abstractions/api-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/abstractions/api-error.ts
@@ -1,0 +1,28 @@
+/**
+ * The server's `message` field, decoded out of the `ErrorResponseModel` JSON the SDK concatenated
+ * onto its transport string, or `undefined` when the message isn't that shape.
+ *
+ * Every PAM error type carries the same `Api` variant: the SDK stringifies the whole failed
+ * response as `error in response: status code 400 Bad Request: {…ErrorResponseModel JSON…}`, so
+ * the human-readable server sentence is buried inside a JSON body. The slice is bounded at both
+ * ends, so content the transport appends after the body does not defeat the parse.
+ *
+ * Callers own what a miss means: some fall back to a generic message, others re-read the raw
+ * string.
+ */
+export function apiErrorBodyMessage(message: string): string | undefined {
+  const bodyStart = message.indexOf("{");
+  const bodyEnd = message.lastIndexOf("}");
+  if (bodyStart === -1 || bodyEnd <= bodyStart) {
+    return undefined;
+  }
+  try {
+    const body: unknown = JSON.parse(message.slice(bodyStart, bodyEnd + 1));
+    const serverMessage = (body as { message?: unknown }).message;
+    return typeof serverMessage === "string" && serverMessage.length > 0
+      ? serverMessage
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
@@ -370,6 +370,45 @@ describe("AccessRequestRouteComponent", () => {
       });
     });
 
+    it("maps the server's reason to a client-side i18n key without leaking the raw payload", async () => {
+      detail.request$.next(request({ status: "approved" }));
+      detail.activate.mockRejectedValue(
+        Object.assign(
+          new Error(
+            'error in response: status code 400 Bad Request: {"object":"error",' +
+              '"message":"The approved access window has already ended.",' +
+              '"validationErrors":null,"exceptionStackTrace":"   at Bit.Services.Pam' +
+              '.OrganizationFeatures.Commands.ActivateAccessRequestCommand.ActivateAsync"}',
+          ),
+          { name: "AccessRequestError", variant: "Api" },
+        ),
+      );
+      create();
+
+      await component["startAccess"]();
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamStartLeaseErrorWindowEnded",
+      });
+      const shown = toastService.showToast.mock.calls[0][0].message as string;
+      expect(shown).not.toContain("exceptionStackTrace");
+      expect(shown).not.toContain("Bit.Services.Pam");
+    });
+
+    it("falls back to the generic message when starting access fails for another reason", async () => {
+      detail.request$.next(request({ status: "approved" }));
+      detail.activate.mockRejectedValue(new Error("offline"));
+      create();
+
+      await component["startAccess"]();
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamStartLeaseError",
+      });
+    });
+
     it("confirms before ending the lease", async () => {
       detail.request$.next(
         request({ status: "approved", producedLeaseId: "lease-1", producedLeaseStatus: "active" }),

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -32,6 +32,7 @@ import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.mod
 
 import {
   AccessRequestView,
+  activateAccessErrorMessageKey,
   durationLabel,
   exactWindow,
   humanApprover,
@@ -318,7 +319,7 @@ export class AccessRequestRouteComponent implements OnInit {
       this.logService.error(e);
       this.toastService.showToast({
         variant: "error",
-        message: this.i18nService.t("pamStartLeaseError"),
+        message: this.i18nService.t(activateAccessErrorMessageKey(e)),
       });
     } finally {
       this.starting.set(false);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -176,8 +176,6 @@ describe("MyRequestsTabComponent", () => {
     const row = requestRow({ id: "req-1" });
 
     it("maps the server's reason to a client-side i18n key without leaking the raw payload", async () => {
-      // The real `.message` on the "Api" variant, not a tidied stand-in: a clean sentence here
-      // passes while the browser is handed the whole serialized body, filesystem paths included.
       const error = Object.assign(
         new Error(
           'error in response: status code 409 Conflict: {"object":"error",' +

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -175,11 +175,9 @@ describe("MyRequestsTabComponent", () => {
   describe("activating an approved request", () => {
     const row = requestRow({ id: "req-1" });
 
-    it("maps the server's reason to approved copy without leaking the raw payload", async () => {
-      // The real `.message` on the "Api" variant, not a tidied stand-in: the SDK transport string
-      // with the whole serialized response body concatenated onto it. An earlier version of this
-      // test asserted a clean sentence here, which is why showing `e.message` looked correct in
-      // Jest while publishing the server's filesystem paths to the requester in a real browser.
+    it("maps the server's reason to a client-side i18n key without leaking the raw payload", async () => {
+      // The real `.message` on the "Api" variant, not a tidied stand-in: a clean sentence here
+      // passes while the browser is handed the whole serialized body, filesystem paths included.
       const error = Object.assign(
         new Error(
           'error in response: status code 409 Conflict: {"object":"error",' +
@@ -203,6 +201,29 @@ describe("MyRequestsTabComponent", () => {
       const shown = toastService.showToast.mock.calls[0][0].message as string;
       expect(shown).not.toContain("exceptionStackTrace");
       expect(shown).not.toContain("Bit.Services.Pam");
+    });
+
+    it("names the unopened window when the server rejects activation for it", async () => {
+      const error = Object.assign(
+        new Error(
+          'error in response: status code 400 Bad Request: {"object":"error",' +
+            '"message":"The approved access window has not started yet.","validationErrors":null,' +
+            '"exceptionMessage":"The approved access window has not started yet.",' +
+            '"exceptionStackTrace":"   at Bit.Services.Pam.OrganizationFeatures.Commands' +
+            ".ActivateAccessRequestCommand.ActivateAsync(Guid userId, Guid requestId) in " +
+            '/src/bitwarden_license/src/Services/Pam/.../ActivateAccessRequestCommand.cs:line 52"}',
+        ),
+        { name: "AccessRequestError", variant: "Api" },
+      );
+      myAccess.activate.mockRejectedValue(error);
+      create();
+
+      await component["activate"](row);
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamStartLeaseErrorWindowNotStarted",
+      });
     });
 
     it("falls back to the generic message for a non-leasing failure", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -205,29 +205,6 @@ describe("MyRequestsTabComponent", () => {
       expect(shown).not.toContain("Bit.Services.Pam");
     });
 
-    it("names the unopened window when the server rejects activation for it", async () => {
-      const error = Object.assign(
-        new Error(
-          'error in response: status code 400 Bad Request: {"object":"error",' +
-            '"message":"The approved access window has not started yet.","validationErrors":null,' +
-            '"exceptionMessage":"The approved access window has not started yet.",' +
-            '"exceptionStackTrace":"   at Bit.Services.Pam.OrganizationFeatures.Commands' +
-            ".ActivateAccessRequestCommand.ActivateAsync(Guid userId, Guid requestId) in " +
-            '/src/bitwarden_license/src/Services/Pam/.../ActivateAccessRequestCommand.cs:line 52"}',
-        ),
-        { name: "AccessRequestError", variant: "Api" },
-      );
-      myAccess.activate.mockRejectedValue(error);
-      create();
-
-      await component["activate"](row);
-
-      expect(toastService.showToast).toHaveBeenCalledWith({
-        variant: "error",
-        message: "pamStartLeaseErrorWindowNotStarted",
-      });
-    });
-
     it("falls back to the generic message for a non-leasing failure", async () => {
       myAccess.activate.mockRejectedValue(new Error("offline"));
       create();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -175,7 +175,7 @@ describe("MyRequestsTabComponent", () => {
   describe("activating an approved request", () => {
     const row = requestRow({ id: "req-1" });
 
-    it("never puts the server's raw error payload in the toast", async () => {
+    it("maps the server's reason to approved copy without leaking the raw payload", async () => {
       // The real `.message` on the "Api" variant, not a tidied stand-in: the SDK transport string
       // with the whole serialized response body concatenated onto it. An earlier version of this
       // test asserted a clean sentence here, which is why showing `e.message` looked correct in
@@ -198,11 +198,34 @@ describe("MyRequestsTabComponent", () => {
 
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "error",
-        message: "pamStartLeaseError",
+        message: "pamStartLeaseErrorNotApproved",
       });
       const shown = toastService.showToast.mock.calls[0][0].message as string;
       expect(shown).not.toContain("exceptionStackTrace");
       expect(shown).not.toContain("Bit.Services.Pam");
+    });
+
+    it("names the unopened window when the server rejects activation for it", async () => {
+      const error = Object.assign(
+        new Error(
+          'error in response: status code 400 Bad Request: {"object":"error",' +
+            '"message":"The approved access window has not started yet.","validationErrors":null,' +
+            '"exceptionMessage":"The approved access window has not started yet.",' +
+            '"exceptionStackTrace":"   at Bit.Services.Pam.OrganizationFeatures.Commands' +
+            ".ActivateAccessRequestCommand.ActivateAsync(Guid userId, Guid requestId) in " +
+            '/src/bitwarden_license/src/Services/Pam/.../ActivateAccessRequestCommand.cs:line 52"}',
+        ),
+        { name: "AccessRequestError", variant: "Api" },
+      );
+      myAccess.activate.mockRejectedValue(error);
+      create();
+
+      await component["activate"](row);
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamStartLeaseErrorWindowNotStarted",
+      });
     });
 
     it("falls back to the generic message for a non-leasing failure", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -327,14 +327,6 @@ export class MyRequestsTabComponent implements OnInit {
       this.logService.error(e);
       // A taken single-active-lease slot, an org-wide freeze, or anything else the server rejects
       // activation for surfaces here; the approved request stays activatable for a manual retry.
-      //
-      // The server's own sentence is still never shown. On the "Api" variant `.message` is the raw
-      // SDK transport string with the entire serialized response body concatenated onto it --
-      // envelope, `exceptionMessage`, and `exceptionStackTrace` carrying the server's absolute
-      // filesystem paths and internal .NET frames. `activateAccessErrorMessageKey` is what turns
-      // that into something showable: it matches the sentence against a checked-in catalog and
-      // hands back an i18n key, never the message, falling back to the generic key when the
-      // rejection isn't one we have copy for.
       this.toastService.showToast({
         variant: "error",
         message: this.i18nService.t(activateAccessErrorMessageKey(e)),

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -35,7 +35,7 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
-import { AccessLeaseId, AccessRequestId } from "..";
+import { AccessLeaseId, AccessRequestId, activateAccessErrorMessageKey } from "..";
 import { AccessBadgeState } from "../access-state-badge/access-badge-state";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationShortPipe } from "../date/duration-short.pipe";
@@ -328,17 +328,16 @@ export class MyRequestsTabComponent implements OnInit {
       // A taken single-active-lease slot, an org-wide freeze, or anything else the server rejects
       // activation for surfaces here; the approved request stays activatable for a manual retry.
       //
-      // The server's own sentence is deliberately NOT shown. On the "Api" variant `.message` is the
-      // raw SDK transport string with the entire serialized response body concatenated onto it --
+      // The server's own sentence is still never shown. On the "Api" variant `.message` is the raw
+      // SDK transport string with the entire serialized response body concatenated onto it --
       // envelope, `exceptionMessage`, and `exceptionStackTrace` carrying the server's absolute
-      // filesystem paths and internal .NET frames. Putting it in a toast published all of that to
-      // the requester (see `classifyAccessRuleError`, which exists for exactly this reason on the
-      // rule path). Surfacing the real reason needs the same treatment: a catalog mapping each
-      // sentence `ActivateAccessRequestCommand` raises to approved copy. None of those six strings
-      // has an approved key yet, so this stays generic until they do.
+      // filesystem paths and internal .NET frames. `activateAccessErrorMessageKey` is what turns
+      // that into something showable: it matches the sentence against a checked-in catalog and
+      // hands back an i18n key, never the message, falling back to the generic key when the
+      // rejection isn't one we have copy for.
       this.toastService.showToast({
         variant: "error",
-        message: this.i18nService.t("pamStartLeaseError"),
+        message: this.i18nService.t(activateAccessErrorMessageKey(e)),
       });
     } finally {
       this.starting.update((s) => {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -886,6 +886,34 @@ describe("CipherViewBannerComponent", () => {
       });
     });
 
+    it("maps the server's reason to a client-side i18n key without leaking the raw payload", async () => {
+      requestsApi.getCipherAccessState.mockResolvedValue(
+        accessState({ approvedRequest: requestView() }),
+      );
+      requestsApi.activateAccessRequest.mockRejectedValue(
+        Object.assign(
+          new Error(
+            'error in response: status code 409 Conflict: {"object":"error",' +
+              '"message":"Another active lease exists for this item. Try again once it ends.",' +
+              '"validationErrors":null,"exceptionStackTrace":"   at Bit.Services.Pam' +
+              '.OrganizationFeatures.Commands.ActivateAccessRequestCommand.ActivateAsync"}',
+          ),
+          { name: "AccessRequestError", variant: "Api" },
+        ),
+      );
+      await create(gatedCipher());
+
+      await component["activateRequest"]();
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamStartLeaseErrorSingleActiveLease",
+      });
+      const shown = toastService.showToast.mock.calls[0][0].message as string;
+      expect(shown).not.toContain("exceptionStackTrace");
+      expect(shown).not.toContain("Bit.Services.Pam");
+    });
+
     it("cancels a pending request once confirmed", async () => {
       requestsApi.getCipherAccessState.mockResolvedValue(
         accessState({ pendingRequest: requestView({ id: "request-3" } as never) }),

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -817,6 +817,12 @@ describe("CipherViewBannerComponent", () => {
       await component["submitRequest"]();
     }
 
+    /** The serialized `ErrorResponseModel` the SDK concatenates onto its transport string. */
+    const wireBody = (serverMessage: string, exceptionMessage = serverMessage) =>
+      `error in response: status code 400 Bad Request: {"object":"error",` +
+      `"message":"${serverMessage}","validationErrors":null,` +
+      `"exceptionMessage":"${exceptionMessage}","exceptionStackTrace":null}`;
+
     it("treats 'already pending' as information, collapsing without an inline error", async () => {
       await submitAndFail(REQUEST_ACCESS_SERVER_ERRORS.AlreadyPending);
 
@@ -838,6 +844,25 @@ describe("CipherViewBannerComponent", () => {
 
     it("echoes a validation failure inline and keeps the fold-out open", async () => {
       await submitAndFail(REQUEST_ACCESS_SERVER_ERRORS.WindowExceedsMax);
+
+      expect(component["requestError"]()).toBe(REQUEST_ACCESS_SERVER_ERRORS.WindowExceedsMax);
+      expect(component["requestFormExpanded"]()).toBe(true);
+    });
+
+    it("classifies on the server's message decoded out of the serialized response", async () => {
+      await submitAndFail(wireBody(REQUEST_ACCESS_SERVER_ERRORS.WindowExceedsMax));
+
+      expect(component["requestError"]()).toBe(REQUEST_ACCESS_SERVER_ERRORS.WindowExceedsMax);
+      expect(component["requestFormExpanded"]()).toBe(true);
+    });
+
+    it("ignores a catalog sentence carried elsewhere in the envelope", async () => {
+      await submitAndFail(
+        wireBody(
+          REQUEST_ACCESS_SERVER_ERRORS.WindowExceedsMax,
+          REQUEST_ACCESS_SERVER_ERRORS.AlreadyActive,
+        ),
+      );
 
       expect(component["requestError"]()).toBe(REQUEST_ACCESS_SERVER_ERRORS.WindowExceedsMax);
       expect(component["requestFormExpanded"]()).toBe(true);

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -44,6 +44,7 @@ import {
   REQUEST_ACCESS_DURATION_PRESETS,
   type RequestDurationOption,
   activateAccessErrorMessageKey,
+  apiErrorBodyMessage,
   classifyRequestAccessError,
   composeRequestWindow,
   defaultRequestWindow,
@@ -613,7 +614,9 @@ export class CipherViewBannerComponent implements OnInit {
       : e instanceof Error
         ? e.message
         : undefined;
-    const outcome = classifyRequestAccessError(message);
+    const outcome = classifyRequestAccessError(
+      message == null ? message : (apiErrorBodyMessage(message) ?? message),
+    );
 
     switch (outcome.kind) {
       case "reconcile":

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -43,6 +43,7 @@ import {
   MAX_REQUEST_ACCESS_WINDOW_SECONDS,
   REQUEST_ACCESS_DURATION_PRESETS,
   type RequestDurationOption,
+  activateAccessErrorMessageKey,
   classifyRequestAccessError,
   composeRequestWindow,
   defaultRequestWindow,
@@ -480,7 +481,7 @@ export class CipherViewBannerComponent implements OnInit {
       // A taken single-active-lease slot surfaces here; the approved request stays activatable.
       this.toastService.showToast({
         variant: "error",
-        message: this.i18nService.t("pamStartLeaseError"),
+        message: this.i18nService.t(activateAccessErrorMessageKey(e)),
       });
     } finally {
       this.notifyAccessChanged();

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
@@ -7,12 +7,7 @@ import {
 const activationError = (variant: string, message: string) =>
   Object.assign(new Error(message), { name: "AccessRequestError", variant });
 
-/**
- * How the wire body actually reaches `.message`: the sentence buried in the serialized response,
- * with its apostrophes escaped as `\u0027` the way `System.Text.Json`'s default encoder writes
- * them. Spelling the sentence out with a literal apostrophe would test a body the server never
- * sends.
- */
+/** The sentence buried in the serialized response, apostrophes escaped as `\u0027`. */
 const wireBody = (serverMessage: string) => {
   const encoded = serverMessage.replace(/'/g, "\\u0027");
   return (

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
@@ -33,6 +33,14 @@ describe("activateAccessErrorMessageKey", () => {
     },
   );
 
+  it("falls back to the raw message when there is no JSON body to decode", () => {
+    expect(
+      activateAccessErrorMessageKey(
+        activationError("Api", ACTIVATE_ACCESS_SERVER_ERRORS.WindowEnded.serverMessage),
+      ),
+    ).toBe(ACTIVATE_ACCESS_SERVER_ERRORS.WindowEnded.messageKey);
+  });
+
   it.each([
     [
       "an unrecognised server message",

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
@@ -7,13 +7,22 @@ import {
 const activationError = (variant: string, message: string) =>
   Object.assign(new Error(message), { name: "AccessRequestError", variant });
 
-/** How the wire body actually reaches `.message`: the sentence buried in the serialized response. */
-const wireBody = (serverMessage: string) =>
-  `error in response: status code 409 Conflict: {"object":"error","message":"${serverMessage}",` +
-  `"validationErrors":null,"exceptionMessage":"${serverMessage}","exceptionStackTrace":"   at ` +
-  "Bit.Services.Pam.OrganizationFeatures.Commands.ActivateAccessRequestCommand.ActivateAsync" +
-  "(Guid userId, Guid requestId) in /src/bitwarden_license/src/Services/Pam/" +
-  'OrganizationFeatures/Commands/ActivateAccessRequestCommand.cs:line 65"}';
+/**
+ * How the wire body actually reaches `.message`: the sentence buried in the serialized response,
+ * with its apostrophes escaped as `\u0027` the way `System.Text.Json`'s default encoder writes
+ * them. Spelling the sentence out with a literal apostrophe would test a body the server never
+ * sends.
+ */
+const wireBody = (serverMessage: string) => {
+  const encoded = serverMessage.replace(/'/g, "\\u0027");
+  return (
+    `error in response: status code 409 Conflict: {"object":"error","message":"${encoded}",` +
+    `"validationErrors":null,"exceptionMessage":"${encoded}","exceptionStackTrace":"   at ` +
+    "Bit.Services.Pam.OrganizationFeatures.Commands.ActivateAccessRequestCommand.ActivateAsync" +
+    "(Guid userId, Guid requestId) in /src/bitwarden_license/src/Services/Pam/" +
+    'OrganizationFeatures/Commands/ActivateAccessRequestCommand.cs:line 65"}'
+  );
+};
 
 describe("activateAccessErrorMessageKey", () => {
   const cases = Object.values(ACTIVATE_ACCESS_SERVER_ERRORS).map(

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
@@ -1,0 +1,58 @@
+import {
+  ACTIVATE_ACCESS_SERVER_ERRORS,
+  activateAccessErrorMessageKey,
+} from "./activate-access-error";
+
+/** The SDK's activation error: a `name`-tagged Error carrying a `variant`. */
+const activationError = (variant: string, message: string) =>
+  Object.assign(new Error(message), { name: "AccessRequestError", variant });
+
+/** How the wire body actually reaches `.message`: the sentence buried in the serialized response. */
+const wireBody = (serverMessage: string) =>
+  `error in response: status code 409 Conflict: {"object":"error","message":"${serverMessage}",` +
+  `"validationErrors":null,"exceptionMessage":"${serverMessage}","exceptionStackTrace":"   at ` +
+  "Bit.Services.Pam.OrganizationFeatures.Commands.ActivateAccessRequestCommand.ActivateAsync" +
+  "(Guid userId, Guid requestId) in /src/bitwarden_license/src/Services/Pam/" +
+  'OrganizationFeatures/Commands/ActivateAccessRequestCommand.cs:line 65"}';
+
+describe("activateAccessErrorMessageKey", () => {
+  const cases = Object.values(ACTIVATE_ACCESS_SERVER_ERRORS).map(
+    (entry) => [entry.serverMessage, entry.messageKey] as const,
+  );
+
+  it.each(cases)(
+    "maps %p out of the serialized response body onto its own copy",
+    (serverMessage, messageKey) => {
+      expect(activateAccessErrorMessageKey(activationError("Api", wireBody(serverMessage)))).toBe(
+        messageKey,
+      );
+    },
+  );
+
+  it.each([
+    [
+      "an unrecognised server message",
+      activationError("Api", wireBody("Something else entirely.")),
+    ],
+    ["an error that isn't the SDK's shape", new Error("offline")],
+    ["an empty message", activationError("Api", "")],
+    ["a non-error", "not an error"],
+    ["nothing at all", undefined],
+  ])("falls back to the generic key for %s", (_name, thrown) => {
+    expect(activateAccessErrorMessageKey(thrown)).toBe("pamStartLeaseError");
+  });
+
+  it("never returns the server's own words, whatever it was handed", () => {
+    const keys = [
+      ...cases.map(([serverMessage]) =>
+        activateAccessErrorMessageKey(activationError("Api", wireBody(serverMessage))),
+      ),
+      activateAccessErrorMessageKey(activationError("Api", wireBody("Something else entirely."))),
+    ];
+
+    for (const key of keys) {
+      expect(key).not.toContain("exceptionStackTrace");
+      expect(key).not.toContain("Bit.Services.Pam");
+    }
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.spec.ts
@@ -41,18 +41,4 @@ describe("activateAccessErrorMessageKey", () => {
   ])("falls back to the generic key for %s", (_name, thrown) => {
     expect(activateAccessErrorMessageKey(thrown)).toBe("pamStartLeaseError");
   });
-
-  it("never returns the server's own words, whatever it was handed", () => {
-    const keys = [
-      ...cases.map(([serverMessage]) =>
-        activateAccessErrorMessageKey(activationError("Api", wireBody(serverMessage))),
-      ),
-      activateAccessErrorMessageKey(activationError("Api", wireBody("Something else entirely."))),
-    ];
-
-    for (const key of keys) {
-      expect(key).not.toContain("exceptionStackTrace");
-      expect(key).not.toContain("Bit.Services.Pam");
-    }
-  });
 });

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
@@ -1,3 +1,5 @@
+import { apiErrorBodyMessage } from "../abstractions/api-error";
+
 /**
  * The activation endpoint's error catalog, as the server words it, paired with the copy we show
  * instead. Reproduced here rather than imported because the strings cross the wire as prose: the
@@ -50,25 +52,10 @@ export const ACTIVATE_ACCESS_SERVER_ERRORS = Object.freeze({
   },
 } as const satisfies Record<string, { serverMessage: string; messageKey: string }>);
 
-/** The server's sentence, decoded out of the JSON envelope the SDK concatenated onto its transport string, or `null` when the message isn't that shape. */
-function serverSentence(message: string): string | null {
-  const bodyStart = message.indexOf("{");
-  const bodyEnd = message.lastIndexOf("}");
-  if (bodyStart === -1 || bodyEnd <= bodyStart) {
-    return null;
-  }
-  try {
-    const body = JSON.parse(message.slice(bodyStart, bodyEnd + 1)) as { message?: unknown };
-    return typeof body?.message === "string" ? body.message : null;
-  } catch {
-    return null;
-  }
-}
-
 /** The i18n key to toast for a rejected activation, generic copy included. */
 export function activateAccessErrorMessageKey(e: unknown): string {
   const message = e instanceof Error ? e.message : "";
-  const candidate = serverSentence(message) ?? message;
+  const candidate = apiErrorBodyMessage(message) ?? message;
   const mapped = Object.values(ACTIVATE_ACCESS_SERVER_ERRORS).find((entry) =>
     candidate.includes(entry.serverMessage),
   );

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
@@ -64,11 +64,7 @@ export const ACTIVATE_ACCESS_SERVER_ERRORS = Object.freeze({
  * none a substring of another, so a substring match is unambiguous while tolerating that framing.
  */
 export function activateAccessErrorMessageKey(e: unknown): string {
-  const message = e instanceof Error ? e.message : undefined;
-  if (!message) {
-    return "pamStartLeaseError";
-  }
-
+  const message = e instanceof Error ? e.message : "";
   const mapped = Object.values(ACTIVATE_ACCESS_SERVER_ERRORS).find((entry) =>
     message.includes(entry.serverMessage),
   );

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
@@ -1,18 +1,4 @@
-/**
- * The activation endpoint's error catalog, as the server words it, paired with the copy we show
- * instead. Reproduced here rather than imported because the strings cross the wire as prose: the
- * SDK surfaces the server's rejection with `variant: "Api"` and the whole serialized response body
- * on `.message` — envelope, `exceptionMessage` and a stack trace carrying the server's absolute
- * filesystem paths — with no machine-readable code to switch on. When the server grows a code, this
- * catalog is the single place to retire.
- *
- * Sourced from `ActivateAccessRequestCommand.ActivateAsync` and `Engine/AccessDenialMessage.cs`.
- * The `NotFoundException` path is deliberately absent: it carries no sentence, and its 404 is
- * indistinguishable from "that request isn't yours" on purpose, so the generic copy is the honest
- * thing to show. The three denial sentences are vague about which condition failed for the same
- * reason — the requester cannot see the rule, and naming the CIDR or the window would let them
- * probe it.
- */
+/** The activation endpoint's error catalog, as the server words it, paired with the copy we show instead. */
 export const ACTIVATE_ACCESS_SERVER_ERRORS = Object.freeze({
   WindowNotStarted: {
     serverMessage: "The approved access window has not started yet.",
@@ -52,18 +38,7 @@ export const ACTIVATE_ACCESS_SERVER_ERRORS = Object.freeze({
   },
 } as const satisfies Record<string, { serverMessage: string; messageKey: string }>);
 
-/**
- * The server's sentence, decoded out of the JSON envelope the SDK concatenated onto its transport
- * string, or `null` when the message isn't that shape.
- *
- * Decoding is not optional: `System.Text.Json`'s default encoder escapes non-alphanumerics, so the
- * apostrophe in `This request's ...` crosses the wire as `\u0027` and the sentence never matches
- * the catalog as raw text. Same extraction as `classifyOpenOrgInviteAcceptError` in
- * `libs/common/src/auth/organization-invite/services/implementations/default-organization-invite.service.ts`,
- * which is coupled to the same `bitwarden-api-base::Error::Response` Display format:
- * `error in response: status code <status> <reason>: <json-body>`. Anchoring on the first `{` and
- * last `}` keeps this working if the prefix drifts.
- */
+/** The server's sentence, decoded out of the JSON envelope the SDK concatenated onto its transport string, or `null` when the message isn't that shape. */
 function serverSentence(message: string): string | null {
   const bodyStart = message.indexOf("{");
   const bodyEnd = message.lastIndexOf("}");
@@ -78,17 +53,7 @@ function serverSentence(message: string): string | null {
   }
 }
 
-/**
- * The i18n key to toast for a rejected activation, generic copy included.
- *
- * An i18n key is all that comes back — the raw error never leaves this function, which is the
- * point: its message is the server's serialized response, and putting it on screen would publish
- * the server's filesystem paths and .NET frames to the requester.
- *
- * Matched with `includes` rather than equality so an envelope this function cannot decode still has
- * a chance of matching on the raw text. The catalog entries are whole, distinct sentences, none a
- * substring of another, so a substring match is unambiguous.
- */
+/** The i18n key to toast for a rejected activation, generic copy included. */
 export function activateAccessErrorMessageKey(e: unknown): string {
   const message = e instanceof Error ? e.message : "";
   const candidate = serverSentence(message) ?? message;

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
@@ -53,20 +53,47 @@ export const ACTIVATE_ACCESS_SERVER_ERRORS = Object.freeze({
 } as const satisfies Record<string, { serverMessage: string; messageKey: string }>);
 
 /**
+ * The server's sentence, decoded out of the JSON envelope the SDK concatenated onto its transport
+ * string, or `null` when the message isn't that shape.
+ *
+ * Decoding is not optional: `System.Text.Json`'s default encoder escapes non-alphanumerics, so the
+ * apostrophe in `This request's ...` crosses the wire as `\u0027` and the sentence never matches
+ * the catalog as raw text. Same extraction as `classifyOpenOrgInviteAcceptError` in
+ * `libs/common/src/auth/organization-invite/services/implementations/default-organization-invite.service.ts`,
+ * which is coupled to the same `bitwarden-api-base::Error::Response` Display format:
+ * `error in response: status code <status> <reason>: <json-body>`. Anchoring on the first `{` and
+ * last `}` keeps this working if the prefix drifts.
+ */
+function serverSentence(message: string): string | null {
+  const bodyStart = message.indexOf("{");
+  const bodyEnd = message.lastIndexOf("}");
+  if (bodyStart === -1 || bodyEnd <= bodyStart) {
+    return null;
+  }
+  try {
+    const body = JSON.parse(message.slice(bodyStart, bodyEnd + 1)) as { message?: unknown };
+    return typeof body?.message === "string" ? body.message : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The i18n key to toast for a rejected activation, generic copy included.
  *
  * An i18n key is all that comes back — the raw error never leaves this function, which is the
  * point: its message is the server's serialized response, and putting it on screen would publish
  * the server's filesystem paths and .NET frames to the requester.
  *
- * Matched with `includes` rather than equality: the wire body wraps the server's sentence in a JSON
- * envelope and repeats it in `exceptionMessage`. The catalog entries are whole, distinct sentences,
- * none a substring of another, so a substring match is unambiguous while tolerating that framing.
+ * Matched with `includes` rather than equality so an envelope this function cannot decode still has
+ * a chance of matching on the raw text. The catalog entries are whole, distinct sentences, none a
+ * substring of another, so a substring match is unambiguous.
  */
 export function activateAccessErrorMessageKey(e: unknown): string {
   const message = e instanceof Error ? e.message : "";
+  const candidate = serverSentence(message) ?? message;
   const mapped = Object.values(ACTIVATE_ACCESS_SERVER_ERRORS).find((entry) =>
-    message.includes(entry.serverMessage),
+    candidate.includes(entry.serverMessage),
   );
   return mapped?.messageKey ?? "pamStartLeaseError";
 }

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
@@ -1,4 +1,16 @@
-/** The activation endpoint's error catalog, as the server words it, paired with the copy we show instead. */
+/**
+ * The activation endpoint's error catalog, as the server words it, paired with the copy we show
+ * instead. Reproduced here rather than imported because the strings cross the wire as prose: the
+ * SDK surfaces the server's rejection as an `AccessRequestError` with `variant: "Api"` and the
+ * whole serialized response body on `.message` — envelope, exception message and server-side stack
+ * trace included — with no machine-readable code to switch on. When the server grows a code, this
+ * catalog is the single place to retire.
+ *
+ * Sourced from `ActivateAccessRequestCommand`, except the three "not permitted" sentences, which
+ * the rule engine's `AccessDenialMessage` words for both this gate and the submit gate. The
+ * rejections are a mix of `400` (window, condition denial) and `409` (state, lease contention), so
+ * the status code does not disambiguate them either.
+ */
 export const ACTIVATE_ACCESS_SERVER_ERRORS = Object.freeze({
   WindowNotStarted: {
     serverMessage: "The approved access window has not started yet.",

--- a/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts
@@ -1,0 +1,76 @@
+/**
+ * The activation endpoint's error catalog, as the server words it, paired with the copy we show
+ * instead. Reproduced here rather than imported because the strings cross the wire as prose: the
+ * SDK surfaces the server's rejection with `variant: "Api"` and the whole serialized response body
+ * on `.message` — envelope, `exceptionMessage` and a stack trace carrying the server's absolute
+ * filesystem paths — with no machine-readable code to switch on. When the server grows a code, this
+ * catalog is the single place to retire.
+ *
+ * Sourced from `ActivateAccessRequestCommand.ActivateAsync` and `Engine/AccessDenialMessage.cs`.
+ * The `NotFoundException` path is deliberately absent: it carries no sentence, and its 404 is
+ * indistinguishable from "that request isn't yours" on purpose, so the generic copy is the honest
+ * thing to show. The three denial sentences are vague about which condition failed for the same
+ * reason — the requester cannot see the rule, and naming the CIDR or the window would let them
+ * probe it.
+ */
+export const ACTIVATE_ACCESS_SERVER_ERRORS = Object.freeze({
+  WindowNotStarted: {
+    serverMessage: "The approved access window has not started yet.",
+    messageKey: "pamStartLeaseErrorWindowNotStarted",
+  },
+  WindowEnded: {
+    serverMessage: "The approved access window has already ended.",
+    messageKey: "pamStartLeaseErrorWindowEnded",
+  },
+  NotApproved: {
+    serverMessage: "This request has not been approved yet.",
+    messageKey: "pamStartLeaseErrorNotApproved",
+  },
+  NoLongerActivatable: {
+    serverMessage: "This request can no longer be activated.",
+    messageKey: "pamStartLeaseErrorNoLongerActivatable",
+  },
+  AlreadyUsed: {
+    serverMessage: "This request's access has already been used and is no longer active.",
+    messageKey: "pamStartLeaseErrorAlreadyUsed",
+  },
+  SingleActiveLease: {
+    serverMessage: "Another active lease exists for this item. Try again once it ends.",
+    messageKey: "pamStartLeaseErrorSingleActiveLease",
+  },
+  NetworkNotPermitted: {
+    serverMessage: "Access to this item is not permitted from your current network.",
+    messageKey: "pamStartLeaseErrorNetworkNotPermitted",
+  },
+  TimeNotPermitted: {
+    serverMessage: "Access to this item is not permitted at this time.",
+    messageKey: "pamStartLeaseErrorTimeNotPermitted",
+  },
+  NotPermitted: {
+    serverMessage: "Access to this item is not permitted right now.",
+    messageKey: "pamStartLeaseErrorNotPermitted",
+  },
+} as const satisfies Record<string, { serverMessage: string; messageKey: string }>);
+
+/**
+ * The i18n key to toast for a rejected activation, generic copy included.
+ *
+ * An i18n key is all that comes back — the raw error never leaves this function, which is the
+ * point: its message is the server's serialized response, and putting it on screen would publish
+ * the server's filesystem paths and .NET frames to the requester.
+ *
+ * Matched with `includes` rather than equality: the wire body wraps the server's sentence in a JSON
+ * envelope and repeats it in `exceptionMessage`. The catalog entries are whole, distinct sentences,
+ * none a substring of another, so a substring match is unambiguous while tolerating that framing.
+ */
+export function activateAccessErrorMessageKey(e: unknown): string {
+  const message = e instanceof Error ? e.message : undefined;
+  if (!message) {
+    return "pamStartLeaseError";
+  }
+
+  const mapped = Object.values(ACTIVATE_ACCESS_SERVER_ERRORS).find((entry) =>
+    message.includes(entry.serverMessage),
+  );
+  return mapped?.messageKey ?? "pamStartLeaseError";
+}

--- a/bitwarden_license/bit-web/src/app/pam/index.ts
+++ b/bitwarden_license/bit-web/src/app/pam/index.ts
@@ -107,3 +107,7 @@ export {
 export type { RequestAccessErrorOutcome } from "./helpers/request-access-error";
 export { accessRuleErrorMessageKey, classifyAccessRuleError } from "./helpers/access-rule-error";
 export type { AccessRuleErrorField, AccessRuleErrorOutcome } from "./helpers/access-rule-error";
+export {
+  ACTIVATE_ACCESS_SERVER_ERRORS,
+  activateAccessErrorMessageKey,
+} from "./helpers/activate-access-error";

--- a/bitwarden_license/bit-web/src/app/pam/index.ts
+++ b/bitwarden_license/bit-web/src/app/pam/index.ts
@@ -14,6 +14,7 @@ export {
   isKnownAccessCondition,
 } from "./abstractions/access-rule";
 export { AccessRuleSdkService } from "./abstractions/access-rule-sdk.service";
+export { apiErrorBodyMessage } from "./abstractions/api-error";
 
 export type {
   AccessApprovalMode,

--- a/bitwarden_license/bit-web/src/app/pam/index.ts
+++ b/bitwarden_license/bit-web/src/app/pam/index.ts
@@ -107,7 +107,4 @@ export {
 export type { RequestAccessErrorOutcome } from "./helpers/request-access-error";
 export { accessRuleErrorMessageKey, classifyAccessRuleError } from "./helpers/access-rule-error";
 export type { AccessRuleErrorField, AccessRuleErrorOutcome } from "./helpers/access-rule-error";
-export {
-  ACTIVATE_ACCESS_SERVER_ERRORS,
-  activateAccessErrorMessageKey,
-} from "./helpers/activate-access-error";
+export { activateAccessErrorMessageKey } from "./helpers/activate-access-error";

--- a/docs/pam-server-asks.md
+++ b/docs/pam-server-asks.md
@@ -14,18 +14,21 @@ PAM endpoints reject with `ErrorResponseModel`, which carries a human-readable `
 machine-readable discriminant. Every failure a client must _act_ on differently is therefore
 identified by matching the server's English sentence.
 
-The web client now keeps **two** such catalogs, eighteen sentences in total, matched with
+The web client now keeps **three** such catalogs, twenty-eight sentences in total, matched with
 `String.includes()`:
 
 - [`helpers/request-access-error.ts`](../bitwarden_license/bit-web/src/app/pam/helpers/request-access-error.ts)
   — twelve sentences from the lease-request endpoint.
+- [`helpers/activate-access-error.ts`](../bitwarden_license/bit-web/src/app/pam/helpers/activate-access-error.ts)
+  — nine from the activation endpoint.
 - [`helpers/access-rule-error.ts`](../bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts)
-  — six from the access-rule write endpoints.
+  — seven from the access-rule write endpoints: six the server words, plus one the SDK raises
+  locally before the request ever leaves the client.
 
-They were written weeks apart by different people, and both carry the same note in their own words:
-_"When the server grows a code, this catalog is the single place to retire."_ Two independent
-authors reaching for the same workaround, and writing down the same wish, is the argument for this
-ask in miniature.
+They were written weeks apart by different people, and all three carry the same note in their own
+words: _"When the server grows a code, this catalog is the single place to retire."_ Three
+independent authors reaching for the same workaround, and writing down the same wish, is the
+argument for this ask in miniature.
 
 Three consequences, in order of severity:
 
@@ -42,10 +45,12 @@ falls back to generic copy. So a sentence the catalog misses is not degraded to 
 words" — it degrades to "something went wrong."
 
 **3. Every other client repeats the work.** Browser, desktop and mobile each need their own copy of
-both catalogs, kept in sync by hand against a server that has never promised to keep the wording
-stable.
+all three catalogs, kept in sync by hand against a server that has never promised to keep the
+wording stable.
 
-Status codes do not disambiguate: these are all `400`.
+Status codes do not disambiguate. The request and rule catalogs are all `400`; activation splits
+`400` and `409`, but both codes cover several distinct sentences apiece, so neither narrows a
+failure to one case.
 
 This has already bitten an adjacent feature. The organization-invite classifier regexes the status
 and JSON body out of the SDK's error string; its own comment calls the coupling _"fragile … accepted
@@ -86,10 +91,32 @@ to any endpoint rather than being PAM-specific:
 | `The requested window exceeds the maximum of 86400 seconds.`                       | `window_exceeds_max`              | Inline form error                             |
 | `This item does not require a lease.`                                              | `cipher_not_gated`                | Inline form error                             |
 
+### Codes needed — activation (`POST /access-requests/{id}/activate`)
+
+Sourced from `ActivateAccessRequestCommand`, except the three condition denials, which
+`AccessDenialMessage` words for both this gate and the submit gate. Each maps to a distinct
+explanation of why the approved request would not start.
+
+| Current message                                                        | Status | Proposed code                    | Why the client must tell it apart           |
+| ---------------------------------------------------------------------- | ------ | -------------------------------- | ------------------------------------------- |
+| `The approved access window has not started yet.`                      | `400`  | `activation_window_not_started`  | Tells the holder to come back later         |
+| `The approved access window has already ended.`                        | `400`  | `activation_window_ended`        | Terminal — the approval is spent            |
+| `This request has not been approved yet.`                              | `409`  | `activation_not_approved`        | Still awaiting an approver, not an error    |
+| `This request can no longer be activated.`                             | `409`  | `activation_no_longer_possible`  | Terminal — denied, cancelled or expired     |
+| `This request's access has already been used and is no longer active.` | `409`  | `activation_already_used`        | Terminal — distinct from "not approved"     |
+| `Another active lease exists for this item. Try again once it ends.`   | `409`  | `activation_single_active_lease` | Retryable — the only case worth retrying    |
+| `Access to this item is not permitted from your current network.`      | `400`  | `activation_network_denied`      | Actionable — change network and retry       |
+| `Access to this item is not permitted at this time.`                   | `400`  | `activation_time_denied`         | Actionable — retry inside the allowed hours |
+| `Access to this item is not permitted right now.`                      | `400`  | `activation_condition_denied`    | Catch-all denial; no action implied         |
+
+The last three share one `AccessDenialMessage` switch with the submit gate, so a code added there
+serves both endpoints.
+
 ### Codes needed — access rules (`POST`/`PUT /organizations/{id}/access-rules`)
 
 Sourced from `AccessRuleWriteValidator` and the create/update commands; each maps to correctable
-copy against a named form control.
+copy against a named form control. The catalog's seventh entry is absent here deliberately: it is
+the SDK's own local, pre-HTTP validation message, so no server code would reach it.
 
 | Current message                                                        | Proposed code                  | Form control                  |
 | ---------------------------------------------------------------------- | ------------------------------ | ----------------------------- |
@@ -114,5 +141,5 @@ Names are suggestions; any stable spelling works as long as the contract below h
 
 The SDK maps codes onto typed error variants (`AccessRequestError::AlreadyPending`,
 `AccessRuleError::CollectionsAlreadyGoverned`, …) — the same way it now maps the server's `404` onto
-`AccessRuleError::NotFound` — and both client catalogs are deleted rather than copied into the next
-client.
+`AccessRuleError::NotFound` — and all three client catalogs are deleted rather than copied into the
+next client.


### PR DESCRIPTION
## 🎟️ Tracking

UAT finding `uat-FLW-05-8ace1187` (P2), from the PAM UAT design review.

## 📔 Objective

Starting access could fail for nine distinct reasons, and every one of them surfaced as "Couldn't start access." The member was told something went wrong but never what, or whether retrying would help.

Adds `helpers/activate-access-error.ts`, mapping the activation endpoint's rejection sentences to i18n keys, and uses it in `MyRequestsTabComponent.activate()`. The raw SDK payload still never reaches the toast. `pamStartLeaseError` is unchanged and remains the fallback for anything unmapped.

## 📸 Screenshots
<img width="897" height="150" alt="image" src="https://github.com/user-attachments/assets/3ac26ee6-4627-4ae6-afa0-41aa479b43c4" />
