### PR TITLE
fix(pam): cap the rule description and clamp its list cell

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -10,7 +10,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService, SelectItemView, ToastService } from "@bitwarden/components";
 
-import { AccessRuleSdkService, AccessRuleView } from "../..";
+import { ACCESS_RULE_DESCRIPTION_MAX_LENGTH, AccessRuleSdkService, AccessRuleView } from "../..";
 
 import { AccessRuleEditComponent } from "./access-rule-edit.component";
 import { CidrValidationService } from "./ip-allowlist/cidr-validation.service";
@@ -911,6 +911,36 @@ describe("AccessRuleEditComponent — form states", () => {
 
       const summary = fixture.nativeElement.querySelector("bit-error-summary") as HTMLElement;
       expect(summary.textContent!.trim()).toBe("");
+    });
+  });
+
+  describe("description bound", () => {
+    it("refuses a description one character over the bound", async () => {
+      await render();
+      fillRequiredFields();
+      controls().description.setValue("D".repeat(ACCESS_RULE_DESCRIPTION_MAX_LENGTH + 1));
+
+      await submitAndRender();
+
+      expect(controls().description.errors).toEqual({
+        maxlength: {
+          requiredLength: ACCESS_RULE_DESCRIPTION_MAX_LENGTH,
+          actualLength: ACCESS_RULE_DESCRIPTION_MAX_LENGTH + 1,
+        },
+      });
+      expect(pamApi.createAccessRule).not.toHaveBeenCalled();
+      expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it("saves a description exactly at the bound", async () => {
+      await render();
+      fillRequiredFields();
+      controls().description.setValue("D".repeat(ACCESS_RULE_DESCRIPTION_MAX_LENGTH));
+
+      await submitAndRender();
+
+      expect(controls().description.errors).toBeNull();
+      expect(pamApi.createAccessRule).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -922,12 +922,7 @@ describe("AccessRuleEditComponent — form states", () => {
 
       await submitAndRender();
 
-      expect(controls().description.errors).toEqual({
-        maxlength: {
-          requiredLength: ACCESS_RULE_DESCRIPTION_MAX_LENGTH,
-          actualLength: ACCESS_RULE_DESCRIPTION_MAX_LENGTH + 1,
-        },
-      });
+      expect(Object.keys(controls().description.errors!)).toEqual(["maxlength"]);
       expect(pamApi.createAccessRule).not.toHaveBeenCalled();
       expect(navigate).not.toHaveBeenCalled();
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.ts
@@ -52,6 +52,7 @@ import {
   AccessRuleId,
   AccessRuleView,
   AccessCondition,
+  ACCESS_RULE_DESCRIPTION_MAX_LENGTH,
   ACCESS_RULE_DURATION_PRESETS,
   ACCESS_RULE_NAME_MAX_LENGTH,
   accessRuleDeleteConfirmOptions,
@@ -205,7 +206,7 @@ export class AccessRuleEditComponent {
 
   protected readonly formGroup = this.formBuilder.nonNullable.group({
     name: ["", [Validators.required, Validators.maxLength(ACCESS_RULE_NAME_MAX_LENGTH)]],
-    description: [""],
+    description: ["", [Validators.maxLength(ACCESS_RULE_DESCRIPTION_MAX_LENGTH)]],
     collections: [[] as SelectItemView[], [Validators.required]],
     defaultLeaseDurationSeconds: [
       snapToNearestAccessRuleDuration(undefined),

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.stories.ts
@@ -78,6 +78,14 @@ const RULES: AccessRuleView[] = [
     defaultLeaseDurationSeconds: 15 * 60,
     revisionDate: "2024-05-10T18:45:00.000Z",
   }),
+  rule({
+    id: "rule-5",
+    name: "Payments platform on-call rotation",
+    description: "D".repeat(512),
+    collections: ["col-5"],
+    defaultLeaseDurationSeconds: 60 * 60,
+    revisionDate: "2024-05-11T10:00:00.000Z",
+  }),
 ];
 
 /** Base SDK mock; per-story decorators override `listAccessRules` for the empty/loading states. */

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.stories.ts
@@ -8,7 +8,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
-import { AccessRuleSdkService, AccessRuleView } from "..";
+import { ACCESS_RULE_DESCRIPTION_MAX_LENGTH, AccessRuleSdkService, AccessRuleView } from "..";
 
 import { AccessRulesComponent } from "./access-rules.component";
 
@@ -81,7 +81,7 @@ const RULES: AccessRuleView[] = [
   rule({
     id: "rule-5",
     name: "Payments platform on-call rotation",
-    description: "D".repeat(512),
+    description: "D".repeat(ACCESS_RULE_DESCRIPTION_MAX_LENGTH),
     collections: ["col-5"],
     defaultLeaseDurationSeconds: 60 * 60,
     revisionDate: "2024-05-11T10:00:00.000Z",

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-request.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-request.ts
@@ -26,13 +26,7 @@ export const NO_DURATION_CAP = 0;
  */
 export const ACCESS_RULE_NAME_MAX_LENGTH = 256;
 
-/**
- * The longest description the edit form accepts. Unlike the name's bound this is NOT a storage
- * limit — `dbo.AccessRule.Description` is `NVARCHAR(MAX)` and the server's `AccessRuleRequestModel`
- * declares no `StringLength` — it is a product bound, so one rule's prose cannot dominate the rules
- * list. A rule already stored with a longer description fails this on load and has to be shortened
- * before it can be saved again.
- */
+/** The longest description the edit form accepts. */
 export const ACCESS_RULE_DESCRIPTION_MAX_LENGTH = 512;
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-request.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-request.ts
@@ -27,6 +27,15 @@ export const NO_DURATION_CAP = 0;
 export const ACCESS_RULE_NAME_MAX_LENGTH = 256;
 
 /**
+ * The longest description the edit form accepts. Unlike the name's bound this is NOT a storage
+ * limit — `dbo.AccessRule.Description` is `NVARCHAR(MAX)` and the server's `AccessRuleRequestModel`
+ * declares no `StringLength` — it is a product bound, so one rule's prose cannot dominate the rules
+ * list. A rule already stored with a longer description fails this on load and has to be shortened
+ * before it can be saved again.
+ */
+export const ACCESS_RULE_DESCRIPTION_MAX_LENGTH = 512;
+
+/**
  * The flattened value of the access-rule edit form (`formGroup.getRawValue()`), as
  * consumed by {@link formValueToRequest}. Declared structurally here — rather than
  * derived from the component's `FormGroup` — so this helper stays framework-agnostic

--- a/bitwarden_license/bit-web/src/app/pam/index.ts
+++ b/bitwarden_license/bit-web/src/app/pam/index.ts
@@ -43,6 +43,7 @@ export { AccessEventService } from "./abstractions/access-event.service";
 export { LeasingErrorService } from "./abstractions/leasing-error.service";
 
 export {
+  ACCESS_RULE_DESCRIPTION_MAX_LENGTH,
   ACCESS_RULE_NAME_MAX_LENGTH,
   accessRuleToFormValue,
   accessRuleToRequest,


### PR DESCRIPTION
## 🎟️ Tracking

UAT findings `uat-SCR-06-0e655ee9` and `uat-SCR-03-27c6da73` (P2), from the PAM UAT design review.

## 📔 Objective

The access rule description had no length bound, and the rules list rendered it unclamped in the Name cell, so one long description could widen the Name column and push the other columns off screen.

Two changes. The edit form now bounds description at 512 characters, matching how Name is already capped, surfacing through the existing `inputMaxLength` string with no new i18n key. The list cell swaps `tw-break-words` for `[overflow-wrap:anywhere]` so an unbroken run can no longer set the column's min content width.

## 📸 Screenshots
<img width="685" height="342" alt="image" src="https://github.com/user-attachments/assets/8ef62ef2-1369-430c-863e-61922ac05601" />

Before:
<img width="891" height="427" alt="image" src="https://github.com/user-attachments/assets/eaef1d4c-6276-4a89-b390-63688f96f2a6" />

After:
<img width="875" height="527" alt="image" src="https://github.com/user-attachments/assets/c589d2be-9466-4273-9edb-10e603dff15e" />
