### PR TITLE
fix(pam): rename the rule form event logs link to Audit log

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16921,6 +16921,9 @@
   "pamAccessRuleEventLogNotice": {
     "message": "All requests and decisions are logged."
   },
+  "pamAccessRuleViewEventLogs": {
+    "message": "View event logs"
+  },
   "pamAccessRuleViewAuditLog": {
     "message": "View audit log"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16924,6 +16924,9 @@
   "pamAccessRuleViewEventLogs": {
     "message": "View event logs"
   },
+  "pamAccessRuleViewAuditLog": {
+    "message": "View audit log"
+  },
   "pamAccessRuleCollectionsLoadError": {
     "message": "Couldn't load collections. Refresh the page to try again."
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16921,9 +16921,6 @@
   "pamAccessRuleEventLogNotice": {
     "message": "All requests and decisions are logged."
   },
-  "pamAccessRuleViewEventLogs": {
-    "message": "View event logs"
-  },
   "pamAccessRuleViewAuditLog": {
     "message": "View audit log"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -242,7 +242,7 @@
         <p bitTypography="body2" class="tw-text-muted">
           {{ "pamAccessRuleEventLogNotice" | i18n }}
           <a bitLink [routerLink]="eventLogRoute" id="access-rule-edit_anchor_event-logs">{{
-            "pamAccessRuleViewEventLogs" | i18n
+            "pamAccessRuleViewAuditLog" | i18n
           }}</a>
         </p>
       }

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -283,6 +283,7 @@ describe("AccessRuleEditComponent — page furniture", () => {
     ) as HTMLAnchorElement | null;
     expect(link).not.toBeNull();
     expect(link!.getAttribute("href")).toBe("/organizations/org-1/pam/audit");
+    expect(link!.textContent!.trim()).toBe("pamAccessRuleViewAuditLog");
   });
 
   it("drops the event log notice for an organization without event log access", async () => {


### PR DESCRIPTION
## 🎟️ Tracking

UAT finding from the PAM UAT design review (batch `pam-calls-audit-trail-audit`).

## 📔 Objective

The access rule form linked to the audit trail as "event logs", a name that appears nowhere else in PAM. The destination is called Audit log in the side nav and on the page itself.

Renames the link to match, so one feature uses one word for one thing.

## 📸 Screenshots

<img width="394" height="51" alt="image" src="https://github.com/user-attachments/assets/1a388418-4209-4ae0-9d76-9c1fe0ddcf14" />

