### PR TITLE
[PM-41306] Web: Update Passkey report banner type to info 

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
@@ -38,7 +38,11 @@
         </bit-callout>
       } @else {
         <bit-callout type="info" title="{{ 'passkeyLoginFound' | i18n }}">
-          {{ "passkeyLoginFoundReportDesc" | i18n: (ciphers().length | number) }}
+          {{ "passkeyLoginFoundInfoPrefix" | i18n }}
+          <strong class="tw-font-semibold">{{
+            "loginsCount" | i18n: (ciphers().length | number)
+          }}</strong>
+          {{ "passkeyLoginFoundInfoSuffixSingular" | i18n }}
         </bit-callout>
         <bit-table-scroll [dataSource]="dataSource" [rowSize]="75" layout="fixed">
           <ng-container header>

--- a/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
@@ -37,7 +37,7 @@
           {{ "noPasskeyLogin" | i18n }}
         </bit-callout>
       } @else {
-        <bit-callout type="warning" title="{{ 'passkeyLoginFound' | i18n }}">
+        <bit-callout type="info" title="{{ 'passkeyLoginFound' | i18n }}">
           {{ "passkeyLoginFoundReportDesc" | i18n: (ciphers().length | number) }}
         </bit-callout>
         <bit-table-scroll [dataSource]="dataSource" [rowSize]="75" layout="fixed">

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
@@ -38,7 +38,11 @@
         </bit-callout>
       } @else {
         <bit-callout type="info" title="{{ 'passkeyLoginFound' | i18n }}">
-          {{ reportDescriptionKey() | i18n: (ciphers().length | number) ?? "" }}
+          {{ "passkeyLoginFoundInfoPrefix" | i18n }}
+          <strong class="tw-font-semibold">{{
+            "loginsCount" | i18n: (ciphers().length | number)
+          }}</strong>
+          {{ infoBannerSuffixKey() | i18n }}
         </bit-callout>
         @if (showFilterToggle()) {
           @if (canDisplayToggleGroup()) {

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
@@ -37,7 +37,7 @@
           {{ "noPasskeyLogin" | i18n }}
         </bit-callout>
       } @else {
-        <bit-callout type="warning" title="{{ 'passkeyLoginFound' | i18n }}">
+        <bit-callout type="info" title="{{ 'passkeyLoginFound' | i18n }}">
           {{ reportDescriptionKey() | i18n: (ciphers().length | number) ?? "" }}
         </bit-callout>
         @if (showFilterToggle()) {

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.ts
@@ -94,7 +94,7 @@ export class PasskeyReportComponent implements OnInit {
   // Filter state
   protected readonly filterStatus = signal<(number | string)[]>([0]);
   protected readonly showFilterToggle = signal(false);
-  protected readonly reportDescriptionKey = signal("passkeyLoginFoundReportDesc");
+  protected readonly infoBannerSuffixKey = signal("passkeyLoginFoundInfoSuffixSingular");
   protected readonly chipSelectOptions = signal<{ label: string; value: string | number }[]>([]);
   protected readonly selectedFilterChip = "0";
   private readonly maxItemsToSwitchToChipSelect = 5;
@@ -287,10 +287,10 @@ export class PasskeyReportComponent implements OnInit {
 
     if (statuses.length > 2) {
       this.showFilterToggle.set(true);
-      this.reportDescriptionKey.set("passkeyLoginFoundReportDescPlural");
+      this.infoBannerSuffixKey.set("passkeyLoginFoundInfoSuffixPlural");
     } else {
       this.showFilterToggle.set(false);
-      this.reportDescriptionKey.set("passkeyLoginFoundReportDesc");
+      this.infoBannerSuffixKey.set("passkeyLoginFoundInfoSuffixSingular");
     }
 
     this.chipSelectOptions.set(this.setupChipSelectOptions(statuses));

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4157,8 +4157,11 @@
   "passkeyLoginFound": {
     "message": "Logins that support passkeys"
   },
-  "passkeyLoginFoundReportDesc": {
-    "message": "We found $COUNT$ login(s) in your vault that support passkeys. To further secure these accounts, consider setting up a passkey where available. Sourced from passkeys.2fa.directory",
+  "passkeyLoginFoundInfoPrefix": {
+    "message": "Great news! We found "
+  },
+  "loginsCount": {
+    "message": "$COUNT$ login(s)",
     "placeholders": {
       "count": {
         "content": "$1",
@@ -4166,14 +4169,11 @@
       }
     }
   },
-  "passkeyLoginFoundReportDescPlural": {
-    "message": "We found $COUNT$ login(s) in your vaults that support passkeys. To further secure these accounts, consider setting up a passkey where available. Sourced from passkeys.2fa.directory",
-    "placeholders": {
-      "count": {
-        "content": "$1",
-        "example": "8"
-      }
-    }
+  "passkeyLoginFoundInfoSuffixSingular": {
+    "message": " in your vault that support passkeys. To further secure these accounts, consider setting up a passkey where available. Sourced from passkeys.2fa.directory"
+  },
+  "passkeyLoginFoundInfoSuffixPlural": {
+    "message": " in your vaults that support passkeys. To further secure these accounts, consider setting up a passkey where available. Sourced from passkeys.2fa.directory"
   },
   "noPasskeyLogin": {
     "message": "No accounts were found in your vault that support passkeys without one configured."


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-41306

## 📔 Objective
Per feedback from design on the innovation sprint's Passkey report feature, we need to update the type of the banner when passkey eligible logins are found to info type, rather than warning type. A few small copy changes are also made to the banner's content.

## 📸 Screenshots
**Individual Passkey report**

<img width="1264" height="426" alt="image" src="https://github.com/user-attachments/assets/3ecd89a7-be28-450a-aed3-f285ed821587" />


**Organization Passkey report**

<img width="1272" height="463" alt="image" src="https://github.com/user-attachments/assets/69497915-27ca-440c-b7d7-e9a169484784" />
