### PR TITLE
feat(pam): align the decide dialog with its design

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17804,14 +17804,26 @@
   "pamApprovalsSearchPlaceholder": {
     "message": "Search credential, collection, requester"
   },
+  "pamDecideAdditionalInformation": {
+    "message": "Additional information"
+  },
+  "pamDecideCommentAuditHint": {
+    "message": "Optional, saved to the audit log"
+  },
   "pamDecideApproveTitle": {
     "message": "Approve access request"
   },
-  "pamDecideCommentHint": {
-    "message": "Optional · saved to the audit log"
-  },
   "pamDecideDenyTitle": {
     "message": "Deny access request"
+  },
+  "pamDecideDenyReasonLabel": {
+    "message": "Reason for denial"
+  },
+  "pamDecideDenyReasonPlaceholder": {
+    "message": "e.g. Access no longer needed"
+  },
+  "pamDecideDenyReasonRequired": {
+    "message": "A reason is required to deny this request."
   },
   "pamInboxApprove": {
     "message": "Approve"
@@ -17831,14 +17843,8 @@
   "pamInboxCommentPlaceholder": {
     "message": "Add an optional comment"
   },
-  "pamInboxConfirmApprove": {
-    "message": "Approve this access request?"
-  },
   "pamInboxConfirmApproveButton": {
     "message": "Approve request"
-  },
-  "pamInboxConfirmDeny": {
-    "message": "Deny this access request?"
   },
   "pamInboxConfirmDenyButton": {
     "message": "Deny request"

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -24,6 +24,7 @@ function row(overrides: Record<string, unknown> = {}, canDecide = true): Approva
     id: "req-1",
     cipherId: "cipher-1",
     collectionId: "col-1",
+    organizationId: "org-1",
     requesterId: "user-1",
     status: "pending",
     leaseNotBefore: "2026-08-17T12:00:00.000Z",
@@ -41,6 +42,7 @@ function row(overrides: Record<string, unknown> = {}, canDecide = true): Approva
       ...emptyResolvedNames(),
       cipherNameById: new Map([["cipher-1", "Prod database"]]),
       collectionNameById: new Map([["col-1", "Production"]]),
+      organizationNameById: new Map([["org-1", "Meridian Group"]]),
     },
     NOW,
     canDecide,
@@ -197,7 +199,7 @@ describe("ApprovalsTabComponent", () => {
 
     it("records an approval once confirmed, and toasts", async () => {
       dialogService.open.mockReturnValue({
-        closed: of({ confirmed: true, comment: "fine" }),
+        closed: of({ confirmed: true, verdict: "approve", comment: "fine" }),
       } as never);
       create();
 
@@ -207,6 +209,23 @@ describe("ApprovalsTabComponent", () => {
       expect(toastService.showToast).toHaveBeenCalledWith(
         expect.objectContaining({ variant: "success" }),
       );
+    });
+
+    it("records the verdict the dialog closed with, not the one it was opened on", async () => {
+      // The approve dialog offers "Deny request" and switches in place; recording the requested
+      // verdict here would approve a request the approver denied.
+      dialogService.open.mockReturnValue({
+        closed: of({ confirmed: true, verdict: "deny", comment: "wrong window" }),
+      } as never);
+      create();
+
+      await component["decide"](component["rows"]()[0], "approve");
+
+      expect(inbox.decide).toHaveBeenCalledWith("req-1", "deny", "wrong window");
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "success",
+        message: "pamInboxDeniedToast",
+      });
     });
 
     it("does nothing when the dialog is dismissed", async () => {
@@ -221,7 +240,7 @@ describe("ApprovalsTabComponent", () => {
 
     it("toasts an error when recording the decision fails", async () => {
       dialogService.open.mockReturnValue({
-        closed: of({ confirmed: true, comment: undefined }),
+        closed: of({ confirmed: true, verdict: "deny", comment: undefined }),
       } as never);
       inbox.decide.mockRejectedValue(new Error("boom"));
       create();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -145,13 +145,19 @@ export class ApprovalsTabComponent {
    * Confirm and record a decision. Only an explicit confirm decides — dismissing the dialog by any
    * other route (Cancel, the header X, Escape, a backdrop click) closes with `undefined` and must
    * leave the request untouched.
+   *
+   * `verdict` is only what the dialog OPENS on. The approve variant offers "Deny request", which
+   * switches it in place, so the decision recorded here has to be the verdict the dialog closed
+   * with — recording the requested one would approve a request the approver denied.
    */
   protected async decide(row: ApprovalRow, verdict: AccessDecisionVerdict): Promise<void> {
     if (!row.canDecide || this.isDeciding(row)) {
       return;
     }
     const result = await firstValueFrom(
-      DecideDialogComponent.open(this.dialogService, { data: { verdict, row } }).closed,
+      DecideDialogComponent.open(this.dialogService, {
+        data: { verdict, row, cipher: this.cipherFor(row.cipherId) },
+      }).closed,
     );
     if (!result?.confirmed) {
       return;
@@ -160,11 +166,11 @@ export class ApprovalsTabComponent {
     const key = String(row.id);
     this.deciding.update((ids) => new Set([...ids, key]));
     try {
-      await this.inbox.decide(row.id, verdict, result.comment);
+      await this.inbox.decide(row.id, result.verdict, result.comment);
       this.toastService.showToast({
         variant: "success",
         message: this.i18nService.t(
-          verdict === "approve" ? "pamInboxApprovedToast" : "pamInboxDeniedToast",
+          result.verdict === "approve" ? "pamInboxApprovedToast" : "pamInboxDeniedToast",
         ),
       });
     } catch (e) {

--- a/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.html
@@ -1,55 +1,45 @@
-<form [formGroup]="formGroup" [bitSubmit]="confirm" bit-dialog>
+<form [formGroup]="formGroup" [bitSubmit]="confirm" bit-dialog background="alt" dialogSize="large">
   <span bitDialogTitle>{{
-    (approve ? "pamDecideApproveTitle" : "pamDecideDenyTitle") | i18n
+    (approve() ? "pamDecideApproveTitle" : "pamDecideDenyTitle") | i18n
   }}</span>
 
   <div bitDialogContent>
-    <p bitTypography="body1" class="tw-mt-0">
-      {{ (approve ? "pamInboxConfirmApprove" : "pamInboxConfirmDeny") | i18n }}
-    </p>
-
-    <div
-      class="tw-mb-4 tw-rounded-lg tw-border tw-border-solid tw-border-border-base tw-bg-background-alt2 tw-p-4"
+    <pam-request-summary
       data-testid="decide-dialog-summary"
-    >
-      <p bitTypography="body2" class="tw-mb-3 tw-mt-0 tw-font-bold">{{ row.cipherName }}</p>
-      <dl class="tw-mb-0 tw-grid tw-grid-cols-[auto_1fr] tw-gap-x-6 tw-gap-y-2 tw-text-sm">
-        <dt class="tw-font-semibold">{{ "pamInboxRequester" | i18n }}</dt>
-        <dd class="tw-m-0">{{ row.requester }}</dd>
+      [cipher]="cipher"
+      [itemName]="row.cipherName"
+      [organizationName]="row.organizationName"
+      [collectionName]="row.collectionName"
+      [requesterName]="row.requester"
+      [requesterEmail]="row.requesterEmail"
+      [duration]="row.duration"
+      [relativeStart]="row.relativeStart"
+      [exactWindow]="row.exactWindow"
+      [reason]="row.reason"
+    />
 
-        <dt class="tw-font-semibold">{{ "pamInboxWindow" | i18n }}</dt>
-        <dd class="tw-m-0" [title]="row.exactWindow">
-          {{ row.duration.key | i18n: row.duration.value }},
-          {{ row.relativeStart.key | i18n: row.relativeStart.value }}
-        </dd>
+    <h2 bitTypography="h6" class="tw-mb-2">{{ "pamDecideAdditionalInformation" | i18n }}</h2>
 
-        <dt class="tw-font-semibold">{{ "pamInboxRequestReasonLabel" | i18n }}</dt>
-        <dd class="tw-m-0">
-          @if (row.reason) {
-            {{ row.reason }}
-          } @else {
-            <span class="tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
-          }
-        </dd>
-
-        @if (row.collectionName) {
-          <dt class="tw-font-semibold">{{ "pamApprovalsCollectionFilter" | i18n }}</dt>
-          <dd class="tw-m-0">{{ row.collectionName }}</dd>
-        }
-      </dl>
-    </div>
-
-    <bit-form-field>
-      <bit-label>{{ "pamInboxCommentLabel" | i18n }}</bit-label>
-      <textarea
-        bitInput
-        rows="3"
-        formControlName="comment"
-        [placeholder]="'pamInboxCommentPlaceholder' | i18n"
-        id="pam-decide-dialog_textarea_comment"
-      ></textarea>
-      <bit-hint>{{ "pamDecideCommentHint" | i18n }}</bit-hint>
-    </bit-form-field>
+    <bit-card>
+      <bit-form-field disableMargin>
+        <bit-label>{{
+          (approve() ? "pamInboxCommentLabel" : "pamDecideDenyReasonLabel") | i18n
+        }}</bit-label>
+        <textarea
+          #commentField
+          bitInput
+          rows="3"
+          formControlName="comment"
+          id="pam-decide-dialog_textarea_comment"
+          [placeholder]="
+            (approve() ? 'pamInboxCommentPlaceholder' : 'pamDecideDenyReasonPlaceholder') | i18n
+          "
+        ></textarea>
+        <bit-hint>{{
+          (approve() ? "pamDecideCommentAuditHint" : "pamDecideDenyReasonRequired") | i18n
+        }}</bit-hint>
+      </bit-form-field>
+    </bit-card>
   </div>
 
   <ng-container bitDialogFooter>
@@ -57,10 +47,11 @@
       type="submit"
       bitButton
       bitFormButton
-      [buttonType]="approve ? 'primary' : 'danger'"
+      [buttonType]="approve() ? 'primary' : 'danger'"
+      [disabled]="confirmDisabled()"
       id="pam-decide-dialog_button_confirm"
     >
-      {{ (approve ? "pamInboxConfirmApproveButton" : "pamInboxConfirmDenyButton") | i18n }}
+      {{ (approve() ? "pamInboxConfirmApproveButton" : "pamInboxConfirmDenyButton") | i18n }}
     </button>
     <button
       type="button"
@@ -71,5 +62,17 @@
     >
       {{ "cancel" | i18n }}
     </button>
+    @if (approve()) {
+      <button
+        type="button"
+        bitButton
+        buttonType="dangerGhost"
+        class="tw-ms-auto"
+        id="pam-decide-dialog_button_switch-to-deny"
+        (click)="switchToDeny()"
+      >
+        {{ "pamInboxConfirmDenyButton" | i18n }}
+      </button>
+    }
   </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.spec.ts
@@ -251,6 +251,21 @@ describe("DecideDialogComponent", () => {
       expect(document.activeElement?.id).toBe("pam-decide-dialog_textarea_comment");
     });
 
+    it("discards a note typed while approving rather than recording it as the denial reason", async () => {
+      await create("approve");
+      component["formGroup"].patchValue({ comment: "Approved for the maintenance window" });
+
+      component["switchToDeny"]();
+      fixture.detectChanges();
+
+      expect(component["formGroup"].getRawValue().comment).toBe("");
+      // The whole point of the required reason: it has to engage on this path too.
+      expect(component["confirmDisabled"]()).toBe(true);
+
+      await component["confirm"]();
+      expect(close).not.toHaveBeenCalled();
+    });
+
     it("closes with deny, not the verdict it was opened on", async () => {
       await create("approve");
 

--- a/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.spec.ts
@@ -17,6 +17,7 @@ function approvalRow(overrides: Record<string, unknown> = {}): ApprovalRow {
     id: "req-1",
     cipherId: "cipher-1",
     collectionId: "col-1",
+    organizationId: "org-1",
     requesterId: "user-1",
     status: "pending",
     leaseNotBefore: "2026-08-17T12:00:00.000Z",
@@ -34,6 +35,7 @@ function approvalRow(overrides: Record<string, unknown> = {}): ApprovalRow {
       ...emptyResolvedNames(),
       cipherNameById: new Map([["cipher-1", "Prod database"]]),
       collectionNameById: new Map([["col-1", "Production"]]),
+      organizationNameById: new Map([["org-1", "Meridian Group"]]),
     },
     NOW,
     true,
@@ -67,6 +69,11 @@ describe("DecideDialogComponent", () => {
     fixture.detectChanges();
   }
 
+  /** Read-only fields render their value on the input, not as element text. */
+  function fieldValue(id: string): string {
+    return (fixture.nativeElement.querySelector(`#${id}`) as HTMLInputElement).value;
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
     TestBed.resetTestingModule();
@@ -86,24 +93,45 @@ describe("DecideDialogComponent", () => {
 
     const summary = fixture.nativeElement.querySelector('[data-testid="decide-dialog-summary"]');
     expect(summary.textContent).toContain("Prod database");
-    expect(summary.textContent).toContain("Grace");
-    expect(summary.textContent).toContain("prod incident");
+    expect(summary.textContent).toContain("Meridian Group");
     expect(summary.textContent).toContain("Production");
+    expect(summary.textContent).toContain("Grace");
+    expect(summary.textContent).toContain("grace@example.com");
+    expect(fieldValue("pam-request-summary_input_reason")).toContain("prod incident");
+    expect(fieldValue("pam-request-summary_input_access-requested")).toContain(
+      "pamInboxDuration1Hour",
+    );
+  });
+
+  it("renders nothing for an organization that did not resolve", async () => {
+    await create("approve", approvalRow({ organizationId: undefined }));
+
+    const summary = fixture.nativeElement.querySelector('[data-testid="decide-dialog-summary"]');
+    expect(summary.textContent).not.toContain("Meridian Group");
+    expect(summary.textContent).not.toContain("org-1");
   });
 
   it("says so explicitly when the request carried no reason", async () => {
     await create("approve", approvalRow({ reason: undefined }));
 
-    expect(fixture.nativeElement.textContent).toContain("pamInboxReasonMissing");
+    const reason = fixture.nativeElement.querySelector(
+      "#pam-request-summary_input_reason",
+    ) as HTMLInputElement;
+    expect(reason.value).toBe("");
+    expect(reason.placeholder).toContain("pamInboxReasonMissing");
   });
 
-  it("closes with the trimmed comment on confirm", async () => {
+  it("closes with the trimmed comment and the verdict on confirm", async () => {
     await create();
     component["formGroup"].patchValue({ comment: "  looks fine  " });
 
     await component["confirm"]();
 
-    expect(close).toHaveBeenCalledWith({ confirmed: true, comment: "looks fine" });
+    expect(close).toHaveBeenCalledWith({
+      confirmed: true,
+      verdict: "approve",
+      comment: "looks fine",
+    });
   });
 
   it("treats a blank comment as absent rather than writing whitespace to the audit log", async () => {
@@ -112,15 +140,23 @@ describe("DecideDialogComponent", () => {
 
     await component["confirm"]();
 
-    expect(close).toHaveBeenCalledWith({ confirmed: true, comment: undefined });
+    expect(close).toHaveBeenCalledWith({
+      confirmed: true,
+      verdict: "approve",
+      comment: undefined,
+    });
   });
 
-  it("confirms with no comment at all — it is optional on both verdicts", async () => {
-    await create("deny");
+  it("confirms with no comment at all when approving — it stays optional", async () => {
+    await create("approve");
 
     await component["confirm"]();
 
-    expect(close).toHaveBeenCalledWith({ confirmed: true, comment: undefined });
+    expect(close).toHaveBeenCalledWith({
+      confirmed: true,
+      verdict: "approve",
+      comment: undefined,
+    });
   });
 
   it("never calls an API itself; the caller records the decision", async () => {
@@ -130,5 +166,103 @@ describe("DecideDialogComponent", () => {
     await component["confirm"]();
 
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  describe("denying", () => {
+    it("will not confirm until a reason is given", async () => {
+      await create("deny");
+      expect(component["confirmDisabled"]()).toBe(true);
+
+      await component["confirm"]();
+      expect(close).not.toHaveBeenCalled();
+
+      component["formGroup"].patchValue({ comment: "no longer needed" });
+      expect(component["confirmDisabled"]()).toBe(false);
+
+      await component["confirm"]();
+      expect(close).toHaveBeenCalledWith({
+        confirmed: true,
+        verdict: "deny",
+        comment: "no longer needed",
+      });
+    });
+
+    it("shows the confirm button as disabled while no reason has been given", async () => {
+      await create("deny");
+
+      const confirm = fixture.nativeElement.querySelector("#pam-decide-dialog_button_confirm");
+      expect(confirm.getAttribute("aria-disabled")).toBe("true");
+
+      component["formGroup"].patchValue({ comment: "no longer needed" });
+      fixture.detectChanges();
+
+      expect(confirm.getAttribute("aria-disabled")).not.toBe("true");
+    });
+
+    it("treats a whitespace-only reason as no reason", async () => {
+      // `Validators.required` accepts "   ", so the trimmed value is what actually gates the button.
+      await create("deny");
+      component["formGroup"].patchValue({ comment: "   " });
+
+      expect(component["confirmDisabled"]()).toBe(true);
+
+      await component["confirm"]();
+      expect(close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("switching the approve variant to deny", () => {
+    it("re-titles and re-labels the dialog in place", async () => {
+      await create("approve");
+
+      component["switchToDeny"]();
+      fixture.detectChanges();
+
+      const text = fixture.nativeElement.textContent as string;
+      expect(text).toContain("pamDecideDenyTitle");
+      expect(text).not.toContain("pamDecideApproveTitle");
+      expect(text).toContain("pamDecideDenyReasonLabel");
+      expect(text).toContain("pamDecideDenyReasonRequired");
+      expect(text).not.toContain("pamInboxCommentLabel");
+    });
+
+    it("applies the deny variant's required reason", async () => {
+      await create("approve");
+      expect(component["confirmDisabled"]()).toBe(false);
+
+      component["switchToDeny"]();
+
+      expect(component["confirmDisabled"]()).toBe(true);
+      expect(component["formGroup"].controls.comment.invalid).toBe(true);
+    });
+
+    it("moves focus onto the reason field, which the removed button would otherwise strand", async () => {
+      await create("approve");
+
+      const switchButton = fixture.nativeElement.querySelector(
+        "#pam-decide-dialog_button_switch-to-deny",
+      ) as HTMLButtonElement;
+      switchButton.click();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector("#pam-decide-dialog_button_switch-to-deny")).toBe(
+        null,
+      );
+      expect(document.activeElement?.id).toBe("pam-decide-dialog_textarea_comment");
+    });
+
+    it("closes with deny, not the verdict it was opened on", async () => {
+      await create("approve");
+
+      component["switchToDeny"]();
+      component["formGroup"].patchValue({ comment: "wrong window" });
+      await component["confirm"]();
+
+      expect(close).toHaveBeenCalledWith({
+        confirmed: true,
+        verdict: "deny",
+        comment: "wrong window",
+      });
+    });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.stories.ts
@@ -21,11 +21,13 @@ const NOW = new Date("2026-08-17T12:00:00.000Z");
 function approvalRow(
   overrides: Record<string, unknown> = {},
   collectionName: string | null = "Production",
+  organizationName: string | null = "Meridian Group",
 ): ApprovalRow {
   const request = {
     id: "req-1",
     cipherId: "cipher-1",
     collectionId: "col-1",
+    organizationId: "org-1",
     requesterId: "user-1",
     status: "pending",
     leaseNotBefore: "2026-08-17T12:00:00.000Z",
@@ -44,6 +46,7 @@ function approvalRow(
       ...emptyResolvedNames(),
       cipherNameById: new Map([["cipher-1", "Prod database"]]),
       collectionNameById: collectionName ? new Map([["col-1", collectionName]]) : new Map(),
+      organizationNameById: organizationName ? new Map([["org-1", organizationName]]) : new Map(),
     },
     NOW,
     true,
@@ -82,7 +85,12 @@ export const Approve: Story = {
   decorators: [withParams({ verdict: "approve", row: approvalRow() })],
 };
 
-/** Denying: same summary and comment field, but the confirm button escalates to danger. */
+/**
+ * Denying: same summary, but the note becomes a required "Reason for denial" — so this opens with
+ * the confirm button already disabled — and that button escalates to danger. Reached either from
+ * the inbox's Deny button or from the approve variant's own "Deny request", which switches this
+ * dialog in place.
+ */
 export const Deny: Story = {
   decorators: [withParams({ verdict: "deny", row: approvalRow() })],
 };
@@ -92,14 +100,22 @@ export const NoReason: Story = {
   decorators: [withParams({ verdict: "approve", row: approvalRow({ reason: null }) })],
 };
 
-/** When the collection name did not resolve, its row is dropped rather than left blank. */
+/** When the collection name did not resolve, it is dropped from the item card rather than blank. */
 export const NoCollection: Story = {
   decorators: [withParams({ verdict: "approve", row: approvalRow({}, null) })],
 };
 
 /**
- * A long justification, to check the summary's `auto 1fr` grid wraps the value column instead of
- * stretching the dialog.
+ * An approver outside the owning organization resolves no name for it. Nothing is rendered — never
+ * the raw uuid, which would tell the approver less than the blank does.
+ */
+export const NoOrganization: Story = {
+  decorators: [withParams({ verdict: "approve", row: approvalRow({}, "Production", null) })],
+};
+
+/**
+ * A long justification, to check the read-only reason field contains it rather than stretching the
+ * dialog.
  */
 export const LongReason: Story = {
   decorators: [

--- a/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.ts
@@ -1,9 +1,22 @@
-import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
-import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  inject,
+  Injector,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
 
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import {
   AsyncActionsModule,
   ButtonModule,
+  CardComponent,
   DIALOG_DATA,
   DialogConfig,
   DialogModule,
@@ -15,26 +28,44 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import type { AccessDecisionVerdict } from "../../abstractions/access-lease";
+import { RequestSummaryComponent } from "../../request-summary/request-summary.component";
 import { ApprovalRow } from "../approval-row";
 
 export type DecideDialogParams = {
+  /** The verdict the inbox button asked for; the approver can still switch it here. */
   verdict: AccessDecisionVerdict;
   row: ApprovalRow;
+  /** The decrypted gated cipher, for the item card's favicon; absent when the approver cannot see it. */
+  cipher?: CipherViewLike;
 };
 
-/** Only an explicit confirm produces a result; every other way out closes with `undefined`. */
-export type DecideDialogResult = { confirmed: true; comment: string | undefined };
+/**
+ * Only an explicit confirm produces a result; every other way out closes with `undefined`.
+ *
+ * `verdict` is the one the approver landed on, which is NOT necessarily the one the dialog was
+ * opened with — the approve variant can be switched to deny in place. Callers must record this
+ * verdict rather than the one they passed.
+ */
+export type DecideDialogResult = {
+  confirmed: true;
+  verdict: AccessDecisionVerdict;
+  comment: string | undefined;
+};
 
 /**
- * Confirms an approve or deny and collects an optional comment.
+ * Confirms an approve or deny and collects the approver's note.
  *
- * A summary of what is being decided — requester, window, reason — is repeated here rather than
- * assumed remembered from the row behind the dialog, because approving the wrong request grants real
- * access to a real secret and the row that was clicked may already have scrolled out of view.
+ * A summary of what is being decided — item, requester, window, reason — is repeated here rather
+ * than assumed remembered from the row behind the dialog, because approving the wrong request
+ * grants real access to a real secret and the row that was clicked may already have scrolled out of
+ * view. It is rendered by the shared {@link RequestSummaryComponent}, the same one
+ * `/pam/requests/:id` uses, so the two surfaces cannot describe a request differently.
  *
- * The comment is optional on BOTH verdicts and trims to `undefined`, so a whitespace-only note is not
- * written to the audit log as if it said something. The dialog makes no API call: it returns the
- * decision and the caller records it, which keeps the retry-and-toast logic in one place.
+ * The verdict is dialog state, not a fixed parameter: the approve variant offers "Deny request",
+ * which switches this dialog to the deny variant instead of closing and reopening. Denying requires
+ * a reason; approving keeps the comment optional and trims a whitespace-only note to `undefined`,
+ * so it is not written to the audit log as if it said something. The dialog makes no API call: it
+ * returns the decision and the caller records it, which keeps the retry-and-toast logic in one place.
  */
 @Component({
   selector: "pam-decide-dialog",
@@ -43,16 +74,20 @@ export type DecideDialogResult = { confirmed: true; comment: string | undefined 
   imports: [
     AsyncActionsModule,
     ButtonModule,
+    CardComponent,
     DialogModule,
     FormFieldModule,
     ReactiveFormsModule,
     TypographyModule,
+    RequestSummaryComponent,
     I18nPipe,
   ],
 })
 export class DecideDialogComponent {
   private readonly dialogRef = inject<DialogRef<DecideDialogResult | undefined>>(DialogRef);
   private readonly formBuilder = inject(FormBuilder);
+  private readonly injector = inject(Injector);
+  private readonly commentField = viewChild<ElementRef<HTMLTextAreaElement>>("commentField");
   protected readonly params = inject<DecideDialogParams>(DIALOG_DATA);
 
   /**
@@ -61,16 +96,59 @@ export class DecideDialogComponent {
    */
   protected readonly formGroup = this.formBuilder.nonNullable.group({ comment: [""] });
 
-  protected readonly approve = this.params.verdict === "approve";
+  protected readonly verdict = signal<AccessDecisionVerdict>(this.params.verdict);
+  protected readonly approve = computed(() => this.verdict() === "approve");
   protected readonly row = this.params.row;
+  protected readonly cipher = this.params.cipher ?? null;
+
+  private readonly comment = toSignal(this.formGroup.controls.comment.valueChanges, {
+    initialValue: "",
+  });
+
+  /**
+   * `Validators.required` accepts a string of spaces, so the button is gated on the trimmed value
+   * as well — a denial whose only recorded reason is whitespace explains nothing to the requester.
+   */
+  protected readonly confirmDisabled = computed(
+    () => !this.approve() && this.comment().trim().length === 0,
+  );
+
+  constructor() {
+    this.applyVerdictValidators();
+  }
+
+  /**
+   * The button that triggers this lives inside the approve-only branch, so the click destroys the
+   * focused element and focus would otherwise fall to `<body>`. Focus moves after the re-render so
+   * the reason field is announced with the label and required state the switch just gave it.
+   */
+  protected switchToDeny(): void {
+    this.verdict.set("deny");
+    this.applyVerdictValidators();
+    afterNextRender(() => this.commentField()?.nativeElement.focus(), { injector: this.injector });
+  }
 
   protected readonly confirm = async (): Promise<void> => {
+    if (this.confirmDisabled()) {
+      return;
+    }
     const comment = this.formGroup.getRawValue().comment.trim();
     void this.dialogRef.close({
       confirmed: true,
+      verdict: this.verdict(),
       comment: comment.length > 0 ? comment : undefined,
     });
   };
+
+  private applyVerdictValidators(): void {
+    const control = this.formGroup.controls.comment;
+    if (this.approve()) {
+      control.removeValidators(Validators.required);
+    } else {
+      control.addValidators(Validators.required);
+    }
+    control.updateValueAndValidity();
+  }
 
   static open(
     dialogService: DialogService,

--- a/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/decide-dialog/decide-dialog.component.ts
@@ -62,7 +62,8 @@ export type DecideDialogResult = {
  * `/pam/requests/:id` uses, so the two surfaces cannot describe a request differently.
  *
  * The verdict is dialog state, not a fixed parameter: the approve variant offers "Deny request",
- * which switches this dialog to the deny variant instead of closing and reopening. Denying requires
+ * which switches this dialog to the deny variant instead of closing and reopening, discarding any
+ * note typed while approving so it cannot become the recorded denial reason. Denying requires
  * a reason; approving keeps the comment optional and trims a whitespace-only note to `undefined`,
  * so it is not written to the audit log as if it said something. The dialog makes no API call: it
  * returns the decision and the caller records it, which keeps the retry-and-toast logic in one place.
@@ -118,12 +119,18 @@ export class DecideDialogComponent {
   }
 
   /**
+   * A note typed while approving is cleared, not carried over: "Approved for the maintenance
+   * window" would arrive at the requester and the audit log as the reason they were denied, and a
+   * non-blank leftover leaves the confirm button already enabled, so the required-reason gate the
+   * deny variant exists to apply never engages.
+   *
    * The button that triggers this lives inside the approve-only branch, so the click destroys the
    * focused element and focus would otherwise fall to `<body>`. Focus moves after the re-render so
    * the reason field is announced with the label and required state the switch just gave it.
    */
   protected switchToDeny(): void {
     this.verdict.set("deny");
+    this.formGroup.controls.comment.reset("");
     this.applyVerdictValidators();
     afterNextRender(() => this.commentField()?.nativeElement.focus(), { injector: this.injector });
   }


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Aligns the approver's decide dialog with its Figma design (frames `2141:27281` approve,
`2172:27924` deny) and switches its summary over to the shared `pam-request-summary` component.

- Denying now requires a reason. The confirm button is disabled until a non-whitespace one is
  entered. Approving keeps the comment optional and trims a blank note to `undefined`.
- The approve variant offers "Deny request", which switches the dialog in place rather than
  closing and reopening: it re-titles, relabels the field and applies `Validators.required`, then
  moves focus onto the reason field.
- Because of that, `DecideDialogResult` now carries the `verdict` the approver landed on, and
  `approvals-tab.component.ts` records `result.verdict` instead of the verdict it opened with.
  Recording the opened verdict would approve a request the approver denied.
- Copy: adds `pamDecideAdditionalInformation`, `pamDecideCommentAuditHint` and the
  `pamDecideDenyReason*` keys; removes `pamDecideCommentHint`, `pamInboxConfirmApprove` and
  `pamInboxConfirmDeny`.

Top of a 3-PR stack, based on `pam/pam-request-summary`.

## 📸 Screenshots

Captured at 1440x1024 from Storybook, before on `pam/uat` and after on this branch.

### Decide dialog, approve

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/3d269bfa7511b98cd6683cb281c13df6/raw/decide-dialog-design-align-before-approve-dialog.png" alt="before-approve-dialog" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/3d269bfa7511b98cd6683cb281c13df6/raw/decide-dialog-design-align-after-approve-dialog.png" alt="after-approve-dialog" width="460"> |

### Decide dialog, deny

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/3d269bfa7511b98cd6683cb281c13df6/raw/decide-dialog-design-align-before-deny-dialog.png" alt="before-deny-dialog" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/3d269bfa7511b98cd6683cb281c13df6/raw/decide-dialog-design-align-after-deny-dialog.png" alt="after-deny-dialog" width="460"> |

### Request detail page

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/3d269bfa7511b98cd6683cb281c13df6/raw/decide-dialog-design-align-before-request-detail.png" alt="before-request-detail" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/3d269bfa7511b98cd6683cb281c13df6/raw/decide-dialog-design-align-after-request-detail.png" alt="after-request-detail" width="460"> |
