### PR TITLE
feat(pam): resolve the owning organization's name for access requests

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-name-resolver.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-name-resolver.service.spec.ts
@@ -2,7 +2,9 @@ import { TestBed } from "@angular/core/testing";
 import { BehaviorSubject, of } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { UserId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
@@ -20,17 +22,23 @@ function collectionViews(entries: Array<[string, string]>): CollectionView[] {
   return entries.map(([id, name]) => ({ id, name })) as unknown as CollectionView[];
 }
 
+function organizations(entries: Array<[string, string]>): Organization[] {
+  return entries.map(([id, name]) => ({ id, name })) as unknown as Organization[];
+}
+
 describe("AccessNameResolverService", () => {
   let service: AccessNameResolverService;
   // Narrowed to the one method the service calls, so the mock says exactly what it depends on.
   let cipherService: jest.Mocked<Pick<CipherService, "getAllDecryptedForIdsIncludingPartials">>;
   let collections$: BehaviorSubject<CollectionView[]>;
+  let organizations$: BehaviorSubject<Organization[]>;
 
   beforeEach(() => {
     cipherService = {
       getAllDecryptedForIdsIncludingPartials: jest.fn().mockResolvedValue([]),
     } as jest.Mocked<Pick<CipherService, "getAllDecryptedForIdsIncludingPartials">>;
     collections$ = new BehaviorSubject<CollectionView[]>([]);
+    organizations$ = new BehaviorSubject<Organization[]>([]);
 
     TestBed.configureTestingModule({
       providers: [
@@ -38,6 +46,7 @@ describe("AccessNameResolverService", () => {
         { provide: AccountService, useValue: { activeAccount$: of({ id: USER_ID }) } },
         { provide: CipherService, useValue: cipherService },
         { provide: CollectionService, useValue: { decryptedCollections$: () => collections$ } },
+        { provide: OrganizationService, useValue: { organizations$: () => organizations$ } },
       ],
     });
     service = TestBed.inject(AccessNameResolverService);
@@ -56,6 +65,26 @@ describe("AccessNameResolverService", () => {
     ]);
     expect(names.cipherNameById.get("cipher-1")).toBe("Prod database");
     expect(names.collectionNameById.get("col-1")).toBe("Production");
+  });
+
+  it("keys every organization the caller belongs to, since a ref carries no organization id", async () => {
+    organizations$.next(
+      organizations([
+        ["org-1", "Meridian Group"],
+        ["org-2", "Northwind"],
+      ]),
+    );
+
+    const names = await service.resolveNames([{ cipherId: "cipher-1", collectionId: "col-1" }]);
+
+    expect(names.organizationNameById.get("org-1")).toBe("Meridian Group");
+    expect(names.organizationNameById.get("org-2")).toBe("Northwind");
+  });
+
+  it("leaves an organization the caller does not belong to absent", async () => {
+    const names = await service.resolveNames([{ cipherId: "cipher-1", collectionId: "col-1" }]);
+
+    expect(names.organizationNameById.get("org-9")).toBeUndefined();
   });
 
   it("resolves names for PAM-gated (partial) ciphers", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-name-resolver.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-name-resolver.service.ts
@@ -2,31 +2,56 @@ import { Injectable, inject } from "@angular/core";
 import { firstValueFrom } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 
+import type { AccessRequestView } from "../abstractions/access-lease";
+
 /**
- * Cipher + collection display names (and the decrypted cipher views, for the item favicon)
- * resolved from local vault state, keyed by the raw (string) id. All three maps hold only what
+ * Cipher + collection + organization display names (and the decrypted cipher views, for the item
+ * favicon) resolved from local vault state, keyed by the raw (string) id. Every map holds only what
  * this client could resolve; a missing entry means the id isn't in the caller's local vault (or
- * collection state wasn't warm), and callers fall back to the raw id / render no favicon.
+ * collection state wasn't warm), and callers fall back to the raw id / render nothing.
  */
 export type ResolvedNames = {
   cipherNameById: Map<string, string>;
   collectionNameById: Map<string, string>;
+  organizationNameById: Map<string, string>;
   /** The decrypted cipher views themselves, keyed by id — the source for favicon rendering. */
   cipherById: Map<string, CipherView>;
 };
 
 /** An empty name lookup — the graceful default before a vault snapshot resolves. */
 export function emptyResolvedNames(): ResolvedNames {
-  return { cipherNameById: new Map(), collectionNameById: new Map(), cipherById: new Map() };
+  return {
+    cipherNameById: new Map(),
+    collectionNameById: new Map(),
+    organizationNameById: new Map(),
+    cipherById: new Map(),
+  };
 }
 
 /**
- * One-shot cipher + collection display-name (and favicon) lookup for the "My access" page and its
+ * The owning organization's display name for a request, or null when the server omitted the id or
+ * the caller's membership does not name it. Never the raw uuid — an organization id tells an
+ * approver nothing, so the surfaces render nothing at all rather than a meaningless pill.
+ */
+export function organizationNameFor(
+  request: Pick<AccessRequestView, "organizationId">,
+  names: ResolvedNames,
+): string | null {
+  const organizationId = request.organizationId;
+  return organizationId == null
+    ? null
+    : (names.organizationNameById.get(uuidAsString(organizationId)) ?? null);
+}
+
+/**
+ * One-shot cipher + collection + organization display-name (and favicon) lookup for the "My access" page and its
  * request-detail route, resolved from local vault state. An access-rule-gated cipher syncs to the
  * vault of anyone who requested it as a partial {@link CipherView} (name already decrypted by
  * {@link CipherService}), and its collection as a {@link CollectionView} — so names and the view
@@ -46,11 +71,12 @@ export class AccessNameResolverService {
   private readonly accountService = inject(AccountService);
   private readonly cipherService = inject(CipherService);
   private readonly collectionService = inject(CollectionService);
+  private readonly organizationService = inject(OrganizationService);
 
   /**
-   * Resolve cipher and collection display names (and cipher views) for the given refs from local
-   * vault state. Unresolvable ids (not in the caller's vault, or collection state not yet warm)
-   * are simply absent from the returned maps — callers fall back to the raw id.
+   * Resolve cipher, collection and organization display names (and cipher views) for the given refs
+   * from local vault state. Unresolvable ids (not in the caller's vault, or collection state not yet
+   * warm) are simply absent from the returned maps — callers fall back to the raw id.
    */
   async resolveNames(
     refs: ReadonlyArray<{ cipherId: string; collectionId: string }>,
@@ -60,14 +86,20 @@ export class AccessNameResolverService {
     }
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
     const cipherIds = [...new Set(refs.map((ref) => ref.cipherId))];
-    const [cipherViews, collections] = await Promise.all([
+    // Organizations are keyed off the caller's whole membership rather than the refs, because a ref
+    // carries no organization id — the requests do, and they are joined against this map by id.
+    const [cipherViews, collections, organizations] = await Promise.all([
       this.cipherService.getAllDecryptedForIdsIncludingPartials(userId, cipherIds),
       firstValueFrom(this.collectionService.decryptedCollections$(userId)),
+      firstValueFrom(this.organizationService.organizations$(userId)),
     ]);
     return {
       cipherNameById: new Map(cipherViews.map((view) => [view.id, view.name])),
       collectionNameById: new Map(
         collections.map((collection) => [collection.id, collection.name]),
+      ),
+      organizationNameById: new Map(
+        organizations.map((organization) => [organization.id, organization.name]),
       ),
       cipherById: new Map(cipherViews.map((view) => [view.id, view])),
     };

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approval-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approval-row.spec.ts
@@ -10,6 +10,7 @@ function request(overrides: Record<string, unknown> = {}): AccessRequestView {
     id: "req-1",
     cipherId: "cipher-1",
     collectionId: "col-1",
+    organizationId: "org-1",
     requesterId: "user-1",
     status: "pending",
     leaseNotBefore: "2026-08-17T12:00:00.000Z",
@@ -28,6 +29,7 @@ function names(overrides: Partial<ResolvedNames> = {}): ResolvedNames {
     ...emptyResolvedNames(),
     cipherNameById: new Map([["cipher-1", "Prod database"]]),
     collectionNameById: new Map([["col-1", "Production"]]),
+    organizationNameById: new Map([["org-1", "Meridian Group"]]),
     ...overrides,
   };
 }
@@ -46,6 +48,17 @@ describe("toApprovalRow", () => {
 
     expect(row.cipherName).toBe("cipher-1");
     expect(row.collectionName).toBeNull();
+  });
+
+  it("resolves the owning organization's name", () => {
+    expect(toApprovalRow(request(), names(), NOW, true).organizationName).toBe("Meridian Group");
+  });
+
+  it("leaves the organization null rather than exposing its raw id", () => {
+    expect(toApprovalRow(request(), emptyResolvedNames(), NOW, true).organizationName).toBeNull();
+    expect(
+      toApprovalRow(request({ organizationId: undefined }), names(), NOW, true).organizationName,
+    ).toBeNull();
   });
 
   it("prefers the requester's name, falling back to their email", () => {

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approval-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approval-row.ts
@@ -1,7 +1,10 @@
 import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 
 import type { AccessRequestId, AccessRequestView } from "../abstractions/access-lease";
-import { ResolvedNames } from "../access-requests/access-name-resolver.service";
+import {
+  ResolvedNames,
+  organizationNameFor,
+} from "../access-requests/access-name-resolver.service";
 import { ElapsedLabel, elapsedLabel } from "../date/elapsed";
 import {
   durationLabel,
@@ -31,6 +34,8 @@ export type ApprovalRow = {
   /** The gated cipher's display name, falling back to its raw id when it isn't in the local vault. */
   cipherName: string;
   collectionName: string | null;
+  /** The owning organization's display name, or null when the request or the lookup lacks it. */
+  organizationName: string | null;
   /** The requester's name, falling back to their email, then empty when the server resolved neither. */
   requester: string;
   requesterEmail: string | null;
@@ -65,6 +70,7 @@ export function toApprovalRow(
   const collectionId = uuidAsString(request.collectionId);
   const cipherName = names.cipherNameById.get(cipherId) ?? cipherId;
   const collectionName = names.collectionNameById.get(collectionId) ?? null;
+  const organizationName = organizationNameFor(request, names);
   const requester = request.requesterName || request.requesterEmail || "";
 
   return {
@@ -74,6 +80,7 @@ export function toApprovalRow(
     collectionId,
     cipherName,
     collectionName,
+    organizationName,
     requester,
     requesterEmail: request.requesterEmail ?? null,
     submittedAtMs: Date.parse(request.submittedAt),

--- a/bitwarden_license/bit-web/src/app/pam/testing/story-fixtures.ts
+++ b/bitwarden_license/bit-web/src/app/pam/testing/story-fixtures.ts
@@ -64,6 +64,7 @@ export function accessRequest(overrides: Record<string, unknown> = {}): AccessRe
     id: "req-1",
     cipherId: "cipher-1",
     collectionId: "col-1",
+    organizationId: "org-1",
     requesterId: "user-1",
     requesterName: "Grace Hopper",
     requesterEmail: "grace@example.com",
@@ -130,6 +131,7 @@ export function storyNames(): ResolvedNames {
       ["col-1", "Production"],
       ["col-2", "Payments"],
     ]),
+    organizationNameById: new Map([["org-1", "Meridian Group"]]),
     cipherById: new Map([
       ["cipher-1", cipherView("cipher-1", "Prod database")],
       ["cipher-2", cipherView("cipher-2", "Payments API key")],


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Resolves the owning organization's display name for PAM access requests, so the surfaces that
describe a request can name the organization it belongs to.

- `AccessNameResolverService` now also returns an `organizationNameById` map, plus an
  `organizationNameFor(request, names)` helper.
- Organizations are keyed off the caller's whole membership rather than off the passed refs,
  because an access-request ref carries no organization id. The requests do, and they are joined
  against the map by id.
- An unresolved organization stays `null` and renders nothing. It is never the raw uuid, which
  would tell an approver less than a blank does.
- `ApprovalRow` gains `organizationName`. Nothing renders it yet.

Bottom of a 3-PR stack, based on `pam/uat`. The consumers land in
`pam/pam-request-summary` and `pam/decide-dialog-design-align`.

## 📸 Screenshots

N/A, no visual change.
