### PR TITLE
feat(pam): share one request summary between the dialog and the detail page

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17339,6 +17339,9 @@
   "pamInboxReasonMissing": {
     "message": "No reason provided"
   },
+  "pamAccessRequestedLabel": {
+    "message": "Access requested"
+  },
   "pamInboxRequester": {
     "message": "Requester"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.html
@@ -3,99 +3,38 @@
 @if (loading() && request() == null && !notFound() && !loadError()) {
   <p bitTypography="body1" class="tw-text-muted">{{ "loading" | i18n }}</p>
 } @else if (request(); as r) {
-  <bit-section>
-    <bit-section-header>
-      <h2 bitTypography="h4">{{ "pamAccessRequestDetailsTitle" | i18n }}</h2>
-    </bit-section-header>
-
-    <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-3">
-      <!-- Item -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnItem" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">
-          <div class="tw-flex tw-items-center tw-gap-3">
-            @if (cipherFor(r.cipherId); as cipher) {
-              <app-vault-icon [cipher]="cipher" />
-            } @else {
-              <bit-icon name="bwi-key" class="tw-text-muted" [fixedWidth]="true"></bit-icon>
-            }
-            <div>
-              <div>{{ cipherName() }}</div>
-              @if (collectionName(); as collection) {
-                <div class="tw-text-xs tw-text-muted">
-                  {{ "pamInboxInCollection" | i18n: collection }}
-                </div>
-              }
-            </div>
-          </div>
-        </dd>
-      </div>
-
-      <!-- Status -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnStatus" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">
-          @if (badge()?.badgeState; as state) {
-            <app-pam-access-state-badge [state]="state" />
-          } @else if (badge()?.statusBadge; as b) {
-            <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
-          }
-        </dd>
-      </div>
-
-      <!-- Requester -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamInboxRequester" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">{{ requesterDisplay() }}</dd>
-      </div>
-
-      <!-- Requested window -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnRequestedWindow" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">
-          <span [bitTooltip]="exactWindowText()">
-            @if (duration(); as d) {
-              {{ d.key | i18n: d.value }}
-            }
-            @if (start(); as s) {
-              <span class="tw-text-muted">&nbsp;·&nbsp;{{ s.key | i18n: s.value }}</span>
-            }
-          </span>
-          <div class="tw-text-xs tw-text-muted">
-            {{ r.leaseNotBefore | date: "short" }} &ndash; {{ r.leaseNotAfter | date: "short" }}
-          </div>
-        </dd>
-      </div>
-
-      <!-- Reason -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamInboxReason" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">
-          @if (reason()) {
-            {{ reason() }}
-          } @else {
-            <span class="tw-italic tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
-          }
-        </dd>
-      </div>
-
-      <!-- Submitted -->
-      <div class="tw-flex tw-gap-4">
-        <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnSubmitted" | i18n }}</dt>
-        <dd class="tw-m-0 tw-flex-1">{{ r.submittedAt | date: "medium" }}</dd>
-      </div>
-
-      <!-- Resolved -->
-      @if (r.resolvedAt) {
-        <div class="tw-flex tw-gap-4">
-          <dt class="tw-w-40 tw-shrink-0 tw-font-bold">{{ "pamColumnResolved" | i18n }}</dt>
-          <dd class="tw-m-0 tw-flex-1">{{ r.resolvedAt | date: "medium" }}</dd>
-        </div>
+  <pam-request-summary
+    data-testid="request-detail-summary"
+    [cipher]="cipherFor(r.cipherId) ?? null"
+    [itemName]="cipherName() ?? ''"
+    [organizationName]="organizationName()"
+    [collectionName]="collectionName()"
+    [requesterName]="requesterDisplay() ?? ''"
+    [requesterEmail]="requesterEmail()"
+    [duration]="duration()"
+    [relativeStart]="start()"
+    [exactWindow]="exactWindowText()"
+    [reason]="reason()"
+  >
+    <pam-summary-field [label]="'pamColumnStatus' | i18n">
+      @if (badge()?.badgeState; as state) {
+        <app-pam-access-state-badge [state]="state" />
+      } @else if (badge()?.statusBadge; as b) {
+        <span bitBadge [variant]="b.variant">{{ b.labelKey | i18n }}</span>
       }
-    </dl>
-  </bit-section>
+    </pam-summary-field>
 
-  <!-- Lease -->
+    <pam-summary-field [label]="'pamColumnSubmitted' | i18n">
+      {{ r.submittedAt | date: "medium" }}
+    </pam-summary-field>
+
+    @if (r.resolvedAt) {
+      <pam-summary-field [label]="'pamColumnResolved' | i18n">
+        {{ r.resolvedAt | date: "medium" }}
+      </pam-summary-field>
+    }
+  </pam-request-summary>
+
   @if (r.producedLeaseId) {
     <bit-section>
       <bit-section-header>
@@ -122,7 +61,6 @@
     </bit-section>
   }
 
-  <!-- Decision log -->
   @if (decisions().length > 0) {
     <bit-section>
       <bit-section-header>
@@ -164,7 +102,6 @@
     </bit-section>
   }
 
-  <!-- Actions -->
   <div class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
     @if (canStart()) {
       <button

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.spec.ts
@@ -26,6 +26,7 @@ function request(overrides: Record<string, unknown> = {}): AccessRequestView {
     id: "req-1",
     cipherId: "cipher-1",
     collectionId: "col-1",
+    organizationId: "org-1",
     requesterId: "user-1",
     status: "pending",
     leaseNotBefore: new Date().toISOString(),
@@ -74,6 +75,7 @@ describe("AccessRequestRouteComponent", () => {
         ...emptyResolvedNames(),
         cipherNameById: new Map([["cipher-1", "Prod database"]]),
         collectionNameById: new Map([["col-1", "Production"]]),
+        organizationNameById: new Map([["org-1", "Meridian Group"]]),
       }),
       cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
       cancel: jest.fn().mockResolvedValue(undefined),
@@ -146,6 +148,40 @@ describe("AccessRequestRouteComponent", () => {
 
       expect(component["cipherName"]()).toBe("cipher-1");
       expect(component["collectionName"]()).toBeNull();
+    });
+
+    it("resolves the owning organization's name, and nothing when it is unknown", () => {
+      create();
+      expect(component["organizationName"]()).toBe("Meridian Group");
+
+      detail.names$.next(emptyResolvedNames());
+      expect(component["organizationName"]()).toBeNull();
+    });
+
+    it("keeps Status, Submitted and Resolved beside the shared request-details rows", () => {
+      detail.request$.next(request({ status: "denied", resolvedAt: new Date().toISOString() }));
+
+      create();
+
+      const details = fixture.nativeElement.querySelector(
+        '[data-testid="request-summary-details"]',
+      ) as HTMLElement;
+      expect(details.textContent).toContain("pamColumnStatus");
+      expect(details.textContent).toContain("pamColumnSubmitted");
+      expect(details.textContent).toContain("pamColumnResolved");
+    });
+
+    it("renders each shared row exactly once, not alongside the page's old list", () => {
+      create();
+
+      const text = fixture.nativeElement.textContent as string;
+      expect(text.split("pamInboxRequester").length - 1).toBe(1);
+      expect(
+        fixture.nativeElement.querySelectorAll("#pam-request-summary_input_reason"),
+      ).toHaveLength(1);
+      expect(
+        fixture.nativeElement.querySelectorAll("#pam-request-summary_input_access-requested"),
+      ).toHaveLength(1);
     });
 
     it("identifies the requester by name, then email, then id", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/access-request-route/access-request-route.component.ts
@@ -13,7 +13,6 @@ import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { RouterModule } from "@angular/router";
 import { filter } from "rxjs";
 
-import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
@@ -22,12 +21,10 @@ import {
   BadgeComponent,
   ButtonModule,
   DialogService,
-  IconModule,
   NoItemsModule,
   SectionComponent,
   SectionHeaderComponent,
   ToastService,
-  TooltipDirective,
   TypographyModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -43,7 +40,9 @@ import {
 } from "../..";
 import { AccessStateBadgeComponent } from "../../access-state-badge/access-state-badge.component";
 import { RemainingTimePipe } from "../../date/remaining-time.pipe";
-import { emptyResolvedNames } from "../access-name-resolver.service";
+import { RequestSummaryComponent } from "../../request-summary/request-summary.component";
+import { SummaryFieldComponent } from "../../request-summary/summary-field.component";
+import { emptyResolvedNames, organizationNameFor } from "../access-name-resolver.service";
 import { historyDisplayStatus } from "../my-access-row";
 
 import { AccessRequestDetailService } from "./access-request-detail.service";
@@ -88,14 +87,13 @@ const DECISION_LABEL_KEYS = {
     AccessStateBadgeComponent,
     BadgeComponent,
     ButtonModule,
-    IconModule,
-    IconComponent,
     NoItemsModule,
     SectionComponent,
     SectionHeaderComponent,
-    TooltipDirective,
     TypographyModule,
     RemainingTimePipe,
+    RequestSummaryComponent,
+    SummaryFieldComponent,
   ],
 })
 export class AccessRequestRouteComponent implements OnInit {
@@ -130,6 +128,12 @@ export class AccessRequestRouteComponent implements OnInit {
     return request == null
       ? null
       : (this.names().collectionNameById.get(collectionId(request)) ?? null);
+  });
+
+  /** Owning organization's name resolved from the caller's membership; null when unknown. */
+  protected readonly organizationName = computed(() => {
+    const request = this.request();
+    return request == null ? null : organizationNameFor(request, this.names());
   });
 
   /** Ticks once a second so the lease / redemption countdowns stay live. */
@@ -171,6 +175,8 @@ export class AccessRequestRouteComponent implements OnInit {
       ? null
       : request.requesterName || request.requesterEmail || uuidAsString(request.requesterId);
   });
+
+  protected readonly requesterEmail = computed(() => this.request()?.requesterEmail ?? null);
 
   /** The recorded decisions as a view model, oldest first (as the server returns them). */
   protected readonly decisions = computed(() => {

--- a/bitwarden_license/bit-web/src/app/pam/request-summary/request-summary.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/request-summary/request-summary.component.html
@@ -1,0 +1,75 @@
+<bit-card class="tw-mb-4" data-testid="request-summary-item">
+  <div class="tw-flex tw-items-center tw-gap-3">
+    @if (cipher(); as itemCipher) {
+      <app-vault-icon [cipher]="itemCipher" [size]="32" />
+    } @else {
+      <bit-icon name="bwi-key" class="tw-text-muted" [fixedWidth]="true"></bit-icon>
+    }
+    <span bitTypography="body1" class="tw-font-bold">{{ itemName() }}</span>
+  </div>
+
+  @if (organizationName() || collectionName()) {
+    <div class="tw-mt-3 tw-flex tw-flex-wrap tw-items-center tw-gap-x-6 tw-gap-y-1 tw-text-sm">
+      @if (organizationName(); as organization) {
+        <span class="tw-flex tw-items-center tw-gap-2">
+          <bit-icon
+            name="bwi-business"
+            class="tw-text-muted"
+            [ariaLabel]="'organization' | i18n"
+            [fixedWidth]="true"
+          ></bit-icon>
+          {{ organization }}
+        </span>
+      }
+      @if (collectionName(); as collection) {
+        <span class="tw-flex tw-items-center tw-gap-2">
+          <bit-icon
+            name="bwi-collection"
+            class="tw-text-muted"
+            [ariaLabel]="'collection' | i18n"
+            [fixedWidth]="true"
+          ></bit-icon>
+          {{ collection }}
+        </span>
+      }
+    </div>
+  }
+</bit-card>
+
+<h2 bitTypography="h6" class="tw-mb-2">{{ "pamAccessRequestDetailsTitle" | i18n }}</h2>
+
+<bit-card class="tw-mb-4" data-testid="request-summary-details">
+  <div class="tw-flex tw-flex-col tw-gap-4">
+    <pam-summary-field [label]="'pamInboxRequester' | i18n">
+      {{ requesterName() }}
+      @if (secondaryEmail(); as email) {
+        <span class="tw-text-fg-body-subtle">&lt;{{ email }}&gt;</span>
+      }
+    </pam-summary-field>
+
+    <bit-form-field disableMargin>
+      <bit-label>{{ "pamAccessRequestedLabel" | i18n }}</bit-label>
+      <input
+        bitInput
+        readonly
+        id="pam-request-summary_input_access-requested"
+        [title]="exactWindow()"
+        [value]="accessRequested()"
+      />
+    </bit-form-field>
+
+    <bit-form-field disableMargin>
+      <bit-label>{{ "pamInboxRequestReasonLabel" | i18n }}</bit-label>
+      <textarea
+        bitInput
+        readonly
+        rows="1"
+        id="pam-request-summary_input_reason"
+        [value]="quotedReason()"
+        [placeholder]="'pamInboxReasonMissing' | i18n"
+      ></textarea>
+    </bit-form-field>
+
+    <ng-content></ng-content>
+  </div>
+</bit-card>

--- a/bitwarden_license/bit-web/src/app/pam/request-summary/request-summary.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/request-summary/request-summary.component.spec.ts
@@ -1,0 +1,137 @@
+import { ChangeDetectionStrategy, Component, signal } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { RequestSummaryComponent } from "./request-summary.component";
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RequestSummaryComponent],
+  template: `
+    <pam-request-summary
+      [itemName]="itemName()"
+      [organizationName]="organizationName()"
+      [collectionName]="collectionName()"
+      [requesterName]="requesterName()"
+      [requesterEmail]="requesterEmail()"
+      [duration]="{ key: 'pamInboxDuration1Hour', value: null }"
+      [relativeStart]="{ key: 'pamInboxStartTomorrow', value: null }"
+      [reason]="reason()"
+    >
+      <div data-testid="host-row">Resolved</div>
+    </pam-request-summary>
+  `,
+})
+class HostComponent {
+  readonly itemName = signal("Prod database");
+  readonly organizationName = signal<string | null>("Meridian Group");
+  readonly collectionName = signal<string | null>("Production");
+  readonly requesterName = signal("Grace Hopper");
+  readonly requesterEmail = signal<string | null>("grace@example.com");
+  readonly reason = signal<string | null>("prod incident");
+}
+
+describe("RequestSummaryComponent", () => {
+  let fixture: ComponentFixture<HostComponent>;
+
+  function card(name: "item" | "details"): HTMLElement {
+    return fixture.nativeElement.querySelector(`[data-testid="request-summary-${name}"]`);
+  }
+
+  function fieldValue(id: string): string {
+    return (fixture.nativeElement.querySelector(`#${id}`) as HTMLInputElement).value;
+  }
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [
+        {
+          provide: I18nService,
+          useValue: { t: (key: string, ...args: unknown[]) => [key, ...args].join(" ").trim() },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+  });
+
+  it("puts the item, its organization and its collection in the item card", () => {
+    expect(card("item").textContent).toContain("Prod database");
+    expect(card("item").textContent).toContain("Meridian Group");
+    expect(card("item").textContent).toContain("Production");
+    expect(card("item").querySelector(".bwi-business")).not.toBeNull();
+    expect(card("item").querySelector(".bwi-collection")).not.toBeNull();
+  });
+
+  it("says which of the two item-card names is the organization and which is the collection", () => {
+    expect(card("item").querySelector(".bwi-business")!.getAttribute("aria-label")).toBe(
+      "organization",
+    );
+    expect(card("item").querySelector(".bwi-collection")!.getAttribute("aria-label")).toBe(
+      "collection",
+    );
+  });
+
+  it("names the collection only in the item card, never as a request-details row", () => {
+    expect(card("details").textContent).not.toContain("Production");
+  });
+
+  it("renders nothing at all for names that did not resolve", () => {
+    fixture.componentInstance.organizationName.set(null);
+    fixture.componentInstance.collectionName.set(null);
+    fixture.detectChanges();
+
+    expect(card("item").querySelector(".bwi-business")).toBeNull();
+    expect(card("item").querySelector(".bwi-collection")).toBeNull();
+  });
+
+  it("shows the requester's name with their email beside it", () => {
+    expect(card("details").textContent).toContain("Grace Hopper");
+    expect(card("details").textContent).toContain("<grace@example.com>");
+  });
+
+  it("does not repeat the email when it is already standing in for the name", () => {
+    fixture.componentInstance.requesterName.set("grace@example.com");
+    fixture.detectChanges();
+
+    expect(card("details").textContent).not.toContain("<grace@example.com>");
+  });
+
+  it("joins the window's duration and start into one requested-access line", () => {
+    expect(fieldValue("pam-request-summary_input_access-requested")).toBe(
+      "pamInboxDuration1Hour, pamInboxStartTomorrow",
+    );
+  });
+
+  it("quotes the reason", () => {
+    expect(fieldValue("pam-request-summary_input_reason")).toBe("“prod incident”");
+  });
+
+  it("wraps a long reason rather than clipping it to a single line", () => {
+    fixture.componentInstance.reason.set("x".repeat(400));
+    fixture.detectChanges();
+
+    const reason = fixture.nativeElement.querySelector("#pam-request-summary_input_reason");
+    expect(reason.tagName).toBe("TEXTAREA");
+    expect(reason.value).toContain("x".repeat(400));
+  });
+
+  it("leaves the reason field empty, with placeholder copy, when none was given", () => {
+    fixture.componentInstance.reason.set(null);
+    fixture.detectChanges();
+
+    const reason = fixture.nativeElement.querySelector(
+      "#pam-request-summary_input_reason",
+    ) as HTMLInputElement;
+    expect(reason.value).toBe("");
+    expect(reason.placeholder).toContain("pamInboxReasonMissing");
+  });
+
+  it("projects the host's extra rows into the request-details card", () => {
+    expect(card("details").querySelector('[data-testid="host-row"]')).not.toBeNull();
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/request-summary/request-summary.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/request-summary/request-summary.component.ts
@@ -1,0 +1,82 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input } from "@angular/core";
+
+import { IconComponent as VaultIconComponent } from "@bitwarden/angular/vault/components/icon.component";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import {
+  CardComponent,
+  FormFieldModule,
+  IconModule,
+  TypographyModule,
+} from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+import type { LabelValue } from "../helpers/approval-window";
+
+import { SummaryFieldComponent } from "./summary-field.component";
+
+/**
+ * The item + "Request details" cards shared by the approver's decide dialog and the requester's
+ * `/pam/requests/:id` page, so the two surfaces cannot describe the same request differently.
+ *
+ * Purely presentational: every value arrives already resolved and already reduced to an i18n
+ * `{ key, value }` pair by the shared `helpers/approval-window` builders. It resolves nothing and
+ * injects no data service, which is what lets the dialog feed it straight off an `ApprovalRow`
+ * while the detail page feeds it off the values it already computes.
+ *
+ * Fields only one surface carries — Status, Submitted, Resolved — are projected through the
+ * `<ng-content>` slot inside the request-details card rather than added as inputs, so they land in
+ * the same card instead of growing a fourth one.
+ */
+@Component({
+  selector: "pam-request-summary",
+  templateUrl: "./request-summary.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CardComponent,
+    FormFieldModule,
+    IconModule,
+    TypographyModule,
+    SummaryFieldComponent,
+    VaultIconComponent,
+    I18nPipe,
+  ],
+})
+export class RequestSummaryComponent {
+  private readonly i18nService = inject(I18nService);
+
+  /** The decrypted gated cipher, for the favicon; null falls back to a generic key icon. */
+  readonly cipher = input<CipherViewLike | null>(null);
+  readonly itemName = input.required<string>();
+  readonly organizationName = input<string | null>(null);
+  readonly collectionName = input<string | null>(null);
+  readonly requesterName = input.required<string>();
+  readonly requesterEmail = input<string | null>(null);
+  readonly duration = input<LabelValue | null>(null);
+  readonly relativeStart = input<LabelValue | null>(null);
+  /** The fully-formatted window, shown on hover behind the coarse "4 hours, tomorrow" label. */
+  readonly exactWindow = input<string>("");
+  readonly reason = input<string | null>(null);
+
+  /**
+   * Suppressed when the requester has no name, because `requesterName` already falls back to the
+   * email — rendering both would read "grace@example.com <grace@example.com>".
+   */
+  protected readonly secondaryEmail = computed(() => {
+    const email = this.requesterEmail();
+    return email == null || email === this.requesterName() ? null : email;
+  });
+
+  /** "4 hours, starting tomorrow" — the two window labels the shared helpers produce, joined once. */
+  protected readonly accessRequested = computed(() =>
+    [this.duration(), this.relativeStart()]
+      .filter((label): label is LabelValue => label != null)
+      .map((label) => this.i18nService.t(label.key, label.value ?? undefined))
+      .join(", "),
+  );
+
+  protected readonly quotedReason = computed(() => {
+    const reason = this.reason();
+    return reason == null ? "" : `“${reason}”`;
+  });
+}

--- a/bitwarden_license/bit-web/src/app/pam/request-summary/summary-field.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/request-summary/summary-field.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+
+/**
+ * One label-over-value row of the request-details card, for a value a read-only `bit-form-field`
+ * cannot carry: that renders its value through a projected `input`/`select`/`textarea`
+ * (`libs/components/src/input/input.directive.ts`), so it is a single text run and cannot hold the
+ * design's two-tone name-then-email or a status badge. The label styling is copied from
+ * `bit-form-field` so a row like this cannot drift from the read-only fields beside it.
+ */
+@Component({
+  selector: "pam-summary-field",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: "tw-flex tw-flex-col" },
+  template: `
+    <span class="tw-text-sm/5 tw-font-medium">{{ label() }}</span>
+    <span class="tw-px-1 tw-text-sm/5"><ng-content /></span>
+  `,
+})
+export class SummaryFieldComponent {
+  readonly label = input.required<string>();
+}


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Extracts the request summary into a shared `pam-request-summary` component (plus a small
`pam-summary-field` row) and adopts it on the requester-facing `/pam/requests/:id` page, so that
page and the approver's decide dialog cannot describe the same request differently.

- The detail route drops its bespoke `<dl>` and projects its own Status, Submitted and Resolved
  rows into the shared "Request details" card through `<ng-content>`.
- The item card shows the organization name resolved by the PR below.
- The request reason is a read-only `<textarea rows="1">`, so a paragraph-length justification
  wraps instead of clipping to one line.
- Behaviour change: the exact `leaseNotBefore`/`leaseNotAfter` range is no longer printed as
  visible text. It stays available on hover via the field's `title`, matching the dialog.
- Adds one key, `pamAccessRequestedLabel`.

Middle of a 3-PR stack, based on `pam/pam-org-name-resolution`. The decide dialog adopts the same
component in `pam/decide-dialog-design-align`.

## 📸 Screenshots

The detail page is unchanged visually apart from the new organization name row.
