### PR TITLE
[PAM] Show live leases on the Approvals tab with a revoke action

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17786,14 +17786,8 @@
   "pamApprovalsCollectionFilter": {
     "message": "Collection"
   },
-  "pamApprovalsPendingHeader": {
-    "message": "Pending approval $COUNT$",
-    "placeholders": {
-      "count": {
-        "content": "$1",
-        "example": "3"
-      }
-    }
+  "pamApprovalsPendingSection": {
+    "message": "Pending approval"
   },
   "pamApprovalsRequesterFilter": {
     "message": "Requester"

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -1,6 +1,6 @@
-@if (loading() && totalRows() === 0) {
+@if (loading() && !hasRows()) {
   <p bitTypography="body2" class="tw-mt-2">{{ "loading" | i18n }}</p>
-} @else if (totalRows() === 0) {
+} @else if (!hasRows()) {
   <bit-no-items class="tw-mt-2 tw-block" data-testid="approvals-empty">
     <span slot="title" class="tw-mt-4 tw-block">{{ "pamInboxEmptyTitle" | i18n }}</span>
     <span slot="description">{{ "pamInboxEmptyDescription" | i18n }}</span>
@@ -27,102 +27,219 @@
     />
   </div>
 
-  @if (rows().length === 0) {
+  @if (rows().length === 0 && leaseRows().length === 0) {
     <!-- Rendered inside the toolbar branch on purpose: a filter that matches nothing must not take
          the filter controls away with it, or there is no way back. -->
     <bit-no-items class="tw-mt-2 tw-block" data-testid="approvals-no-results">
       <span slot="title" class="tw-mt-4 tw-block">{{ "pamApprovalsNoResults" | i18n }}</span>
     </bit-no-items>
   } @else {
-    <h2 bitTypography="h4">{{ "pamApprovalsPendingHeader" | i18n: rows().length }}</h2>
+    <bit-accordion-group>
+      <bit-accordion [title]="'pamApprovalsPendingSection' | i18n" [open]="true">
+        <span slot="end" bitBadge variant="secondary">{{ rows().length }}</span>
 
-    <bit-table [dataSource]="dataSource">
-      <ng-container header>
-        <tr>
-          <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-          <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
-          <th bitCell>{{ "pamInboxWindow" | i18n }}</th>
-          <th bitCell>{{ "pamInboxReason" | i18n }}</th>
-          <th bitCell bitSortable="submittedAtMs" default="asc">
-            {{ "pamColumnSubmitted" | i18n }}
-          </th>
-          <th bitCell>{{ "pamColumnActions" | i18n }}</th>
-        </tr>
-      </ng-container>
-      <ng-template body let-rows$>
-        <tr bitRow *ngFor="let row of rows$ | async" [attr.data-testid]="'approvals-row-' + row.id">
-          <td bitCell>
-            <div class="tw-flex tw-items-center tw-gap-3">
-              @if (cipherFor(row.cipherId); as cipher) {
-                <app-vault-icon [cipher]="cipher" />
-              }
-              <div>
-                <a [routerLink]="['/pam/requests', row.id]">{{ row.cipherName }}</a>
-                @if (row.collectionName) {
-                  <div class="tw-text-xs tw-text-muted">
-                    {{ "pamInboxInCollection" | i18n: row.collectionName }}
+        @if (rows().length === 0) {
+          <p
+            bitTypography="body2"
+            class="tw-mb-0 tw-text-muted"
+            data-testid="approvals-pending-empty"
+          >
+            {{ "pamMyRequestsPendingEmpty" | i18n }}
+          </p>
+        } @else {
+          <bit-table [dataSource]="dataSource">
+            <ng-container header>
+              <tr>
+                <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
+                <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
+                <th bitCell>{{ "pamInboxWindow" | i18n }}</th>
+                <th bitCell>{{ "pamInboxReason" | i18n }}</th>
+                <th bitCell bitSortable="submittedAtMs" default="asc">
+                  {{ "pamColumnSubmitted" | i18n }}
+                </th>
+                <th bitCell>{{ "pamColumnActions" | i18n }}</th>
+              </tr>
+            </ng-container>
+            <ng-template body let-rows$>
+              <tr
+                bitRow
+                *ngFor="let row of rows$ | async"
+                [attr.data-testid]="'approvals-row-' + row.id"
+              >
+                <td bitCell>
+                  <div class="tw-flex tw-items-center tw-gap-3">
+                    @if (cipherFor(row.cipherId); as cipher) {
+                      <app-vault-icon [cipher]="cipher" />
+                    }
+                    <div>
+                      <a [routerLink]="['/pam/requests', row.id]">{{ row.cipherName }}</a>
+                      @if (row.collectionName) {
+                        <div class="tw-text-xs tw-text-muted">
+                          {{ "pamInboxInCollection" | i18n: row.collectionName }}
+                        </div>
+                      }
+                    </div>
                   </div>
-                }
-              </div>
-            </div>
-          </td>
-          <td bitCell>
-            <div>{{ row.requester }}</div>
-            @if (row.requesterEmail && row.requesterEmail !== row.requester) {
-              <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
-            }
-          </td>
-          <td bitCell>
-            <span class="tw-whitespace-nowrap" [title]="row.exactWindow">
-              {{ row.duration.key | i18n: row.duration.value }},
-              {{ row.relativeStart.key | i18n: row.relativeStart.value }}
-            </span>
-          </td>
-          <td bitCell>
-            @if (row.reason) {
-              <div class="tw-line-clamp-2 tw-max-w-xs tw-break-words" [title]="row.reason">
-                {{ row.reason }}
-              </div>
-            } @else {
-              <span class="tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
-            }
-          </td>
-          <td bitCell>
-            <span class="tw-whitespace-nowrap" [title]="row.request.submittedAt | date: 'medium'">
-              {{ row.elapsed.key | i18n: row.elapsed.value }}
-            </span>
-          </td>
-          <td bitCell>
-            <div class="tw-flex tw-gap-2">
-              <button
-                type="button"
-                bitButton
-                buttonType="primary"
-                size="small"
-                [disabled]="!row.canDecide || isDeciding(row)"
-                [loading]="isDeciding(row)"
-                [bitTooltip]="row.canDecide ? '' : ('pamInboxCannotApproveOwn' | i18n)"
-                (click)="decide(row, 'approve')"
-                [attr.data-testid]="'approvals-approve-' + row.id"
+                </td>
+                <td bitCell>
+                  <div>{{ row.requester }}</div>
+                  @if (row.requesterEmail && row.requesterEmail !== row.requester) {
+                    <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
+                  }
+                </td>
+                <td bitCell>
+                  <span class="tw-whitespace-nowrap" [title]="row.exactWindow">
+                    {{ row.duration.key | i18n: row.duration.value }},
+                    {{ row.relativeStart.key | i18n: row.relativeStart.value }}
+                  </span>
+                </td>
+                <td bitCell>
+                  @if (row.reason) {
+                    <div class="tw-line-clamp-2 tw-max-w-xs tw-break-words" [title]="row.reason">
+                      {{ row.reason }}
+                    </div>
+                  } @else {
+                    <span class="tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
+                  }
+                </td>
+                <td bitCell>
+                  <span
+                    class="tw-whitespace-nowrap"
+                    [title]="row.request.submittedAt | date: 'medium'"
+                  >
+                    {{ row.elapsed.key | i18n: row.elapsed.value }}
+                  </span>
+                </td>
+                <td bitCell>
+                  <div class="tw-flex tw-gap-2">
+                    <button
+                      type="button"
+                      bitButton
+                      buttonType="primary"
+                      size="small"
+                      [disabled]="!row.canDecide || isDeciding(row)"
+                      [loading]="isDeciding(row)"
+                      [bitTooltip]="row.canDecide ? '' : ('pamInboxCannotApproveOwn' | i18n)"
+                      (click)="decide(row, 'approve')"
+                      [attr.data-testid]="'approvals-approve-' + row.id"
+                    >
+                      {{ "pamInboxApprove" | i18n }}
+                    </button>
+                    <button
+                      type="button"
+                      bitButton
+                      buttonType="secondary"
+                      size="small"
+                      [disabled]="!row.canDecide || isDeciding(row)"
+                      [bitTooltip]="row.canDecide ? '' : ('pamInboxCannotApproveOwn' | i18n)"
+                      (click)="decide(row, 'deny')"
+                      [attr.data-testid]="'approvals-deny-' + row.id"
+                    >
+                      {{ "pamInboxDeny" | i18n }}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </ng-template>
+          </bit-table>
+        }
+      </bit-accordion>
+
+      <bit-accordion [title]="'pamMyRequestsGroupCheckedOut' | i18n" [open]="true">
+        <span slot="end" bitBadge variant="secondary">{{ leaseRows().length }}</span>
+
+        @if (leaseRows().length === 0) {
+          <p
+            bitTypography="body2"
+            class="tw-mb-0 tw-text-muted"
+            data-testid="approvals-checked-out-empty"
+          >
+            {{ "pamMyLeasesActiveEmpty" | i18n }}
+          </p>
+        } @else {
+          <bit-table [dataSource]="leasesDataSource">
+            <ng-container header>
+              <tr>
+                <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
+                <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
+                <th bitCell>{{ "pamColumnWindow" | i18n }}</th>
+                <th bitCell bitSortable="endsAtMs" default="asc">
+                  {{ "pamColumnRemaining" | i18n }}
+                </th>
+                <th bitCell>{{ "pamColumnActions" | i18n }}</th>
+              </tr>
+            </ng-container>
+            <ng-template body let-rows$>
+              <tr
+                bitRow
+                *ngFor="let row of rows$ | async"
+                [attr.data-testid]="'approvals-lease-' + row.leaseId"
               >
-                {{ "pamInboxApprove" | i18n }}
-              </button>
-              <button
-                type="button"
-                bitButton
-                buttonType="secondary"
-                size="small"
-                [disabled]="!row.canDecide || isDeciding(row)"
-                [bitTooltip]="row.canDecide ? '' : ('pamInboxCannotApproveOwn' | i18n)"
-                (click)="decide(row, 'deny')"
-                [attr.data-testid]="'approvals-deny-' + row.id"
-              >
-                {{ "pamInboxDeny" | i18n }}
-              </button>
-            </div>
-          </td>
-        </tr>
-      </ng-template>
-    </bit-table>
+                <td bitCell>
+                  <div class="tw-flex tw-items-center tw-gap-3">
+                    @if (cipherFor(row.cipherId); as cipher) {
+                      <app-vault-icon [cipher]="cipher" />
+                    }
+                    <div>
+                      <a [routerLink]="['/pam/requests', row.requestId]">{{
+                        row.cipherName ?? row.cipherId
+                      }}</a>
+                      @if (row.collectionName) {
+                        <div class="tw-text-xs tw-text-muted">
+                          {{ "pamInboxInCollection" | i18n: row.collectionName }}
+                        </div>
+                      }
+                      @if (row.extendedUntil) {
+                        <span
+                          bitBadge
+                          variant="secondary"
+                          class="tw-mt-1 tw-inline-block"
+                          [attr.data-testid]="'approvals-lease-extended-' + row.leaseId"
+                        >
+                          {{
+                            "pamExtendedBadge"
+                              | i18n
+                                : (row.extendedBySeconds | durationShort)
+                                : (row.extendedUntil | date: "short")
+                          }}
+                        </span>
+                      }
+                    </div>
+                  </div>
+                </td>
+                <td bitCell>
+                  <div>{{ row.requester }}</div>
+                  @if (row.requesterEmail && row.requesterEmail !== row.requester) {
+                    <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
+                  }
+                </td>
+                <td bitCell>
+                  <span class="tw-whitespace-nowrap">
+                    {{ row.startsAt | date: "short" }} &ndash; {{ row.endsAt | date: "short" }}
+                  </span>
+                </td>
+                <td bitCell>
+                  <app-pam-access-state-badge [state]="leaseBadgeState(row.leaseId)" />
+                </td>
+                <td bitCell>
+                  <button
+                    type="button"
+                    bitButton
+                    buttonType="danger"
+                    size="small"
+                    [disabled]="isRevoking(row)"
+                    [loading]="isRevoking(row)"
+                    (click)="revoke(row)"
+                    [attr.data-testid]="'approvals-revoke-' + row.leaseId"
+                  >
+                    {{ "pamInboxRevoke" | i18n }}
+                  </button>
+                </td>
+              </tr>
+            </ng-template>
+          </bit-table>
+        }
+      </bit-accordion>
+    </bit-accordion-group>
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -10,17 +10,24 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
-import type { AccessRequestView } from "../abstractions/access-lease";
+import type { AccessLeaseId, AccessRequestView } from "../abstractions/access-lease";
 import { ApprovalRow, toApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
+import { ManagedLeaseRow, toManagedLeaseRow } from "../approvals/managed-lease-row";
 
 import { emptyResolvedNames } from "./access-name-resolver.service";
 import { ApprovalsTabComponent } from "./approvals-tab.component";
 
 const NOW = new Date("2026-08-17T12:00:00.000Z");
 
-function row(overrides: Record<string, unknown> = {}, canDecide = true): ApprovalRow {
-  const request = {
+const NAMES = {
+  ...emptyResolvedNames(),
+  cipherNameById: new Map([["cipher-1", "Prod database"]]),
+  collectionNameById: new Map([["col-1", "Production"]]),
+};
+
+function accessRequest(overrides: Record<string, unknown> = {}): AccessRequestView {
+  return {
     id: "req-1",
     cipherId: "cipher-1",
     collectionId: "col-1",
@@ -35,15 +42,25 @@ function row(overrides: Record<string, unknown> = {}, canDecide = true): Approva
     requesterEmail: "grace@example.com",
     ...overrides,
   } as unknown as AccessRequestView;
-  return toApprovalRow(
-    request,
-    {
-      ...emptyResolvedNames(),
-      cipherNameById: new Map([["cipher-1", "Prod database"]]),
-      collectionNameById: new Map([["col-1", "Production"]]),
-    },
-    NOW,
-    canDecide,
+}
+
+function row(overrides: Record<string, unknown> = {}, canDecide = true): ApprovalRow {
+  return toApprovalRow(accessRequest(overrides), NAMES, NOW, canDecide);
+}
+
+function leaseRow(
+  overrides: Record<string, unknown> = {},
+  extension?: { addedSeconds: number; latestEndMs: number },
+): ManagedLeaseRow {
+  return toManagedLeaseRow(
+    accessRequest({
+      status: "approved",
+      producedLeaseId: "lease-1",
+      producedLeaseStatus: "active",
+      ...overrides,
+    }) as AccessRequestView & { producedLeaseId: AccessLeaseId },
+    NAMES,
+    extension,
   );
 }
 
@@ -52,9 +69,11 @@ describe("ApprovalsTabComponent", () => {
   let component: ApprovalsTabComponent;
   let inbox: {
     inboxRows$: BehaviorSubject<ApprovalRow[]>;
+    activeLeaseRows$: BehaviorSubject<ManagedLeaseRow[]>;
     cipherById$: BehaviorSubject<Map<string, CipherView>>;
     loading$: BehaviorSubject<boolean>;
     decide: jest.Mock;
+    revokeLease: jest.Mock;
   };
   let dialogService: MockProxy<DialogService>;
   let toastService: MockProxy<ToastService>;
@@ -72,9 +91,11 @@ describe("ApprovalsTabComponent", () => {
   beforeEach(async () => {
     inbox = {
       inboxRows$: new BehaviorSubject<ApprovalRow[]>([]),
+      activeLeaseRows$: new BehaviorSubject<ManagedLeaseRow[]>([]),
       cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
       loading$: new BehaviorSubject<boolean>(false),
       decide: jest.fn().mockResolvedValue(undefined),
+      revokeLease: jest.fn().mockResolvedValue(undefined),
     };
     dialogService = mock<DialogService>();
     toastService = mock<ToastService>();
@@ -242,6 +263,87 @@ describe("ApprovalsTabComponent", () => {
 
       expect(dialogService.open).not.toHaveBeenCalled();
       expect(inbox.decide).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("currently checked out", () => {
+    it("renders a row per live lease, with the holder and the item on it", () => {
+      inbox.activeLeaseRows$.next([
+        leaseRow({ producedLeaseId: "lease-1" }),
+        leaseRow(
+          { id: "req-2", producedLeaseId: "lease-2", requesterName: "Alan" },
+          {
+            addedSeconds: 3600,
+            latestEndMs: Date.parse("2026-08-17T14:00:00.000Z"),
+          },
+        ),
+      ]);
+
+      create();
+
+      expect(query('[data-testid="approvals-lease-lease-1"]')).not.toBeNull();
+      expect(query('[data-testid="approvals-lease-lease-2"]')).not.toBeNull();
+      expect(query('[data-testid="approvals-lease-extended-lease-2"]')).not.toBeNull();
+      const text = fixture.nativeElement.textContent as string;
+      expect(text).toContain("Prod database");
+      expect(text).toContain("Grace");
+      expect(text).toContain("Alan");
+    });
+
+    it("shows both sections when there is live access but nothing pending", () => {
+      inbox.activeLeaseRows$.next([leaseRow()]);
+
+      create();
+
+      expect(query('[data-testid="approvals-empty"]')).toBeNull();
+      expect(query("bit-accordion-group")).not.toBeNull();
+      expect(query('[data-testid="approvals-pending-empty"]')).not.toBeNull();
+      expect(query('[data-testid="approvals-lease-lease-1"]')).not.toBeNull();
+    });
+
+    it("shows the inbox-zero empty state only when both sections are empty", () => {
+      create();
+
+      expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
+      expect(query("bit-accordion-group")).toBeNull();
+    });
+
+    it("revokes the lease once confirmed, and toasts", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+      inbox.activeLeaseRows$.next([leaseRow()]);
+      create();
+
+      await component["revoke"](component["leaseRows"]()[0]);
+
+      expect(inbox.revokeLease).toHaveBeenCalledWith("req-1", "lease-1");
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "success" }),
+      );
+    });
+
+    it("does nothing when the confirm is dismissed", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+      inbox.activeLeaseRows$.next([leaseRow()]);
+      create();
+
+      await component["revoke"](component["leaseRows"]()[0]);
+
+      expect(inbox.revokeLease).not.toHaveBeenCalled();
+      expect(toastService.showToast).not.toHaveBeenCalled();
+    });
+
+    it("toasts an error when the revoke fails", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+      inbox.revokeLease.mockRejectedValue(new Error("boom"));
+      inbox.activeLeaseRows$.next([leaseRow()]);
+      create();
+
+      await component["revoke"](component["leaseRows"]()[0]);
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamInboxRevokeFailed",
+      });
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
@@ -5,13 +5,16 @@ import { of } from "rxjs";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
+import type { AccessLeaseId, AccessRequestView } from "../abstractions/access-lease";
 import { ApprovalRow, toApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
+import { ManagedLeaseRow, toManagedLeaseRow } from "../approvals/managed-lease-row";
 import {
   HOUR,
   MINUTE,
   STORY_NOW,
   accessRequest,
+  liveFromNow,
   provideStoryChangeDetection,
   provideStoryLogService,
   storyNames,
@@ -50,22 +53,86 @@ const ROWS: ApprovalRow[] = [
   row({ id: "req-4", cipherId: "cipher-2", requesterName: "You", reason: "Own request." }, false),
 ];
 
-function inbox(options: { rows?: ApprovalRow[]; loading?: boolean } = {}) {
-  const { rows = ROWS, loading = false } = options;
+/**
+ * Lease ends are stamped off the real clock, not {@link STORY_NOW}: the remaining-time badge runs
+ * its own countdown, so a STORY_NOW-relative window renders as already expired.
+ */
+function lease(overrides: Record<string, unknown>): ManagedLeaseRow {
+  return toManagedLeaseRow(
+    accessRequest({
+      status: "approved",
+      producedLeaseStatus: "active",
+      ...overrides,
+    }) as AccessRequestView & { producedLeaseId: AccessLeaseId },
+    names,
+  );
+}
+
+function activeLeases(): ManagedLeaseRow[] {
+  return [
+    lease({
+      id: "req-live-1",
+      producedLeaseId: "lease-1",
+      leaseNotBefore: liveFromNow(-20 * MINUTE),
+      leaseNotAfter: liveFromNow(40 * MINUTE),
+    }),
+    lease({
+      id: "req-live-2",
+      cipherId: "cipher-2",
+      collectionId: "col-2",
+      producedLeaseId: "lease-2",
+      requesterName: "Alan Turing",
+      requesterEmail: "alan@example.com",
+      leaseNotBefore: liveFromNow(-2 * HOUR),
+      leaseNotAfter: liveFromNow(3 * HOUR),
+    }),
+    // Extended in place: the row must end at the extension's end, not the request's own.
+    toManagedLeaseRow(
+      accessRequest({
+        id: "req-live-3",
+        cipherId: "cipher-3",
+        status: "approved",
+        producedLeaseId: "lease-3",
+        producedLeaseStatus: "active",
+        requesterName: "Katherine Johnson",
+        requesterEmail: "katherine@example.com",
+        leaseNotBefore: liveFromNow(-90 * MINUTE),
+        leaseNotAfter: liveFromNow(30 * MINUTE),
+      }) as AccessRequestView & { producedLeaseId: AccessLeaseId },
+      names,
+      { addedSeconds: 2 * 60 * 60, latestEndMs: Date.now() + 2.5 * HOUR },
+    ),
+  ];
+}
+
+function inbox(
+  options: { rows?: ApprovalRow[]; leases?: () => ManagedLeaseRow[]; loading?: boolean } = {},
+) {
+  const { rows = ROWS, leases = () => [], loading = false } = options;
   return moduleMetadata({
     imports: [ApprovalsTabComponent],
     providers: [
       {
         provide: ApproverInboxService,
-        useValue: {
+        // A factory rather than a value, so the real-clock lease windows are stamped when the
+        // story renders rather than when this module was first evaluated.
+        useFactory: () => ({
           loading$: of(loading),
           loadError$: of(null),
           inboxRows$: of(rows),
+          activeLeaseRows$: of(leases()),
           cipherById$: of(names.cipherById),
           decide: () => Promise.resolve(),
+          revokeLease: () => Promise.resolve(),
+        }),
+      },
+      {
+        provide: DialogService,
+        useValue: {
+          open: () => ({ closed: of(undefined) }),
+          openSimpleDialog: () => Promise.resolve(false),
         },
       },
-      { provide: DialogService, useValue: { open: () => ({ closed: of(undefined) }) } },
       { provide: ToastService, useValue: { showToast: () => {} } },
     ],
   });
@@ -88,9 +155,14 @@ export default {
 
 type Story = StoryObj<ApprovalsTabComponent>;
 
-/** The populated inbox, oldest-waiting first, with the search and chip filters above it. */
+/** Both sections populated: decisions to make, and access already running. */
 export const Default: Story = {
-  decorators: [inbox()],
+  decorators: [inbox({ leases: activeLeases })],
+};
+
+/** Nothing left to decide, but access the operator granted is still live and can be ended. */
+export const CheckedOutOnly: Story = {
+  decorators: [inbox({ rows: [], leases: activeLeases })],
 };
 
 /** Nothing awaiting a decision — distinct from a filter that matched nothing. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
@@ -57,7 +57,10 @@ const ROWS: ApprovalRow[] = [
  * Lease ends are stamped off the real clock, not {@link STORY_NOW}: the remaining-time badge runs
  * its own countdown, so a STORY_NOW-relative window renders as already expired.
  */
-function lease(overrides: Record<string, unknown>): ManagedLeaseRow {
+function lease(
+  overrides: Record<string, unknown>,
+  extension?: { addedSeconds: number; latestEndMs: number },
+): ManagedLeaseRow {
   return toManagedLeaseRow(
     accessRequest({
       status: "approved",
@@ -65,6 +68,7 @@ function lease(overrides: Record<string, unknown>): ManagedLeaseRow {
       ...overrides,
     }) as AccessRequestView & { producedLeaseId: AccessLeaseId },
     names,
+    extension,
   );
 }
 
@@ -87,19 +91,16 @@ function activeLeases(): ManagedLeaseRow[] {
       leaseNotAfter: liveFromNow(3 * HOUR),
     }),
     // Extended in place: the row must end at the extension's end, not the request's own.
-    toManagedLeaseRow(
-      accessRequest({
+    lease(
+      {
         id: "req-live-3",
         cipherId: "cipher-3",
-        status: "approved",
         producedLeaseId: "lease-3",
-        producedLeaseStatus: "active",
         requesterName: "Katherine Johnson",
         requesterEmail: "katherine@example.com",
         leaseNotBefore: liveFromNow(-90 * MINUTE),
         leaseNotAfter: liveFromNow(30 * MINUTE),
-      }) as AccessRequestView & { producedLeaseId: AccessLeaseId },
-      names,
+      },
       { addedSeconds: 2 * 60 * 60, latestEndMs: Date.now() + 2.5 * HOUR },
     ),
   ];

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -17,6 +17,9 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
+  AccordionComponent,
+  AccordionGroupComponent,
+  BadgeComponent,
   ButtonModule,
   ChipFilterComponent,
   ChipFilterOption,
@@ -32,20 +35,25 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import type { AccessDecisionVerdict } from "../abstractions/access-lease";
+import { AccessBadgeState } from "../access-state-badge/access-badge-state";
+import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { ApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import { DecideDialogComponent } from "../approvals/decide-dialog/decide-dialog.component";
+import { ManagedLeaseRow } from "../approvals/managed-lease-row";
+import { DurationShortPipe } from "../date/duration-short.pipe";
 
 /**
- * "Approvals" tab — the requests awaiting the caller's decision, oldest first.
+ * "Approvals" tab — the requests awaiting the caller's decision, oldest first, and the access
+ * already running on the collections they manage.
  *
  * Only ever rendered for an approver: `canViewApprovalsGuard` redirects a non-approver's deep
  * link to the sibling `my-requests` tab, and the shell (`access-requests.component.html`) only
  * renders the "Approvals" tab-link when {@link ApprovalPrivilegeService} says so — so a non-approver
  * never reaches this component.
  *
- * Data, ordering, and the optimistic decide live in {@link ApproverInboxService} (shared with the
- * History tab); this component owns the toolbar, the table, the dialog, and the toasts.
+ * Data, ordering, and the optimistic decide/revoke live in {@link ApproverInboxService} (shared with
+ * the History tab); this component owns the toolbar, the tables, the dialogs, and the toasts.
  */
 @Component({
   selector: "pam-approvals-tab",
@@ -55,8 +63,13 @@ import { DecideDialogComponent } from "../approvals/decide-dialog/decide-dialog.
     CommonModule,
     ReactiveFormsModule,
     RouterModule,
+    AccessStateBadgeComponent,
+    AccordionComponent,
+    AccordionGroupComponent,
+    BadgeComponent,
     ButtonModule,
     ChipFilterComponent,
+    DurationShortPipe,
     IconComponent,
     NoItemsModule,
     SearchModule,
@@ -76,6 +89,9 @@ export class ApprovalsTabComponent {
   /** Ids currently being decided, so a second click on the same row is a no-op. */
   private readonly deciding = signal<Set<string>>(new Set());
 
+  /** Lease ids currently being revoked, for the same reason as {@link deciding}. */
+  private readonly revoking = signal<Set<string>>(new Set());
+
   protected readonly loading = toSignal(this.inbox.loading$, { initialValue: true });
 
   protected readonly searchControl = new FormControl<string>("", { nonNullable: true });
@@ -92,44 +108,80 @@ export class ApprovalsTabComponent {
 
   private readonly allRows = toSignal(this.inbox.inboxRows$, { initialValue: [] as ApprovalRow[] });
 
+  private readonly allLeases = toSignal(this.inbox.activeLeaseRows$, {
+    initialValue: [] as ManagedLeaseRow[],
+  });
+
   private readonly cipherById = toSignal(this.inbox.cipherById$, {
     initialValue: new Map<string, CipherView>(),
   });
 
-  /** Every distinct collection present in the inbox, for the Collection filter. */
+  /** Every distinct collection present on the tab, for the Collection filter. */
   protected readonly collectionOptions = computed<ChipFilterOption<string>[]>(() =>
-    distinctOptions(this.allRows().map((row) => row.collectionName)),
+    distinctOptions([...this.allRows(), ...this.allLeases()].map((row) => row.collectionName)),
   );
 
-  /** Every distinct requester present in the inbox, for the Requester filter. */
+  /** Every distinct requester present on the tab, for the Requester filter. */
   protected readonly requesterOptions = computed<ChipFilterOption<string>[]>(() =>
-    distinctOptions(this.allRows().map((row) => row.requester)),
+    distinctOptions([...this.allRows(), ...this.allLeases()].map((row) => row.requester)),
   );
 
-  protected readonly rows = computed(() => {
-    const term = this.searchTerm().trim().toLowerCase();
-    const collection = this.collectionFilter();
-    const requester = this.requesterFilter();
-    return this.allRows().filter(
-      (row) =>
-        (term === "" || row.searchText.includes(term)) &&
-        (collection == null || row.collectionName === collection) &&
-        (requester == null || row.requester === requester),
-    );
-  });
+  protected readonly rows = computed(() =>
+    this.allRows().filter((row) =>
+      matchesFilters(
+        row,
+        this.searchTerm().trim().toLowerCase(),
+        this.collectionFilter(),
+        this.requesterFilter(),
+      ),
+    ),
+  );
+
+  protected readonly leaseRows = computed(() =>
+    this.allLeases().filter((row) =>
+      matchesFilters(
+        row,
+        this.searchTerm().trim().toLowerCase(),
+        this.collectionFilter(),
+        this.requesterFilter(),
+      ),
+    ),
+  );
 
   /**
-   * How many requests await a decision before filtering. Distinguishes an empty inbox (nothing to
-   * do) from a filter that matched nothing (something to do, just not visible), which need different
-   * copy and, for the latter, the filter controls left on screen.
+   * Whether the tab has anything at all before filtering, across both sections. Distinguishes an
+   * empty inbox (nothing to do) from a filter that matched nothing (something to do, just not
+   * visible), which need different copy and, for the latter, the filter controls left on screen.
    */
-  protected readonly totalRows = computed(() => this.allRows().length);
+  protected readonly hasRows = computed(
+    () => this.allRows().length > 0 || this.allLeases().length > 0,
+  );
 
   protected readonly dataSource = new TableDataSource<ApprovalRow>();
+  protected readonly leasesDataSource = new TableDataSource<ManagedLeaseRow>();
+
+  /**
+   * Badge state is memoised per lease so the shared badge component sees a stable input. A fresh
+   * object would re-run the badge's own effect and restart the countdown interval it runs itself.
+   * Keyed off the unfiltered rows so that typing in the search box does not churn the surviving
+   * badges.
+   */
+  private readonly leaseBadgeStates = computed(
+    () =>
+      new Map<string, AccessBadgeState>(
+        this.allLeases().map((row) => [
+          String(row.leaseId),
+          { kind: "active", expiresAt: new Date(row.endsAt) },
+        ]),
+      ),
+  );
 
   constructor() {
     effect(() => {
       this.dataSource.data = this.rows();
+    });
+    effect(() => {
+      this.leasesDataSource.data = this.leaseRows();
     });
   }
 
@@ -137,8 +189,16 @@ export class ApprovalsTabComponent {
     return this.cipherById().get(cipherId);
   }
 
+  protected leaseBadgeState(id: ManagedLeaseRow["leaseId"]): AccessBadgeState | null {
+    return this.leaseBadgeStates().get(String(id)) ?? null;
+  }
+
   protected isDeciding(row: ApprovalRow): boolean {
     return this.deciding().has(String(row.id));
+  }
+
+  protected isRevoking(row: ManagedLeaseRow): boolean {
+    return this.revoking().has(String(row.leaseId));
   }
 
   /**
@@ -181,6 +241,64 @@ export class ApprovalsTabComponent {
       });
     }
   }
+
+  /**
+   * Confirm and end a lease that is running right now. The confirm is not optional: this cuts off
+   * access someone is already using, and every dismissal route resolves false.
+   */
+  protected async revoke(row: ManagedLeaseRow): Promise<void> {
+    if (this.isRevoking(row)) {
+      return;
+    }
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "pamInboxRevoke" },
+      content: { key: "pamInboxRevokeConfirm" },
+      acceptButtonText: { key: "pamInboxRevoke" },
+      type: "warning",
+    });
+    if (!confirmed) {
+      return;
+    }
+
+    const key = String(row.leaseId);
+    this.revoking.update((ids) => new Set([...ids, key]));
+    try {
+      await this.inbox.revokeLease(row.requestId, row.leaseId);
+      this.toastService.showToast({
+        variant: "success",
+        message: this.i18nService.t("pamInboxRevokedToast"),
+      });
+    } catch (e) {
+      this.logService.error(e);
+      this.toastService.showToast({
+        variant: "error",
+        message: this.i18nService.t("pamInboxRevokeFailed"),
+      });
+    } finally {
+      this.revoking.update((ids) => {
+        const next = new Set(ids);
+        next.delete(key);
+        return next;
+      });
+    }
+  }
+}
+
+/**
+ * The toolbar's three filters, applied to either section's rows. Both row models carry the same
+ * three fields, so one predicate keeps the two sections from drifting apart.
+ */
+function matchesFilters(
+  row: { searchText: string; collectionName: string | null; requester: string },
+  term: string,
+  collection: string | null,
+  requester: string | null,
+): boolean {
+  return (
+    (term === "" || row.searchText.includes(term)) &&
+    (collection == null || row.collectionName === collection) &&
+    (requester == null || row.requester === requester)
+  );
 }
 
 /** Deduped, locale-sorted chip options from a list of possibly-blank labels. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -43,6 +43,9 @@ import { DecideDialogComponent } from "../approvals/decide-dialog/decide-dialog.
 import { ManagedLeaseRow } from "../approvals/managed-lease-row";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 
+/** The fields the toolbar filters against, carried by both sections' row models. */
+type FilterableRow = { searchText: string; collectionName: string | null; requester: string };
+
 /**
  * "Approvals" tab — the requests awaiting the caller's decision, oldest first, and the access
  * already running on the collections they manage.
@@ -116,37 +119,25 @@ export class ApprovalsTabComponent {
     initialValue: new Map<string, CipherView>(),
   });
 
+  /** Both sections' rows before filtering — what the chip filters offer options from. */
+  private readonly filterableRows = computed<FilterableRow[]>(() => [
+    ...this.allRows(),
+    ...this.allLeases(),
+  ]);
+
   /** Every distinct collection present on the tab, for the Collection filter. */
   protected readonly collectionOptions = computed<ChipFilterOption<string>[]>(() =>
-    distinctOptions([...this.allRows(), ...this.allLeases()].map((row) => row.collectionName)),
+    distinctOptions(this.filterableRows().map((row) => row.collectionName)),
   );
 
   /** Every distinct requester present on the tab, for the Requester filter. */
   protected readonly requesterOptions = computed<ChipFilterOption<string>[]>(() =>
-    distinctOptions([...this.allRows(), ...this.allLeases()].map((row) => row.requester)),
+    distinctOptions(this.filterableRows().map((row) => row.requester)),
   );
 
-  protected readonly rows = computed(() =>
-    this.allRows().filter((row) =>
-      matchesFilters(
-        row,
-        this.searchTerm().trim().toLowerCase(),
-        this.collectionFilter(),
-        this.requesterFilter(),
-      ),
-    ),
-  );
+  protected readonly rows = computed(() => this.applyFilters(this.allRows()));
 
-  protected readonly leaseRows = computed(() =>
-    this.allLeases().filter((row) =>
-      matchesFilters(
-        row,
-        this.searchTerm().trim().toLowerCase(),
-        this.collectionFilter(),
-        this.requesterFilter(),
-      ),
-    ),
-  );
+  protected readonly leaseRows = computed(() => this.applyFilters(this.allLeases()));
 
   /**
    * Whether the tab has anything at all before filtering, across both sections. Distinguishes an
@@ -183,6 +174,22 @@ export class ApprovalsTabComponent {
     effect(() => {
       this.leasesDataSource.data = this.leaseRows();
     });
+  }
+
+  /**
+   * The toolbar's three filters, applied to either section's rows. Both row models carry the same
+   * three fields, so one predicate keeps the two sections from drifting apart.
+   */
+  private applyFilters<T extends FilterableRow>(rows: T[]): T[] {
+    const term = this.searchTerm().trim().toLowerCase();
+    const collection = this.collectionFilter();
+    const requester = this.requesterFilter();
+    return rows.filter(
+      (row) =>
+        (term === "" || row.searchText.includes(term)) &&
+        (collection == null || row.collectionName === collection) &&
+        (requester == null || row.requester === requester),
+    );
   }
 
   protected cipherFor(cipherId: string): CipherView | undefined {
@@ -282,23 +289,6 @@ export class ApprovalsTabComponent {
       });
     }
   }
-}
-
-/**
- * The toolbar's three filters, applied to either section's rows. Both row models carry the same
- * three fields, so one predicate keeps the two sections from drifting apart.
- */
-function matchesFilters(
-  row: { searchText: string; collectionName: string | null; requester: string },
-  term: string,
-  collection: string | null,
-  requester: string | null,
-): boolean {
-  return (
-    (term === "" || row.searchText.includes(term)) &&
-    (collection == null || row.collectionName === collection) &&
-    (requester == null || row.requester === requester)
-  );
 }
 
 /** Deduped, locale-sorted chip options from a list of possibly-blank labels. */

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
@@ -348,6 +348,49 @@ describe("ApproverInboxService", () => {
       expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(1);
     });
 
+    it("drops a lease whose window has closed, however the server still reports its status", async () => {
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "lapsed",
+          status: "approved",
+          leaseNotAfter: new Date(Date.now() - 1000).toISOString(),
+          producedLeaseId: "lease-lapsed",
+          producedLeaseStatus: "active",
+        }),
+      ]);
+
+      await service.load();
+
+      expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(0);
+    });
+
+    it("keeps a lease an extension has carried past the request's own end", async () => {
+      const requestEnd = new Date(Date.now() - 1000).toISOString();
+      const extendedEnd = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "original",
+          status: "approved",
+          leaseNotAfter: requestEnd,
+          producedLeaseId: "lease-1",
+          producedLeaseStatus: "active",
+        }),
+        request({
+          id: "the-extension",
+          status: "approved",
+          extensionOfLeaseId: "lease-1",
+          leaseNotBefore: requestEnd,
+          leaseNotAfter: extendedEnd,
+        }),
+      ]);
+
+      await service.load();
+
+      const rows = await firstValueFrom(service.activeLeaseRows$);
+      expect(rows.map((r) => r.requestId)).toEqual(["original"]);
+      expect(rows[0].endsAt).toBe(extendedEnd);
+    });
+
     it("ends the row at the applied extension's end, not the originating request's", async () => {
       const requestEnd = new Date(Date.now() + 60 * 60 * 1000).toISOString();
       const extendedEnd = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
@@ -303,6 +303,109 @@ describe("ApproverInboxService", () => {
     });
   });
 
+  describe("activeLeaseRows$", () => {
+    it("lists only the requests whose produced lease is still active", async () => {
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "live",
+          status: "approved",
+          producedLeaseId: "lease-live",
+          producedLeaseStatus: "active",
+        }),
+        request({
+          id: "ended",
+          status: "approved",
+          producedLeaseId: "lease-ended",
+          producedLeaseStatus: "revoked",
+        }),
+        request({ id: "never-started", status: "approved", producedLeaseId: undefined }),
+      ]);
+
+      await service.load();
+
+      const rows = await firstValueFrom(service.activeLeaseRows$);
+      expect(rows.map((r) => r.requestId)).toEqual(["live"]);
+      expect(rows[0].leaseId).toBe("lease-live");
+      expect(rows[0].requester).toBe("Grace");
+    });
+
+    it("lists an activated grant whose status does not read as approved", async () => {
+      // The server can serve an activated grant with a status the client reads as denied
+      // (uat-FLW-06-9e1cc0ec), which is why liveness is read off the produced lease and never off
+      // the display badge. Reverting this filter onto `statusBadge` empties the section in the
+      // product while every other test here still passes.
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "reads-denied",
+          status: "denied",
+          producedLeaseId: "lease-live",
+          producedLeaseStatus: "active",
+        }),
+      ]);
+
+      await service.load();
+
+      expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(1);
+    });
+
+    it("ends the row at the applied extension's end, not the originating request's", async () => {
+      const requestEnd = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const extendedEnd = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "original",
+          status: "approved",
+          leaseNotAfter: requestEnd,
+          producedLeaseId: "lease-1",
+          producedLeaseStatus: "active",
+        }),
+        request({
+          id: "the-extension",
+          status: "approved",
+          extensionOfLeaseId: "lease-1",
+          leaseNotBefore: requestEnd,
+          leaseNotAfter: extendedEnd,
+        }),
+      ]);
+
+      await service.load();
+
+      const [row] = await firstValueFrom(service.activeLeaseRows$);
+      expect(row.endsAt).toBe(extendedEnd);
+      expect(row.endsAtMs).toBe(Date.parse(extendedEnd));
+      expect(row.extendedUntil).toBe(extendedEnd);
+      expect(row.extendedBySeconds).toBe(2 * 60 * 60);
+    });
+
+    it("drops the row on revoke and puts it back when the SDK rejects", async () => {
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "req-1",
+          status: "approved",
+          producedLeaseId: "lease-1",
+          producedLeaseStatus: "active",
+        }),
+      ]);
+      await service.load();
+
+      await service.revokeLease(
+        "req-1" as unknown as AccessRequestId,
+        "lease-1" as unknown as AccessLeaseId,
+      );
+      expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(0);
+
+      leasesApi.endLease.mockRejectedValue(new Error("boom"));
+      await service.load();
+      await expect(
+        service.revokeLease(
+          "req-1" as unknown as AccessRequestId,
+          "lease-1" as unknown as AccessLeaseId,
+        ),
+      ).rejects.toThrow("boom");
+      expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(1);
+    });
+  });
+
   it("sorts history newest-resolved first", async () => {
     approvalApi.listHistory.mockResolvedValue([
       request({ id: "older", status: "denied", resolvedAt: "2026-08-17T09:00:00.000Z" }),

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.ts
@@ -32,10 +32,15 @@ import {
   ResolvedNames,
   emptyResolvedNames,
 } from "../access-requests/access-name-resolver.service";
-import { MyAccessRequestRow, toRequestRow } from "../access-requests/my-access-row";
+import {
+  MyAccessRequestRow,
+  extensionsByLeaseId,
+  toRequestRow,
+} from "../access-requests/my-access-row";
 
 import { ApprovalRow, sortApprovalRows, toApprovalRow } from "./approval-row";
 import { isActionableInboxRequest } from "./inbox-request-filter";
+import { ManagedLeaseRow, isLiveManagedLease, toManagedLeaseRow } from "./managed-lease-row";
 
 /**
  * Page-level data service for the approver surfaces: the pending inbox and the decided history for
@@ -108,6 +113,29 @@ export class ApproverInboxService {
         .map((request) => toRequestRow(request, names))
         .sort((a, b) => resolvedOrSubmittedMs(b) - resolvedOrSubmittedMs(a)),
     ),
+  );
+
+  /**
+   * The leases that are live RIGHT NOW on the collections the caller manages, soonest to end first —
+   * the access an operator can still cut off.
+   *
+   * A filter over the history read rather than a governance read of its own: `listHistory()` already
+   * returns every managed non-pending request with its produced lease's id and status, and the SDK
+   * omits a list-active-leases call on purpose.
+   */
+  readonly activeLeaseRows$: Observable<ManagedLeaseRow[]> = combineLatest([
+    this._history$,
+    this._names$,
+  ]).pipe(
+    map(([requests, names]) => {
+      const extensions = extensionsByLeaseId(requests);
+      return requests
+        .filter(isLiveManagedLease)
+        .map((request) =>
+          toManagedLeaseRow(request, names, extensions.get(uuidAsString(request.producedLeaseId))),
+        )
+        .sort((a, b) => a.endsAtMs - b.endsAtMs);
+    }),
   );
 
   /**

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.ts
@@ -122,18 +122,25 @@ export class ApproverInboxService {
    * A filter over the history read rather than a governance read of its own: `listHistory()` already
    * returns every managed non-pending request with its produced lease's id and status, and the SDK
    * omits a list-active-leases call on purpose.
+   *
+   * The window is tested as well as the status, and only once the row's effective end is known: the
+   * server never transitions a lease out of `active` when its window closes, so status alone would
+   * keep listing — and offering Revoke on — access that ended on its own, while testing the
+   * request's own end first would drop a lease an extension has carried past it.
    */
   readonly activeLeaseRows$: Observable<ManagedLeaseRow[]> = combineLatest([
     this._history$,
     this._names$,
+    this._renderedAt$,
   ]).pipe(
-    map(([requests, names]) => {
+    map(([requests, names, now]) => {
       const extensions = extensionsByLeaseId(requests);
       return requests
         .filter(isLiveManagedLease)
         .map((request) =>
           toManagedLeaseRow(request, names, extensions.get(uuidAsString(request.producedLeaseId))),
         )
+        .filter((row) => row.endsAtMs > now.getTime())
         .sort((a, b) => a.endsAtMs - b.endsAtMs);
     }),
   );

--- a/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
@@ -1,0 +1,93 @@
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+
+import type {
+  AccessLeaseId,
+  AccessRequestId,
+  AccessRequestView,
+} from "../abstractions/access-lease";
+import { ResolvedNames } from "../access-requests/access-name-resolver.service";
+import { LeaseExtensionSummary } from "../access-requests/my-access-row";
+
+/**
+ * A lease that is live right now on a collection the caller manages.
+ *
+ * Separate from {@link MyAccessRequestRow} rather than an extension of it: that model carries no
+ * requester identity and is shared with the requester-facing tabs, where "who holds this" is always
+ * the viewer.
+ */
+export type ManagedLeaseRow = {
+  /** The request that produced the lease — every row links to /pam/requests/:id. */
+  requestId: AccessRequestId;
+  /** The live lease itself, the id `ApproverInboxService.revokeLease` ends. */
+  leaseId: AccessLeaseId;
+  cipherId: string;
+  collectionId: string;
+  /** null when the cipher isn't in the caller's local vault; the template falls back to the id. */
+  cipherName: string | null;
+  collectionName: string | null;
+  /** The holder's name, falling back to their email, then empty. */
+  requester: string;
+  requesterEmail: string | null;
+  startsAt: string;
+  /** The lease's EFFECTIVE end: the latest applied extension's end, else the request's window end. */
+  endsAt: string;
+  /** Sort key for the Remaining column. */
+  endsAtMs: number;
+  extendedBySeconds: number | null;
+  extendedUntil: string | null;
+  /** Lowercased haystack for the free-text filter. */
+  searchText: string;
+};
+
+/**
+ * Whether this request's grant is running right now.
+ *
+ * Reads the request, never the display badge: `historyDisplayStatus` only reaches its activated
+ * branch for `status === "approved"`, and an activated grant can arrive with a status the client
+ * reads otherwise, which would empty this section in the product while every test still passed.
+ */
+export function isLiveManagedLease(
+  request: AccessRequestView,
+): request is AccessRequestView & { producedLeaseId: AccessLeaseId } {
+  return request.producedLeaseId != null && request.producedLeaseStatus === "active";
+}
+
+/**
+ * Build one live-lease row.
+ *
+ * `extension` is the summary for the produced lease, if any. An extension is applied to the lease in
+ * place and never moves the originating request's `leaseNotAfter`, so an extended lease whose row
+ * showed the request's end would tell an operator that access ends sooner than it does.
+ */
+export function toManagedLeaseRow(
+  request: AccessRequestView & { producedLeaseId: AccessLeaseId },
+  names: ResolvedNames,
+  extension?: LeaseExtensionSummary,
+): ManagedLeaseRow {
+  const cipherId = uuidAsString(request.cipherId);
+  const collectionId = uuidAsString(request.collectionId);
+  const cipherName = names.cipherNameById.get(cipherId) ?? null;
+  const collectionName = names.collectionNameById.get(collectionId) ?? null;
+  const extended = extension != null && extension.latestEndMs > 0;
+  const endsAt = extended ? new Date(extension.latestEndMs).toISOString() : request.leaseNotAfter;
+
+  return {
+    requestId: request.id,
+    leaseId: request.producedLeaseId,
+    cipherId,
+    collectionId,
+    cipherName,
+    collectionName,
+    requester: request.requesterName || request.requesterEmail || "",
+    requesterEmail: request.requesterEmail ?? null,
+    startsAt: request.leaseNotBefore,
+    endsAt,
+    endsAtMs: Date.parse(endsAt),
+    extendedBySeconds: extended ? extension.addedSeconds : null,
+    extendedUntil: extended ? endsAt : null,
+    searchText: [cipherName, collectionName, request.requesterName, request.requesterEmail]
+      .filter((value): value is string => !!value)
+      .join(" ")
+      .toLowerCase(),
+  };
+}

--- a/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
@@ -40,7 +40,10 @@ export type ManagedLeaseRow = {
 };
 
 /**
- * Whether this request's grant is running right now.
+ * Whether this request minted a lease the server still holds open.
+ *
+ * Not on its own "live right now": nothing ever moves a lease out of `active` when its window
+ * closes, so a caller listing running access must also test the effective end.
  *
  * Reads the request, never the display badge: `historyDisplayStatus` only reaches its activated
  * branch for `status === "approved"`, and an activated grant can arrive with a status the client

--- a/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
@@ -69,7 +69,8 @@ export function toManagedLeaseRow(
   const cipherName = names.cipherNameById.get(cipherId) ?? null;
   const collectionName = names.collectionNameById.get(collectionId) ?? null;
   const extended = extension != null && extension.latestEndMs > 0;
-  const endsAt = extended ? new Date(extension.latestEndMs).toISOString() : request.leaseNotAfter;
+  const endsAtMs = extended ? extension.latestEndMs : Date.parse(request.leaseNotAfter);
+  const endsAt = extended ? new Date(endsAtMs).toISOString() : request.leaseNotAfter;
 
   return {
     requestId: request.id,
@@ -82,7 +83,7 @@ export function toManagedLeaseRow(
     requesterEmail: request.requesterEmail ?? null,
     startsAt: request.leaseNotBefore,
     endsAt,
-    endsAtMs: Date.parse(endsAt),
+    endsAtMs,
     extendedBySeconds: extended ? extension.addedSeconds : null,
     extendedUntil: extended ? endsAt : null,
     searchText: [cipherName, collectionName, request.requesterName, request.requesterEmail]


### PR DESCRIPTION
## Objective

Give the Approvals tab a "Currently checked out" section, so an operator can see the access they granted and end it without leaving the tab.

Closes UAT finding [`uat-FLW-06-f8b8c201`](https://pam.run.ventures/uat-report/).

- Approvals was a flat `h2` + `bit-table` headed "Pending approval" — it answered "what needs me?" and nothing about access that is live right now.
- The only Revoke control in the product sat two tabs away, in History under "For my collections".
- Adds the section using the shape the requester's side already ships: `my-requests-tab.component.html` is a `bit-accordion-group`.

Presentation-layer only: `ApproverInboxService._history$` already carries `producedLeaseId` and `producedLeaseStatus` for every managed request, so the new section filters data the client holds. No new fetch, no new endpoint.

> **Draft — do not merge.** Produced by the PAM UAT polish pipeline (run `wf_d3228d2d-3d3`) and pushed early to exercise `gh stack`. QA and Visual QA had not completed at push time. All new user-facing strings are **proposed** wording pending the designer.
