### PR TITLE
[PAM] Default the history scope and guard its managed action

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17816,8 +17816,8 @@
   "pamInboxApprovedToast": {
     "message": "Request approved"
   },
-  "pamInboxCancelApproval": {
-    "message": "Cancel"
+  "pamInboxWithdrawApproval": {
+    "message": "Withdraw approval"
   },
   "pamInboxCannotApproveOwn": {
     "message": "You cannot approve your own request."
@@ -17888,8 +17888,8 @@
   "pamInboxHistoryEmpty": {
     "message": "No history to display"
   },
-  "pamInboxHistoryFilterLabel": {
-    "message": "Filter history by status"
+  "pamHistoryScopeLabel": {
+    "message": "History scope"
   },
   "pamInboxLoadFailed": {
     "message": "Could not load inbox"
@@ -17906,11 +17906,11 @@
   "pamInboxRevokedToast": {
     "message": "Access revoked"
   },
-  "pamInboxApprovalCanceledToast": {
-    "message": "Approval canceled"
+  "pamInboxApprovalWithdrawnToast": {
+    "message": "Approval withdrawn"
   },
-  "pamInboxCancelApprovalFailed": {
-    "message": "Could not cancel approval"
+  "pamInboxWithdrawApprovalFailed": {
+    "message": "Could not withdraw approval"
   },
   "pamInboxWindow": {
     "message": "Requested window"
@@ -17926,6 +17926,15 @@
   },
   "pamInboxRevokeConfirm": {
     "message": "This immediately revokes the member's access. They will need a new approval to regain it."
+  },
+  "pamInboxWithdrawApprovalConfirm": {
+    "message": "This withdraws the member's approval for $ITEM$. Access will not start, and they will need a new approval to get it.",
+    "placeholders": {
+      "item": {
+        "content": "$1",
+        "example": "Prod database"
+      }
+    }
   },
   "pamCollectionAccessRuleCalloutTitle": {
     "message": "Access rule"

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -1,9 +1,9 @@
-@if (hasManagedHistory()) {
+@if (canSwitchScope()) {
   <div class="tw-mb-4 tw-flex tw-justify-end">
     <bit-toggle-group
       [selected]="scope()"
-      (selectedChange)="scope.set($event)"
-      [attr.aria-label]="'pamInboxHistoryFilterLabel' | i18n"
+      (selectedChange)="selectScope($event)"
+      [label]="'pamHistoryScopeLabel' | i18n"
     >
       <bit-toggle [value]="HistoryScope.Mine" data-testid="history-scope-mine">
         {{ "pamHistoryScopeMine" | i18n }}
@@ -131,7 +131,7 @@
                 (click)="cancelApproval(row)"
                 [attr.data-testid]="'history-cancel-approval-' + row.id"
               >
-                {{ "pamInboxCancelApproval" | i18n }}
+                {{ "pamInboxWithdrawApproval" | i18n }}
               </button>
             } @else {
               <span class="tw-text-muted">&mdash;</span>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -73,7 +73,7 @@ describe("HistoryTabComponent", () => {
 
   /** Switch to the approver-side scope and re-render. */
   function showManaged(): void {
-    component["chosenScope"].set("managed");
+    component["selectScope"]("managed");
     fixture.detectChanges();
   }
 
@@ -186,8 +186,8 @@ describe("HistoryTabComponent", () => {
       expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
     });
 
-    // The fallback now runs through canSwitchScope(): a non-approver whose managed rows go away
-    // loses the toggle, so the pinned scope stops applying.
+    // A non-approver whose managed rows go away loses the toggle, so their pinned scope stops
+    // applying.
     it("falls back to the caller's own rows if the managed side empties out", () => {
       managedRows$.next([historyRow({ id: "managed-1" })]);
       myRows$.next([historyRow({ id: "mine-1" })]);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -10,6 +10,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
+import { ApprovalPrivilegeService } from "../approvals/approval-privilege.service";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 
 import { HistoryTabComponent } from "./history-tab.component";
@@ -56,6 +57,7 @@ describe("HistoryTabComponent", () => {
     revokeLease: jest.Mock;
     cancelApproval: jest.Mock;
   };
+  let canApprove$: BehaviorSubject<boolean>;
   let dialogService: MockProxy<DialogService>;
   let toastService: MockProxy<ToastService>;
 
@@ -71,7 +73,7 @@ describe("HistoryTabComponent", () => {
 
   /** Switch to the approver-side scope and re-render. */
   function showManaged(): void {
-    component["scope"].set("managed");
+    component["chosenScope"].set("managed");
     fixture.detectChanges();
   }
 
@@ -86,6 +88,7 @@ describe("HistoryTabComponent", () => {
       revokeLease: jest.fn().mockResolvedValue(undefined),
       cancelApproval: jest.fn().mockResolvedValue(undefined),
     };
+    canApprove$ = new BehaviorSubject(false);
     dialogService = mock<DialogService>();
     toastService = mock<ToastService>();
     dialogService.openSimpleDialog.mockResolvedValue(true);
@@ -102,6 +105,7 @@ describe("HistoryTabComponent", () => {
           },
         },
         { provide: ApproverInboxService, useValue: inbox },
+        { provide: ApprovalPrivilegeService, useValue: { canApprove$ } },
         { provide: DialogService, useValue: dialogService },
         { provide: ToastService, useValue: toastService },
         { provide: LogService, useValue: mock<LogService>() },
@@ -132,12 +136,43 @@ describe("HistoryTabComponent", () => {
       expect(query('[data-testid="history-scope-managed"]')).not.toBeNull();
     });
 
-    it("shows the caller's own rows by default", () => {
+    it("offers the toggle to an approver with no managed history yet", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+
+      create();
+
+      expect(query('[data-testid="history-scope-managed"]')).not.toBeNull();
+    });
+
+    it("lands on the managed side when there is managed history", () => {
       myRows$.next([historyRow({ id: "mine-1" })]);
       managedRows$.next([historyRow({ id: "managed-1" })]);
 
       create();
 
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
+    });
+
+    it("lands on the caller's own rows when there is no managed history", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+
+      create();
+
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
+    });
+
+    it("keeps the viewer on the scope they picked when managed history arrives", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      create();
+
+      component["selectScope"]("mine");
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      fixture.detectChanges();
+
+      expect(component["showingManaged"]()).toBe(false);
       expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
     });
 
@@ -151,6 +186,8 @@ describe("HistoryTabComponent", () => {
       expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
     });
 
+    // The fallback now runs through canSwitchScope(): a non-approver whose managed rows go away
+    // loses the toggle, so the pinned scope stops applying.
     it("falls back to the caller's own rows if the managed side empties out", () => {
       managedRows$.next([historyRow({ id: "managed-1" })]);
       myRows$.next([historyRow({ id: "mine-1" })]);
@@ -215,7 +252,7 @@ describe("HistoryTabComponent", () => {
       expect(component["canRevoke"](revoked)).toBe(false);
     });
 
-    it("offers Cancel for an approval the requester has not started", () => {
+    it("offers Withdraw approval for an approval the requester has not started", () => {
       managedRows$.next([unstartedApproval]);
       create();
       showManaged();
@@ -273,21 +310,33 @@ describe("HistoryTabComponent", () => {
       });
     });
 
-    it("cancels an approval without a confirm — nothing is in use yet", async () => {
+    it("confirms before withdrawing an approval", async () => {
       managedRows$.next([unstartedApproval]);
       create();
       showManaged();
 
       await component["cancelApproval"](unstartedApproval);
 
+      expect(dialogService.openSimpleDialog).toHaveBeenCalled();
       expect(inbox.cancelApproval).toHaveBeenCalledWith("managed-2");
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "success",
-        message: "pamInboxApprovalCanceledToast",
+        message: "pamInboxApprovalWithdrawnToast",
       });
     });
 
-    it("toasts an error when cancelling an approval fails", async () => {
+    it("does not withdraw the approval when the confirm is dismissed", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+      managedRows$.next([unstartedApproval]);
+      create();
+      showManaged();
+
+      await component["cancelApproval"](unstartedApproval);
+
+      expect(inbox.cancelApproval).not.toHaveBeenCalled();
+    });
+
+    it("toasts an error when withdrawing an approval fails", async () => {
       inbox.cancelApproval.mockRejectedValue(new Error("boom"));
       managedRows$.next([unstartedApproval]);
       create();
@@ -297,7 +346,7 @@ describe("HistoryTabComponent", () => {
 
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "error",
-        message: "pamInboxCancelApprovalFailed",
+        message: "pamInboxWithdrawApprovalFailed",
       });
     });
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
@@ -5,6 +5,7 @@ import { of } from "rxjs";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
+import { ApprovalPrivilegeService } from "../approvals/approval-privilege.service";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import {
   DAY,
@@ -94,8 +95,14 @@ function managedRows() {
   ];
 }
 
-function history(options: { mine?: typeof MY_ROWS; managed?: () => typeof MY_ROWS } = {}) {
-  const { mine = MY_ROWS, managed } = options;
+function history(
+  options: {
+    mine?: typeof MY_ROWS;
+    managed?: () => typeof MY_ROWS;
+    canApprove?: boolean;
+  } = {},
+) {
+  const { mine = MY_ROWS, managed, canApprove = managed != null } = options;
   return moduleMetadata({
     imports: [HistoryTabComponent],
     providers: [
@@ -123,6 +130,7 @@ function history(options: { mine?: typeof MY_ROWS; managed?: () => typeof MY_ROW
           };
         },
       },
+      { provide: ApprovalPrivilegeService, useValue: { canApprove$: of(canApprove) } },
       { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
       { provide: ToastService, useValue: { showToast: () => {} } },
     ],
@@ -147,8 +155,8 @@ export default {
 type Story = StoryObj<HistoryTabComponent>;
 
 /**
- * The caller's own history. With no managed rows the Mine/Managed toggle is not rendered at all —
- * a scope switch with one option is noise.
+ * The caller's own history, for a member who cannot approve. With no managed rows and no approval
+ * privilege the Mine/Managed toggle is not rendered at all — a scope switch with one option is noise.
  */
 export const Default: Story = {
   decorators: [history()],
@@ -160,12 +168,17 @@ export const Empty: Story = {
 };
 
 /**
- * An approver's view: the Mine/Managed toggle appears because there is managed history behind it.
- * The table still opens on Mine — switch the toggle to see the revoke and cancel-approval actions,
- * which only exist on the managed scope.
+ * An approver's view: the table opens on the managed scope because there is history behind it, with
+ * the revoke and withdraw-approval actions that only exist there. Switch the toggle for the rows the
+ * approver raised themselves.
  */
 export const WithManagedHistory: Story = {
   decorators: [history({ managed: managedRows })],
+};
+
+/** An approver with nothing decided yet: the scope toggle is offered before it has content. */
+export const ApproverWithoutManagedHistory: Story = {
+  decorators: [history({ canApprove: true })],
 };
 
 /** An approver whose own history is empty but who has decided other people's requests. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -29,6 +29,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 
 import type { AccessLeaseId, AccessRequestId } from "../abstractions/access-lease";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
+import { ApprovalPrivilegeService } from "../approvals/approval-privilege.service";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { RelativeTimePipe } from "../date/relative-time.pipe";
@@ -45,8 +46,12 @@ type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
  *
  *  - Mine: the caller's own terminal requests (everything but pending/approved, which live on the My
  *    requests tab).
- *  - Managed: the decided requests for the collections the caller manages — visible only to
- *    approvers, and the only place they can undo a decision.
+ *  - Managed: the decided requests for the collections the caller manages — offered to anyone who
+ *    can approve, and the only place they can undo a decision.
+ *
+ * An untouched toggle lands on Managed whenever that side has rows, since this tab is aimed at the
+ * approver and answering them with an empty table hides the history they came for behind a control
+ * they have no reason to press.
  *
  * A toggle rather than one merged table. Merging them would put "a request I raised" and "a request I
  * decided" in the same list with the same columns but different available actions, so a row's
@@ -84,9 +89,16 @@ export class HistoryTabComponent {
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
+  private readonly approvalPrivileges = inject(ApprovalPrivilegeService);
 
   protected readonly HistoryScope = HistoryScope;
-  protected readonly scope = signal<HistoryScope>(HistoryScope.Mine);
+
+  protected readonly canApprove = toSignal(this.approvalPrivileges.canApprove$, {
+    initialValue: false,
+  });
+
+  /** The scope the viewer picked from the toggle, or null while the default below still applies. */
+  private readonly chosenScope = signal<HistoryScope | null>(null);
 
   /** Request ids currently being acted on, so a second click on the same row is a no-op. */
   private readonly acting = signal<Set<string>>(new Set());
@@ -108,11 +120,27 @@ export class HistoryTabComponent {
     initialValue: new Map<string, CipherView>(),
   });
 
-  /** The Managed toggle only appears once there is managed history to show. */
-  protected readonly hasManagedHistory = computed(() => this.managedRows().length > 0);
+  /** A pure computed rather than a one-shot latch, so it tracks the managed rows as they load. */
+  private readonly defaultScope = computed<HistoryScope>(() =>
+    this.managedRows().length > 0 ? HistoryScope.Managed : HistoryScope.Mine,
+  );
+
+  protected readonly scope = computed<HistoryScope>(
+    () => this.chosenScope() ?? this.defaultScope(),
+  );
+
+  /**
+   * The toggle is offered to anyone who can approve, rows or not — gating it on rows hides the
+   * second scope until it has content, which is exactly when the reader no longer needs telling it
+   * exists. The `managedRows()` term keeps it for a viewer whose privilege stream has not resolved
+   * but whose rows have.
+   */
+  protected readonly canSwitchScope = computed(
+    () => this.canApprove() || this.managedRows().length > 0,
+  );
 
   protected readonly showingManaged = computed(
-    () => this.scope() === HistoryScope.Managed && this.hasManagedHistory(),
+    () => this.scope() === HistoryScope.Managed && this.canSwitchScope(),
   );
 
   protected readonly historyRows = computed(() =>
@@ -125,6 +153,11 @@ export class HistoryTabComponent {
     effect(() => {
       this.historyDataSource.data = this.historyRows();
     });
+  }
+
+  /** Pin the scope to the viewer's choice, so a later load cannot move them off it. */
+  protected selectScope(scope: HistoryScope): void {
+    this.chosenScope.set(scope);
   }
 
   /** The decrypted cipher for a row, or undefined when it isn't in the caller's vault. */
@@ -180,12 +213,30 @@ export class HistoryTabComponent {
     );
   }
 
-  /** Withdraw an approval the requester has not started. */
+  /**
+   * Withdraw an approval the requester has not started. Confirmed first, like {@link revoke}: it
+   * takes a decision away from a third party, cannot be undone from this screen, and the requester
+   * is not told.
+   */
   protected async cancelApproval(row: MyAccessRequestRow): Promise<void> {
     if (!this.canCancelApproval(row) || this.isActing(row)) {
       return;
     }
-    await this.act(row, "pamInboxApprovalCanceledToast", "pamInboxCancelApprovalFailed", () =>
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "pamInboxWithdrawApproval" },
+      content: {
+        key: "pamInboxWithdrawApprovalConfirm",
+        // The same expression the Item column renders, so the dialog and its row always name the
+        // item identically — including when the cipher is not in the approver's vault.
+        placeholders: [row.cipherName ?? row.cipherId],
+      },
+      acceptButtonText: { key: "pamInboxWithdrawApproval" },
+      type: "warning",
+    });
+    if (!confirmed) {
+      return;
+    }
+    await this.act(row, "pamInboxApprovalWithdrawnToast", "pamInboxWithdrawApprovalFailed", () =>
       this.inbox.cancelApproval(row.id as AccessRequestId),
     );
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -93,7 +93,7 @@ export class HistoryTabComponent {
 
   protected readonly HistoryScope = HistoryScope;
 
-  protected readonly canApprove = toSignal(this.approvalPrivileges.canApprove$, {
+  private readonly canApprove = toSignal(this.approvalPrivileges.canApprove$, {
     initialValue: false,
   });
 
@@ -120,24 +120,24 @@ export class HistoryTabComponent {
     initialValue: new Map<string, CipherView>(),
   });
 
-  /** A pure computed rather than a one-shot latch, so it tracks the managed rows as they load. */
-  private readonly defaultScope = computed<HistoryScope>(() =>
-    this.managedRows().length > 0 ? HistoryScope.Managed : HistoryScope.Mine,
-  );
+  private readonly hasManagedHistory = computed(() => this.managedRows().length > 0);
 
+  /**
+   * The default half is derived rather than latched on first load, so it keeps tracking the managed
+   * rows until the viewer pins a scope of their own.
+   */
   protected readonly scope = computed<HistoryScope>(
-    () => this.chosenScope() ?? this.defaultScope(),
+    () =>
+      this.chosenScope() ?? (this.hasManagedHistory() ? HistoryScope.Managed : HistoryScope.Mine),
   );
 
   /**
    * The toggle is offered to anyone who can approve, rows or not — gating it on rows hides the
    * second scope until it has content, which is exactly when the reader no longer needs telling it
-   * exists. The `managedRows()` term keeps it for a viewer whose privilege stream has not resolved
-   * but whose rows have.
+   * exists. The `hasManagedHistory()` term keeps it for a viewer whose privilege stream has not
+   * resolved but whose rows have.
    */
-  protected readonly canSwitchScope = computed(
-    () => this.canApprove() || this.managedRows().length > 0,
-  );
+  protected readonly canSwitchScope = computed(() => this.canApprove() || this.hasManagedHistory());
 
   protected readonly showingManaged = computed(
     () => this.scope() === HistoryScope.Managed && this.canSwitchScope(),


### PR DESCRIPTION
## Objective

Make the managed History scope reachable, name its action for the operator doing it, and confirm before it fires.

Closes UAT findings [`uat-FLW-06-88122152`](https://pam.run.ventures/uat-report/), [`uat-FLW-03-8274af45`](https://pam.run.ventures/uat-report/), [`uat-FLW-06-61d11195`](https://pam.run.ventures/uat-report/).

- History opened on `HistoryScope.Mine` and the toggle only rendered once `hasManagedHistory()` was true, so an approver's first view was "No request history" while rows sat one unadvertised button away.
- The one control on a managed row read "Cancel" — the holder's word on an operator-facing filter.
- `cancelApproval()` called straight through with no confirmation, while the sibling `revoke()` opens `openSimpleDialog` with `pamInboxRevokeConfirm`. Two adjacent controls, both taking access from a third party, guarded to two different standards.

Batched together because all three land on `history-tab.component.{ts,html}`.

> **Draft — do not merge.** Produced by the PAM UAT polish pipeline (run `wf_d3228d2d-3d3`) and pushed early to exercise `gh stack`. Review, QA and Visual QA had not run at push time. All new user-facing strings are **proposed** wording pending the designer.
