### PR TITLE
PM-36618 [Defect] Export button in Event Logs uses incorrect sign-in icon instead of export icon

### DIFF
--- a/apps/web/src/app/dirt/event-logs/components/organization-events/events.component.html
+++ b/apps/web/src/app/dirt/event-logs/components/organization-events/events.component.html
@@ -55,7 +55,7 @@
         bitFormButton
         [bitAction]="exportEvents"
         [disabled]="dirtyDates || usePlaceHolderEvents"
-        endIcon="bwi-sign-in"
+        endIcon="bwi-import"
       >
         {{ "exportVerb" | i18n }}
       </button>

--- a/apps/web/src/app/dirt/event-logs/components/organization-events/events.component.spec.ts
+++ b/apps/web/src/app/dirt/event-logs/components/organization-events/events.component.spec.ts
@@ -1,5 +1,9 @@
-import { ActivatedRoute, Router } from "@angular/router";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { ActivatedRoute, convertToParamMap, Router } from "@angular/router";
 import { mock } from "jest-mock-extended";
+import { BehaviorSubject, of } from "rxjs";
 
 import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
@@ -16,6 +20,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 
+import { HeaderModule } from "../../../../layouts/header/header.module";
 import { EventExportService } from "../../../../tools/event-export";
 import {
   EventService,
@@ -191,5 +196,93 @@ describe("EventsComponent Send access linking", () => {
       expect(dialogService.open).not.toHaveBeenCalled();
       expect(router.navigate).not.toHaveBeenCalled();
     });
+  });
+});
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: "app-header",
+  template: "<div></div>",
+})
+class MockHeaderComponent {}
+
+describe("EventsComponent Export button", () => {
+  let fixture: ComponentFixture<EventsComponent>;
+
+  beforeEach(async () => {
+    // The template-only assertions below don't need the data load; ngOnInit needs a live route
+    // and org lookup, neither of which affect the Export button's rendering.
+    jest.spyOn(EventsComponent.prototype, "ngOnInit").mockResolvedValue(undefined);
+
+    const eventService = mock<EventService>();
+    eventService.getDefaultDateFilters.mockReturnValue(["", ""]);
+    const i18nService = mock<I18nService>();
+    i18nService.t.mockImplementation((id: string) => id);
+    const accountService = mock<AccountService>();
+    accountService.activeAccount$ = new BehaviorSubject(null);
+    const organizationService = mock<OrganizationService>();
+    organizationService.organizations$.mockReturnValue(of([]));
+    const activatedRoute = mock<ActivatedRoute>();
+    activatedRoute.params = of({});
+    activatedRoute.paramMap = of(convertToParamMap({}));
+    // The component library's DialogModule providers are instantiated for real (they live in the
+    // component's own environment injector), so the Router mock needs a usable url/events.
+    const router = mock<Router>();
+    router.url = "/";
+    router.events = of();
+
+    await TestBed.configureTestingModule({
+      imports: [EventsComponent],
+      providers: [
+        { provide: ApiService, useValue: mock<ApiService>() },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        { provide: EventService, useValue: eventService },
+        { provide: I18nService, useValue: i18nService },
+        { provide: EventExportService, useValue: mock<EventExportService>() },
+        { provide: PlatformUtilsService, useValue: mock<PlatformUtilsService>() },
+        { provide: LogService, useValue: mock<LogService>() },
+        { provide: UserNamePipe, useValue: mock<UserNamePipe>() },
+        { provide: OrganizationService, useValue: organizationService },
+        { provide: OrganizationUserApiService, useValue: mock<OrganizationUserApiService>() },
+        {
+          provide: OrganizationApiServiceAbstraction,
+          useValue: mock<OrganizationApiServiceAbstraction>(),
+        },
+        { provide: ProviderService, useValue: mock<ProviderService>() },
+        { provide: FileDownloadService, useValue: mock<FileDownloadService>() },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: AccountService, useValue: accountService },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: ConfigService, useValue: mock<ConfigService>() },
+        { provide: Router, useValue: router },
+      ],
+    })
+      .overrideComponent(EventsComponent, {
+        remove: { imports: [HeaderModule] },
+        add: { imports: [MockHeaderComponent] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(EventsComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // The ngOnInit spy is installed on the shared prototype, so it has to be restored to keep it
+    // from leaking into any describe block added below this one.
+    jest.restoreAllMocks();
+  });
+
+  const exportButton = () =>
+    fixture.debugElement
+      .queryAll(By.css("button[bitButton]"))
+      .find((button) => button.nativeElement.textContent.trim() === "exportVerb");
+
+  it("renders the export (bwi-import) icon, not the sign-in icon", () => {
+    const icon = exportButton().query(By.css("i.bwi"));
+
+    expect(icon).not.toBeNull();
+    expect(icon.nativeElement.classList).toContain("bwi-import");
+    expect(icon.nativeElement.classList).not.toContain("bwi-sign-in");
   });
 });

--- a/bitwarden_license/bit-web/src/app/dirt/provider-events/events.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/provider-events/events.component.html
@@ -43,7 +43,7 @@
         bitFormButton
         [bitAction]="exportEvents"
         [disabled]="dirtyDates"
-        endIcon="bwi-sign-in"
+        endIcon="bwi-import"
       >
         {{ "exportVerb" | i18n }}
       </button>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-36618](https://bitwarden.atlassian.net/browse/PM-36618)

## 📔 Objective

The Export button in Admin Console > Event Logs displayed a sign-in icon (arrow pointing into a box) instead of the export icon, inconsistent with the Export button in the Member Access Report.

**Root cause:** the button used `endIcon="bwi-sign-in"` instead of `endIcon="bwi-import"`. `bwi-import` maps to the same glyph as `bwi-upload` (arrow pointing up out of a box) per `libs/angular/src/scss/bwicons/styles/style.css`, and is what Member Access Report's Export button already correctly uses.

While verifying, found the identical bug in Provider Events' Export button (same component pattern) — not called out in the original ticket, but fixed here too since it's the same one-line root cause.

**Scope note:** a third, structurally identical Export button exists in Secrets Manager's service-accounts event logs page (`service-accounts-events.component.html`), owned by a different team. Left untouched intentionally — recommend a follow-up ticket with that team so the three buttons don't keep drifting apart.

**Testing:** added a fixture-based test asserting the rendered icon class on the Event Logs Export button, with a negative-control check confirming it fails against the old `bwi-sign-in` value. No spec file exists yet for the Provider Events component, so that occurrence is fixed but untested by automation — worth a manual smoke test (Provider Portal → Clients → Event Logs).

## 📸 Screenshots

<img width="1196" height="1179" alt="image" src="https://github.com/user-attachments/assets/76251ec2-42b3-41ea-830e-a2198a41e15d" />


[PM-36618]: https://bitwarden.atlassian.net/browse/PM-36618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ