### PR TITLE
fix(web): mount PAM inside the shared user shell so the side nav resolves

### DIFF
--- a/apps/web/src/app/layouts/user-layout-nav-resolution.spec.ts
+++ b/apps/web/src/app/layouts/user-layout-nav-resolution.spec.ts
@@ -1,0 +1,220 @@
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { provideRouter, Routes } from "@angular/router";
+import { RouterTestingHarness } from "@angular/router/testing";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject, of } from "rxjs";
+
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { SyncService } from "@bitwarden/common/platform/sync";
+import { FakeGlobalStateProvider } from "@bitwarden/common/spec";
+import { UserId } from "@bitwarden/common/types/guid";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
+import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
+import { NavigationModule, SideNavService } from "@bitwarden/components";
+import { SendPolicyService } from "@bitwarden/send-ui";
+import { GlobalStateProvider } from "@bitwarden/state";
+import { VaultNavService, VaultsNavViewModel } from "@bitwarden/vault";
+
+import { PremiumSubscriptionRoutingService } from "../billing/individual/services/premium-subscription-routing.service";
+import { BillingFreeFamiliesNavItemComponent } from "../billing/shared/billing-free-families-nav-item.component";
+import { PamUserNavSlotComponent } from "../pam/user-nav-slot/pam-user-nav-slot.component";
+import { CoachmarkComponent, CoachmarkService } from "../vault/components/coachmark";
+
+import { UserLayoutComponent } from "./user-layout.component";
+import { WebLayoutModule } from "./web-layout.module";
+
+@Component({
+  selector: "app-layout",
+  template: "<ng-content></ng-content>",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockWebLayoutComponent {}
+
+@Component({
+  selector: "app-side-nav",
+  template: "<ng-content></ng-content>",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockWebSideNavComponent {}
+
+@Component({
+  selector: "billing-free-families-nav-item",
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockBillingFreeFamiliesNavItemComponent {}
+
+@Component({
+  selector: "app-pam-user-nav-slot",
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockPamUserNavSlotComponent {}
+
+@Component({
+  selector: "app-coachmark",
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockCoachmarkComponent {
+  popover(): undefined {
+    return undefined;
+  }
+}
+
+@Component({
+  selector: "app-feature-page",
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class FeaturePageComponent {}
+
+const userId = "user-id" as UserId;
+
+const emptyViewModel: VaultsNavViewModel = { vaults: [], organizationDataOwnership: false };
+
+/**
+ * The production shape: ONE `UserLayoutComponent` mount at the root, with every feature — `/pam`
+ * included — as a child of it. See `OssRoutingModule`.
+ */
+const routes: Routes = [
+  {
+    path: "",
+    component: UserLayoutComponent,
+    children: [
+      { path: "vault", component: FeaturePageComponent },
+      { path: "pam", children: [{ path: "", component: FeaturePageComponent }] },
+    ],
+  },
+];
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: true,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+/**
+ * The side nav's ~20 items use RELATIVE routes (`route="settings/account"`), and Angular resolves
+ * a relative `routerLink` against the `ActivatedRoute` of the component rendering it. Mounting a
+ * second `UserLayoutComponent` at a top-level path therefore silently re-bases the whole nav
+ * beneath that path. This pins the property that keeps the links correct: however deep the user
+ * navigates, the layout stays mounted at the root and its links stay root-relative.
+ */
+describe("UserLayoutComponent nav link resolution", () => {
+  const flag$ = new BehaviorSubject<boolean>(true);
+  const viewModel$ = new BehaviorSubject<VaultsNavViewModel>(emptyViewModel);
+  const canArchive$ = new BehaviorSubject<boolean>(true);
+
+  const configService = mock<ConfigService>();
+  const vaultNavService = mock<VaultNavService>();
+  const i18nService = mock<I18nService>();
+  const policyService = mock<PolicyService>();
+  const cipherArchiveService = mock<CipherArchiveService>();
+
+  const setup = async () => {
+    jest.clearAllMocks();
+    flag$.next(true);
+    viewModel$.next(emptyViewModel);
+    canArchive$.next(true);
+
+    i18nService.t.mockImplementation((key: string) => key);
+    configService.getFeatureFlag$.mockReturnValue(flag$);
+    policyService.policyAppliesToUser$.mockReturnValue(of(false));
+    cipherArchiveService.userCanArchive$.mockReturnValue(canArchive$);
+    Object.defineProperty(vaultNavService, "viewModel$", { value: viewModel$ });
+
+    await TestBed.configureTestingModule({
+      imports: [UserLayoutComponent, NavigationModule],
+      providers: [
+        provideRouter(routes),
+        { provide: I18nService, useValue: i18nService },
+        { provide: ConfigService, useValue: configService },
+        { provide: VaultNavService, useValue: vaultNavService },
+        { provide: PolicyService, useValue: policyService },
+        { provide: GlobalStateProvider, useValue: new FakeGlobalStateProvider() },
+        { provide: SyncService, useValue: mock<SyncService>() },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: userId }) } },
+        { provide: OrganizationService, useValue: { organizations$: () => of([]) } },
+        { provide: SendPolicyService, useValue: { disableSend$: of(false) } },
+        {
+          provide: PremiumSubscriptionRoutingService,
+          useValue: { getSubscriptionRoute$: () => of(null) },
+        },
+        { provide: CoachmarkService, useValue: mock<CoachmarkService>() },
+        { provide: CipherArchiveService, useValue: cipherArchiveService },
+        { provide: PremiumUpgradePromptService, useValue: mock<PremiumUpgradePromptService>() },
+      ],
+    })
+      .overrideComponent(UserLayoutComponent, {
+        remove: {
+          imports: [
+            WebLayoutModule,
+            BillingFreeFamiliesNavItemComponent,
+            CoachmarkComponent,
+            PamUserNavSlotComponent,
+          ],
+        },
+        add: {
+          imports: [
+            NavigationModule,
+            MockWebLayoutComponent,
+            MockWebSideNavComponent,
+            MockBillingFreeFamiliesNavItemComponent,
+            MockCoachmarkComponent,
+            MockPamUserNavSlotComponent,
+          ],
+        },
+      })
+      .compileComponents();
+
+    TestBed.inject(SideNavService).open.set(true);
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl("/pam");
+    harness.detectChanges();
+    return harness;
+  };
+
+  /** Settings items live in a collapsed group; open it so their anchors render. */
+  const expandSettings = (harness: RouterTestingHarness) => {
+    const group = harness.fixture.debugElement
+      .queryAll(By.css("bit-nav-group"))
+      .find((el) => el.componentInstance.text() === "settings");
+    group.componentInstance.open.set(true);
+    harness.detectChanges();
+  };
+
+  it("keeps every nav link at the root while a child feature route is active", async () => {
+    const harness = await setup();
+    expandSettings(harness);
+
+    const hrefs = Array.from(
+      harness.fixture.nativeElement.querySelectorAll<HTMLAnchorElement>("a[href]"),
+    ).map((anchor) => anchor.getAttribute("href"));
+
+    expect(hrefs).toContain("/settings/account");
+    expect(hrefs).toContain("/reports");
+    expect(hrefs.filter((href) => href.startsWith("/pam/"))).toEqual([]);
+  });
+});

--- a/apps/web/src/app/oss-routing.module.ts
+++ b/apps/web/src/app/oss-routing.module.ts
@@ -1,5 +1,5 @@
-import { NgModule } from "@angular/core";
-import { Route, RouterModule, Routes } from "@angular/router";
+import { inject, NgModule } from "@angular/core";
+import { LoadChildrenCallback, Route, RouterModule, Routes } from "@angular/router";
 import { map, switchMap } from "rxjs";
 
 import { organizationPolicyGuard } from "@bitwarden/angular/admin-console/guards";
@@ -87,6 +87,7 @@ import { DataRecoveryComponent } from "./key-management/data-recovery/data-recov
 import { ConfirmKeyConnectorDomainComponent } from "./key-management/key-connector/confirm-key-connector-domain.component";
 import { FrontendLayoutComponent } from "./layouts/frontend-layout.component";
 import { UserLayoutComponent } from "./layouts/user-layout.component";
+import { PAM_ROUTES } from "./pam/pam-routes.token";
 import { RequestSMAccessComponent } from "./secrets-manager/secrets-manager-landing/request-sm-access.component";
 import { SMLandingComponent } from "./secrets-manager/secrets-manager-landing/sm-landing.component";
 import { AppearanceComponent } from "./settings/appearance.component";
@@ -676,6 +677,19 @@ const routes: Routes = [
         path: "vault",
         canActivate: [premiumInterestRedirectGuard, setupExtensionRedirectGuard],
         loadChildren: () => VaultModule,
+      },
+      {
+        // A child of the shared user shell rather than a top-level route with its own
+        // UserLayoutComponent: the side nav's routerLinks are relative, so a second layout
+        // instance re-bases every one of them beneath this path. The pages themselves are
+        // commercial and are reached only through the optional PAM_ROUTES seam, which an
+        // OSS-only build leaves unprovided so canMatch declines and /pam is not a route at all.
+        path: "pam",
+        canMatch: [() => inject(PAM_ROUTES, { optional: true }) != null],
+        canActivate: [canAccessFeature(FeatureFlag.Pam)],
+        // The type argument is load-bearing: SafeInjectionToken carries its generic on a private
+        // property, so inject() widens it to unknown without one.
+        loadChildren: () => inject<LoadChildrenCallback>(PAM_ROUTES)(),
       },
       {
         path: "sends",

--- a/apps/web/src/app/pam/CLAUDE.md
+++ b/apps/web/src/app/pam/CLAUDE.md
@@ -9,6 +9,9 @@ The feature itself, including its domain contracts, lives in
 `bitwarden_license/bit-web/src/app/pam/`.
 
 `pam-nav-badge.service.ts` is the abstract count behind the user nav slot's badge, bound in
-commercial code by `providePam()`. Every seam here follows the same rule: inject it
+commercial code by `providePam()`. `pam-routes.token.ts` is the lazy loader for the user-scoped
+pages themselves: `OssRoutingModule` mounts them at `/pam` as children of the shared
+`UserLayoutComponent`, because the side nav's `routerLink`s are relative and a second layout
+instance would re-base all of them. Every seam here follows the same rule: inject it
 `{ optional: true }` and fall back to an inert default (`of(0)` for the badge), so an OSS-only
 build where nothing provides it behaves as if PAM did not exist.

--- a/apps/web/src/app/pam/pam-mount-nav-resolution.spec.ts
+++ b/apps/web/src/app/pam/pam-mount-nav-resolution.spec.ts
@@ -23,11 +23,11 @@ import { VaultNavService, VaultsNavViewModel } from "@bitwarden/vault";
 
 import { PremiumSubscriptionRoutingService } from "../billing/individual/services/premium-subscription-routing.service";
 import { BillingFreeFamiliesNavItemComponent } from "../billing/shared/billing-free-families-nav-item.component";
-import { PamUserNavSlotComponent } from "../pam/user-nav-slot/pam-user-nav-slot.component";
+import { UserLayoutComponent } from "../layouts/user-layout.component";
+import { WebLayoutModule } from "../layouts/web-layout.module";
 import { CoachmarkComponent, CoachmarkService } from "../vault/components/coachmark";
 
-import { UserLayoutComponent } from "./user-layout.component";
-import { WebLayoutModule } from "./web-layout.module";
+import { PamUserNavSlotComponent } from "./user-nav-slot/pam-user-nav-slot.component";
 
 @Component({
   selector: "app-layout",
@@ -116,12 +116,15 @@ Object.defineProperty(window, "matchMedia", {
 
 /**
  * The side nav's ~20 items use RELATIVE routes (`route="settings/account"`), and Angular resolves
- * a relative `routerLink` against the `ActivatedRoute` of the component rendering it. Mounting a
- * second `UserLayoutComponent` at a top-level path therefore silently re-bases the whole nav
- * beneath that path. This pins the property that keeps the links correct: however deep the user
- * navigates, the layout stays mounted at the root and its links stay root-relative.
+ * a relative `routerLink` against the `ActivatedRoute` of the component rendering it. Mounting PAM
+ * under a second `UserLayoutComponent` at a top-level path therefore silently re-bases the whole
+ * nav beneath `/pam`. This pins the constraint that mounting PAM places on itself: it joins the
+ * root layout as a child, so the shared nav's links stay root-relative while a PAM page is open.
+ *
+ * `UserLayoutComponent` is the fixture here, not the subject — the nav is free to switch to
+ * absolute routes without touching this spec; only a change to where PAM mounts breaks it.
  */
-describe("UserLayoutComponent nav link resolution", () => {
+describe("PAM mount / shared nav link resolution", () => {
   const flag$ = new BehaviorSubject<boolean>(true);
   const viewModel$ = new BehaviorSubject<VaultsNavViewModel>(emptyViewModel);
   const canArchive$ = new BehaviorSubject<boolean>(true);

--- a/apps/web/src/app/pam/pam-mount-nav-resolution.spec.ts
+++ b/apps/web/src/app/pam/pam-mount-nav-resolution.spec.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
-import { provideRouter, Routes } from "@angular/router";
+import { LoadChildrenCallback, provideRouter, Routes } from "@angular/router";
 import { RouterTestingHarness } from "@angular/router/testing";
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
@@ -27,6 +27,7 @@ import { UserLayoutComponent } from "../layouts/user-layout.component";
 import { WebLayoutModule } from "../layouts/web-layout.module";
 import { CoachmarkComponent, CoachmarkService } from "../vault/components/coachmark";
 
+import { PAM_ROUTES } from "./pam-routes.token";
 import { PamUserNavSlotComponent } from "./user-nav-slot/pam-user-nav-slot.component";
 
 @Component({
@@ -79,9 +80,14 @@ const userId = "user-id" as UserId;
 
 const emptyViewModel: VaultsNavViewModel = { vaults: [], organizationDataOwnership: false };
 
+const pamChildRoutes: Routes = [{ path: "", component: FeaturePageComponent }];
+
 /**
  * The production shape: ONE `UserLayoutComponent` mount at the root, with every feature — `/pam`
  * included — as a child of it. See `OssRoutingModule`.
+ *
+ * `/pam` reaches its pages through the same lazy `PAM_ROUTES` seam production uses rather than
+ * eager `children`, so what renders inside the layout here is what a licensed build renders.
  */
 const routes: Routes = [
   {
@@ -89,7 +95,11 @@ const routes: Routes = [
     component: UserLayoutComponent,
     children: [
       { path: "vault", component: FeaturePageComponent },
-      { path: "pam", children: [{ path: "", component: FeaturePageComponent }] },
+      {
+        path: "pam",
+        canMatch: [() => inject(PAM_ROUTES, { optional: true }) != null],
+        loadChildren: () => inject<LoadChildrenCallback>(PAM_ROUTES)(),
+      },
     ],
   },
 ];
@@ -151,6 +161,7 @@ describe("PAM mount / shared nav link resolution", () => {
       imports: [UserLayoutComponent, NavigationModule],
       providers: [
         provideRouter(routes),
+        { provide: PAM_ROUTES, useValue: () => pamChildRoutes },
         { provide: I18nService, useValue: i18nService },
         { provide: ConfigService, useValue: configService },
         { provide: VaultNavService, useValue: vaultNavService },

--- a/apps/web/src/app/pam/pam-route-seam.spec.ts
+++ b/apps/web/src/app/pam/pam-route-seam.spec.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, Provider } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
-import { provideRouter, Router, RouterOutlet, Routes } from "@angular/router";
+import { LoadChildrenCallback, provideRouter, Router, RouterOutlet, Routes } from "@angular/router";
 import { RouterTestingHarness } from "@angular/router/testing";
 
 import { PAM_ROUTES } from "./pam-routes.token";
@@ -42,6 +42,11 @@ describe("PAM_ROUTES seam", () => {
    * The shape `OssRoutingModule` gives the user shell: one `UserLayoutComponent` mount behind
    * `deepLinkGuard` + `authGuard`, with `pam` as one of its children. The guards are recorders
    * rather than the real ones so their relative order is observable.
+   *
+   * `canMatch` and `loadChildren` are copied verbatim from `OssRoutingModule` rather than
+   * simplified: both reach the seam through `inject()`, which is legal only because the router
+   * calls them inside an injection context. Nothing else fails if that stops holding — the
+   * callback runs on navigation, so neither `test:types` nor a production build executes it.
    */
   const routes: Routes = [
     {
@@ -54,7 +59,7 @@ describe("PAM_ROUTES seam", () => {
           path: "pam",
           canMatch: [() => inject(PAM_ROUTES, { optional: true }) != null],
           canActivate: [record("canAccessFeature(Pam)")],
-          loadChildren: () => pamChildRoutes,
+          loadChildren: () => inject<LoadChildrenCallback>(PAM_ROUTES)(),
         },
       ],
     },

--- a/apps/web/src/app/pam/pam-route-seam.spec.ts
+++ b/apps/web/src/app/pam/pam-route-seam.spec.ts
@@ -1,0 +1,102 @@
+import { ChangeDetectionStrategy, Component, inject, Provider } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { provideRouter, Router, RouterOutlet, Routes } from "@angular/router";
+import { RouterTestingHarness } from "@angular/router/testing";
+
+import { PAM_ROUTES } from "./pam-routes.token";
+
+@Component({
+  selector: "app-shell",
+  template: "<router-outlet></router-outlet>",
+  imports: [RouterOutlet],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class ShellComponent {}
+
+@Component({
+  selector: "app-blank",
+  template: "blank",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class BlankComponent {}
+
+@Component({
+  selector: "app-pam",
+  template: "pam-page",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class PamPageComponent {}
+
+const pamChildRoutes: Routes = [{ path: "", component: PamPageComponent }];
+
+describe("PAM_ROUTES seam", () => {
+  let calls: string[];
+
+  /** Stands in for a real guard, recording that it ran and allowing navigation. */
+  const record = (name: string) => () => {
+    calls.push(name);
+    return true;
+  };
+
+  /**
+   * The shape `OssRoutingModule` gives the user shell: one `UserLayoutComponent` mount behind
+   * `deepLinkGuard` + `authGuard`, with `pam` as one of its children. The guards are recorders
+   * rather than the real ones so their relative order is observable.
+   */
+  const routes: Routes = [
+    {
+      path: "",
+      component: ShellComponent,
+      canActivate: [record("deepLinkGuard"), record("authGuard")],
+      children: [
+        { path: "vault", component: BlankComponent },
+        {
+          path: "pam",
+          canMatch: [() => inject(PAM_ROUTES, { optional: true }) != null],
+          canActivate: [record("canAccessFeature(Pam)")],
+          loadChildren: () => pamChildRoutes,
+        },
+      ],
+    },
+    { path: "**", redirectTo: "" },
+  ];
+
+  const setup = async (providePamRoutes: boolean) => {
+    calls = [];
+    const providers: Provider[] = [provideRouter(routes)];
+    if (providePamRoutes) {
+      providers.push({ provide: PAM_ROUTES, useValue: () => pamChildRoutes });
+    }
+    TestBed.configureTestingModule({ providers });
+    return await RouterTestingHarness.create();
+  };
+
+  it("resolves /pam to the commercial pages when a host provides the seam", async () => {
+    const harness = await setup(true);
+
+    await harness.navigateByUrl("/pam");
+    harness.detectChanges();
+
+    expect(TestBed.inject(Router).url).toBe("/pam");
+    expect(harness.fixture.nativeElement.textContent).toContain("pam-page");
+  });
+
+  it("gates /pam behind the shell's auth guards before the feature-flag guard", async () => {
+    const harness = await setup(true);
+
+    await harness.navigateByUrl("/pam");
+
+    expect(calls).toEqual(["deepLinkGuard", "authGuard", "canAccessFeature(Pam)"]);
+  });
+
+  it("never matches /pam in an OSS-only build where nothing provides the seam", async () => {
+    const harness = await setup(false);
+
+    await harness.navigateByUrl("/pam");
+
+    // canMatch declines, so /pam is not a route at all and the wildcard sends the user home —
+    // how an OSS-only build treats any unknown path.
+    expect(TestBed.inject(Router).url).toBe("/");
+    expect(calls).not.toContain("canAccessFeature(Pam)");
+  });
+});

--- a/apps/web/src/app/pam/pam-routes.token.ts
+++ b/apps/web/src/app/pam/pam-routes.token.ts
@@ -1,0 +1,18 @@
+import { LoadChildrenCallback } from "@angular/router";
+
+import { SafeInjectionToken } from "@bitwarden/ui-common";
+
+/**
+ * Lazy route loader for the commercial PAM feature's user-scoped pages ("Access requests").
+ *
+ * A host that ships privileged access provides a loader returning those routes, or the NgModule
+ * declaring them; the OSS root shell mounts them under `/pam` as children of the same
+ * `UserLayoutComponent` instance every other user page renders in. Sharing that instance is the
+ * point rather than an incidental tidiness: the side nav's `routerLink`s are relative, so they
+ * resolve against the `ActivatedRoute` of the layout rendering them, and a second layout mounted
+ * at a top-level path re-bases all ~20 of them beneath it.
+ *
+ * Read `{ optional: true }` by the route's `canMatch`, so an OSS-only build, where nothing
+ * provides it, never matches `/pam` and behaves as if PAM did not exist.
+ */
+export const PAM_ROUTES = new SafeInjectionToken<LoadChildrenCallback>("PamRoutes");

--- a/bitwarden_license/bit-web/src/app/app-routing.module.ts
+++ b/bitwarden_license/bit-web/src/app/app-routing.module.ts
@@ -1,17 +1,18 @@
 import { NgModule } from "@angular/core";
 import { RouterModule, Routes } from "@angular/router";
 
-import { authGuard, unauthGuardFn } from "@bitwarden/angular/auth/guards";
-import { canAccessFeature } from "@bitwarden/angular/platform/guard/feature-flag.guard";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { unauthGuardFn } from "@bitwarden/angular/auth/guards";
 import { AnonLayoutWrapperComponent } from "@bitwarden/components";
 import { deepLinkGuard } from "@bitwarden/web-vault/app/auth/guards/deep-link/deep-link.guard";
 import { RouteDataProperties } from "@bitwarden/web-vault/app/core";
-import { UserLayoutComponent } from "@bitwarden/web-vault/app/layouts/user-layout.component";
 
 import { ProvidersModule } from "./admin-console/providers/providers.module";
 import { VerifyRecoverDeleteProviderComponent } from "./admin-console/providers/verify-recover-delete-provider.component";
 
+// Registered before OssRoutingModule, so an empty-path route here would match "/" and run its
+// guards before the root redirectGuard can send anonymous users to /login. Routes in this
+// module need a literal path segment; anything user-scoped belongs in the OSS root shell's
+// children, reached across the license boundary through an optional injection token.
 const routes: Routes = [
   {
     path: "providers",
@@ -35,18 +36,6 @@ const routes: Routes = [
         data: { titleId: "deleteAccount" } satisfies RouteDataProperties,
       },
     ],
-  },
-  {
-    // Mounted on "pam" rather than an empty-path shell: this module is registered before
-    // OssRoutingModule, so an empty-path route here matches "/" and its authGuard fires
-    // before the root redirectGuard can send anonymous users to /login.
-    path: "pam",
-    component: UserLayoutComponent,
-    canActivate: [deepLinkGuard(), authGuard, canAccessFeature(FeatureFlag.Pam)],
-    loadChildren: () =>
-      import("./pam/access-requests/access-requests-routing.module").then(
-        (m) => m.AccessRequestsRoutingModule,
-      ),
   },
 ];
 

--- a/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
+++ b/bitwarden_license/bit-web/src/app/pam/provide-pam.ts
@@ -14,6 +14,7 @@ import {
 } from "@bitwarden/vault";
 import { COLLECTION_ACCESS_RULE_CALLOUT } from "@bitwarden/web-vault/app/admin-console/organizations/shared/components/collection-dialog/collection-access-rule-callout.token";
 import { PamNavBadgeService } from "@bitwarden/web-vault/app/pam/pam-nav-badge.service";
+import { PAM_ROUTES } from "@bitwarden/web-vault/app/pam/pam-routes.token";
 import { VaultRowAccessActionsService } from "@bitwarden/web-vault/app/vault/components/vault-items/vault-row-access-actions.service";
 import { VAULT_ROW_LEASE_BADGE } from "@bitwarden/web-vault/app/vault/components/vault-items/vault-row-lease-badge.token";
 import { VAULT_CONTROLLED_ACCESS_FILTER } from "@bitwarden/web-vault/app/vault/individual-vault/vault-controlled-access-filter.token";
@@ -85,15 +86,24 @@ import {
  * list), `GATED_CIPHER_RELOADER` (the observable that reveals a gated cipher in place
  * once a lease covers it),
  * `COLLECTION_ACCESS_RULE_CALLOUT` (the governing-rule notice in the collection
- * edit dialog), `PamNavBadgeService` (the nav badge count), and
+ * edit dialog), `PamNavBadgeService` (the nav badge count),
  * `VaultRowAccessActionsService` (withdrawing a gated row's outstanding access
- * request from the vault-list menu).
+ * request from the vault-list menu), and `PAM_ROUTES` (the lazy loader for the user-scoped
+ * "Access requests" pages, which the OSS root shell mounts inside the shared user layout so
+ * the side nav's relative links keep resolving against the root).
  *
  * `AccessEventService` turns the server's access push into a tick; `AccessRefreshService`
  * merges that tick with local mutations so every leasing surface re-reads through one path.
  */
 export function providePam(): SafeProvider[] {
   return [
+    safeProvider({
+      provide: PAM_ROUTES,
+      useValue: () =>
+        import("./access-requests/access-requests-routing.module").then(
+          (m) => m.AccessRequestsRoutingModule,
+        ),
+    }),
     safeProvider({
       provide: AccessRuleSdkService,
       useClass: AccessRulesSdkService,


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-SCR-11-8932b7c9`, also closes `uat-FLW-05-b39fcd27`.

## 📔 Objective

Mount PAM inside the existing root user shell instead of a second copy at `/pam`, so the side nav's relative links resolve correctly.

- `UserLayoutComponent` is not PAM's. OSS mounts it once at `path: ""` and every subpage is a child of that mount, so its relative `routerLink`s resolve against the root. PAM mounted a second instance at `path: "pam"`, so the nav's `ActivatedRoute` became `/pam` and every link re-based: `settings/account` resolved to `/pam/settings/account`.
- PAM now attaches to the root mount through `PAM_ROUTES`, an optional injection token, the same seam `apps/web/src/app/pam/` already uses for the nav slot and badge. No route string changes, so a nav item added later cannot reintroduce this.
- Parity verified: guard order stays `deepLinkGuard`, `authGuard`, `canAccessFeature(Pam)`; the tab paths and `/pam/requests/:id` are unchanged; the built chunk graph is identical and PAM still lazy loads. `canMatch` keeps `/pam` out of the route table entirely in an OSS-only build.
- Size: 7 files, 396 insertions(+), 21 deletions(-). Every file is PAM-owned or unowned.
- Stack: sits on `pam/uat`; `audit-event-filter-menu` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

### Web vault -> Access requests (/pam/*) -> side navigation

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/d02e9fe5017dd12bf4dde0c8cc031fb35ab776f5/before-uat-SCR-11-8932b7c9.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/ea0f7a75ec6da8eb881cdb04ae0546d79b80aa78/after-uat-SCR-11-8932b7c9.png" alt="after" width="460"> |

## Known gaps

`user-layout.component.spec.ts` has 8 pre-existing `NullInjector` failures on `pam/uat`; they fail identically on the clean base and are untouched here. `npm run test:types` reports 1 pre-existing strict error, in `access-rule-edit.component.spec.ts` (#22635).
