### PR TITLE
fix(pam): move the audit Event filter to bit-filter-menu

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -43,12 +43,11 @@
         [placeholder]="'pamAuditSearchPlaceholder' | i18n"
         [formControl]="searchControl"
       ></bit-search>
-      <bit-chip-filter
-        [placeholderText]="'pamAuditColumnEvent' | i18n"
-        placeholderIcon="bwi-filter"
-        [options]="kindOptions()"
-        [formControl]="kindControl"
-      ></bit-chip-filter>
+      <bit-filter-menu key="kind" [placeholderText]="'pamAuditColumnEvent' | i18n">
+        @for (option of kindOptions(); track option.value) {
+          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+        }
+      </bit-filter-menu>
     </div>
 
     @if (filteredRows().length === 0) {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -43,7 +43,11 @@
         [placeholder]="'pamAuditSearchPlaceholder' | i18n"
         [formControl]="searchControl"
       ></bit-search>
-      <bit-filter-menu key="kind" [placeholderText]="'pamAuditColumnEvent' | i18n">
+      <bit-filter-menu
+        key="kind"
+        [placeholderText]="'pamAuditColumnEvent' | i18n"
+        [unsetLabel]="'all' | i18n"
+      >
         @for (option of kindOptions(); track option.value) {
           <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
         }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -97,7 +97,7 @@ describe("AccessAuditComponent", () => {
             pamAuditKindLeaseRevoked: "Lease revoked",
             pamAuditKindLeaseEndedByHolder: "Lease ended by holder",
             all: "All",
-            removeItem: (name: string) => `Remove ${name}`,
+            removeItem: (name?: string) => `Remove ${name}`,
             search: "Search",
             resetSearch: "Reset search",
           }),
@@ -144,7 +144,7 @@ describe("AccessAuditComponent", () => {
    * into a CDK overlay on the document, not inside the fixture's host element.
    */
   const openKindMenu = () => {
-    fixture.nativeElement
+    (fixture.nativeElement as HTMLElement)
       .querySelector<HTMLButtonElement>("bit-filter-menu button[aria-haspopup]")!
       .click();
     fixture.detectChanges();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -9,7 +9,7 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { FilterMenuComponent, I18nMockService } from "@bitwarden/components";
+import { FilterMenuComponent, FilterOptionComponent, I18nMockService } from "@bitwarden/components";
 import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import {
@@ -132,6 +132,25 @@ describe("AccessAuditComponent", () => {
     fixture.debugElement.query(By.directive(FilterMenuComponent))
       .componentInstance as FilterMenuComponent;
 
+  /** The options declared into the Event menu, in template order. */
+  const kindMenuOptions = () =>
+    fixture.debugElement.queryAll(By.directive(FilterOptionComponent)).map((option) => ({
+      label: (option.componentInstance as FilterOptionComponent).label(),
+      value: (option.componentInstance as FilterOptionComponent).value(),
+    }));
+
+  /**
+   * Opens the Event menu and returns its rendered rows, "All" first. The menu body is stamped
+   * into a CDK overlay on the document, not inside the fixture's host element.
+   */
+  const openKindMenu = () => {
+    fixture.nativeElement
+      .querySelector<HTMLButtonElement>("bit-filter-menu button[aria-haspopup]")!
+      .click();
+    fixture.detectChanges();
+    return Array.from(document.querySelectorAll<HTMLButtonElement>("[role='menuitemradio']"));
+  };
+
   it("reads the trail for the organization in the route", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
 
@@ -225,9 +244,10 @@ describe("AccessAuditComponent", () => {
 
     fixture.detectChanges();
     await fixture.whenStable();
+    fixture.detectChanges();
 
     // Labelled and sorted alphabetically, one entry per distinct kind label key.
-    expect(component().kindOptions()).toEqual([
+    expect(kindMenuOptions()).toEqual([
       { label: "Lease activated", value: "pamAuditKindLeaseActivated" },
       { label: "Request approved", value: "pamAuditKindRequestApproved" },
     ]);
@@ -245,7 +265,15 @@ describe("AccessAuditComponent", () => {
     expect(component().filteredRows()).toHaveLength(2);
     expect(fixture.nativeElement.querySelector("bit-chip-filter")).toBeNull();
 
-    kindChip().toggle("pamAuditKindLeaseActivated");
+    const rows = openKindMenu();
+    expect(rows.map((row) => row.textContent?.trim())).toEqual([
+      "All",
+      "Lease activated",
+      "Request approved",
+    ]);
+
+    rows[1].click();
+    fixture.detectChanges();
 
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].kindLabelKey).toBe("pamAuditKindLeaseActivated");
@@ -267,7 +295,7 @@ describe("AccessAuditComponent", () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(component().kindOptions()).toEqual([
+    expect(kindMenuOptions()).toEqual([
       { label: "Lease ended by holder", value: "pamAuditKindLeaseEndedByHolder" },
       { label: "Lease revoked", value: "pamAuditKindLeaseRevoked" },
     ]);

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -8,7 +8,7 @@ import { OrganizationService } from "@bitwarden/common/admin-console/abstraction
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { I18nMockService } from "@bitwarden/components";
+import { FilterMenuComponent, I18nMockService } from "@bitwarden/components";
 import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import {
@@ -93,6 +93,14 @@ describe("AccessAuditComponent", () => {
             pamAuditKindRequestApproved: "Request approved",
             pamAuditKindLeaseActivated: "Lease activated",
             pamAuditKindRuleCreated: "Access rule created",
+            pamAuditKindLeaseRevoked: "Lease revoked",
+            pamAuditKindLeaseEndedByHolder: "Lease ended by holder",
+            all: "All",
+            clear: "Clear",
+            noMatchingItems: "No matching items",
+            removeItem: (name: string) => `Remove ${name}`,
+            search: "Search",
+            resetSearch: "Reset search",
           }),
         },
       ],
@@ -235,6 +243,60 @@ describe("AccessAuditComponent", () => {
 
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].kindLabelKey).toBe("pamAuditKindLeaseActivated");
+  });
+
+  // A LeaseRevoked whose actor is the requester is relabelled "Lease ended by holder" by
+  // toAuditRow. The filter is keyed on that same label, so the two can no longer disagree.
+  it("offers holder-ended access as its own option, separate from an operator revoke", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ Kind: "leaseRevoked", ActorId: "user-1", ActorName: "Ada", RequesterId: "user-2" }),
+      event({ Kind: "leaseRevoked", ActorId: "user-2", ActorName: "Grace", RequesterId: "user-2" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component().kindOptions()).toEqual([
+      { label: "Lease ended by holder", value: "pamAuditKindLeaseEndedByHolder" },
+      { label: "Lease revoked", value: "pamAuditKindLeaseRevoked" },
+    ]);
+
+    component().kindControl.setValue("pamAuditKindLeaseEndedByHolder");
+    expect(component().filteredRows()).toHaveLength(1);
+    expect(component().filteredRows()[0].actor).toBe("Grace");
+
+    component().kindControl.setValue("pamAuditKindLeaseRevoked");
+    expect(component().filteredRows()).toHaveLength(1);
+    expect(component().filteredRows()[0].actor).toBe("Ada");
+  });
+
+  it("filters through the Event chip, which drives kindControl rather than binding to it", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ Kind: "leaseActivated" }),
+      event({ Kind: "requestApproved" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector("bit-chip-filter")).toBeNull();
+    const chip = fixture.debugElement
+      .queryAllNodes(() => true)
+      .find((node: any) => node.nativeNode?.tagName === "BIT-FILTER-MENU")!
+      .injector.get(FilterMenuComponent);
+
+    chip.toggle("pamAuditKindLeaseActivated");
+    fixture.detectChanges();
+
+    expect(component().kindControl.value).toBe("pamAuditKindLeaseActivated");
+    expect(component().filteredRows()).toHaveLength(1);
+
+    chip.clear();
+    fixture.detectChanges();
+
+    expect(component().kindControl.value).toBeNull();
+    expect(component().filteredRows()).toHaveLength(2);
   });
 
   it("filters rows by free text over actor, requester, item, and detail", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1,5 +1,6 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { ActivatedRoute } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import { of } from "rxjs";
@@ -96,8 +97,6 @@ describe("AccessAuditComponent", () => {
             pamAuditKindLeaseRevoked: "Lease revoked",
             pamAuditKindLeaseEndedByHolder: "Lease ended by holder",
             all: "All",
-            clear: "Clear",
-            noMatchingItems: "No matching items",
             removeItem: (name: string) => `Remove ${name}`,
             search: "Search",
             resetSearch: "Reset search",
@@ -127,6 +126,11 @@ describe("AccessAuditComponent", () => {
 
   /** The component's protected surface, reached the way the template reaches it. */
   const component = () => fixture.componentInstance as unknown as Record<string, any>;
+
+  /** The Event chip, driven the way the menu rows drive it. */
+  const kindChip = () =>
+    fixture.debugElement.query(By.directive(FilterMenuComponent))
+      .componentInstance as FilterMenuComponent;
 
   it("reads the trail for the organization in the route", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
@@ -229,7 +233,7 @@ describe("AccessAuditComponent", () => {
     ]);
   });
 
-  it("filters rows by the selected kind", async () => {
+  it("filters rows by the kind selected on the Event chip", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([
       event({ Kind: "leaseActivated" }),
       event({ Kind: "requestApproved" }),
@@ -237,12 +241,18 @@ describe("AccessAuditComponent", () => {
 
     fixture.detectChanges();
     await fixture.whenStable();
+    fixture.detectChanges();
     expect(component().filteredRows()).toHaveLength(2);
+    expect(fixture.nativeElement.querySelector("bit-chip-filter")).toBeNull();
 
-    component().kindControl.setValue("pamAuditKindLeaseActivated");
+    kindChip().toggle("pamAuditKindLeaseActivated");
 
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].kindLabelKey).toBe("pamAuditKindLeaseActivated");
+
+    kindChip().clear();
+
+    expect(component().filteredRows()).toHaveLength(2);
   });
 
   // A LeaseRevoked whose actor is the requester is relabelled "Lease ended by holder" by
@@ -255,48 +265,20 @@ describe("AccessAuditComponent", () => {
 
     fixture.detectChanges();
     await fixture.whenStable();
+    fixture.detectChanges();
 
     expect(component().kindOptions()).toEqual([
       { label: "Lease ended by holder", value: "pamAuditKindLeaseEndedByHolder" },
       { label: "Lease revoked", value: "pamAuditKindLeaseRevoked" },
     ]);
 
-    component().kindControl.setValue("pamAuditKindLeaseEndedByHolder");
+    kindChip().toggle("pamAuditKindLeaseEndedByHolder");
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].actor).toBe("Grace");
 
-    component().kindControl.setValue("pamAuditKindLeaseRevoked");
+    kindChip().toggle("pamAuditKindLeaseRevoked");
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].actor).toBe("Ada");
-  });
-
-  it("filters through the Event chip, which drives kindControl rather than binding to it", async () => {
-    auditApiService.listAccessAuditTrail.mockResolvedValue([
-      event({ Kind: "leaseActivated" }),
-      event({ Kind: "requestApproved" }),
-    ]);
-
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement.querySelector("bit-chip-filter")).toBeNull();
-    const chip = fixture.debugElement
-      .queryAllNodes(() => true)
-      .find((node: any) => node.nativeNode?.tagName === "BIT-FILTER-MENU")!
-      .injector.get(FilterMenuComponent);
-
-    chip.toggle("pamAuditKindLeaseActivated");
-    fixture.detectChanges();
-
-    expect(component().kindControl.value).toBe("pamAuditKindLeaseActivated");
-    expect(component().filteredRows()).toHaveLength(1);
-
-    chip.clear();
-    fixture.detectChanges();
-
-    expect(component().kindControl.value).toBeNull();
-    expect(component().filteredRows()).toHaveLength(2);
   });
 
   it("filters rows by free text over actor, requester, item, and detail", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -67,8 +67,14 @@ const EVENTS: AccessAuditEventResponse[] = [
     kind: AccessAuditEventKind.LeaseRevoked,
     occurredAt: fromNow(-20 * MINUTE),
     leaseId: "lease-2",
+    actorId: "user-2",
     actorName: "Ada Lovelace",
     detail: "Incident closed early.",
+  }),
+  event({
+    kind: AccessAuditEventKind.LeaseRevoked,
+    occurredAt: fromNow(-25 * MINUTE),
+    leaseId: "lease-3",
   }),
   event({
     kind: AccessAuditEventKind.LeaseExtended,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -4,7 +4,6 @@ import {
   Component,
   OnInit,
   computed,
-  effect,
   inject,
   signal,
   viewChild,
@@ -41,8 +40,6 @@ import { AuditRow, auditRowMatchesFilter, toAuditRow } from "./access-audit-row"
 import { AuditApiService } from "./audit-api.service";
 
 type AuditStatus = "loading" | "ready" | "empty" | "error";
-
-type AuditKindOption = { label: string; value: string };
 
 /**
  * The organization's PAM access-audit trail, read from the dedicated append-only audit store.
@@ -121,34 +118,20 @@ export class AccessAuditComponent implements OnInit {
 
   // --- Toolbar filters (client-side over the fetched window) ---
   protected readonly searchControl = new FormControl("", { nonNullable: true });
-  protected readonly kindControl = new FormControl<string | null>(null);
 
   private readonly searchText = toSignal(this.searchControl.valueChanges, { initialValue: "" });
-  private readonly kindValue = toSignal(this.kindControl.valueChanges, { initialValue: null });
 
   /**
    * The Event chip. `bit-filter-menu` is not a `ControlValueAccessor` — it owns its selection and
-   * publishes it as a signal — so the chip is the source and `kindControl` mirrors it, rather than
-   * the other way round.
+   * publishes it as a signal, so the filter reads the chip directly rather than a form control
+   * bound to it.
    */
   private readonly kindMenu = viewChild(FilterMenuComponent);
 
-  constructor() {
-    let mirrored: string | null = null;
-    effect(() => {
-      const selected = (this.kindMenu()?.value() ?? null) as string | null;
-      // Only a real change to the chip's own selection is pushed, so a value set directly on
-      // kindControl is not clobbered when the effect re-runs for an unrelated reason.
-      if (selected === mirrored) {
-        return;
-      }
-      mirrored = selected;
-      this.kindControl.setValue(selected);
-    });
-  }
+  private readonly kindValue = computed(() => (this.kindMenu()?.value() ?? null) as string | null);
 
   /** Event-kind chip options, limited to the labels actually present in the trail, sorted. */
-  protected readonly kindOptions = computed<AuditKindOption[]>(() =>
+  protected readonly kindOptions = computed(() =>
     [...new Set(this.rows().map((row) => row.kindLabelKey))]
       .map((labelKey) => ({ label: this.i18nService.t(labelKey), value: labelKey }))
       .sort((a, b) => a.label.localeCompare(b.label)),

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -4,8 +4,10 @@ import {
   Component,
   OnInit,
   computed,
+  effect,
   inject,
   signal,
+  viewChild,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
@@ -22,8 +24,8 @@ import {
   BadgeModule,
   ButtonModule,
   CalloutModule,
-  ChipFilterComponent,
-  ChipFilterOption,
+  FilterMenuComponent,
+  FilterOptionComponent,
   LinkModule,
   NoItemsModule,
   SearchModule,
@@ -39,6 +41,8 @@ import { AuditRow, auditRowMatchesFilter, toAuditRow } from "./access-audit-row"
 import { AuditApiService } from "./audit-api.service";
 
 type AuditStatus = "loading" | "ready" | "empty" | "error";
+
+type AuditKindOption = { label: string; value: string };
 
 /**
  * The organization's PAM access-audit trail, read from the dedicated append-only audit store.
@@ -67,7 +71,8 @@ type AuditStatus = "loading" | "ready" | "empty" | "error";
     BadgeModule,
     ButtonModule,
     CalloutModule,
-    ChipFilterComponent,
+    FilterMenuComponent,
+    FilterOptionComponent,
     HeaderModule,
     LinkModule,
     NoItemsModule,
@@ -121,8 +126,29 @@ export class AccessAuditComponent implements OnInit {
   private readonly searchText = toSignal(this.searchControl.valueChanges, { initialValue: "" });
   private readonly kindValue = toSignal(this.kindControl.valueChanges, { initialValue: null });
 
+  /**
+   * The Event chip. `bit-filter-menu` is not a `ControlValueAccessor` — it owns its selection and
+   * publishes it as a signal — so the chip is the source and `kindControl` mirrors it, rather than
+   * the other way round.
+   */
+  private readonly kindMenu = viewChild(FilterMenuComponent);
+
+  constructor() {
+    let mirrored: string | null = null;
+    effect(() => {
+      const selected = (this.kindMenu()?.value() ?? null) as string | null;
+      // Only a real change to the chip's own selection is pushed, so a value set directly on
+      // kindControl is not clobbered when the effect re-runs for an unrelated reason.
+      if (selected === mirrored) {
+        return;
+      }
+      mirrored = selected;
+      this.kindControl.setValue(selected);
+    });
+  }
+
   /** Event-kind chip options, limited to the labels actually present in the trail, sorted. */
-  protected readonly kindOptions = computed<ChipFilterOption<string>[]>(() =>
+  protected readonly kindOptions = computed<AuditKindOption[]>(() =>
     [...new Set(this.rows().map((row) => row.kindLabelKey))]
       .map((labelKey) => ({ label: this.i18nService.t(labelKey), value: labelKey }))
       .sort((a, b) => a.label.localeCompare(b.label)),


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-07-dce21ea2`, also closes `uat-SCR-09-c46fb373`.

## 📔 Objective

Move the audit Event filter to bit-filter-menu.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

### Admin Console -> PAM -> Audit (filtered)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/4de518100615448a0e001c6bae8d59263169b57d/before-uat-FLW-07-dce21ea2.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/9f27c7b96dc4d4f9dfc442b6d5c4f5dd214be890/after-uat-FLW-07-dce21ea2.png" alt="after" width="460"> |