### PR TITLE
feat(pam): show live access with a revoke action on the Approvals tab

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17836,17 +17836,20 @@
   "requestAccessModalRequestCreatedSuccess": {
     "message": "Request submitted — awaiting approval."
   },
+  "pamApprovalsActiveAccessEmpty": {
+    "message": "No active access"
+  },
+  "pamApprovalsActiveAccessSection": {
+    "message": "Active access"
+  },
   "pamApprovalsCollectionFilter": {
     "message": "Collection"
   },
-  "pamApprovalsPendingHeader": {
-    "message": "Pending approval $COUNT$",
-    "placeholders": {
-      "count": {
-        "content": "$1",
-        "example": "3"
-      }
-    }
+  "pamApprovalsPendingEmpty": {
+    "message": "No requests waiting for your decision"
+  },
+  "pamApprovalsPendingSection": {
+    "message": "Pending approval"
   },
   "pamApprovalsRequesterFilter": {
     "message": "Requester"

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -181,9 +181,7 @@
                       <app-vault-icon [cipher]="cipher" />
                     }
                     <div>
-                      <a [routerLink]="['/pam/requests', row.requestId]">{{
-                        row.cipherName ?? row.cipherId
-                      }}</a>
+                      <a [routerLink]="['/pam/requests', row.requestId]">{{ row.cipherName }}</a>
                       @if (row.collectionName) {
                         <div class="tw-text-xs tw-text-muted">
                           {{ "pamInboxInCollection" | i18n: row.collectionName }}

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -1,6 +1,6 @@
-@if (loading() && totalRows() === 0) {
+@if (loading() && !hasRows()) {
   <p bitTypography="body2" class="tw-mt-2">{{ "loading" | i18n }}</p>
-} @else if (totalRows() === 0) {
+} @else if (!hasRows()) {
   <bit-no-items class="tw-mt-2 tw-block" data-testid="approvals-empty">
     <span slot="title" class="tw-mt-4 tw-block">{{ "pamInboxEmptyTitle" | i18n }}</span>
     <span slot="description">{{ "pamInboxEmptyDescription" | i18n }}</span>
@@ -27,102 +27,219 @@
     />
   </div>
 
-  @if (rows().length === 0) {
+  @if (rows().length === 0 && leaseRows().length === 0) {
     <!-- Rendered inside the toolbar branch on purpose: a filter that matches nothing must not take
          the filter controls away with it, or there is no way back. -->
     <bit-no-items class="tw-mt-2 tw-block" data-testid="approvals-no-results">
       <span slot="title" class="tw-mt-4 tw-block">{{ "pamApprovalsNoResults" | i18n }}</span>
     </bit-no-items>
   } @else {
-    <h2 bitTypography="h4">{{ "pamApprovalsPendingHeader" | i18n: rows().length }}</h2>
+    <bit-accordion-group>
+      <bit-accordion [title]="'pamApprovalsPendingSection' | i18n" [open]="true">
+        <span slot="end" bitBadge variant="secondary">{{ rows().length }}</span>
 
-    <bit-table [dataSource]="dataSource">
-      <ng-container header>
-        <tr>
-          <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-          <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
-          <th bitCell>{{ "pamInboxWindow" | i18n }}</th>
-          <th bitCell>{{ "pamInboxReason" | i18n }}</th>
-          <th bitCell bitSortable="submittedAtMs" default="asc">
-            {{ "pamColumnSubmitted" | i18n }}
-          </th>
-          <th bitCell>{{ "pamColumnActions" | i18n }}</th>
-        </tr>
-      </ng-container>
-      <ng-template body let-rows$>
-        <tr bitRow *ngFor="let row of rows$ | async" [attr.data-testid]="'approvals-row-' + row.id">
-          <td bitCell>
-            <div class="tw-flex tw-items-center tw-gap-3">
-              @if (cipherFor(row.cipherId); as cipher) {
-                <app-vault-icon [cipher]="cipher" />
-              }
-              <div>
-                <a [routerLink]="['/pam/requests', row.id]">{{ row.cipherName }}</a>
-                @if (row.collectionName) {
-                  <div class="tw-text-xs tw-text-muted">
-                    {{ "pamInboxInCollection" | i18n: row.collectionName }}
+        @if (rows().length === 0) {
+          <p
+            bitTypography="body2"
+            class="tw-mb-0 tw-text-muted"
+            data-testid="approvals-pending-empty"
+          >
+            {{ "pamApprovalsPendingEmpty" | i18n }}
+          </p>
+        } @else {
+          <bit-table [dataSource]="dataSource">
+            <ng-container header>
+              <tr>
+                <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
+                <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
+                <th bitCell>{{ "pamInboxWindow" | i18n }}</th>
+                <th bitCell>{{ "pamInboxReason" | i18n }}</th>
+                <th bitCell bitSortable="submittedAtMs" default="asc">
+                  {{ "pamColumnSubmitted" | i18n }}
+                </th>
+                <th bitCell>{{ "pamColumnActions" | i18n }}</th>
+              </tr>
+            </ng-container>
+            <ng-template body let-rows$>
+              <tr
+                bitRow
+                *ngFor="let row of rows$ | async"
+                [attr.data-testid]="'approvals-row-' + row.id"
+              >
+                <td bitCell>
+                  <div class="tw-flex tw-items-center tw-gap-3">
+                    @if (cipherFor(row.cipherId); as cipher) {
+                      <app-vault-icon [cipher]="cipher" />
+                    }
+                    <div>
+                      <a [routerLink]="['/pam/requests', row.id]">{{ row.cipherName }}</a>
+                      @if (row.collectionName) {
+                        <div class="tw-text-xs tw-text-muted">
+                          {{ "pamInboxInCollection" | i18n: row.collectionName }}
+                        </div>
+                      }
+                    </div>
                   </div>
-                }
-              </div>
-            </div>
-          </td>
-          <td bitCell>
-            <div>{{ row.requester }}</div>
-            @if (row.requesterEmail && row.requesterEmail !== row.requester) {
-              <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
-            }
-          </td>
-          <td bitCell>
-            <span class="tw-whitespace-nowrap" [title]="row.exactWindow">
-              {{ row.duration.key | i18n: row.duration.value }},
-              {{ row.relativeStart.key | i18n: row.relativeStart.value }}
-            </span>
-          </td>
-          <td bitCell>
-            @if (row.reason) {
-              <div class="tw-line-clamp-2 tw-max-w-xs tw-break-words" [title]="row.reason">
-                {{ row.reason }}
-              </div>
-            } @else {
-              <span class="tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
-            }
-          </td>
-          <td bitCell>
-            <span class="tw-whitespace-nowrap" [title]="row.request.submittedAt | date: 'medium'">
-              {{ row.elapsed.key | i18n: row.elapsed.value }}
-            </span>
-          </td>
-          <td bitCell>
-            <div class="tw-flex tw-gap-2">
-              <button
-                type="button"
-                bitButton
-                buttonType="primary"
-                size="small"
-                [disabled]="!row.canDecide || isDeciding(row)"
-                [loading]="isDeciding(row)"
-                [bitTooltip]="row.canDecide ? '' : ('pamInboxCannotApproveOwn' | i18n)"
-                (click)="decide(row, 'approve')"
-                [attr.data-testid]="'approvals-approve-' + row.id"
+                </td>
+                <td bitCell>
+                  <div>{{ row.requester }}</div>
+                  @if (row.requesterEmail && row.requesterEmail !== row.requester) {
+                    <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
+                  }
+                </td>
+                <td bitCell>
+                  <span class="tw-whitespace-nowrap" [title]="row.exactWindow">
+                    {{ row.duration.key | i18n: row.duration.value }},
+                    {{ row.relativeStart.key | i18n: row.relativeStart.value }}
+                  </span>
+                </td>
+                <td bitCell>
+                  @if (row.reason) {
+                    <div class="tw-line-clamp-2 tw-max-w-xs tw-break-words" [title]="row.reason">
+                      {{ row.reason }}
+                    </div>
+                  } @else {
+                    <span class="tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
+                  }
+                </td>
+                <td bitCell>
+                  <span
+                    class="tw-whitespace-nowrap"
+                    [title]="row.request.submittedAt | date: 'medium'"
+                  >
+                    {{ row.elapsed.key | i18n: row.elapsed.value }}
+                  </span>
+                </td>
+                <td bitCell>
+                  <div class="tw-flex tw-gap-2">
+                    <button
+                      type="button"
+                      bitButton
+                      buttonType="primary"
+                      size="small"
+                      [disabled]="!row.canDecide || isDeciding(row)"
+                      [loading]="isDeciding(row)"
+                      [bitTooltip]="row.canDecide ? '' : ('pamInboxCannotApproveOwn' | i18n)"
+                      (click)="decide(row, 'approve')"
+                      [attr.data-testid]="'approvals-approve-' + row.id"
+                    >
+                      {{ "pamInboxApprove" | i18n }}
+                    </button>
+                    <button
+                      type="button"
+                      bitButton
+                      buttonType="secondary"
+                      size="small"
+                      [disabled]="!row.canDecide || isDeciding(row)"
+                      [bitTooltip]="row.canDecide ? '' : ('pamInboxCannotApproveOwn' | i18n)"
+                      (click)="decide(row, 'deny')"
+                      [attr.data-testid]="'approvals-deny-' + row.id"
+                    >
+                      {{ "pamInboxDeny" | i18n }}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </ng-template>
+          </bit-table>
+        }
+      </bit-accordion>
+
+      <bit-accordion [title]="'pamApprovalsActiveAccessSection' | i18n" [open]="true">
+        <span slot="end" bitBadge variant="secondary">{{ leaseRows().length }}</span>
+
+        @if (leaseRows().length === 0) {
+          <p
+            bitTypography="body2"
+            class="tw-mb-0 tw-text-muted"
+            data-testid="approvals-active-access-empty"
+          >
+            {{ "pamApprovalsActiveAccessEmpty" | i18n }}
+          </p>
+        } @else {
+          <bit-table [dataSource]="leasesDataSource">
+            <ng-container header>
+              <tr>
+                <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
+                <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
+                <th bitCell>{{ "pamColumnWindow" | i18n }}</th>
+                <th bitCell bitSortable="endsAtMs" default="asc">
+                  {{ "pamColumnRemaining" | i18n }}
+                </th>
+                <th bitCell>{{ "pamColumnActions" | i18n }}</th>
+              </tr>
+            </ng-container>
+            <ng-template body let-rows$>
+              <tr
+                bitRow
+                *ngFor="let row of rows$ | async"
+                [attr.data-testid]="'approvals-lease-' + row.leaseId"
               >
-                {{ "pamInboxApprove" | i18n }}
-              </button>
-              <button
-                type="button"
-                bitButton
-                buttonType="secondary"
-                size="small"
-                [disabled]="!row.canDecide || isDeciding(row)"
-                [bitTooltip]="row.canDecide ? '' : ('pamInboxCannotApproveOwn' | i18n)"
-                (click)="decide(row, 'deny')"
-                [attr.data-testid]="'approvals-deny-' + row.id"
-              >
-                {{ "pamInboxDeny" | i18n }}
-              </button>
-            </div>
-          </td>
-        </tr>
-      </ng-template>
-    </bit-table>
+                <td bitCell>
+                  <div class="tw-flex tw-items-center tw-gap-3">
+                    @if (cipherFor(row.cipherId); as cipher) {
+                      <app-vault-icon [cipher]="cipher" />
+                    }
+                    <div>
+                      <a [routerLink]="['/pam/requests', row.requestId]">{{
+                        row.cipherName ?? row.cipherId
+                      }}</a>
+                      @if (row.collectionName) {
+                        <div class="tw-text-xs tw-text-muted">
+                          {{ "pamInboxInCollection" | i18n: row.collectionName }}
+                        </div>
+                      }
+                      @if (row.extendedUntil) {
+                        <span
+                          bitBadge
+                          variant="secondary"
+                          class="tw-mt-1 tw-inline-block"
+                          [attr.data-testid]="'approvals-lease-extended-' + row.leaseId"
+                        >
+                          {{
+                            "pamExtendedBadge"
+                              | i18n
+                                : (row.extendedBySeconds | durationShort)
+                                : (row.extendedUntil | date: "short")
+                          }}
+                        </span>
+                      }
+                    </div>
+                  </div>
+                </td>
+                <td bitCell>
+                  <div>{{ row.requester }}</div>
+                  @if (row.requesterEmail && row.requesterEmail !== row.requester) {
+                    <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
+                  }
+                </td>
+                <td bitCell>
+                  <span class="tw-whitespace-nowrap">
+                    {{ row.startsAt | date: "short" }} &ndash; {{ row.endsAt | date: "short" }}
+                  </span>
+                </td>
+                <td bitCell>
+                  <app-pam-access-state-badge [state]="leaseBadgeState(row.leaseId)" />
+                </td>
+                <td bitCell>
+                  <button
+                    type="button"
+                    bitButton
+                    buttonType="danger"
+                    size="small"
+                    [disabled]="isRevoking(row)"
+                    [loading]="isRevoking(row)"
+                    (click)="revoke(row)"
+                    [attr.data-testid]="'approvals-revoke-' + row.leaseId"
+                  >
+                    {{ "pamInboxRevoke" | i18n }}
+                  </button>
+                </td>
+              </tr>
+            </ng-template>
+          </bit-table>
+        }
+      </bit-accordion>
+    </bit-accordion-group>
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -170,7 +170,13 @@
               <tr>
                 <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
                 <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
-                <th bitCell>{{ "pamColumnWindow" | i18n }}</th>
+                <th
+                  bitCell
+                  class="tw-hidden xl:tw-table-cell"
+                  data-testid="active-access-col-window"
+                >
+                  {{ "pamColumnWindow" | i18n }}
+                </th>
                 <th bitCell bitSortable="endsAtMs" default="asc">
                   {{ "pamColumnRemaining" | i18n }}
                 </th>
@@ -219,7 +225,7 @@
                     <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
                   }
                 </td>
-                <td bitCell>
+                <td bitCell class="tw-hidden xl:tw-table-cell">
                   <span class="tw-whitespace-nowrap">
                     {{ row.startsAt | date: "short" }} &ndash; {{ row.endsAt | date: "short" }}
                   </span>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -44,7 +44,10 @@
             class="tw-mb-0 tw-text-muted"
             data-testid="approvals-pending-empty"
           >
-            {{ "pamApprovalsPendingEmpty" | i18n }}
+            {{
+              (pendingHiddenByFilters() ? "pamApprovalsNoResults" : "pamApprovalsPendingEmpty")
+                | i18n
+            }}
           </p>
         } @else {
           <bit-table [dataSource]="dataSource">
@@ -154,7 +157,12 @@
             class="tw-mb-0 tw-text-muted"
             data-testid="approvals-active-access-empty"
           >
-            {{ "pamApprovalsActiveAccessEmpty" | i18n }}
+            {{
+              (activeAccessHiddenByFilters()
+                ? "pamApprovalsNoResults"
+                : "pamApprovalsActiveAccessEmpty"
+              ) | i18n
+            }}
           </p>
         } @else {
           <bit-table [dataSource]="leasesDataSource">

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -69,6 +69,16 @@ function leaseRow(
   );
 }
 
+/**
+ * The ids of the once-a-second clocks a spied `setInterval` created, told apart from the
+ * zero-delay timers Angular's own scheduler queues during change detection.
+ */
+function secondlyIntervalIds(spy: jest.SpyInstance): unknown[] {
+  return spy.mock.results
+    .filter((_, index) => spy.mock.calls[index][1] === 1000)
+    .map((result) => result.value);
+}
+
 describe("ApprovalsTabComponent", () => {
   let fixture: ComponentFixture<ApprovalsTabComponent>;
   let component: ApprovalsTabComponent;
@@ -135,6 +145,7 @@ describe("ApprovalsTabComponent", () => {
   afterEach(() => {
     fixture?.destroy();
     jest.useRealTimers();
+    jest.restoreAllMocks();
   });
 
   describe("rendering", () => {
@@ -386,6 +397,36 @@ describe("ApprovalsTabComponent", () => {
 
       expect(query('[data-testid="approvals-lease-lease-1"]')).toBeNull();
       expect(query('[data-testid="approvals-active-access-empty"]')).not.toBeNull();
+    });
+
+    it("runs no clock at all when there is no lease to expire", () => {
+      // The shared ticker is ref-counted, so a pending-only queue must leave it torn down rather
+      // than scheduling a round of change detection every second that can never change anything.
+      const setIntervalSpy = jest.spyOn(global, "setInterval");
+      inbox.inboxRows$.next([row()]);
+
+      create();
+
+      expect(secondlyIntervalIds(setIntervalSpy)).toHaveLength(0);
+    });
+
+    it("shares one clock with the badges it renders, and tears it down on destroy", () => {
+      const setIntervalSpy = jest.spyOn(global, "setInterval");
+      const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+      inbox.activeLeaseRows$.next([
+        leaseRow(),
+        leaseRow({ id: "req-2", producedLeaseId: "lease-2" }),
+      ]);
+
+      create();
+
+      const [intervalId] = secondlyIntervalIds(setIntervalSpy);
+      expect(secondlyIntervalIds(setIntervalSpy)).toHaveLength(1);
+      expect(clearIntervalSpy).not.toHaveBeenCalledWith(intervalId);
+
+      fixture.destroy();
+
+      expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId);
     });
 
     it("revokes the lease once confirmed, and toasts", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -23,7 +23,10 @@ const NOW = new Date("2026-08-17T12:00:00.000Z");
 const NAMES = {
   ...emptyResolvedNames(),
   cipherNameById: new Map([["cipher-1", "Prod database"]]),
-  collectionNameById: new Map([["col-1", "Production"]]),
+  collectionNameById: new Map([
+    ["col-1", "Production"],
+    ["col-2", "Staging"],
+  ]),
   organizationNameById: new Map([["org-1", "Meridian Group"]]),
 };
 
@@ -335,6 +338,34 @@ describe("ApprovalsTabComponent", () => {
       expect(query("bit-accordion-group")).not.toBeNull();
       expect(query('[data-testid="approvals-active-access-empty"]')).not.toBeNull();
       expect(query('[data-testid="approvals-empty"]')).toBeNull();
+    });
+
+    it("does not claim there is no active access when a filter hid the live rows", () => {
+      inbox.inboxRows$.next([row({ id: "req-pending", collectionId: "col-2" })]);
+      inbox.activeLeaseRows$.next([leaseRow()]);
+      create();
+
+      component["collectionControl"].setValue("Staging");
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-lease-lease-1"]')).toBeNull();
+      expect(query('[data-testid="approvals-active-access-empty"]')?.textContent).toContain(
+        "pamApprovalsNoResults",
+      );
+    });
+
+    it("does not claim there is nothing to decide when a filter hid the pending rows", () => {
+      inbox.inboxRows$.next([row()]);
+      inbox.activeLeaseRows$.next([leaseRow({ id: "req-live", collectionId: "col-2" })]);
+      create();
+
+      component["collectionControl"].setValue("Staging");
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-row-req-1"]')).toBeNull();
+      expect(query('[data-testid="approvals-pending-empty"]')?.textContent).toContain(
+        "pamApprovalsNoResults",
+      );
     });
 
     it("shows the inbox-zero empty state only when both sections are empty", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -91,6 +91,8 @@ describe("ApprovalsTabComponent", () => {
   }
 
   beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
     inbox = {
       inboxRows$: new BehaviorSubject<ApprovalRow[]>([]),
       activeLeaseRows$: new BehaviorSubject<ManagedLeaseRow[]>([]),
@@ -125,6 +127,11 @@ describe("ApprovalsTabComponent", () => {
       // has no interest in.
       .overrideComponent(ApprovalsTabComponent, { add: { schemas: [NO_ERRORS_SCHEMA] } })
       .compileComponents();
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    jest.useRealTimers();
   });
 
   describe("rendering", () => {
@@ -335,6 +342,19 @@ describe("ApprovalsTabComponent", () => {
 
       expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
       expect(query("bit-accordion-group")).toBeNull();
+    });
+
+    it("stops listing a lease once its window closes, with no server push", () => {
+      inbox.inboxRows$.next([row()]);
+      inbox.activeLeaseRows$.next([leaseRow({ leaseNotAfter: "2026-08-17T12:00:30.000Z" })]);
+      create();
+      expect(query('[data-testid="approvals-lease-lease-1"]')).not.toBeNull();
+
+      jest.advanceTimersByTime(31_000);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-lease-lease-1"]')).toBeNull();
+      expect(query('[data-testid="approvals-active-access-empty"]')).not.toBeNull();
     });
 
     it("revokes the lease once confirmed, and toasts", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -10,17 +10,25 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
-import type { AccessRequestView } from "../abstractions/access-lease";
+import type { AccessLeaseId, AccessRequestView } from "../abstractions/access-lease";
 import { ApprovalRow, toApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
+import { ManagedLeaseRow, toManagedLeaseRow } from "../approvals/managed-lease-row";
 
 import { emptyResolvedNames } from "./access-name-resolver.service";
 import { ApprovalsTabComponent } from "./approvals-tab.component";
 
 const NOW = new Date("2026-08-17T12:00:00.000Z");
 
-function row(overrides: Record<string, unknown> = {}, canDecide = true): ApprovalRow {
-  const request = {
+const NAMES = {
+  ...emptyResolvedNames(),
+  cipherNameById: new Map([["cipher-1", "Prod database"]]),
+  collectionNameById: new Map([["col-1", "Production"]]),
+  organizationNameById: new Map([["org-1", "Meridian Group"]]),
+};
+
+function accessRequest(overrides: Record<string, unknown> = {}): AccessRequestView {
+  return {
     id: "req-1",
     cipherId: "cipher-1",
     collectionId: "col-1",
@@ -36,16 +44,25 @@ function row(overrides: Record<string, unknown> = {}, canDecide = true): Approva
     requesterEmail: "grace@example.com",
     ...overrides,
   } as unknown as AccessRequestView;
-  return toApprovalRow(
-    request,
-    {
-      ...emptyResolvedNames(),
-      cipherNameById: new Map([["cipher-1", "Prod database"]]),
-      collectionNameById: new Map([["col-1", "Production"]]),
-      organizationNameById: new Map([["org-1", "Meridian Group"]]),
-    },
-    NOW,
-    canDecide,
+}
+
+function row(overrides: Record<string, unknown> = {}, canDecide = true): ApprovalRow {
+  return toApprovalRow(accessRequest(overrides), NAMES, NOW, canDecide);
+}
+
+function leaseRow(
+  overrides: Record<string, unknown> = {},
+  extension?: { addedSeconds: number; latestEndMs: number },
+): ManagedLeaseRow {
+  return toManagedLeaseRow(
+    accessRequest({
+      status: "approved",
+      producedLeaseId: "lease-1",
+      producedLeaseStatus: "active",
+      ...overrides,
+    }) as AccessRequestView & { producedLeaseId: AccessLeaseId },
+    NAMES,
+    extension,
   );
 }
 
@@ -54,9 +71,11 @@ describe("ApprovalsTabComponent", () => {
   let component: ApprovalsTabComponent;
   let inbox: {
     inboxRows$: BehaviorSubject<ApprovalRow[]>;
+    activeLeaseRows$: BehaviorSubject<ManagedLeaseRow[]>;
     cipherById$: BehaviorSubject<Map<string, CipherView>>;
     loading$: BehaviorSubject<boolean>;
     decide: jest.Mock;
+    revokeLease: jest.Mock;
   };
   let dialogService: MockProxy<DialogService>;
   let toastService: MockProxy<ToastService>;
@@ -74,9 +93,11 @@ describe("ApprovalsTabComponent", () => {
   beforeEach(async () => {
     inbox = {
       inboxRows$: new BehaviorSubject<ApprovalRow[]>([]),
+      activeLeaseRows$: new BehaviorSubject<ManagedLeaseRow[]>([]),
       cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
       loading$: new BehaviorSubject<boolean>(false),
       decide: jest.fn().mockResolvedValue(undefined),
+      revokeLease: jest.fn().mockResolvedValue(undefined),
     };
     dialogService = mock<DialogService>();
     toastService = mock<ToastService>();
@@ -261,6 +282,97 @@ describe("ApprovalsTabComponent", () => {
 
       expect(dialogService.open).not.toHaveBeenCalled();
       expect(inbox.decide).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("active access", () => {
+    it("renders a row per live lease, with the holder and the item on it", () => {
+      inbox.activeLeaseRows$.next([
+        leaseRow({ producedLeaseId: "lease-1" }),
+        leaseRow(
+          { id: "req-2", producedLeaseId: "lease-2", requesterName: "Alan" },
+          {
+            addedSeconds: 3600,
+            latestEndMs: Date.parse("2026-08-17T14:00:00.000Z"),
+          },
+        ),
+      ]);
+
+      create();
+
+      expect(query('[data-testid="approvals-lease-lease-1"]')).not.toBeNull();
+      expect(query('[data-testid="approvals-lease-lease-2"]')).not.toBeNull();
+      expect(query('[data-testid="approvals-lease-extended-lease-2"]')).not.toBeNull();
+      const text = fixture.nativeElement.textContent as string;
+      expect(text).toContain("Prod database");
+      expect(text).toContain("Grace");
+      expect(text).toContain("Alan");
+    });
+
+    it("shows both sections when there is live access but nothing pending", () => {
+      inbox.activeLeaseRows$.next([leaseRow()]);
+
+      create();
+
+      expect(query('[data-testid="approvals-empty"]')).toBeNull();
+      expect(query("bit-accordion-group")).not.toBeNull();
+      expect(query('[data-testid="approvals-pending-empty"]')).not.toBeNull();
+      expect(query('[data-testid="approvals-lease-lease-1"]')).not.toBeNull();
+    });
+
+    it("still renders the section, empty, when there is nothing live but something pending", () => {
+      inbox.inboxRows$.next([row()]);
+
+      create();
+
+      expect(query("bit-accordion-group")).not.toBeNull();
+      expect(query('[data-testid="approvals-active-access-empty"]')).not.toBeNull();
+      expect(query('[data-testid="approvals-empty"]')).toBeNull();
+    });
+
+    it("shows the inbox-zero empty state only when both sections are empty", () => {
+      create();
+
+      expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
+      expect(query("bit-accordion-group")).toBeNull();
+    });
+
+    it("revokes the lease once confirmed, and toasts", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+      inbox.activeLeaseRows$.next([leaseRow()]);
+      create();
+
+      await component["revoke"](component["leaseRows"]()[0]);
+
+      expect(inbox.revokeLease).toHaveBeenCalledWith("req-1", "lease-1");
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "success" }),
+      );
+    });
+
+    it("does nothing when the confirm is dismissed", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+      inbox.activeLeaseRows$.next([leaseRow()]);
+      create();
+
+      await component["revoke"](component["leaseRows"]()[0]);
+
+      expect(inbox.revokeLease).not.toHaveBeenCalled();
+      expect(toastService.showToast).not.toHaveBeenCalled();
+    });
+
+    it("toasts an error when the revoke fails", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+      inbox.revokeLease.mockRejectedValue(new Error("boom"));
+      inbox.activeLeaseRows$.next([leaseRow()]);
+      create();
+
+      await component["revoke"](component["leaseRows"]()[0]);
+
+      expect(toastService.showToast).toHaveBeenCalledWith({
+        variant: "error",
+        message: "pamInboxRevokeFailed",
+      });
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
@@ -5,13 +5,16 @@ import { of } from "rxjs";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
+import type { AccessLeaseId, AccessRequestView } from "../abstractions/access-lease";
 import { ApprovalRow, toApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
+import { ManagedLeaseRow, toManagedLeaseRow } from "../approvals/managed-lease-row";
 import {
   HOUR,
   MINUTE,
   STORY_NOW,
   accessRequest,
+  liveFromNow,
   provideStoryChangeDetection,
   provideStoryLogService,
   storyNames,
@@ -50,22 +53,87 @@ const ROWS: ApprovalRow[] = [
   row({ id: "req-4", cipherId: "cipher-2", requesterName: "You", reason: "Own request." }, false),
 ];
 
-function inbox(options: { rows?: ApprovalRow[]; loading?: boolean } = {}) {
-  const { rows = ROWS, loading = false } = options;
+/**
+ * Lease ends are stamped off the real clock, not {@link STORY_NOW}: the remaining-time badge runs
+ * its own countdown, so a STORY_NOW-relative window renders as already expired.
+ */
+function lease(
+  overrides: Record<string, unknown>,
+  extension?: { addedSeconds: number; latestEndMs: number },
+): ManagedLeaseRow {
+  return toManagedLeaseRow(
+    accessRequest({
+      status: "approved",
+      producedLeaseStatus: "active",
+      ...overrides,
+    }) as AccessRequestView & { producedLeaseId: AccessLeaseId },
+    names,
+    extension,
+  );
+}
+
+function activeLeases(): ManagedLeaseRow[] {
+  return [
+    lease({
+      id: "req-live-1",
+      producedLeaseId: "lease-1",
+      leaseNotBefore: liveFromNow(-20 * MINUTE),
+      leaseNotAfter: liveFromNow(40 * MINUTE),
+    }),
+    lease({
+      id: "req-live-2",
+      cipherId: "cipher-2",
+      collectionId: "col-2",
+      producedLeaseId: "lease-2",
+      requesterName: "Alan Turing",
+      requesterEmail: "alan@example.com",
+      leaseNotBefore: liveFromNow(-2 * HOUR),
+      leaseNotAfter: liveFromNow(3 * HOUR),
+    }),
+    // Extended in place: the row must end at the extension's end, not the request's own.
+    lease(
+      {
+        id: "req-live-3",
+        cipherId: "cipher-3",
+        producedLeaseId: "lease-3",
+        requesterName: "Katherine Johnson",
+        requesterEmail: "katherine@example.com",
+        leaseNotBefore: liveFromNow(-90 * MINUTE),
+        leaseNotAfter: liveFromNow(30 * MINUTE),
+      },
+      { addedSeconds: 2 * 60 * 60, latestEndMs: Date.now() + 2.5 * HOUR },
+    ),
+  ];
+}
+
+function inbox(
+  options: { rows?: ApprovalRow[]; leases?: () => ManagedLeaseRow[]; loading?: boolean } = {},
+) {
+  const { rows = ROWS, leases = () => [], loading = false } = options;
   return moduleMetadata({
     imports: [ApprovalsTabComponent],
     providers: [
       {
         provide: ApproverInboxService,
-        useValue: {
+        // A factory rather than a value, so the real-clock lease windows are stamped when the
+        // story renders rather than when this module was first evaluated.
+        useFactory: () => ({
           loading$: of(loading),
           loadError$: of(null),
           inboxRows$: of(rows),
+          activeLeaseRows$: of(leases()),
           cipherById$: of(names.cipherById),
           decide: () => Promise.resolve(),
+          revokeLease: () => Promise.resolve(),
+        }),
+      },
+      {
+        provide: DialogService,
+        useValue: {
+          open: () => ({ closed: of(undefined) }),
+          openSimpleDialog: () => Promise.resolve(false),
         },
       },
-      { provide: DialogService, useValue: { open: () => ({ closed: of(undefined) }) } },
       { provide: ToastService, useValue: { showToast: () => {} } },
     ],
   });
@@ -88,9 +156,14 @@ export default {
 
 type Story = StoryObj<ApprovalsTabComponent>;
 
-/** The populated inbox, oldest-waiting first, with the search and chip filters above it. */
+/** Both sections populated: decisions to make, and access already running. */
 export const Default: Story = {
-  decorators: [inbox()],
+  decorators: [inbox({ leases: activeLeases })],
+};
+
+/** Nothing left to decide, but the access the operator granted is still live and can be ended. */
+export const ActiveAccessOnly: Story = {
+  decorators: [inbox({ rows: [], leases: activeLeases })],
 };
 
 /** Nothing awaiting a decision — distinct from a filter that matched nothing. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
@@ -90,7 +90,6 @@ function activeLeases(): ManagedLeaseRow[] {
       leaseNotBefore: liveFromNow(-2 * HOUR),
       leaseNotAfter: liveFromNow(3 * HOUR),
     }),
-    // Extended in place: the row must end at the extension's end, not the request's own.
     lease(
       {
         id: "req-live-3",

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -2,18 +2,15 @@ import { CommonModule } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
-  NgZone,
-  OnInit,
   computed,
   effect,
   inject,
   signal,
 } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { firstValueFrom } from "rxjs";
+import { EMPTY, firstValueFrom, switchMap } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -39,6 +36,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 
 import type { AccessDecisionVerdict } from "../abstractions/access-lease";
 import { AccessBadgeState } from "../access-state-badge/access-badge-state";
+import { AccessBadgeTickerService } from "../access-state-badge/access-badge-ticker.service";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { ApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
@@ -85,14 +83,13 @@ type FilterableRow = { searchText: string; collectionName: string | null; reques
     I18nPipe,
   ],
 })
-export class ApprovalsTabComponent implements OnInit {
+export class ApprovalsTabComponent {
   private readonly inbox = inject(ApproverInboxService);
   private readonly dialogService = inject(DialogService);
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
-  private readonly destroyRef = inject(DestroyRef);
-  private readonly ngZone = inject(NgZone);
+  private readonly ticker = inject(AccessBadgeTickerService);
 
   /** Ids currently being decided, so a second click on the same row is a no-op. */
   private readonly deciding = signal<Set<string>>(new Set());
@@ -101,9 +98,6 @@ export class ApprovalsTabComponent implements OnInit {
   private readonly revoking = signal<Set<string>>(new Set());
 
   protected readonly loading = toSignal(this.inbox.loading$, { initialValue: true });
-
-  /** Ticks once a second so a lease that lapses while the tab is open stops being listed. */
-  private readonly nowMs = signal(Date.now());
 
   protected readonly searchControl = new FormControl<string>("", { nonNullable: true });
   protected readonly collectionControl = new FormControl<string | null>(null);
@@ -122,6 +116,19 @@ export class ApprovalsTabComponent implements OnInit {
   private readonly allLeases = toSignal(this.inbox.activeLeaseRows$, {
     initialValue: [] as ManagedLeaseRow[],
   });
+
+  /**
+   * Ticks once a second so a lease that lapses while the tab is open stops being listed. Shares the
+   * one clock the badges already run on, and only observes it while there is a lease to expire — an
+   * approver sitting on a pending-only queue leaves that clock torn down rather than scheduling a
+   * round of change detection every second that can never change anything.
+   */
+  private readonly nowMs = toSignal(
+    toObservable(computed(() => this.allLeases().length > 0)).pipe(
+      switchMap((anyLeases) => (anyLeases ? this.ticker.ticks$ : EMPTY)),
+    ),
+    { initialValue: Date.now() },
+  );
 
   private readonly cipherById = toSignal(this.inbox.cipherById$, {
     initialValue: new Map<string, CipherView>(),
@@ -184,10 +191,9 @@ export class ApprovalsTabComponent implements OnInit {
   protected readonly leasesDataSource = new TableDataSource<ManagedLeaseRow>();
 
   /**
-   * Badge state is memoised per lease so the shared badge component sees a stable input. A fresh
-   * object would re-run the badge's own effect and restart the countdown interval it runs itself.
-   * Keyed off the unfiltered rows so that typing in the search box does not churn the surviving
-   * badges.
+   * Badge state is memoised per lease so the `[state]` input does not change identity on every
+   * change-detection pass. Keyed off the unfiltered rows so that typing in the search box does not
+   * churn the surviving badges.
    */
   private readonly leaseBadgeStates = computed(
     () =>
@@ -205,16 +211,6 @@ export class ApprovalsTabComponent implements OnInit {
     });
     effect(() => {
       this.leasesDataSource.data = this.leaseRows();
-    });
-  }
-
-  ngOnInit(): void {
-    // Outside the Angular zone: a periodic in-zone timer never lets NgZone settle, which would hang
-    // `fixture.whenStable()` for any host that embeds this view. The signal write still drives
-    // change detection on its own.
-    this.ngZone.runOutsideAngular(() => {
-      const intervalId = setInterval(() => this.nowMs.set(Date.now()), 1000);
-      this.destroyRef.onDestroy(() => clearInterval(intervalId));
     });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -161,6 +161,19 @@ export class ApprovalsTabComponent implements OnInit {
   protected readonly leaseRows = computed(() => this.applyFilters(this.liveLeases()));
 
   /**
+   * Whether a section is empty only because the toolbar filters excluded its own rows. Its empty
+   * copy asserts an absolute, so rendering it in this case tells an operator that no privileged
+   * access is running while a lease the filters hid is still live and still revocable.
+   */
+  protected readonly pendingHiddenByFilters = computed(
+    () => this.rows().length === 0 && this.allRows().length > 0,
+  );
+
+  protected readonly activeAccessHiddenByFilters = computed(
+    () => this.leaseRows().length === 0 && this.liveLeases().length > 0,
+  );
+
+  /**
    * Whether the tab has anything at all before filtering, across both sections. Distinguishes an
    * empty inbox (nothing to do) from a filter that matched nothing (something to do, just not
    * visible), which need different copy and, for the latter, the filter controls left on screen.

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -17,6 +17,9 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
+  AccordionComponent,
+  AccordionGroupComponent,
+  BadgeComponent,
   ButtonModule,
   ChipFilterComponent,
   ChipFilterOption,
@@ -32,20 +35,28 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import type { AccessDecisionVerdict } from "../abstractions/access-lease";
+import { AccessBadgeState } from "../access-state-badge/access-badge-state";
+import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { ApprovalRow } from "../approvals/approval-row";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import { DecideDialogComponent } from "../approvals/decide-dialog/decide-dialog.component";
+import { ManagedLeaseRow } from "../approvals/managed-lease-row";
+import { DurationShortPipe } from "../date/duration-short.pipe";
+
+/** The fields the toolbar filters against, carried by both sections' row models. */
+type FilterableRow = { searchText: string; collectionName: string | null; requester: string };
 
 /**
- * "Approvals" tab — the requests awaiting the caller's decision, oldest first.
+ * "Approvals" tab — the requests awaiting the caller's decision, oldest first, and the access
+ * already running on the collections they manage.
  *
  * Only ever rendered for an approver: `canViewApprovalsGuard` redirects a non-approver's deep
  * link to the sibling `my-requests` tab, and the shell (`access-requests.component.html`) only
  * renders the "Approvals" tab-link when {@link ApprovalPrivilegeService} says so — so a non-approver
  * never reaches this component.
  *
- * Data, ordering, and the optimistic decide live in {@link ApproverInboxService} (shared with the
- * History tab); this component owns the toolbar, the table, the dialog, and the toasts.
+ * Data, ordering, and the optimistic decide/revoke live in {@link ApproverInboxService} (shared with
+ * the History tab); this component owns the toolbar, the tables, the dialogs, and the toasts.
  */
 @Component({
   selector: "pam-approvals-tab",
@@ -55,8 +66,13 @@ import { DecideDialogComponent } from "../approvals/decide-dialog/decide-dialog.
     CommonModule,
     ReactiveFormsModule,
     RouterModule,
+    AccessStateBadgeComponent,
+    AccordionComponent,
+    AccordionGroupComponent,
+    BadgeComponent,
     ButtonModule,
     ChipFilterComponent,
+    DurationShortPipe,
     IconComponent,
     NoItemsModule,
     SearchModule,
@@ -76,6 +92,9 @@ export class ApprovalsTabComponent {
   /** Ids currently being decided, so a second click on the same row is a no-op. */
   private readonly deciding = signal<Set<string>>(new Set());
 
+  /** Lease ids currently being revoked, for the same reason as {@link deciding}. */
+  private readonly revoking = signal<Set<string>>(new Set());
+
   protected readonly loading = toSignal(this.inbox.loading$, { initialValue: true });
 
   protected readonly searchControl = new FormControl<string>("", { nonNullable: true });
@@ -92,53 +111,101 @@ export class ApprovalsTabComponent {
 
   private readonly allRows = toSignal(this.inbox.inboxRows$, { initialValue: [] as ApprovalRow[] });
 
+  private readonly allLeases = toSignal(this.inbox.activeLeaseRows$, {
+    initialValue: [] as ManagedLeaseRow[],
+  });
+
   private readonly cipherById = toSignal(this.inbox.cipherById$, {
     initialValue: new Map<string, CipherView>(),
   });
 
-  /** Every distinct collection present in the inbox, for the Collection filter. */
+  /** Both sections' rows before filtering — what the chip filters offer options from. */
+  private readonly filterableRows = computed<FilterableRow[]>(() => [
+    ...this.allRows(),
+    ...this.allLeases(),
+  ]);
+
+  /** Every distinct collection present on the tab, for the Collection filter. */
   protected readonly collectionOptions = computed<ChipFilterOption<string>[]>(() =>
-    distinctOptions(this.allRows().map((row) => row.collectionName)),
+    distinctOptions(this.filterableRows().map((row) => row.collectionName)),
   );
 
-  /** Every distinct requester present in the inbox, for the Requester filter. */
+  /** Every distinct requester present on the tab, for the Requester filter. */
   protected readonly requesterOptions = computed<ChipFilterOption<string>[]>(() =>
-    distinctOptions(this.allRows().map((row) => row.requester)),
+    distinctOptions(this.filterableRows().map((row) => row.requester)),
   );
 
-  protected readonly rows = computed(() => {
-    const term = this.searchTerm().trim().toLowerCase();
-    const collection = this.collectionFilter();
-    const requester = this.requesterFilter();
-    return this.allRows().filter(
-      (row) =>
-        (term === "" || row.searchText.includes(term)) &&
-        (collection == null || row.collectionName === collection) &&
-        (requester == null || row.requester === requester),
-    );
-  });
+  protected readonly rows = computed(() => this.applyFilters(this.allRows()));
+
+  protected readonly leaseRows = computed(() => this.applyFilters(this.allLeases()));
 
   /**
-   * How many requests await a decision before filtering. Distinguishes an empty inbox (nothing to
-   * do) from a filter that matched nothing (something to do, just not visible), which need different
-   * copy and, for the latter, the filter controls left on screen.
+   * Whether the tab has anything at all before filtering, across both sections. Distinguishes an
+   * empty inbox (nothing to do) from a filter that matched nothing (something to do, just not
+   * visible), which need different copy and, for the latter, the filter controls left on screen.
    */
-  protected readonly totalRows = computed(() => this.allRows().length);
+  protected readonly hasRows = computed(
+    () => this.allRows().length > 0 || this.allLeases().length > 0,
+  );
 
   protected readonly dataSource = new TableDataSource<ApprovalRow>();
+  protected readonly leasesDataSource = new TableDataSource<ManagedLeaseRow>();
+
+  /**
+   * Badge state is memoised per lease so the shared badge component sees a stable input. A fresh
+   * object would re-run the badge's own effect and restart the countdown interval it runs itself.
+   * Keyed off the unfiltered rows so that typing in the search box does not churn the surviving
+   * badges.
+   */
+  private readonly leaseBadgeStates = computed(
+    () =>
+      new Map<string, AccessBadgeState>(
+        this.allLeases().map((row) => [
+          String(row.leaseId),
+          { kind: "active", expiresAt: new Date(row.endsAt) },
+        ]),
+      ),
+  );
 
   constructor() {
     effect(() => {
       this.dataSource.data = this.rows();
     });
+    effect(() => {
+      this.leasesDataSource.data = this.leaseRows();
+    });
+  }
+
+  /**
+   * The toolbar's three filters, applied to either section's rows. Both row models carry the same
+   * three fields, so one predicate keeps the two sections from drifting apart.
+   */
+  private applyFilters<T extends FilterableRow>(rows: T[]): T[] {
+    const term = this.searchTerm().trim().toLowerCase();
+    const collection = this.collectionFilter();
+    const requester = this.requesterFilter();
+    return rows.filter(
+      (row) =>
+        (term === "" || row.searchText.includes(term)) &&
+        (collection == null || row.collectionName === collection) &&
+        (requester == null || row.requester === requester),
+    );
   }
 
   protected cipherFor(cipherId: string): CipherView | undefined {
     return this.cipherById().get(cipherId);
   }
 
+  protected leaseBadgeState(id: ManagedLeaseRow["leaseId"]): AccessBadgeState | null {
+    return this.leaseBadgeStates().get(String(id)) ?? null;
+  }
+
   protected isDeciding(row: ApprovalRow): boolean {
     return this.deciding().has(String(row.id));
+  }
+
+  protected isRevoking(row: ManagedLeaseRow): boolean {
+    return this.revoking().has(String(row.leaseId));
   }
 
   /**
@@ -181,6 +248,47 @@ export class ApprovalsTabComponent {
       });
     } finally {
       this.deciding.update((ids) => {
+        const next = new Set(ids);
+        next.delete(key);
+        return next;
+      });
+    }
+  }
+
+  /**
+   * Confirm and end a lease that is running right now. The confirm is not optional: this cuts off
+   * access someone is already using, and every dismissal route resolves false.
+   */
+  protected async revoke(row: ManagedLeaseRow): Promise<void> {
+    if (this.isRevoking(row)) {
+      return;
+    }
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "pamInboxRevoke" },
+      content: { key: "pamInboxRevokeConfirm" },
+      acceptButtonText: { key: "pamInboxRevoke" },
+      type: "warning",
+    });
+    if (!confirmed) {
+      return;
+    }
+
+    const key = String(row.leaseId);
+    this.revoking.update((ids) => new Set([...ids, key]));
+    try {
+      await this.inbox.revokeLease(row.requestId, row.leaseId);
+      this.toastService.showToast({
+        variant: "success",
+        message: this.i18nService.t("pamInboxRevokedToast"),
+      });
+    } catch (e) {
+      this.logService.error(e);
+      this.toastService.showToast({
+        variant: "error",
+        message: this.i18nService.t("pamInboxRevokeFailed"),
+      });
+    } finally {
+      this.revoking.update((ids) => {
         const next = new Set(ids);
         next.delete(key);
         return next;

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -218,7 +218,7 @@ export class ApprovalsTabComponent {
    * The toolbar's three filters, applied to either section's rows. Both row models carry the same
    * three fields, so one predicate keeps the two sections from drifting apart.
    */
-  private applyFilters<T extends FilterableRow>(rows: T[]): T[] {
+  private applyFilters<T extends FilterableRow>(rows: readonly T[]): T[] {
     const term = this.searchTerm().trim().toLowerCase();
     const collection = this.collectionFilter();
     const requester = this.requesterFilter();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -2,6 +2,9 @@ import { CommonModule } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
+  NgZone,
+  OnInit,
   computed,
   effect,
   inject,
@@ -82,12 +85,14 @@ type FilterableRow = { searchText: string; collectionName: string | null; reques
     I18nPipe,
   ],
 })
-export class ApprovalsTabComponent {
+export class ApprovalsTabComponent implements OnInit {
   private readonly inbox = inject(ApproverInboxService);
   private readonly dialogService = inject(DialogService);
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly ngZone = inject(NgZone);
 
   /** Ids currently being decided, so a second click on the same row is a no-op. */
   private readonly deciding = signal<Set<string>>(new Set());
@@ -96,6 +101,9 @@ export class ApprovalsTabComponent {
   private readonly revoking = signal<Set<string>>(new Set());
 
   protected readonly loading = toSignal(this.inbox.loading$, { initialValue: true });
+
+  /** Ticks once a second so a lease that lapses while the tab is open stops being listed. */
+  private readonly nowMs = signal(Date.now());
 
   protected readonly searchControl = new FormControl<string>("", { nonNullable: true });
   protected readonly collectionControl = new FormControl<string | null>(null);
@@ -119,10 +127,23 @@ export class ApprovalsTabComponent {
     initialValue: new Map<string, CipherView>(),
   });
 
+  /**
+   * The leases still inside their window. `activeLeaseRows$` tests the window too, but against the
+   * clock stamped at load, and a lease lapsing on its own produces no server push to reload it away
+   * — so without a live clock here the row would stay listed, counted and revocable indefinitely.
+   *
+   * Compared by identity so the once-a-second tick only reaches `leasesDataSource` when the rows
+   * really change; reassigning its data every second would re-create every row.
+   */
+  private readonly liveLeases = computed(
+    () => this.allLeases().filter((row) => row.endsAtMs > this.nowMs()),
+    { equal: sameRows },
+  );
+
   /** Both sections' rows before filtering — what the chip filters offer options from. */
   private readonly filterableRows = computed<FilterableRow[]>(() => [
     ...this.allRows(),
-    ...this.allLeases(),
+    ...this.liveLeases(),
   ]);
 
   /** Every distinct collection present on the tab, for the Collection filter. */
@@ -137,7 +158,7 @@ export class ApprovalsTabComponent {
 
   protected readonly rows = computed(() => this.applyFilters(this.allRows()));
 
-  protected readonly leaseRows = computed(() => this.applyFilters(this.allLeases()));
+  protected readonly leaseRows = computed(() => this.applyFilters(this.liveLeases()));
 
   /**
    * Whether the tab has anything at all before filtering, across both sections. Distinguishes an
@@ -171,6 +192,16 @@ export class ApprovalsTabComponent {
     });
     effect(() => {
       this.leasesDataSource.data = this.leaseRows();
+    });
+  }
+
+  ngOnInit(): void {
+    // Outside the Angular zone: a periodic in-zone timer never lets NgZone settle, which would hang
+    // `fixture.whenStable()` for any host that embeds this view. The signal write still drives
+    // change detection on its own.
+    this.ngZone.runOutsideAngular(() => {
+      const intervalId = setInterval(() => this.nowMs.set(Date.now()), 1000);
+      this.destroyRef.onDestroy(() => clearInterval(intervalId));
     });
   }
 
@@ -293,6 +324,11 @@ export class ApprovalsTabComponent {
       });
     }
   }
+}
+
+/** Whether two row lists hold the same row objects in the same order. */
+function sameRows(a: readonly ManagedLeaseRow[], b: readonly ManagedLeaseRow[]): boolean {
+  return a.length === b.length && a.every((row, index) => row === b[index]);
 }
 
 /** Deduped, locale-sorted chip options from a list of possibly-blank labels. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -144,9 +144,7 @@ export class ApprovalsTabComponent {
    * empty inbox (nothing to do) from a filter that matched nothing (something to do, just not
    * visible), which need different copy and, for the latter, the filter controls left on screen.
    */
-  protected readonly hasRows = computed(
-    () => this.allRows().length > 0 || this.allLeases().length > 0,
-  );
+  protected readonly hasRows = computed(() => this.filterableRows().length > 0);
 
   protected readonly dataSource = new TableDataSource<ApprovalRow>();
   protected readonly leasesDataSource = new TableDataSource<ManagedLeaseRow>();

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
@@ -384,6 +384,23 @@ describe("ApproverInboxService", () => {
       expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(0);
     });
 
+    it("names a cipher outside the local vault by its id, the text the Item column shows", async () => {
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "unresolved",
+          status: "approved",
+          producedLeaseId: "lease-unresolved",
+          producedLeaseStatus: "active",
+        }),
+      ]);
+
+      await service.load();
+
+      const [row] = await firstValueFrom(service.activeLeaseRows$);
+      expect(row.cipherName).toBe("cipher-1");
+      expect(row.searchText).toContain("cipher-1");
+    });
+
     it("keeps a lease an extension has carried past the request's own end", async () => {
       const requestEnd = new Date(Date.now() - 1000).toISOString();
       const extendedEnd = new Date(Date.now() + 60 * 60 * 1000).toISOString();

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
@@ -303,6 +303,152 @@ describe("ApproverInboxService", () => {
     });
   });
 
+  describe("activeLeaseRows$", () => {
+    it("lists only the requests whose produced lease is still active", async () => {
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "live",
+          status: "approved",
+          producedLeaseId: "lease-live",
+          producedLeaseStatus: "active",
+        }),
+        request({
+          id: "ended",
+          status: "approved",
+          producedLeaseId: "lease-ended",
+          producedLeaseStatus: "revoked",
+        }),
+        request({ id: "never-started", status: "approved", producedLeaseId: undefined }),
+      ]);
+
+      await service.load();
+
+      const rows = await firstValueFrom(service.activeLeaseRows$);
+      expect(rows.map((r) => r.requestId)).toEqual(["live"]);
+      expect(rows[0].leaseId).toBe("lease-live");
+      expect(rows[0].requester).toBe("Grace");
+    });
+
+    it("lists an activated grant whose status does not read as approved", async () => {
+      // The server can serve an activated grant with a status the client reads as denied
+      // (uat-FLW-06-9e1cc0ec), which is why liveness is read off the produced lease and never off
+      // the display badge. Reverting this filter onto `statusBadge` empties the section in the
+      // product while every other test here still passes.
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "reads-denied",
+          status: "denied",
+          producedLeaseId: "lease-live",
+          producedLeaseStatus: "active",
+        }),
+      ]);
+
+      await service.load();
+
+      expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(1);
+    });
+
+    it("drops a lease whose window has closed, however the server still reports its status", async () => {
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "lapsed",
+          status: "approved",
+          leaseNotAfter: new Date(Date.now() - 1000).toISOString(),
+          producedLeaseId: "lease-lapsed",
+          producedLeaseStatus: "active",
+        }),
+      ]);
+
+      await service.load();
+
+      expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(0);
+    });
+
+    it("keeps a lease an extension has carried past the request's own end", async () => {
+      const requestEnd = new Date(Date.now() - 1000).toISOString();
+      const extendedEnd = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "original",
+          status: "approved",
+          leaseNotAfter: requestEnd,
+          producedLeaseId: "lease-1",
+          producedLeaseStatus: "active",
+        }),
+        request({
+          id: "the-extension",
+          status: "approved",
+          extensionOfLeaseId: "lease-1",
+          leaseNotBefore: requestEnd,
+          leaseNotAfter: extendedEnd,
+        }),
+      ]);
+
+      await service.load();
+
+      const rows = await firstValueFrom(service.activeLeaseRows$);
+      expect(rows.map((r) => r.requestId)).toEqual(["original"]);
+      expect(rows[0].endsAt).toBe(extendedEnd);
+    });
+
+    it("ends the row at the applied extension's end, not the originating request's", async () => {
+      const requestEnd = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      const extendedEnd = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "original",
+          status: "approved",
+          leaseNotAfter: requestEnd,
+          producedLeaseId: "lease-1",
+          producedLeaseStatus: "active",
+        }),
+        request({
+          id: "the-extension",
+          status: "approved",
+          extensionOfLeaseId: "lease-1",
+          leaseNotBefore: requestEnd,
+          leaseNotAfter: extendedEnd,
+        }),
+      ]);
+
+      await service.load();
+
+      const [row] = await firstValueFrom(service.activeLeaseRows$);
+      expect(row.endsAt).toBe(extendedEnd);
+      expect(row.endsAtMs).toBe(Date.parse(extendedEnd));
+      expect(row.extendedUntil).toBe(extendedEnd);
+      expect(row.extendedBySeconds).toBe(2 * 60 * 60);
+    });
+
+    it("drops the row on revoke and puts it back when the SDK rejects", async () => {
+      approvalApi.listHistory.mockResolvedValue([
+        request({
+          id: "req-1",
+          status: "approved",
+          producedLeaseId: "lease-1",
+          producedLeaseStatus: "active",
+        }),
+      ]);
+      await service.load();
+
+      await service.revokeLease(
+        "req-1" as unknown as AccessRequestId,
+        "lease-1" as unknown as AccessLeaseId,
+      );
+      expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(0);
+
+      leasesApi.endLease.mockRejectedValue(new Error("boom"));
+      await service.load();
+      await expect(
+        service.revokeLease(
+          "req-1" as unknown as AccessRequestId,
+          "lease-1" as unknown as AccessLeaseId,
+        ),
+      ).rejects.toThrow("boom");
+      expect(await firstValueFrom(service.activeLeaseRows$)).toHaveLength(1);
+    });
+  });
+
   it("sorts history newest-resolved first", async () => {
     approvalApi.listHistory.mockResolvedValue([
       request({ id: "older", status: "denied", resolvedAt: "2026-08-17T09:00:00.000Z" }),

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.spec.ts
@@ -45,6 +45,26 @@ function request(overrides: Record<string, unknown> = {}): AccessRequestView {
   } as unknown as AccessRequestView;
 }
 
+/** An activated request whose lease an approved extension has already carried to `extendedEnd`. */
+function extendedLease(requestEnd: string, extendedEnd: string): AccessRequestView[] {
+  return [
+    request({
+      id: "original",
+      status: "approved",
+      leaseNotAfter: requestEnd,
+      producedLeaseId: "lease-1",
+      producedLeaseStatus: "active",
+    }),
+    request({
+      id: "the-extension",
+      status: "approved",
+      extensionOfLeaseId: "lease-1",
+      leaseNotBefore: requestEnd,
+      leaseNotAfter: extendedEnd,
+    }),
+  ];
+}
+
 describe("ApproverInboxService", () => {
   let service: ApproverInboxService;
   let approvalApi: MockProxy<ApprovalSdkService>;
@@ -367,22 +387,7 @@ describe("ApproverInboxService", () => {
     it("keeps a lease an extension has carried past the request's own end", async () => {
       const requestEnd = new Date(Date.now() - 1000).toISOString();
       const extendedEnd = new Date(Date.now() + 60 * 60 * 1000).toISOString();
-      approvalApi.listHistory.mockResolvedValue([
-        request({
-          id: "original",
-          status: "approved",
-          leaseNotAfter: requestEnd,
-          producedLeaseId: "lease-1",
-          producedLeaseStatus: "active",
-        }),
-        request({
-          id: "the-extension",
-          status: "approved",
-          extensionOfLeaseId: "lease-1",
-          leaseNotBefore: requestEnd,
-          leaseNotAfter: extendedEnd,
-        }),
-      ]);
+      approvalApi.listHistory.mockResolvedValue(extendedLease(requestEnd, extendedEnd));
 
       await service.load();
 
@@ -394,22 +399,7 @@ describe("ApproverInboxService", () => {
     it("ends the row at the applied extension's end, not the originating request's", async () => {
       const requestEnd = new Date(Date.now() + 60 * 60 * 1000).toISOString();
       const extendedEnd = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
-      approvalApi.listHistory.mockResolvedValue([
-        request({
-          id: "original",
-          status: "approved",
-          leaseNotAfter: requestEnd,
-          producedLeaseId: "lease-1",
-          producedLeaseStatus: "active",
-        }),
-        request({
-          id: "the-extension",
-          status: "approved",
-          extensionOfLeaseId: "lease-1",
-          leaseNotBefore: requestEnd,
-          leaseNotAfter: extendedEnd,
-        }),
-      ]);
+      approvalApi.listHistory.mockResolvedValue(extendedLease(requestEnd, extendedEnd));
 
       await service.load();
 

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.ts
@@ -32,10 +32,15 @@ import {
   ResolvedNames,
   emptyResolvedNames,
 } from "../access-requests/access-name-resolver.service";
-import { MyAccessRequestRow, toRequestRow } from "../access-requests/my-access-row";
+import {
+  MyAccessRequestRow,
+  extensionsByLeaseId,
+  toRequestRow,
+} from "../access-requests/my-access-row";
 
 import { ApprovalRow, sortApprovalRows, toApprovalRow } from "./approval-row";
 import { isActionableInboxRequest } from "./inbox-request-filter";
+import { ManagedLeaseRow, isLiveManagedLease, toManagedLeaseRow } from "./managed-lease-row";
 
 /**
  * Page-level data service for the approver surfaces: the pending inbox and the decided history for
@@ -108,6 +113,36 @@ export class ApproverInboxService {
         .map((request) => toRequestRow(request, names))
         .sort((a, b) => resolvedOrSubmittedMs(b) - resolvedOrSubmittedMs(a)),
     ),
+  );
+
+  /**
+   * The leases that are live RIGHT NOW on the collections the caller manages, soonest to end first —
+   * the access an operator can still cut off.
+   *
+   * A filter over the history read rather than a governance read of its own: `listHistory()` already
+   * returns every managed non-pending request with its produced lease's id and status, and the SDK
+   * omits a list-active-leases call on purpose.
+   *
+   * The window is tested as well as the status, and only once the row's effective end is known: the
+   * server never transitions a lease out of `active` when its window closes, so status alone would
+   * keep listing — and offering Revoke on — access that ended on its own, while testing the
+   * request's own end first would drop a lease an extension has carried past it.
+   */
+  readonly activeLeaseRows$: Observable<ManagedLeaseRow[]> = combineLatest([
+    this._history$,
+    this._names$,
+    this._renderedAt$,
+  ]).pipe(
+    map(([requests, names, now]) => {
+      const extensions = extensionsByLeaseId(requests);
+      return requests
+        .filter(isLiveManagedLease)
+        .map((request) =>
+          toManagedLeaseRow(request, names, extensions.get(uuidAsString(request.producedLeaseId))),
+        )
+        .filter((row) => row.endsAtMs > now.getTime())
+        .sort((a, b) => a.endsAtMs - b.endsAtMs);
+    }),
   );
 
   /**

--- a/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
@@ -22,8 +22,8 @@ export type ManagedLeaseRow = {
   leaseId: AccessLeaseId;
   cipherId: string;
   collectionId: string;
-  /** null when the cipher isn't in the caller's local vault; the template falls back to the id. */
-  cipherName: string | null;
+  /** The gated cipher's display name, falling back to its raw id when it isn't in the local vault. */
+  cipherName: string;
   collectionName: string | null;
   /** The holder's name, falling back to their email, then empty. */
   requester: string;
@@ -69,7 +69,7 @@ export function toManagedLeaseRow(
 ): ManagedLeaseRow {
   const cipherId = uuidAsString(request.cipherId);
   const collectionId = uuidAsString(request.collectionId);
-  const cipherName = names.cipherNameById.get(cipherId) ?? null;
+  const cipherName = names.cipherNameById.get(cipherId) ?? cipherId;
   const collectionName = names.collectionNameById.get(collectionId) ?? null;
   const extended = extension != null && extension.latestEndMs > 0;
   const endsAtMs = extended ? extension.latestEndMs : Date.parse(request.leaseNotAfter);

--- a/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
@@ -1,0 +1,97 @@
+import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+
+import type {
+  AccessLeaseId,
+  AccessRequestId,
+  AccessRequestView,
+} from "../abstractions/access-lease";
+import { ResolvedNames } from "../access-requests/access-name-resolver.service";
+import { LeaseExtensionSummary } from "../access-requests/my-access-row";
+
+/**
+ * A lease that is live right now on a collection the caller manages.
+ *
+ * Separate from {@link MyAccessRequestRow} rather than an extension of it: that model carries no
+ * requester identity and is shared with the requester-facing tabs, where "who holds this" is always
+ * the viewer.
+ */
+export type ManagedLeaseRow = {
+  /** The request that produced the lease — every row links to /pam/requests/:id. */
+  requestId: AccessRequestId;
+  /** The live lease itself, the id `ApproverInboxService.revokeLease` ends. */
+  leaseId: AccessLeaseId;
+  cipherId: string;
+  collectionId: string;
+  /** null when the cipher isn't in the caller's local vault; the template falls back to the id. */
+  cipherName: string | null;
+  collectionName: string | null;
+  /** The holder's name, falling back to their email, then empty. */
+  requester: string;
+  requesterEmail: string | null;
+  startsAt: string;
+  /** The lease's EFFECTIVE end: the latest applied extension's end, else the request's window end. */
+  endsAt: string;
+  /** Sort key for the Remaining column. */
+  endsAtMs: number;
+  extendedBySeconds: number | null;
+  extendedUntil: string | null;
+  /** Lowercased haystack for the free-text filter. */
+  searchText: string;
+};
+
+/**
+ * Whether this request minted a lease the server still holds open.
+ *
+ * Not on its own "live right now": nothing ever moves a lease out of `active` when its window
+ * closes, so a caller listing running access must also test the effective end.
+ *
+ * Reads the request, never the display badge: `historyDisplayStatus` only reaches its activated
+ * branch for `status === "approved"`, and an activated grant can arrive with a status the client
+ * reads otherwise, which would empty this section in the product while every test still passed.
+ */
+export function isLiveManagedLease(
+  request: AccessRequestView,
+): request is AccessRequestView & { producedLeaseId: AccessLeaseId } {
+  return request.producedLeaseId != null && request.producedLeaseStatus === "active";
+}
+
+/**
+ * Build one live-lease row.
+ *
+ * `extension` is the summary for the produced lease, if any. An extension is applied to the lease in
+ * place and never moves the originating request's `leaseNotAfter`, so an extended lease whose row
+ * showed the request's end would tell an operator that access ends sooner than it does.
+ */
+export function toManagedLeaseRow(
+  request: AccessRequestView & { producedLeaseId: AccessLeaseId },
+  names: ResolvedNames,
+  extension?: LeaseExtensionSummary,
+): ManagedLeaseRow {
+  const cipherId = uuidAsString(request.cipherId);
+  const collectionId = uuidAsString(request.collectionId);
+  const cipherName = names.cipherNameById.get(cipherId) ?? null;
+  const collectionName = names.collectionNameById.get(collectionId) ?? null;
+  const extended = extension != null && extension.latestEndMs > 0;
+  const endsAtMs = extended ? extension.latestEndMs : Date.parse(request.leaseNotAfter);
+  const endsAt = extended ? new Date(endsAtMs).toISOString() : request.leaseNotAfter;
+
+  return {
+    requestId: request.id,
+    leaseId: request.producedLeaseId,
+    cipherId,
+    collectionId,
+    cipherName,
+    collectionName,
+    requester: request.requesterName || request.requesterEmail || "",
+    requesterEmail: request.requesterEmail ?? null,
+    startsAt: request.leaseNotBefore,
+    endsAt,
+    endsAtMs,
+    extendedBySeconds: extended ? extension.addedSeconds : null,
+    extendedUntil: extended ? endsAt : null,
+    searchText: [cipherName, collectionName, request.requesterName, request.requesterEmail]
+      .filter((value): value is string => !!value)
+      .join(" ")
+      .toLowerCase(),
+  };
+}


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-06-f8b8c201`, also closes `uat-NEW-operator-live-access`.

## 📔 Objective

Show live access with a revoke action on the Approvals tab.

- What was wrong: Verified at pam/uat: approvals-tab.component.html is a single flat table under an h2 reading pamApprovalsPendingHeader ("Pending approval $COUNT$").
- Surface: `Password Manager -> Access requests -> Approvals`.
- Size: 8 files, 941 insertions(+), 140 deletions(-).
- Stack: sits on `pam/uat-t-audit-event-filter-menu`; `approvals-actions-column-breakpoints` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

### Password Manager -> Access requests -> Approvals

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/e8ee4726fc759fbfca1b214e8fecfe33d86ec417/before-uat-FLW-06-f8b8c201.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/ee538d7d15a75e7a0fdd88f8c0e876e9dd3e13c6/after-uat-FLW-06-f8b8c201.png" alt="after" width="460"> |