### PR TITLE
fix(pam): ladder the approvals table columns so Approve and Deny stay on screen

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -55,12 +55,22 @@
               <tr>
                 <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
                 <th bitCell bitSortable="requester">{{ "pamInboxRequester" | i18n }}</th>
-                <th bitCell>{{ "pamInboxWindow" | i18n }}</th>
-                <th bitCell>{{ "pamInboxReason" | i18n }}</th>
-                <th bitCell bitSortable="submittedAtMs" default="asc">
+                <th bitCell class="tw-hidden xl:tw-table-cell" data-testid="approvals-col-window">
+                  {{ "pamInboxWindow" | i18n }}
+                </th>
+                <th bitCell class="tw-hidden xl:tw-table-cell" data-testid="approvals-col-reason">
+                  {{ "pamInboxReason" | i18n }}
+                </th>
+                <th
+                  bitCell
+                  bitSortable="submittedAtMs"
+                  default="asc"
+                  class="tw-hidden lg:tw-table-cell"
+                  data-testid="approvals-col-submitted"
+                >
                   {{ "pamColumnSubmitted" | i18n }}
                 </th>
-                <th bitCell>{{ "pamColumnActions" | i18n }}</th>
+                <th bitCell data-testid="approvals-col-actions">{{ "pamColumnActions" | i18n }}</th>
               </tr>
             </ng-container>
             <ng-template body let-rows$>
@@ -90,13 +100,21 @@
                     <div class="tw-text-xs tw-text-muted">{{ row.requesterEmail }}</div>
                   }
                 </td>
-                <td bitCell>
+                <td
+                  bitCell
+                  class="tw-hidden xl:tw-table-cell"
+                  [attr.data-testid]="'approvals-cell-window-' + row.id"
+                >
                   <span class="tw-whitespace-nowrap" [title]="row.exactWindow">
                     {{ row.duration.key | i18n: row.duration.value }},
                     {{ row.relativeStart.key | i18n: row.relativeStart.value }}
                   </span>
                 </td>
-                <td bitCell>
+                <td
+                  bitCell
+                  class="tw-hidden xl:tw-table-cell"
+                  [attr.data-testid]="'approvals-cell-reason-' + row.id"
+                >
                   @if (row.reason) {
                     <div class="tw-line-clamp-2 tw-max-w-xs tw-break-words" [title]="row.reason">
                       {{ row.reason }}
@@ -105,7 +123,11 @@
                     <span class="tw-text-muted">{{ "pamInboxReasonMissing" | i18n }}</span>
                   }
                 </td>
-                <td bitCell>
+                <td
+                  bitCell
+                  class="tw-hidden lg:tw-table-cell"
+                  [attr.data-testid]="'approvals-cell-submitted-' + row.id"
+                >
                   <span
                     class="tw-whitespace-nowrap"
                     [title]="row.request.submittedAt | date: 'medium'"

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -185,6 +185,66 @@ describe("ApprovalsTabComponent", () => {
       expect(text).toContain("prod incident");
     });
 
+    // jsdom performs no layout and loads no stylesheet, so these assert the breakpoint classes are
+    // present on both halves of each column pair, not that the buttons are on screen. The 1024px
+    // behaviour is verified in a browser.
+    it("drops the window and reason columns below the xl breakpoint", () => {
+      inbox.inboxRows$.next([row({ id: "req-1" })]);
+
+      create();
+
+      for (const column of ["window", "reason"]) {
+        const header = query(`[data-testid="approvals-col-${column}"]`);
+        const cell = query(`[data-testid="approvals-cell-${column}-req-1"]`);
+
+        for (const element of [header, cell]) {
+          expect(element).not.toBeNull();
+          expect(element?.classList).toContain("tw-hidden");
+          expect(element?.classList).toContain("xl:tw-table-cell");
+          expect(element?.classList).not.toContain("lg:tw-table-cell");
+        }
+      }
+    });
+
+    it("drops the submitted column below the lg breakpoint", () => {
+      inbox.inboxRows$.next([row({ id: "req-1" })]);
+
+      create();
+
+      const header = query('[data-testid="approvals-col-submitted"]');
+      const cell = query('[data-testid="approvals-cell-submitted-req-1"]');
+
+      for (const element of [header, cell]) {
+        expect(element).not.toBeNull();
+        expect(element?.classList).toContain("tw-hidden");
+        expect(element?.classList).toContain("lg:tw-table-cell");
+        expect(element?.classList).not.toContain("xl:tw-table-cell");
+      }
+    });
+
+    it("keeps the actions column visible at every width", () => {
+      inbox.inboxRows$.next([row({ id: "req-1" })]);
+
+      create();
+
+      expect(query('[data-testid="approvals-col-actions"]')?.classList).not.toContain("tw-hidden");
+      const actionsCell = query('[data-testid="approvals-approve-req-1"]')?.closest("td");
+      expect(actionsCell).not.toBeNull();
+      expect(actionsCell?.classList).not.toContain("tw-hidden");
+    });
+
+    it("keeps the full window and reason reachable from the row", () => {
+      const reason = "prod incident ".repeat(40).trim();
+      inbox.inboxRows$.next([row({ id: "req-1", reason })]);
+
+      create();
+
+      expect(query('[data-testid="approvals-row-req-1"] a')?.getAttribute("href")).toBe(
+        "/pam/requests/req-1",
+      );
+      expect(query(".tw-line-clamp-2")?.getAttribute("title")).toBe(reason);
+    });
+
     it("says so explicitly when a request carries no reason", () => {
       inbox.inboxRows$.next([row({ reason: undefined })]);
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -187,7 +187,7 @@ describe("ApprovalsTabComponent", () => {
 
     // jsdom performs no layout and loads no stylesheet, so these assert the breakpoint classes on
     // both the header and the cell of each column, not that the buttons are on screen. The 1024px
-    // behaviour still needs verifying in a browser.
+    // and 1280px behaviour still needs verifying in a browser.
     it.each([
       ["window", "xl"],
       ["reason", "xl"],

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -187,7 +187,7 @@ describe("ApprovalsTabComponent", () => {
 
     // jsdom performs no layout and loads no stylesheet, so these assert the breakpoint classes on
     // both the header and the cell of each column, not that the buttons are on screen. The 1024px
-    // behaviour is verified in a browser.
+    // behaviour still needs verifying in a browser.
     it.each([
       ["window", "xl"],
       ["reason", "xl"],
@@ -220,15 +220,22 @@ describe("ApprovalsTabComponent", () => {
       expect(actionsCell?.classList).not.toContain("tw-hidden");
     });
 
-    it("keeps the full window and reason reachable from the row", () => {
-      const pending = row({ id: "req-1" });
-      inbox.inboxRows$.next([pending]);
+    it("links each row to the request detail, which is where a hidden column is read", () => {
+      inbox.inboxRows$.next([row({ id: "req-1" })]);
 
       create();
 
       expect(query('[data-testid="approvals-row-req-1"] a')?.getAttribute("href")).toBe(
         "/pam/requests/req-1",
       );
+    });
+
+    it("carries the exact window and the unclamped reason on title, where those columns show", () => {
+      const pending = row({ id: "req-1" });
+      inbox.inboxRows$.next([pending]);
+
+      create();
+
       expect(query('[data-testid="approvals-cell-window-req-1"] span')?.title).toBe(
         pending.exactWindow,
       );

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -185,40 +185,27 @@ describe("ApprovalsTabComponent", () => {
       expect(text).toContain("prod incident");
     });
 
-    // jsdom performs no layout and loads no stylesheet, so these assert the breakpoint classes are
-    // present on both halves of each column pair, not that the buttons are on screen. The 1024px
+    // jsdom performs no layout and loads no stylesheet, so these assert the breakpoint classes on
+    // both the header and the cell of each column, not that the buttons are on screen. The 1024px
     // behaviour is verified in a browser.
-    it("drops the window and reason columns below the xl breakpoint", () => {
+    it.each([
+      ["window", "xl"],
+      ["reason", "xl"],
+      ["submitted", "lg"],
+    ] as const)("shows the %s column only from the %s breakpoint up", (column, visibleFrom) => {
       inbox.inboxRows$.next([row({ id: "req-1" })]);
 
       create();
 
-      for (const column of ["window", "reason"]) {
-        const header = query(`[data-testid="approvals-col-${column}"]`);
-        const cell = query(`[data-testid="approvals-cell-${column}-req-1"]`);
-
-        for (const element of [header, cell]) {
-          expect(element).not.toBeNull();
-          expect(element?.classList).toContain("tw-hidden");
-          expect(element?.classList).toContain("xl:tw-table-cell");
-          expect(element?.classList).not.toContain("lg:tw-table-cell");
-        }
-      }
-    });
-
-    it("drops the submitted column below the lg breakpoint", () => {
-      inbox.inboxRows$.next([row({ id: "req-1" })]);
-
-      create();
-
-      const header = query('[data-testid="approvals-col-submitted"]');
-      const cell = query('[data-testid="approvals-cell-submitted-req-1"]');
-
-      for (const element of [header, cell]) {
+      for (const element of [
+        query(`[data-testid="approvals-col-${column}"]`),
+        query(`[data-testid="approvals-cell-${column}-req-1"]`),
+      ]) {
         expect(element).not.toBeNull();
         expect(element?.classList).toContain("tw-hidden");
-        expect(element?.classList).toContain("lg:tw-table-cell");
-        expect(element?.classList).not.toContain("xl:tw-table-cell");
+        expect([...(element?.classList ?? [])].filter((c) => c.endsWith(":tw-table-cell"))).toEqual(
+          [`${visibleFrom}:tw-table-cell`],
+        );
       }
     });
 
@@ -234,15 +221,18 @@ describe("ApprovalsTabComponent", () => {
     });
 
     it("keeps the full window and reason reachable from the row", () => {
-      const reason = "prod incident ".repeat(40).trim();
-      inbox.inboxRows$.next([row({ id: "req-1", reason })]);
+      const pending = row({ id: "req-1" });
+      inbox.inboxRows$.next([pending]);
 
       create();
 
       expect(query('[data-testid="approvals-row-req-1"] a')?.getAttribute("href")).toBe(
         "/pam/requests/req-1",
       );
-      expect(query(".tw-line-clamp-2")?.getAttribute("title")).toBe(reason);
+      expect(query('[data-testid="approvals-cell-window-req-1"] span')?.title).toBe(
+        pending.exactWindow,
+      );
+      expect(query('[data-testid="approvals-cell-reason-req-1"] div')?.title).toBe(pending.reason);
     });
 
     it("says so explicitly when a request carries no reason", () => {


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-SCR-13-908bdd01`.

## 📔 Objective

Ladder the approvals table columns so Approve and Deny stay on screen.

- What was wrong: At 1024x836 all four Approve/Deny buttons sit past the right edge (Approve 1039-1113, Deny 1121-1177 against innerWidth 1024), behind 165px of horizontal scroll inside main with no visible affordance 
- Surface: `Password Manager -> Access requests -> Approvals, populated inbox at 1024px`.
- Size: 2 files, 86 insertions(+), 7 deletions(-).
- Stack: sits on `pam/uat-t-approvals-active-access-section`; `approvals-loading-skeleton` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

Captured at 1440x1024 (the column-ladder pair at 1024x836, its defect width). Before is `pam/uat`; after is the assembled stack tip, so the after side shows this change alongside the rest of the stack.

### Password Manager -> Access requests -> Approvals, populated inbox at 1024px

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/223d176678d1fc77f30420162bf8e833b392ee41/before-uat-SCR-13-908bdd01.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/dedcd6fae78f6de19c8ba348cdd9379ae67a0baf/after-uat-SCR-13-908bdd01.png" alt="after" width="460"> |


## Known gaps

- CI here inherits failures already on `pam/uat` (`Run tests`, `Rust lint`, two cloud builds) plus a pre-existing `tsc-strict` error in `access-rule-edit.component.spec.ts` from #22635. None originate in this stack: the PAM suite passes on the assembled tip, 67 suites and 792 tests.
