### PR TITLE
fix(pam): replace the Approvals loading paragraph with skeleton rows

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17980,6 +17980,9 @@
   "pamApprovalsNoResults": {
     "message": "No access requests match your filters."
   },
+  "pamApprovalsLoaded": {
+    "message": "Access requests loaded"
+  },
   "pamHistoryScopeMine": {
     "message": "Raised by me"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -1,6 +1,8 @@
 <div class="tw-sr-only" role="status" aria-live="polite" data-testid="approvals-loading-status">
   @if (skeletonVisible()) {
     {{ "loading" | i18n }}
+  } @else if (announceLoaded()) {
+    {{ "pamApprovalsLoaded" | i18n }}
   }
 </div>
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -1,9 +1,13 @@
-@if (loading() && !hasRows()) {
-  <div data-testid="approvals-loading">
-    <span class="tw-sr-only" role="status">{{ "loading" | i18n }}</span>
+<div class="tw-sr-only" role="status" aria-live="polite" data-testid="approvals-loading-status">
+  @if (skeletonVisible()) {
+    {{ "loading" | i18n }}
+  }
+</div>
 
-    @if (showSkeleton()) {
-      <bit-table>
+@if ((loading() || showSkeleton()) && !hasRows()) {
+  <div data-testid="approvals-loading">
+    @if (skeletonVisible()) {
+      <bit-table aria-hidden="true">
         <ng-container header>
           <tr>
             <th bitCell>{{ "pamColumnItem" | i18n }}</th>
@@ -33,7 +37,7 @@
               <td bitCell class="tw-hidden lg:tw-table-cell">
                 <bit-skeleton-text class="tw-w-24"></bit-skeleton-text>
               </td>
-              <td bitCell><bit-skeleton-text class="tw-w-36"></bit-skeleton-text></td>
+              <td bitCell></td>
             </tr>
           }
         </ng-template>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -1,5 +1,45 @@
 @if (loading() && !hasRows()) {
-  <p bitTypography="body2" class="tw-mt-2">{{ "loading" | i18n }}</p>
+  <div data-testid="approvals-loading">
+    <span class="tw-sr-only" role="status">{{ "loading" | i18n }}</span>
+
+    @if (showSkeleton()) {
+      <bit-table>
+        <ng-container header>
+          <tr>
+            <th bitCell>{{ "pamColumnItem" | i18n }}</th>
+            <th bitCell>{{ "pamInboxRequester" | i18n }}</th>
+            <th bitCell class="tw-hidden xl:tw-table-cell">{{ "pamInboxWindow" | i18n }}</th>
+            <th bitCell class="tw-hidden xl:tw-table-cell">{{ "pamInboxReason" | i18n }}</th>
+            <th bitCell class="tw-hidden lg:tw-table-cell">{{ "pamColumnSubmitted" | i18n }}</th>
+            <th bitCell>{{ "pamColumnActions" | i18n }}</th>
+          </tr>
+        </ng-container>
+        <ng-template body>
+          @for (skeletonRow of skeletonRows; track skeletonRow) {
+            <tr bitRow>
+              <td bitCell>
+                <div class="tw-flex tw-items-center tw-gap-3">
+                  <bit-skeleton class="tw-size-6 tw-shrink-0"></bit-skeleton>
+                  <bit-skeleton-text [lines]="2" class="tw-w-40"></bit-skeleton-text>
+                </div>
+              </td>
+              <td bitCell><bit-skeleton-text [lines]="2" class="tw-w-40"></bit-skeleton-text></td>
+              <td bitCell class="tw-hidden xl:tw-table-cell">
+                <bit-skeleton-text class="tw-w-48"></bit-skeleton-text>
+              </td>
+              <td bitCell class="tw-hidden xl:tw-table-cell">
+                <bit-skeleton-text class="tw-w-56"></bit-skeleton-text>
+              </td>
+              <td bitCell class="tw-hidden lg:tw-table-cell">
+                <bit-skeleton-text class="tw-w-24"></bit-skeleton-text>
+              </td>
+              <td bitCell><bit-skeleton-text class="tw-w-36"></bit-skeleton-text></td>
+            </tr>
+          }
+        </ng-template>
+      </bit-table>
+    }
+  </div>
 } @else if (!hasRows()) {
   <bit-no-items class="tw-mt-2 tw-block" data-testid="approvals-empty">
     <span slot="title" class="tw-mt-4 tw-block">{{ "pamInboxEmptyTitle" | i18n }}</span>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.html
@@ -6,7 +6,7 @@
   }
 </div>
 
-@if ((loading() || showSkeleton()) && !hasRows()) {
+@if (loadingVisible()) {
   <div data-testid="approvals-loading">
     @if (skeletonVisible()) {
       <bit-table aria-hidden="true">
@@ -14,9 +14,27 @@
           <tr>
             <th bitCell>{{ "pamColumnItem" | i18n }}</th>
             <th bitCell>{{ "pamInboxRequester" | i18n }}</th>
-            <th bitCell class="tw-hidden xl:tw-table-cell">{{ "pamInboxWindow" | i18n }}</th>
-            <th bitCell class="tw-hidden xl:tw-table-cell">{{ "pamInboxReason" | i18n }}</th>
-            <th bitCell class="tw-hidden lg:tw-table-cell">{{ "pamColumnSubmitted" | i18n }}</th>
+            <th
+              bitCell
+              class="tw-hidden xl:tw-table-cell"
+              data-testid="approvals-skeleton-col-window"
+            >
+              {{ "pamInboxWindow" | i18n }}
+            </th>
+            <th
+              bitCell
+              class="tw-hidden xl:tw-table-cell"
+              data-testid="approvals-skeleton-col-reason"
+            >
+              {{ "pamInboxReason" | i18n }}
+            </th>
+            <th
+              bitCell
+              class="tw-hidden lg:tw-table-cell"
+              data-testid="approvals-skeleton-col-submitted"
+            >
+              {{ "pamColumnSubmitted" | i18n }}
+            </th>
             <th bitCell>{{ "pamColumnActions" | i18n }}</th>
           </tr>
         </ng-container>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -194,7 +194,9 @@ describe("ApprovalsTabComponent", () => {
 
       expect(query("bit-skeleton")).toBeNull();
       expect(query('[data-testid="approvals-loading"]')).toBeNull();
-      expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent).toContain(
+        "pamApprovalsLoaded",
+      );
       expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
     });
 
@@ -215,6 +217,7 @@ describe("ApprovalsTabComponent", () => {
       fixture.detectChanges();
 
       expect(query("bit-skeleton")).toBeNull();
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
       expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -271,6 +271,69 @@ describe("ApprovalsTabComponent", () => {
       expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
     });
 
+    it("does not announce a retry of a failed load as loaded while it is still in flight", () => {
+      inbox.loading$.next(true);
+
+      create();
+
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      inbox.loadError$.next(new Error("boom"));
+      inbox.loading$.next(false);
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
+
+      // A push retries the load, and the service clears the error before the fetch is even sent.
+      inbox.loading$.next(true);
+      inbox.loadError$.next(null);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
+
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent).toContain("loading");
+
+      inbox.loading$.next(false);
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent).toContain(
+        "pamApprovalsLoaded",
+      );
+    });
+
+    it("does not announce a reload that shows no skeleton as loaded", () => {
+      inbox.loading$.next(true);
+
+      create();
+
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      inbox.loading$.next(false);
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent).toContain(
+        "pamApprovalsLoaded",
+      );
+
+      inbox.loading$.next(true);
+      fixture.detectChanges();
+      jest.advanceTimersByTime(500);
+      inbox.loading$.next(false);
+      jest.advanceTimersByTime(500);
+      fixture.detectChanges();
+
+      expect(query("bit-skeleton")).toBeNull();
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
+    });
+
     it("shows the empty state when there is nothing to approve", () => {
       create();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -154,6 +154,10 @@ describe("ApprovalsTabComponent", () => {
 
       create();
 
+      const status = query('[data-testid="approvals-loading-status"]');
+      expect(status?.getAttribute("role")).toBe("status");
+      expect(status?.getAttribute("aria-live")).toBe("polite");
+      expect(status?.textContent?.trim()).toBe("");
       expect(query('[data-testid="approvals-loading"]')).not.toBeNull();
       expect(query("bit-skeleton")).toBeNull();
 
@@ -162,9 +166,36 @@ describe("ApprovalsTabComponent", () => {
 
       const skeleton = query('[data-testid="approvals-loading"]');
       expect(skeleton?.querySelectorAll("bit-skeleton").length).toBeGreaterThan(0);
-      expect(skeleton?.querySelector('[role="status"]')?.textContent).toContain("loading");
+      expect(skeleton?.querySelector("bit-table")?.getAttribute("aria-hidden")).toBe("true");
+      expect(query('[data-testid="approvals-loading-status"]')).toBe(status);
+      expect(status?.textContent).toContain("loading");
       expect(query('p[bitTypography="body2"]')).toBeNull();
       expect(query('[data-testid="approvals-empty"]')).toBeNull();
+    });
+
+    it("keeps the skeleton on screen for its minimum display time", () => {
+      inbox.loading$.next(true);
+
+      create();
+
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query("bit-skeleton")).not.toBeNull();
+
+      inbox.loading$.next(false);
+      jest.advanceTimersByTime(300);
+      fixture.detectChanges();
+
+      expect(query("bit-skeleton")).not.toBeNull();
+
+      jest.advanceTimersByTime(700);
+      fixture.detectChanges();
+
+      expect(query("bit-skeleton")).toBeNull();
+      expect(query('[data-testid="approvals-loading"]')).toBeNull();
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
+      expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
     });
 
     it("never shows the skeleton when the inbox arrives inside a second", () => {
@@ -177,6 +208,7 @@ describe("ApprovalsTabComponent", () => {
 
       expect(query('[data-testid="approvals-loading"]')).not.toBeNull();
       expect(query("bit-skeleton")).toBeNull();
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
 
       inbox.loading$.next(false);
       jest.advanceTimersByTime(1000);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -79,6 +79,15 @@ function secondlyIntervalIds(spy: jest.SpyInstance): unknown[] {
     .map((result) => result.value);
 }
 
+/** Asserts a cell is hidden below `visibleFrom` and shown from it up, and laddered nowhere else. */
+function expectVisibleFrom(element: HTMLElement | null, visibleFrom: string): void {
+  expect(element).not.toBeNull();
+  expect(element?.classList).toContain("tw-hidden");
+  expect([...(element?.classList ?? [])].filter((c) => c.endsWith(":tw-table-cell"))).toEqual([
+    `${visibleFrom}:tw-table-cell`,
+  ]);
+}
+
 describe("ApprovalsTabComponent", () => {
   let fixture: ComponentFixture<ApprovalsTabComponent>;
   let component: ApprovalsTabComponent;
@@ -87,6 +96,7 @@ describe("ApprovalsTabComponent", () => {
     activeLeaseRows$: BehaviorSubject<ManagedLeaseRow[]>;
     cipherById$: BehaviorSubject<Map<string, CipherView>>;
     loading$: BehaviorSubject<boolean>;
+    loadError$: BehaviorSubject<unknown | null>;
     decide: jest.Mock;
     revokeLease: jest.Mock;
   };
@@ -111,6 +121,7 @@ describe("ApprovalsTabComponent", () => {
       activeLeaseRows$: new BehaviorSubject<ManagedLeaseRow[]>([]),
       cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
       loading$: new BehaviorSubject<boolean>(false),
+      loadError$: new BehaviorSubject<unknown | null>(null),
       decide: jest.fn().mockResolvedValue(undefined),
       revokeLease: jest.fn().mockResolvedValue(undefined),
     };
@@ -221,6 +232,45 @@ describe("ApprovalsTabComponent", () => {
       expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
     });
 
+    it("leaves the empty state up while an already-loaded empty inbox reloads", () => {
+      // PAM pushes on every managed request change, so an approver sitting on inbox zero reloads
+      // repeatedly; blanking the panel for the pre-skeleton second flickers the page each time.
+      create();
+
+      expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
+
+      inbox.loading$.next(true);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
+      expect(query('[data-testid="approvals-loading"]')).toBeNull();
+
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-empty"]')).toBeNull();
+      expect(query("bit-skeleton")).not.toBeNull();
+    });
+
+    it("does not announce a load that failed as loaded", () => {
+      inbox.loading$.next(true);
+
+      create();
+
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent).toContain("loading");
+
+      inbox.loadError$.next(new Error("boom"));
+      inbox.loading$.next(false);
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query("bit-skeleton")).toBeNull();
+      expect(query('[data-testid="approvals-loading-status"]')?.textContent?.trim()).toBe("");
+    });
+
     it("shows the empty state when there is nothing to approve", () => {
       create();
 
@@ -264,12 +314,19 @@ describe("ApprovalsTabComponent", () => {
         query(`[data-testid="approvals-col-${column}"]`),
         query(`[data-testid="approvals-cell-${column}-req-1"]`),
       ]) {
-        expect(element).not.toBeNull();
-        expect(element?.classList).toContain("tw-hidden");
-        expect([...(element?.classList ?? [])].filter((c) => c.endsWith(":tw-table-cell"))).toEqual(
-          [`${visibleFrom}:tw-table-cell`],
-        );
+        expectVisibleFrom(element, visibleFrom);
       }
+
+      // The skeleton stands in for that table, so it has to hide the same columns at the same
+      // widths — otherwise the layout jumps as the real rows land.
+      fixture.destroy();
+      inbox.inboxRows$.next([]);
+      inbox.loading$.next(true);
+      create();
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expectVisibleFrom(query(`[data-testid="approvals-skeleton-col-${column}"]`), visibleFrom);
     });
 
     it("keeps the actions column visible at every width", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -149,13 +149,42 @@ describe("ApprovalsTabComponent", () => {
   });
 
   describe("rendering", () => {
-    it("shows the loading message while loading and nothing has arrived yet", () => {
+    it("shows the skeleton table once loading has run for a second", () => {
       inbox.loading$.next(true);
 
       create();
 
-      expect(query('[bitTypography="body2"]')?.textContent).toContain("loading");
+      expect(query('[data-testid="approvals-loading"]')).not.toBeNull();
+      expect(query("bit-skeleton")).toBeNull();
+
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      const skeleton = query('[data-testid="approvals-loading"]');
+      expect(skeleton?.querySelectorAll("bit-skeleton").length).toBeGreaterThan(0);
+      expect(skeleton?.querySelector('[role="status"]')?.textContent).toContain("loading");
+      expect(query('p[bitTypography="body2"]')).toBeNull();
       expect(query('[data-testid="approvals-empty"]')).toBeNull();
+    });
+
+    it("never shows the skeleton when the inbox arrives inside a second", () => {
+      inbox.loading$.next(true);
+
+      create();
+
+      // Still loading, so the block is on screen and an ungated skeleton would be visible here.
+      jest.advanceTimersByTime(500);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="approvals-loading"]')).not.toBeNull();
+      expect(query("bit-skeleton")).toBeNull();
+
+      inbox.loading$.next(false);
+      jest.advanceTimersByTime(1000);
+      fixture.detectChanges();
+
+      expect(query("bit-skeleton")).toBeNull();
+      expect(query('[data-testid="approvals-empty"]')).not.toBeNull();
     });
 
     it("shows the empty state when there is nothing to approve", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.spec.ts
@@ -172,7 +172,6 @@ describe("ApprovalsTabComponent", () => {
 
       create();
 
-      // Still loading, so the block is on screen and an ungated skeleton would be visible here.
       jest.advanceTimersByTime(500);
       fixture.detectChanges();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
@@ -172,10 +172,12 @@ export const Empty: Story = {
 
 /**
  * The first load, before any row has arrived. The skeleton is held back for a second, per the
- * component library's display guidance, so this story renders blank for its first second.
+ * component library's display guidance, so this story renders blank for its first second — the
+ * Chromatic capture is delayed past that so the snapshot covers the skeleton, not the blank.
  */
 export const Loading: Story = {
   decorators: [inbox({ rows: [], loading: true })],
+  parameters: { chromatic: { delay: 1500 } },
 };
 
 /** A single request — the narrowest the table gets before the empty state takes over. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.stories.ts
@@ -170,7 +170,10 @@ export const Empty: Story = {
   decorators: [inbox({ rows: [] })],
 };
 
-/** The first load, before any row has arrived. */
+/**
+ * The first load, before any row has arrived. The skeleton is held back for a second, per the
+ * component library's display guidance, so this story renders blank for its first second.
+ */
 export const Loading: Story = {
   decorators: [inbox({ rows: [], loading: true })],
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -10,7 +10,7 @@ import {
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { EMPTY, distinctUntilChanged, firstValueFrom, switchMap } from "rxjs";
+import { EMPTY, distinctUntilChanged, filter, firstValueFrom, map, switchMap } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -113,6 +113,20 @@ export class ApprovalsTabComponent {
     { initialValue: false },
   );
 
+  /**
+   * Whether a load has ever completed. Latched, because only the first one has nothing to leave on
+   * screen — every later reload already has a rendered tab behind it.
+   */
+  private readonly hasLoadedOnce = toSignal(
+    this.inbox.loading$.pipe(
+      filter((loading) => !loading),
+      map(() => true),
+    ),
+    { initialValue: false },
+  );
+
+  private readonly loadError = toSignal(this.inbox.loadError$, { initialValue: null });
+
   protected readonly searchControl = new FormControl<string>("", { nonNullable: true });
   protected readonly collectionControl = new FormControl<string | null>(null);
   protected readonly requesterControl = new FormControl<string | null>(null);
@@ -207,6 +221,19 @@ export class ApprovalsTabComponent {
    */
   protected readonly skeletonVisible = computed(() => this.showSkeleton() && !this.hasRows());
 
+  /**
+   * Whether the loading region replaces the tab's content. Before anything has loaded it covers the
+   * whole load, skeleton or not, since there is nothing else to show; afterwards only the skeleton
+   * may take over, so a reload of an inbox that is already empty leaves its empty state up rather
+   * than blanking the tab for the length of the skeleton's show delay. PAM reloads on every managed
+   * request change, so that blank would recur for as long as the tab is left open.
+   */
+  protected readonly loadingVisible = computed(() =>
+    this.hasLoadedOnce()
+      ? this.skeletonVisible()
+      : (this.loading() || this.showSkeleton()) && !this.hasRows(),
+  );
+
   /** Five fills the space the table occupies without implying a row count the inbox may not have. */
   protected readonly skeletonRows = [0, 1, 2, 3, 4];
 
@@ -217,10 +244,12 @@ export class ApprovalsTabComponent {
    * Whether the live region announces that the content has arrived. Emptying the region announces
    * nothing on its own, so the "loading" announcement needs a counterpart once the rows land. Gated
    * on the skeleton having been shown, so a load that finishes inside the delay announces neither
-   * half.
+   * half, and on the load having succeeded — a failed load leaves the same empty table behind, and
+   * announcing it as loaded is the one reading a sighted user cannot correct against the shell's
+   * error toast.
    */
   protected readonly announceLoaded = computed(
-    () => this.skeletonShown() && !this.skeletonVisible(),
+    () => this.skeletonShown() && !this.skeletonVisible() && this.loadError() == null,
   );
 
   protected readonly dataSource = new TableDataSource<ApprovalRow>();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -201,6 +201,12 @@ export class ApprovalsTabComponent {
    */
   protected readonly hasRows = computed(() => this.filterableRows().length > 0);
 
+  /**
+   * Whether the skeleton table is on screen. Drives the `role="status"` announcement as well, so
+   * that a load finishing inside the delay never announces a screen the user was not shown.
+   */
+  protected readonly skeletonVisible = computed(() => this.showSkeleton() && !this.hasRows());
+
   /** Five fills the space the table occupies without implying a row count the inbox may not have. */
   protected readonly skeletonRows = [0, 1, 2, 3, 4];
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -237,7 +237,12 @@ export class ApprovalsTabComponent {
   /** Five fills the space the table occupies without implying a row count the inbox may not have. */
   protected readonly skeletonRows = [0, 1, 2, 3, 4];
 
-  /** Latched once the skeleton has been on screen, so its removal can be announced in turn. */
+  /**
+   * Whether the load on screen has shown its skeleton, so that skeleton's removal can be announced
+   * in turn. Held for the length of one load rather than the component's life: a reload that never
+   * reaches the skeleton has nothing to announce the end of, and a retry must not inherit the
+   * previous attempt's skeleton.
+   */
   private readonly skeletonShown = signal(false);
 
   /**
@@ -280,6 +285,8 @@ export class ApprovalsTabComponent {
     effect(() => {
       if (this.skeletonVisible()) {
         this.skeletonShown.set(true);
+      } else if (this.loading()) {
+        this.skeletonShown.set(false);
       }
     });
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -210,6 +210,19 @@ export class ApprovalsTabComponent {
   /** Five fills the space the table occupies without implying a row count the inbox may not have. */
   protected readonly skeletonRows = [0, 1, 2, 3, 4];
 
+  /** Latched once the skeleton has been on screen, so its removal can be announced in turn. */
+  private readonly skeletonShown = signal(false);
+
+  /**
+   * Whether the live region announces that the content has arrived. Emptying the region announces
+   * nothing on its own, so the "loading" announcement needs a counterpart once the rows land. Gated
+   * on the skeleton having been shown, so a load that finishes inside the delay announces neither
+   * half.
+   */
+  protected readonly announceLoaded = computed(
+    () => this.skeletonShown() && !this.skeletonVisible(),
+  );
+
   protected readonly dataSource = new TableDataSource<ApprovalRow>();
   protected readonly leasesDataSource = new TableDataSource<ManagedLeaseRow>();
 
@@ -234,6 +247,11 @@ export class ApprovalsTabComponent {
     });
     effect(() => {
       this.leasesDataSource.data = this.leaseRows();
+    });
+    effect(() => {
+      if (this.skeletonVisible()) {
+        this.skeletonShown.set(true);
+      }
     });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/approvals-tab.component.ts
@@ -10,12 +10,13 @@ import {
 import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
-import { EMPTY, firstValueFrom, switchMap } from "rxjs";
+import { EMPTY, distinctUntilChanged, firstValueFrom, switchMap } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { skeletonLoadingDelay } from "@bitwarden/common/vault/utils/skeleton-loading.operator";
 import {
   AccordionComponent,
   AccordionGroupComponent,
@@ -26,6 +27,8 @@ import {
   DialogService,
   NoItemsModule,
   SearchModule,
+  SkeletonComponent,
+  SkeletonTextComponent,
   TableDataSource,
   TableModule,
   ToastService,
@@ -77,6 +80,8 @@ type FilterableRow = { searchText: string; collectionName: string | null; reques
     IconComponent,
     NoItemsModule,
     SearchModule,
+    SkeletonComponent,
+    SkeletonTextComponent,
     TableModule,
     TooltipDirective,
     TypographyModule,
@@ -98,6 +103,15 @@ export class ApprovalsTabComponent {
   private readonly revoking = signal<Set<string>>(new Set());
 
   protected readonly loading = toSignal(this.inbox.loading$, { initialValue: true });
+
+  /**
+   * The skeleton is held back until the load has run for a second, per the component library's
+   * display guidance, so an inbox that arrives quickly never flashes it.
+   */
+  protected readonly showSkeleton = toSignal(
+    this.inbox.loading$.pipe(distinctUntilChanged(), skeletonLoadingDelay()),
+    { initialValue: false },
+  );
 
   protected readonly searchControl = new FormControl<string>("", { nonNullable: true });
   protected readonly collectionControl = new FormControl<string | null>(null);
@@ -186,6 +200,9 @@ export class ApprovalsTabComponent {
    * visible), which need different copy and, for the latter, the filter controls left on screen.
    */
   protected readonly hasRows = computed(() => this.filterableRows().length > 0);
+
+  /** Five fills the space the table occupies without implying a row count the inbox may not have. */
+  protected readonly skeletonRows = [0, 1, 2, 3, 4];
 
   protected readonly dataSource = new TableDataSource<ApprovalRow>();
   protected readonly leasesDataSource = new TableDataSource<ManagedLeaseRow>();


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-SCR-13-1cf85398`.

## 📔 Objective

Replace the Approvals loading paragraph with skeleton rows.

- What was wrong: Verified at pam/uat, approvals-tab.component.html line 2: while the inbox request is in flight the tab renders <p bitTypography="body2" class="tw-mt-2">{{ "loading" | i18n }}</p> - the single word "Lo
- Surface: `Password Manager -> Access requests -> Approvals, first load`.
- Size: 4 files, 136 insertions(+), 6 deletions(-).
- Stack: sits on `pam/uat-t-approvals-actions-column-breakpoints`; `history-managed-action-label` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

Captured at 1440x1024 (the column-ladder pair at 1024x836, its defect width). Before is `pam/uat`; after is the assembled stack tip, so the after side shows this change alongside the rest of the stack.

### Password Manager -> Access requests -> Approvals, first load

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/5b24ee8eb8aa3d2d96cb9ed9a629345446c7ca29/before-uat-SCR-13-1cf85398.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/d3563de7579f9abbfe0d5abcdc8cabf959db6590/after-uat-SCR-13-1cf85398.png" alt="after" width="460"> |


## Known gaps

- CI here inherits failures already on `pam/uat` (`Run tests`, `Rust lint`, two cloud builds) plus a pre-existing `tsc-strict` error in `access-rule-edit.component.spec.ts` from #22635. None originate in this stack: the PAM suite passes on the assembled tip, 67 suites and 792 tests.
