### PR TITLE
fix(pam): label the approver's withdraw action on History for what it does

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17884,8 +17884,8 @@
   "pamInboxApprovedToast": {
     "message": "Request approved"
   },
-  "pamInboxCancelApproval": {
-    "message": "Cancel"
+  "pamInboxWithdrawApproval": {
+    "message": "Withdraw approval"
   },
   "pamInboxCannotApproveOwn": {
     "message": "You cannot approve your own request."
@@ -17968,11 +17968,11 @@
   "pamInboxRevokedToast": {
     "message": "Access revoked"
   },
-  "pamInboxApprovalCanceledToast": {
-    "message": "Approval canceled"
+  "pamInboxApprovalWithdrawnToast": {
+    "message": "Approval withdrawn"
   },
-  "pamInboxCancelApprovalFailed": {
-    "message": "Could not cancel approval"
+  "pamInboxWithdrawApprovalFailed": {
+    "message": "Could not withdraw approval"
   },
   "pamInboxWindow": {
     "message": "Requested window"

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -131,7 +131,7 @@
                 (click)="cancelApproval(row)"
                 [attr.data-testid]="'history-cancel-approval-' + row.id"
               >
-                {{ "pamInboxCancelApproval" | i18n }}
+                {{ "pamInboxWithdrawApproval" | i18n }}
               </button>
             } @else {
               <span class="tw-text-muted">&mdash;</span>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -215,13 +215,16 @@ describe("HistoryTabComponent", () => {
       expect(component["canRevoke"](revoked)).toBe(false);
     });
 
-    it("offers Cancel for an approval the requester has not started", () => {
+    it("offers Withdraw approval for an approval the requester has not started", () => {
       managedRows$.next([unstartedApproval]);
       create();
       showManaged();
 
       expect(component["canCancelApproval"](unstartedApproval)).toBe(true);
       expect(query('[data-testid="history-cancel-approval-managed-2"]')).not.toBeNull();
+      expect(query('[data-testid="history-cancel-approval-managed-2"]')!.textContent).toContain(
+        "pamInboxWithdrawApproval",
+      );
     });
 
     it("offers no action for a row the caller does not manage", () => {
@@ -283,11 +286,11 @@ describe("HistoryTabComponent", () => {
       expect(inbox.cancelApproval).toHaveBeenCalledWith("managed-2");
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "success",
-        message: "pamInboxApprovalCanceledToast",
+        message: "pamInboxApprovalWithdrawnToast",
       });
     });
 
-    it("toasts an error when cancelling an approval fails", async () => {
+    it("toasts an error when withdrawing an approval fails", async () => {
       inbox.cancelApproval.mockRejectedValue(new Error("boom"));
       managedRows$.next([unstartedApproval]);
       create();
@@ -297,7 +300,7 @@ describe("HistoryTabComponent", () => {
 
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "error",
-        message: "pamInboxCancelApprovalFailed",
+        message: "pamInboxWithdrawApprovalFailed",
       });
     });
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -220,11 +220,11 @@ describe("HistoryTabComponent", () => {
       create();
       showManaged();
 
+      const withdraw = query('[data-testid="history-cancel-approval-managed-2"]');
+
       expect(component["canCancelApproval"](unstartedApproval)).toBe(true);
-      expect(query('[data-testid="history-cancel-approval-managed-2"]')).not.toBeNull();
-      expect(query('[data-testid="history-cancel-approval-managed-2"]')!.textContent).toContain(
-        "pamInboxWithdrawApproval",
-      );
+      expect(withdraw).not.toBeNull();
+      expect(withdraw?.textContent).toContain("pamInboxWithdrawApproval");
     });
 
     it("offers no action for a row the caller does not manage", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -37,6 +37,7 @@ function historyRow(overrides: Record<string, unknown> = {}): MyAccessRequestRow
     resolverName: "Ada",
     approverComment: null,
     producedLeaseId: null,
+    producedLeaseStatus: null,
     extendedBySeconds: null,
     extendedUntil: null,
     ...overrides,
@@ -171,6 +172,7 @@ describe("HistoryTabComponent", () => {
       status: "approved",
       statusBadge: { labelKey: "pamStatusActivated", variant: "success" },
       producedLeaseId: "lease-1",
+      producedLeaseStatus: "active",
     });
     const unstartedApproval = historyRow({
       id: "managed-2",
@@ -201,12 +203,29 @@ describe("HistoryTabComponent", () => {
       expect(query('[data-testid="history-revoke-managed-1"]')).not.toBeNull();
     });
 
+    it("offers Revoke for a live lease whose request status did not survive the round trip", () => {
+      const mislabelled = historyRow({
+        id: "managed-1",
+        status: "denied",
+        statusBadge: { labelKey: "pamStatusDenied", variant: "danger" },
+        producedLeaseId: "lease-1",
+        producedLeaseStatus: "active",
+      });
+      managedRows$.next([mislabelled]);
+      create();
+      showManaged();
+
+      expect(component["canRevoke"](mislabelled)).toBe(true);
+      expect(query('[data-testid="history-revoke-managed-1"]')).not.toBeNull();
+    });
+
     it("offers no Revoke once the lease has already ended", () => {
       const revoked = historyRow({
         id: "managed-1",
         status: "approved",
         statusBadge: { labelKey: "pamStatusRevoked", variant: "subtle" },
         producedLeaseId: "lease-1",
+        producedLeaseStatus: "revoked",
       });
       managedRows$.next([revoked]);
       create();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
@@ -63,7 +63,10 @@ const MY_ROWS = [
   }),
 ];
 
-/** A grant the caller decided as an approver, still running — the only revocable shape. */
+/**
+ * Rows the caller decided as an approver: a running grant (the only revocable shape), an approval
+ * the requester has not started (the only withdrawable one), and a denial, which offers neither.
+ */
 function managedRows() {
   return [
     toRequestRow(
@@ -76,6 +79,19 @@ function managedRows() {
         producedLeaseStatus: "active",
         resolvedAt: liveFromNow(-30 * MINUTE),
         leaseNotAfter: liveFromNow(HOUR),
+        decisions: [decision()],
+      }),
+      names,
+    ),
+    toRequestRow(
+      accessRequest({
+        id: "req-managed-approved",
+        cipherId: "cipher-3",
+        requesterName: "Grace Hopper",
+        status: "approved",
+        resolvedAt: fromNow(-2 * HOUR),
+        leaseNotBefore: fromNow(HOUR),
+        leaseNotAfter: fromNow(3 * HOUR),
         decisions: [decision()],
       }),
       names,

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
@@ -1,6 +1,7 @@
 import { importProvidersFrom } from "@angular/core";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
+import { userEvent } from "storybook/test";
 
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
@@ -24,6 +25,8 @@ import { toRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
 
 const names = storyNames();
+
+const MANAGED_TOGGLE = '[data-testid="history-scope-managed"] label';
 
 const request = (overrides: Record<string, unknown>) =>
   toRequestRow(accessRequest(overrides), names);
@@ -184,7 +187,14 @@ export const WithManagedHistory: Story = {
   decorators: [history({ managed: managedRows })],
 };
 
-/** An approver whose own history is empty but who has decided other people's requests. */
+/**
+ * An approver whose own history is empty but who has decided other people's requests. Opens on the
+ * managed scope: the Actions column exists nowhere else, so this is the only story that renders the
+ * revoke and withdraw buttons.
+ */
 export const ManagedOnly: Story = {
   decorators: [history({ mine: [], managed: managedRows })],
+  play: async ({ canvasElement }) => {
+    await userEvent.click(canvasElement.querySelector<HTMLLabelElement>(MANAGED_TOGGLE)!);
+  },
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
@@ -1,7 +1,7 @@
 import { importProvidersFrom } from "@angular/core";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
-import { userEvent } from "storybook/test";
+import { userEvent, within } from "storybook/test";
 
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
@@ -25,8 +25,6 @@ import { toRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
 
 const names = storyNames();
-
-const MANAGED_TOGGLE = '[data-testid="history-scope-managed"] label';
 
 const request = (overrides: Record<string, unknown>) =>
   toRequestRow(accessRequest(overrides), names);
@@ -180,8 +178,8 @@ export const Empty: Story = {
 
 /**
  * An approver's view: the Mine/Managed toggle appears because there is managed history behind it.
- * The table still opens on Mine — switch the toggle to see the revoke and cancel-approval actions,
- * which only exist on the managed scope.
+ * The table still opens on Mine — switch the toggle to see the revoke and withdraw actions, which
+ * only exist on the managed scope.
  */
 export const WithManagedHistory: Story = {
   decorators: [history({ managed: managedRows })],
@@ -195,6 +193,7 @@ export const WithManagedHistory: Story = {
 export const ManagedOnly: Story = {
   decorators: [history({ mine: [], managed: managedRows })],
   play: async ({ canvasElement }) => {
-    await userEvent.click(canvasElement.querySelector<HTMLLabelElement>(MANAGED_TOGGLE)!);
+    const managed = await within(canvasElement).findByTestId("history-scope-managed");
+    await userEvent.click(within(managed).getByRole("radio"));
   },
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -56,7 +56,7 @@ type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
  *
  * Own rows are read-only, so `Mine` has no action column and no clock. `Managed` adds revoke (end a
  * lease the caller granted) and withdraw (take back an approval the requester has not started), both
- * of which the SDK serves — only the two history reads themselves go over raw HTTP.
+ * of which the SDK serves.
  */
 @Component({
   selector: "pam-history-tab",
@@ -140,9 +140,13 @@ export class HistoryTabComponent {
 
   /**
    * A lease the caller granted and can still end: the row is one they manage, it produced a lease,
-   * and that lease is still live. Liveness comes from {@link isLiveManagedLease}, the same predicate
-   * the Approvals tab's Active access section lists by, so the two surfaces cannot disagree about
-   * whether a given lease can be ended.
+   * and the server still holds that lease open. Openness comes from {@link isLiveManagedLease} — the
+   * same lease-status signal the Approvals tab's Active access section lists by, read off the
+   * request rather than off the derived status badge.
+   *
+   * Membership is not identical to that section's: Active access also drops rows whose effective end
+   * has passed, a test these rows cannot make because `toRequestRow` leaves them no `extendedUntil`.
+   * A lease still marked `active` past its window is therefore revocable here and absent there.
    */
   protected canRevoke(row: MyAccessRequestRow): boolean {
     return (

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -185,7 +185,7 @@ export class HistoryTabComponent {
     if (!this.canCancelApproval(row) || this.isActing(row)) {
       return;
     }
-    await this.act(row, "pamInboxApprovalCanceledToast", "pamInboxCancelApprovalFailed", () =>
+    await this.act(row, "pamInboxApprovalWithdrawnToast", "pamInboxWithdrawApprovalFailed", () =>
       this.inbox.cancelApproval(row.id as AccessRequestId),
     );
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -30,6 +30,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 import type { AccessLeaseId, AccessRequestId } from "../abstractions/access-lease";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
+import { isLiveManagedLease } from "../approvals/managed-lease-row";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { RelativeTimePipe } from "../date/relative-time.pipe";
 
@@ -54,8 +55,8 @@ type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
  * answerable from what is on screen.
  *
  * Own rows are read-only, so `Mine` has no action column and no clock. `Managed` adds revoke (end a
- * lease the caller granted) and cancel-approval (withdraw an approval the requester has not started),
- * both of which the SDK serves — only the two history reads themselves go over raw HTTP.
+ * lease the caller granted) and withdraw (take back an approval the requester has not started), both
+ * of which the SDK serves — only the two history reads themselves go over raw HTTP.
  */
 @Component({
   selector: "pam-history-tab",
@@ -139,15 +140,13 @@ export class HistoryTabComponent {
 
   /**
    * A lease the caller granted and can still end: the row is one they manage, it produced a lease,
-   * and that lease is still live. `statusBadge` is the already-resolved display status, so this
-   * reads the same conclusion the badge shows rather than re-deriving it.
+   * and that lease is still live. Liveness comes from {@link isLiveManagedLease}, the same predicate
+   * the Approvals tab's Active access section lists by, so the two surfaces cannot disagree about
+   * whether a given lease can be ended.
    */
   protected canRevoke(row: MyAccessRequestRow): boolean {
     return (
-      this.showingManaged() &&
-      this.managedIds().has(String(row.id)) &&
-      row.producedLeaseId != null &&
-      row.statusBadge?.labelKey === "pamStatusActivated"
+      this.showingManaged() && this.managedIds().has(String(row.id)) && isLiveManagedLease(row)
     );
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
@@ -249,6 +249,26 @@ describe("toRequestRow", () => {
     expect(row.producedLeaseId).toBe("lease-1");
   });
 
+  it("carries the produced lease's status, whatever the request's own status says", () => {
+    const row = toRequestRow(
+      request("req-1", {
+        status: "denied",
+        producedLeaseId: "lease-1",
+        producedLeaseStatus: "active",
+      }),
+      emptyResolvedNames(),
+    );
+
+    expect(row.producedLeaseStatus).toBe("active");
+    expect(row.statusBadge).toEqual({ labelKey: "pamStatusDenied", variant: "danger" });
+  });
+
+  it("leaves the produced lease's status null when the request never activated", () => {
+    const row = toRequestRow(request("req-1"), emptyResolvedNames());
+
+    expect(row.producedLeaseStatus).toBeNull();
+  });
+
   it("reads the resolver + comment from the human decision", () => {
     const row = toRequestRow(
       request("req-1", {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -3,6 +3,7 @@ import type { BadgeVariant } from "@bitwarden/components";
 
 import {
   AccessLeaseId,
+  AccessLeaseStatus,
   AccessLeaseView,
   AccessRequestDecisionView,
   AccessRequestId,
@@ -53,6 +54,12 @@ export type MyAccessRequestRow = {
    * lease is still active (shown in Active leases instead).
    */
   producedLeaseId: string | null;
+  /**
+   * The produced lease's status as of the read this row was built from; null until activation. The
+   * source {@link statusBadge} is derived from, and the honest read for "is this access still
+   * running?" — see {@link isLiveManagedLease}.
+   */
+  producedLeaseStatus: AccessLeaseStatus | null;
   /**
    * Set when this request minted a lease that was later extended: the total time added across all
    * applied extensions, and the lease's current end. Both null when the request was never
@@ -216,6 +223,7 @@ export function toRequestRow(request: AccessRequestView, names: ResolvedNames): 
     approverComment:
       human?.comment ?? request.decisions.find((d) => d.comment != null)?.comment ?? null,
     producedLeaseId: request.producedLeaseId == null ? null : uuidAsString(request.producedLeaseId),
+    producedLeaseStatus: request.producedLeaseStatus ?? null,
     // Defaults; buildMyAccessRequestRows fills these in for an original whose lease was extended.
     extendedBySeconds: null,
     extendedUntil: null,

--- a/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
@@ -57,8 +57,10 @@ type LeaseProducing = {
  * reads otherwise, which would empty this section in the product while every test still passed.
  *
  * Structural rather than tied to {@link AccessRequestView} so every surface offering to end a lease
- * — Active access here, History's Managed scope over `MyAccessRequestRow` — answers the question
- * with this one predicate, and no two of them can disagree about the same lease.
+ * — Active access here, History's Managed scope over `MyAccessRequestRow` — reads this one
+ * lease-status signal rather than its own display badge. That is the shared floor, not the whole
+ * test: a surface that also applies the effective-end check above offers Revoke on strictly fewer
+ * leases than one that stops here.
  */
 export function isLiveManagedLease<T extends LeaseProducing>(
   request: T,

--- a/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/managed-lease-row.ts
@@ -2,6 +2,7 @@ import { uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.se
 
 import type {
   AccessLeaseId,
+  AccessLeaseStatus,
   AccessRequestId,
   AccessRequestView,
 } from "../abstractions/access-lease";
@@ -39,6 +40,12 @@ export type ManagedLeaseRow = {
   searchText: string;
 };
 
+/** The fields {@link isLiveManagedLease} reads, so a raw request and a built row both qualify. */
+type LeaseProducing = {
+  producedLeaseId: unknown;
+  producedLeaseStatus: AccessLeaseStatus | null | undefined;
+};
+
 /**
  * Whether this request minted a lease the server still holds open.
  *
@@ -48,10 +55,14 @@ export type ManagedLeaseRow = {
  * Reads the request, never the display badge: `historyDisplayStatus` only reaches its activated
  * branch for `status === "approved"`, and an activated grant can arrive with a status the client
  * reads otherwise, which would empty this section in the product while every test still passed.
+ *
+ * Structural rather than tied to {@link AccessRequestView} so every surface offering to end a lease
+ * — Active access here, History's Managed scope over `MyAccessRequestRow` — answers the question
+ * with this one predicate, and no two of them can disagree about the same lease.
  */
-export function isLiveManagedLease(
-  request: AccessRequestView,
-): request is AccessRequestView & { producedLeaseId: AccessLeaseId } {
+export function isLiveManagedLease<T extends LeaseProducing>(
+  request: T,
+): request is T & { producedLeaseId: NonNullable<T["producedLeaseId"]> } {
   return request.producedLeaseId != null && request.producedLeaseStatus === "active";
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-03-8274af45`.

## 📔 Objective

Label the approver's withdraw action on History for what it does.

## 📸 Screenshots

### Password Manager -> Access requests -> History -> For my collections

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/14ab688d4d96b9094a8c540f64e794664cd67fd6/before-uat-FLW-03-8274af45.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/01b80cb899d6ddfbcf67bb330f62071b116e4da9/after-uat-FLW-03-8274af45.png" alt="after" width="460"> |
