### PR TITLE
fix(pam): confirm before withdrawing another member's approval

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17992,6 +17992,15 @@
   "pamInboxRevokeConfirm": {
     "message": "This immediately revokes the member's access. They will need a new approval to regain it."
   },
+  "pamInboxWithdrawApprovalConfirm": {
+    "message": "This withdraws the member's approval for $ITEM$. Access will not start, and they will need a new approval to get it.",
+    "placeholders": {
+      "item": {
+        "content": "$1",
+        "example": "Prod database"
+      }
+    }
+  },
   "pamCollectionAccessRuleCalloutTitle": {
     "message": "Access rule"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -328,7 +328,7 @@ describe("HistoryTabComponent", () => {
     });
 
     it("names the item by id in the confirm when the cipher is not in the approver's vault", async () => {
-      const unnamed = historyRow({ ...unstartedApproval, cipherName: null });
+      const unnamed = { ...unstartedApproval, cipherName: null };
       managedRows$.next([unnamed]);
       create();
       showManaged();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -337,7 +337,7 @@ describe("HistoryTabComponent", () => {
 
       expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: expect.objectContaining({ placeholders: ["cipher-1"] }),
+          content: { key: "pamInboxWithdrawApprovalConfirm", placeholders: ["cipher-1"] },
         }),
       );
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -295,18 +295,51 @@ describe("HistoryTabComponent", () => {
       });
     });
 
-    it("cancels an approval without a confirm — nothing is in use yet", async () => {
+    it("confirms before withdrawing an approval", async () => {
       managedRows$.next([unstartedApproval]);
       create();
       showManaged();
 
       await component["cancelApproval"](unstartedApproval);
 
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: { key: "pamInboxWithdrawApprovalConfirm", placeholders: ["Prod database"] },
+          type: "warning",
+        }),
+      );
       expect(inbox.cancelApproval).toHaveBeenCalledWith("managed-2");
       expect(toastService.showToast).toHaveBeenCalledWith({
         variant: "success",
         message: "pamInboxApprovalWithdrawnToast",
       });
+    });
+
+    it("does not withdraw the approval when the confirm is dismissed", async () => {
+      dialogService.openSimpleDialog.mockResolvedValue(false);
+      managedRows$.next([unstartedApproval]);
+      create();
+      showManaged();
+
+      await component["cancelApproval"](unstartedApproval);
+
+      expect(inbox.cancelApproval).not.toHaveBeenCalled();
+      expect(toastService.showToast).not.toHaveBeenCalled();
+    });
+
+    it("names the item by id in the confirm when the cipher is not in the approver's vault", async () => {
+      const unnamed = historyRow({ ...unstartedApproval, cipherName: null });
+      managedRows$.next([unnamed]);
+      create();
+      showManaged();
+
+      await component["cancelApproval"](unnamed);
+
+      expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.objectContaining({ placeholders: ["cipher-1"] }),
+        }),
+      );
     });
 
     it("toasts an error when withdrawing an approval fails", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -184,9 +184,8 @@ export class HistoryTabComponent {
   }
 
   /**
-   * Withdraw an approval the requester has not started. Confirmed first, like {@link revoke}: it
-   * takes a decision away from a third party, cannot be undone from this screen, and the requester
-   * is not told.
+   * Withdraw an approval the requester has not started. Confirmed first because it takes a decision
+   * away from a third party, cannot be undone from this screen, and the requester is not told.
    */
   protected async cancelApproval(row: MyAccessRequestRow): Promise<void> {
     if (!this.canCancelApproval(row) || this.isActing(row)) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -197,7 +197,7 @@ export class HistoryTabComponent {
       content: {
         key: "pamInboxWithdrawApprovalConfirm",
         // The same expression the Item column renders, so the dialog and its row can never name the
-        // item differently — including when the cipher is not in the approver's vault.
+        // item differently.
         placeholders: [row.cipherName ?? row.cipherId],
       },
       acceptButtonText: { key: "pamInboxWithdrawApproval" },

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -183,9 +183,27 @@ export class HistoryTabComponent {
     );
   }
 
-  /** Withdraw an approval the requester has not started. */
+  /**
+   * Withdraw an approval the requester has not started. Confirmed first, like {@link revoke}: it
+   * takes a decision away from a third party, cannot be undone from this screen, and the requester
+   * is not told.
+   */
   protected async cancelApproval(row: MyAccessRequestRow): Promise<void> {
     if (!this.canCancelApproval(row) || this.isActing(row)) {
+      return;
+    }
+    const confirmed = await this.dialogService.openSimpleDialog({
+      title: { key: "pamInboxWithdrawApproval" },
+      content: {
+        key: "pamInboxWithdrawApprovalConfirm",
+        // The same expression the Item column renders, so the dialog and its row can never name the
+        // item differently — including when the cipher is not in the approver's vault.
+        placeholders: [row.cipherName ?? row.cipherId],
+      },
+      acceptButtonText: { key: "pamInboxWithdrawApproval" },
+      type: "warning",
+    });
+    if (!confirmed) {
       return;
     }
     await this.act(row, "pamInboxApprovalWithdrawnToast", "pamInboxWithdrawApprovalFailed", () =>


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-06-61d11195`.

## 📔 Objective

Confirm before withdrawing another member's approval.

- What was wrong: Verified at pam/uat, history-tab.component.ts:184-190: cancelApproval() calls straight through to inbox.cancelApproval() with no dialog.
- Surface: `Password Manager -> Access requests -> History (managed scope)`.
- Size: 3 files, 61 insertions(+), 2 deletions(-).
- Stack: sits on `pam/uat-t-history-managed-action-label`; `history-default-scope` sits on it.