### PR TITLE
fix(pam): open History on All and make the scopes filters

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17980,6 +17980,9 @@
   "pamApprovalsLoaded": {
     "message": "Access requests loaded"
   },
+  "pamHistoryScopeAll": {
+    "message": "All"
+  },
   "pamHistoryScopeMine": {
     "message": "Raised by me"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17995,6 +17995,9 @@
   "pamHistoryScopeLabel": {
     "message": "History scope"
   },
+  "pamHistoryEmpty": {
+    "message": "No request history to display"
+  },
   "pamInboxRevokeConfirm": {
     "message": "This immediately revokes the member's access. They will need a new approval to regain it."
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17980,6 +17980,9 @@
   "pamApprovalsLoaded": {
     "message": "Access requests loaded"
   },
+  "pamHistoryLoaded": {
+    "message": "Request history loaded"
+  },
   "pamHistoryScopeAll": {
     "message": "All"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17950,9 +17950,6 @@
   "pamInboxHistoryEmpty": {
     "message": "No history to display"
   },
-  "pamInboxHistoryFilterLabel": {
-    "message": "Filter history by status"
-  },
   "pamInboxLoadFailed": {
     "message": "Could not load inbox"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17989,6 +17989,9 @@
   "pamHistoryScopeManaged": {
     "message": "For my collections"
   },
+  "pamHistoryScopeLabel": {
+    "message": "History scope"
+  },
   "pamInboxRevokeConfirm": {
     "message": "This immediately revokes the member's access. They will need a new approval to regain it."
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -1,10 +1,13 @@
-@if (historyReady() && canSwitchScope()) {
+@if (!showSkeleton() && canSwitchScope()) {
   <div class="tw-mb-4 tw-flex tw-justify-end">
     <bit-toggle-group
       [selected]="scope()"
       (selectedChange)="selectScope($event)"
       [label]="'pamHistoryScopeLabel' | i18n"
     >
+      <bit-toggle [value]="HistoryScope.All" data-testid="history-scope-all">
+        {{ "pamHistoryScopeAll" | i18n }}
+      </bit-toggle>
       <bit-toggle [value]="HistoryScope.Mine" data-testid="history-scope-mine">
         {{ "pamHistoryScopeMine" | i18n }}
       </bit-toggle>
@@ -15,7 +18,7 @@
   </div>
 }
 
-@if (!historyReady()) {
+@if (showSkeleton()) {
   <div data-testid="history-loading">
     <span class="tw-sr-only" role="status">{{ "loading" | i18n }}</span>
 
@@ -53,9 +56,7 @@
   </div>
 } @else if (historyRows().length === 0) {
   <bit-no-items class="tw-mt-2 tw-block" data-testid="my-access-history-empty">
-    <span slot="title" class="tw-mt-4 tw-block">{{
-      (showingManaged() ? "pamInboxHistoryEmpty" : "pamMyRequestsHistoryEmpty") | i18n
-    }}</span>
+    <span slot="title" class="tw-mt-4 tw-block">{{ emptyMessageKey() | i18n }}</span>
   </bit-no-items>
 } @else {
   <bit-table [dataSource]="historyDataSource">
@@ -66,7 +67,7 @@
         <th bitCell>{{ "pamColumnResolver" | i18n }}</th>
         <th bitCell>{{ "pamColumnComment" | i18n }}</th>
         <th bitCell bitSortable="resolvedAt" default="desc">{{ "pamColumnResolved" | i18n }}</th>
-        @if (showingManaged()) {
+        @if (showActionsColumn()) {
           <th bitCell>{{ "pamColumnActions" | i18n }}</th>
         }
       </tr>
@@ -141,7 +142,7 @@
             </span>
           }
         </td>
-        @if (showingManaged()) {
+        @if (showActionsColumn()) {
           <td bitCell>
             @if (canRevoke(row)) {
               <button

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -1,4 +1,12 @@
-@if (!showSkeleton() && canSwitchScope()) {
+<div class="tw-sr-only" role="status" aria-live="polite" data-testid="history-loading-status">
+  @if (skeletonVisible()) {
+    {{ "loading" | i18n }}
+  } @else if (announceLoaded()) {
+    {{ "pamHistoryLoaded" | i18n }}
+  }
+</div>
+
+@if (historyLoaded() && canSwitchScope()) {
   <div class="tw-mb-4 tw-flex tw-justify-end">
     <bit-toggle-group
       [selected]="scope()"
@@ -18,42 +26,42 @@
   </div>
 }
 
-@if (showSkeleton()) {
-  <div data-testid="history-loading">
-    <span class="tw-sr-only" role="status">{{ "loading" | i18n }}</span>
+@if (!historyLoaded()) {
+  @if (skeletonVisible()) {
+    <div data-testid="history-loading" aria-hidden="true">
+      <div class="tw-mb-4 tw-flex tw-justify-end">
+        <bit-skeleton class="tw-h-10 tw-w-64"></bit-skeleton>
+      </div>
 
-    <div class="tw-mb-4 tw-flex tw-justify-end">
-      <bit-skeleton class="tw-h-10 tw-w-64"></bit-skeleton>
-    </div>
-
-    <bit-table>
-      <ng-container header>
-        <tr>
-          <th bitCell>{{ "pamColumnItem" | i18n }}</th>
-          <th bitCell>{{ "pamColumnStatus" | i18n }}</th>
-          <th bitCell>{{ "pamColumnResolver" | i18n }}</th>
-          <th bitCell>{{ "pamColumnComment" | i18n }}</th>
-          <th bitCell>{{ "pamColumnResolved" | i18n }}</th>
-        </tr>
-      </ng-container>
-      <ng-template body>
-        @for (skeletonRow of skeletonRows; track skeletonRow) {
-          <tr bitRow>
-            <td bitCell>
-              <div class="tw-flex tw-items-center tw-gap-3">
-                <bit-skeleton class="tw-size-6 tw-shrink-0"></bit-skeleton>
-                <bit-skeleton-text [lines]="2" class="tw-w-40"></bit-skeleton-text>
-              </div>
-            </td>
-            <td bitCell><bit-skeleton-text class="tw-w-24"></bit-skeleton-text></td>
-            <td bitCell><bit-skeleton-text class="tw-w-32"></bit-skeleton-text></td>
-            <td bitCell><bit-skeleton-text class="tw-w-56"></bit-skeleton-text></td>
-            <td bitCell><bit-skeleton-text class="tw-w-24"></bit-skeleton-text></td>
+      <bit-table>
+        <ng-container header>
+          <tr>
+            <th bitCell>{{ "pamColumnItem" | i18n }}</th>
+            <th bitCell>{{ "pamColumnStatus" | i18n }}</th>
+            <th bitCell>{{ "pamColumnResolver" | i18n }}</th>
+            <th bitCell>{{ "pamColumnComment" | i18n }}</th>
+            <th bitCell>{{ "pamColumnResolved" | i18n }}</th>
           </tr>
-        }
-      </ng-template>
-    </bit-table>
-  </div>
+        </ng-container>
+        <ng-template body>
+          @for (skeletonRow of skeletonRows; track skeletonRow) {
+            <tr bitRow>
+              <td bitCell>
+                <div class="tw-flex tw-items-center tw-gap-3">
+                  <bit-skeleton class="tw-size-6 tw-shrink-0"></bit-skeleton>
+                  <bit-skeleton-text [lines]="2" class="tw-w-40"></bit-skeleton-text>
+                </div>
+              </td>
+              <td bitCell><bit-skeleton-text class="tw-w-24"></bit-skeleton-text></td>
+              <td bitCell><bit-skeleton-text class="tw-w-32"></bit-skeleton-text></td>
+              <td bitCell><bit-skeleton-text class="tw-w-56"></bit-skeleton-text></td>
+              <td bitCell><bit-skeleton-text class="tw-w-24"></bit-skeleton-text></td>
+            </tr>
+          }
+        </ng-template>
+      </bit-table>
+    </div>
+  }
 } @else if (historyRows().length === 0) {
   <bit-no-items class="tw-mt-2 tw-block" data-testid="my-access-history-empty">
     <span slot="title" class="tw-mt-4 tw-block">{{ emptyMessageKey() | i18n }}</span>
@@ -66,7 +74,9 @@
         <th bitCell bitSortable="status">{{ "pamColumnStatus" | i18n }}</th>
         <th bitCell>{{ "pamColumnResolver" | i18n }}</th>
         <th bitCell>{{ "pamColumnComment" | i18n }}</th>
-        <th bitCell bitSortable="resolvedAt" default="desc">{{ "pamColumnResolved" | i18n }}</th>
+        <th bitCell bitSortable="resolvedAt" default="desc" [fn]="byResolvedOrSubmitted">
+          {{ "pamColumnResolved" | i18n }}
+        </th>
         @if (showActionsColumn()) {
           <th bitCell>{{ "pamColumnActions" | i18n }}</th>
         }

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.html
@@ -1,9 +1,9 @@
-@if (hasManagedHistory()) {
+@if (historyReady() && canSwitchScope()) {
   <div class="tw-mb-4 tw-flex tw-justify-end">
     <bit-toggle-group
       [selected]="scope()"
-      (selectedChange)="scope.set($event)"
-      [attr.aria-label]="'pamInboxHistoryFilterLabel' | i18n"
+      (selectedChange)="selectScope($event)"
+      [label]="'pamHistoryScopeLabel' | i18n"
     >
       <bit-toggle [value]="HistoryScope.Mine" data-testid="history-scope-mine">
         {{ "pamHistoryScopeMine" | i18n }}
@@ -15,7 +15,43 @@
   </div>
 }
 
-@if (historyRows().length === 0) {
+@if (!historyReady()) {
+  <div data-testid="history-loading">
+    <span class="tw-sr-only" role="status">{{ "loading" | i18n }}</span>
+
+    <div class="tw-mb-4 tw-flex tw-justify-end">
+      <bit-skeleton class="tw-h-10 tw-w-64"></bit-skeleton>
+    </div>
+
+    <bit-table>
+      <ng-container header>
+        <tr>
+          <th bitCell>{{ "pamColumnItem" | i18n }}</th>
+          <th bitCell>{{ "pamColumnStatus" | i18n }}</th>
+          <th bitCell>{{ "pamColumnResolver" | i18n }}</th>
+          <th bitCell>{{ "pamColumnComment" | i18n }}</th>
+          <th bitCell>{{ "pamColumnResolved" | i18n }}</th>
+        </tr>
+      </ng-container>
+      <ng-template body>
+        @for (skeletonRow of skeletonRows; track skeletonRow) {
+          <tr bitRow>
+            <td bitCell>
+              <div class="tw-flex tw-items-center tw-gap-3">
+                <bit-skeleton class="tw-size-6 tw-shrink-0"></bit-skeleton>
+                <bit-skeleton-text [lines]="2" class="tw-w-40"></bit-skeleton-text>
+              </div>
+            </td>
+            <td bitCell><bit-skeleton-text class="tw-w-24"></bit-skeleton-text></td>
+            <td bitCell><bit-skeleton-text class="tw-w-32"></bit-skeleton-text></td>
+            <td bitCell><bit-skeleton-text class="tw-w-56"></bit-skeleton-text></td>
+            <td bitCell><bit-skeleton-text class="tw-w-24"></bit-skeleton-text></td>
+          </tr>
+        }
+      </ng-template>
+    </bit-table>
+  </div>
+} @else if (historyRows().length === 0) {
   <bit-no-items class="tw-mt-2 tw-block" data-testid="my-access-history-empty">
     <span slot="title" class="tw-mt-4 tw-block">{{
       (showingManaged() ? "pamInboxHistoryEmpty" : "pamMyRequestsHistoryEmpty") | i18n

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -332,6 +332,25 @@ describe("HistoryTabComponent", () => {
       expect(component["scope"]()).toBe("all");
       expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
     });
+
+    // The fallback has to forget the pick, not just stop applying it: a background load that brings
+    // a managed row back would otherwise narrow the table again with no user action.
+    it("does not restore the filter it fell back from when the toggle returns", () => {
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      create();
+      showManaged();
+
+      managedRows$.next([]);
+      fixture.detectChanges();
+      expect(component["scope"]()).toBe("all");
+
+      managedRows$.next([historyRow({ id: "managed-2", resolvedAt: "2026-08-17T12:00:00.000Z" })]);
+      fixture.detectChanges();
+
+      expect(component["scope"]()).toBe("all");
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-2", "mine-1"]);
+    });
   });
 
   describe("loading", () => {
@@ -377,6 +396,79 @@ describe("HistoryTabComponent", () => {
       expect(query("bit-skeleton")).toBeNull();
       expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
       expect(query('[data-testid="history-loading-status"]')?.textContent?.trim()).toBe("");
+    });
+
+    // The skeleton operator holds its own minimum display time, but what the reader sees is gated
+    // on the content: the rows replace the skeleton the moment they land, rather than sitting
+    // behind a skeleton drawn over a history that is already in hand.
+    it("swaps the skeleton for the history the moment it lands, mid minimum-display-time", () => {
+      canApprove$.next(true);
+      managedLoading$.next(true);
+
+      create();
+      passSkeletonDelay();
+
+      expect(query('[data-testid="history-loading"]')).not.toBeNull();
+
+      jest.advanceTimersByTime(200);
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      managedLoading$.next(false);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="history-loading"]')).toBeNull();
+      expect(query('[data-testid="my-access-history-managed-1"]')).not.toBeNull();
+      expect(query('[data-testid="history-loading-status"]')?.textContent).toContain(
+        "pamHistoryLoaded",
+      );
+
+      jest.advanceTimersByTime(800);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="history-loading"]')).toBeNull();
+      expect(query('[data-testid="my-access-history-managed-1"]')).not.toBeNull();
+    });
+
+    // A latched announcement leaves the region reporting a load that finished long ago to assistive
+    // tech that re-reads region contents later in the session.
+    it("clears the loaded announcement once it has been made", () => {
+      canApprove$.next(true);
+      managedLoading$.next(true);
+
+      create();
+      passSkeletonDelay();
+
+      const status = query('[data-testid="history-loading-status"]');
+      expect(status?.textContent).toContain("loading");
+
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      managedLoading$.next(false);
+      fixture.detectChanges();
+
+      expect(status?.textContent).toContain("pamHistoryLoaded");
+
+      jest.advanceTimersByTime(2000);
+      fixture.detectChanges();
+
+      expect(status?.textContent?.trim()).toBe("");
+      expect(query('[data-testid="my-access-history-managed-1"]')).not.toBeNull();
+    });
+
+    // The latch never resolves for a non-approver on a session that has not synced, so nothing but
+    // teardown ends the subscription it keeps on the privilege stream — and that stream keeps
+    // organization and collection state decrypting behind it.
+    it("drops its load-latch subscription when the tab is destroyed", () => {
+      lastSync$.next(null);
+      managedLoading$.next(true);
+
+      create();
+      passSkeletonDelay();
+
+      expect(component["historyLoaded"]()).toBe(false);
+      expect(canApprove$.observed).toBe(true);
+
+      fixture.destroy();
+
+      expect(canApprove$.observed).toBe(false);
     });
 
     // A live region has to be in the DOM before its text changes for assistive tech to announce
@@ -714,9 +806,16 @@ describe("HistoryTabComponent", () => {
     });
   });
 
+  // All spans both sources, so it cannot borrow either side's wording: an approver with no history
+  // at all lands here and would be told they have raised nothing.
   it("says which slice is empty", () => {
     canApprove$.next(true);
     create();
+
+    expect(fixture.nativeElement.textContent).toContain("pamHistoryEmpty");
+
+    component["selectScope"]("mine");
+    fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain("pamMyRequestsHistoryEmpty");
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -54,12 +54,14 @@ describe("HistoryTabComponent", () => {
   let managedIds$: BehaviorSubject<Set<string>>;
   let managedLoading$: BehaviorSubject<boolean>;
   let myLoading$: BehaviorSubject<boolean>;
+  let myLoadError$: BehaviorSubject<unknown | null>;
   let lastSync$: BehaviorSubject<Date | null>;
   let inbox: {
     historyRows$: BehaviorSubject<MyAccessRequestRow[]>;
     managedIds$: BehaviorSubject<Set<string>>;
     cipherById$: BehaviorSubject<Map<string, CipherView>>;
     loading$: BehaviorSubject<boolean>;
+    loadError$: BehaviorSubject<unknown | null>;
     revokeLease: jest.Mock;
     cancelApproval: jest.Mock;
   };
@@ -110,12 +112,14 @@ describe("HistoryTabComponent", () => {
     managedIds$ = new BehaviorSubject<Set<string>>(new Set());
     managedLoading$ = new BehaviorSubject(false);
     myLoading$ = new BehaviorSubject(false);
+    myLoadError$ = new BehaviorSubject<unknown | null>(null);
     lastSync$ = new BehaviorSubject<Date | null>(new Date("2026-08-20T09:00:00.000Z"));
     inbox = {
       historyRows$: managedRows$,
       managedIds$,
       cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
       loading$: managedLoading$,
+      loadError$: new BehaviorSubject<unknown | null>(null),
       revokeLease: jest.fn().mockResolvedValue(undefined),
       cancelApproval: jest.fn().mockResolvedValue(undefined),
     };
@@ -134,6 +138,7 @@ describe("HistoryTabComponent", () => {
             historyRows$: myRows$,
             cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
             loading$: myLoading$,
+            loadError$: myLoadError$,
           },
         },
         { provide: ApproverInboxService, useValue: inbox },
@@ -502,6 +507,45 @@ describe("HistoryTabComponent", () => {
 
       expect(query('[data-testid="history-loading-status"]')).toBe(status);
       expect(status?.textContent).toContain("pamHistoryLoaded");
+    });
+
+    // The latch resolves on the loading flags alone, so a failed read ends the skeleton exactly like
+    // a successful one and falls through to the same empty table — with the shell toasting the error
+    // beside it. A sighted reader can weigh those two against each other; "Request history loaded"
+    // read into the live region is the one claim that cannot be corrected.
+    it("does not announce a failed managed-history load as loaded", () => {
+      canApprove$.next(true);
+      managedLoading$.next(true);
+
+      create();
+      passSkeletonDelay();
+
+      expect(query('[data-testid="history-loading-status"]')?.textContent).toContain("loading");
+
+      inbox.loadError$.next(new Error("boom"));
+      managedLoading$.next(false);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="history-loading"]')).toBeNull();
+      expect(query('[data-testid="history-loading-status"]')?.textContent?.trim()).toBe("");
+    });
+
+    // Either read failing leaves the merged list short by everything that side holds, so the
+    // requester's own history guards the announcement on the same terms as the managed one.
+    it("does not announce a failed own-history load as loaded", () => {
+      myLoading$.next(true);
+
+      create();
+      passSkeletonDelay();
+
+      expect(query('[data-testid="history-loading-status"]')?.textContent).toContain("loading");
+
+      myLoadError$.next(new Error("boom"));
+      myLoading$.next(false);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="history-loading"]')).toBeNull();
+      expect(query('[data-testid="history-loading-status"]')?.textContent?.trim()).toBe("");
     });
 
     // The shell never loads the inbox for a member who cannot approve, so its loading flag stays

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -84,6 +84,13 @@ describe("HistoryTabComponent", () => {
     );
   }
 
+  /** The text of every column header the table renders. */
+  function renderedHeaders(): (string | undefined)[] {
+    return [...fixture.nativeElement.querySelectorAll("th")].map((th: HTMLElement) =>
+      th.textContent?.trim(),
+    );
+  }
+
   /** Switch to the approver-side scope and re-render. */
   function showManaged(): void {
     component["selectScope"]("managed");
@@ -615,22 +622,59 @@ describe("HistoryTabComponent", () => {
       myRows$.next([historyRow({ id: "mine-1" })]);
       create();
 
-      const headers = [...fixture.nativeElement.querySelectorAll("th")].map((th: HTMLElement) =>
-        th.textContent?.trim(),
-      );
-      expect(headers).not.toContain("pamColumnActions");
+      expect(renderedHeaders()).not.toContain("pamColumnActions");
     });
 
-    it("shows the Actions column once a listed row is one the caller manages", () => {
+    // The column has to answer "can anything here be acted on", not "does the caller manage
+    // anything here" — a decided-and-done managed history is all a mature approver ever has.
+    it("hides the Actions column when every managed row is already terminal", () => {
+      canApprove$.next(true);
+      managedRows$.next([
+        historyRow({ id: "managed-1", status: "denied" }),
+        historyRow({
+          id: "managed-2",
+          status: "approved",
+          statusBadge: { labelKey: "pamStatusRevoked", variant: "subtle" },
+          producedLeaseId: "lease-1",
+          producedLeaseStatus: "revoked",
+        }),
+      ]);
+      create();
+      showManaged();
+
+      expect(renderedRowIds().sort()).toEqual(["managed-1", "managed-2"]);
+      expect(renderedHeaders()).not.toContain("pamColumnActions");
+    });
+
+    // A request the caller raised against a collection they also manage is in `managedIds`, but
+    // "Raised by me" only ever lists it once it is past anything Revoke or Withdraw could reach.
+    it("hides the Actions column under Mine for a terminal row the caller both raised and manages", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "managed-1", status: "denied" })]);
+      create();
+      component["selectScope"]("mine");
+      fixture.detectChanges();
+
+      expect(renderedRowIds()).toEqual(["managed-1"]);
+      expect(renderedHeaders()).not.toContain("pamColumnActions");
+    });
+
+    it("shows the Actions column once a listed row can be acted on", () => {
       canApprove$.next(true);
       myRows$.next([historyRow({ id: "mine-1" })]);
       managedRows$.next([activeGrant]);
       create();
 
-      const headers = [...fixture.nativeElement.querySelectorAll("th")].map((th: HTMLElement) =>
-        th.textContent?.trim(),
-      );
-      expect(headers).toContain("pamColumnActions");
+      expect(renderedHeaders()).toContain("pamColumnActions");
+    });
+
+    it("shows the Actions column for a managed approval the requester has not started", () => {
+      canApprove$.next(true);
+      managedRows$.next([unstartedApproval]);
+      create();
+      showManaged();
+
+      expect(renderedHeaders()).toContain("pamColumnActions");
     });
 
     it("keeps a managed row's actions when the caller filters down to All's subsets", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -132,11 +132,23 @@ describe("HistoryTabComponent", () => {
   });
 
   describe("scope toggle", () => {
-    it("is hidden when there is no managed history to switch to", () => {
+    it("lands on All", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+
+      create();
+
+      expect(component["scope"]()).toBe("all");
+      expect(query('[data-testid="history-scope-all"]')).not.toBeNull();
+    });
+
+    it("is hidden from a viewer who can neither approve nor has managed rows", () => {
       myRows$.next([historyRow()]);
 
       create();
 
+      expect(query('[data-testid="history-scope-all"]')).toBeNull();
       expect(query('[data-testid="history-scope-managed"]')).toBeNull();
     });
 
@@ -157,7 +169,118 @@ describe("HistoryTabComponent", () => {
       expect(query('[data-testid="history-scope-managed"]')).not.toBeNull();
     });
 
-    it("shows nothing until the managed history has loaded, so the scope cannot swap under the reader", () => {
+    it("shows both sources merged under All, newest first", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1", resolvedAt: "2026-08-17T10:00:00.000Z" })]);
+      managedRows$.next([
+        historyRow({ id: "managed-1", resolvedAt: "2026-08-17T12:00:00.000Z" }),
+        historyRow({ id: "managed-2", resolvedAt: "2026-08-17T09:00:00.000Z" }),
+      ]);
+
+      create();
+
+      expect(component["historyRows"]().map((r) => r.id)).toEqual([
+        "managed-1",
+        "mine-1",
+        "managed-2",
+      ]);
+    });
+
+    // A request the caller raised against a collection they also manage comes back from both reads.
+    it("lists a request that is both raised and managed by the caller only once under All", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "both-1" })]);
+      managedRows$.next([historyRow({ id: "both-1" })]);
+
+      create();
+
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["both-1"]);
+    });
+
+    it("sorts a row with no decision by when it was raised", () => {
+      canApprove$.next(true);
+      myRows$.next([
+        historyRow({ id: "mine-1", resolvedAt: null, submittedAt: "2026-08-17T13:00:00.000Z" }),
+      ]);
+      managedRows$.next([historyRow({ id: "managed-1", resolvedAt: "2026-08-17T12:00:00.000Z" })]);
+
+      create();
+
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1", "managed-1"]);
+    });
+
+    it("narrows to the caller's own rows, then restores the union", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      managedRows$.next([historyRow({ id: "managed-1", resolvedAt: "2026-08-17T12:00:00.000Z" })]);
+      create();
+
+      component["selectScope"]("mine");
+      fixture.detectChanges();
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
+
+      component["selectScope"]("all");
+      fixture.detectChanges();
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1", "mine-1"]);
+    });
+
+    it("narrows to the managed rows, then restores the union", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      managedRows$.next([historyRow({ id: "managed-1", resolvedAt: "2026-08-17T12:00:00.000Z" })]);
+      create();
+
+      showManaged();
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
+
+      component["selectScope"]("all");
+      fixture.detectChanges();
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1", "mine-1"]);
+    });
+
+    it("keeps the viewer on the filter they picked when managed history arrives", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      create();
+
+      component["selectScope"]("mine");
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      fixture.detectChanges();
+
+      expect(component["scope"]()).toBe("mine");
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
+    });
+
+    it("does not move the reader off All when managed history arrives in the background", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      create();
+
+      managedRows$.next([historyRow({ id: "managed-1", resolvedAt: "2026-08-17T12:00:00.000Z" })]);
+      fixture.detectChanges();
+
+      expect(component["scope"]()).toBe("all");
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1", "mine-1"]);
+    });
+
+    // A non-approver whose managed rows go away loses the toggle, so their pinned filter stops
+    // applying.
+    it("falls back to All if the toggle goes away while a filter is applied", () => {
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      create();
+      showManaged();
+
+      managedRows$.next([]);
+      fixture.detectChanges();
+
+      expect(component["scope"]()).toBe("all");
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
+    });
+  });
+
+  describe("loading", () => {
+    it("shows the skeleton until the managed history has loaded", () => {
       canApprove$.next(true);
       managedLoading$.next(true);
       myRows$.next([historyRow({ id: "mine-1" })]);
@@ -168,12 +291,12 @@ describe("HistoryTabComponent", () => {
       expect(skeleton).not.toBeNull();
       expect(skeleton?.querySelectorAll("bit-skeleton").length).toBeGreaterThan(0);
       expect(skeleton?.querySelector('[role="status"]')?.textContent).toContain("loading");
-      expect(query('[data-testid="my-access-history-mine-1"]')).toBeNull();
 
       managedRows$.next([historyRow({ id: "managed-1" })]);
       managedLoading$.next(false);
       fixture.detectChanges();
 
+      expect(query('[data-testid="history-loading"]')).toBeNull();
       expect(query('[data-testid="my-access-history-managed-1"]')).not.toBeNull();
     });
 
@@ -185,6 +308,7 @@ describe("HistoryTabComponent", () => {
 
       create();
 
+      expect(query('[data-testid="history-loading"]')).toBeNull();
       expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
     });
 
@@ -204,11 +328,11 @@ describe("HistoryTabComponent", () => {
 
       canApprove$.next(true);
       lastSync$.next(new Date("2026-08-20T09:05:00.000Z"));
-      managedRows$.next([historyRow({ id: "managed-1" })]);
+      managedRows$.next([historyRow({ id: "managed-1", resolvedAt: "2026-08-17T12:00:00.000Z" })]);
       managedLoading$.next(false);
       fixture.detectChanges();
 
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1", "mine-1"]);
     });
 
     it("waits on the caller's own history too, so its empty state cannot flash", () => {
@@ -226,73 +350,15 @@ describe("HistoryTabComponent", () => {
       expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
     });
 
-    it("lands on the managed side when there is managed history", () => {
-      myRows$.next([historyRow({ id: "mine-1" })]);
-      managedRows$.next([historyRow({ id: "managed-1" })]);
-
-      create();
-
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
-    });
-
-    it("lands on the caller's own rows when there is no managed history", () => {
-      canApprove$.next(true);
-      myRows$.next([historyRow({ id: "mine-1" })]);
-
-      create();
-
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
-    });
-
-    it("keeps the viewer on the scope they picked when managed history arrives", () => {
-      canApprove$.next(true);
+    it("does not replace rows already on screen with a skeleton when a reload starts", () => {
       myRows$.next([historyRow({ id: "mine-1" })]);
       create();
 
-      component["selectScope"]("mine");
-      managedRows$.next([historyRow({ id: "managed-1" })]);
+      myLoading$.next(true);
       fixture.detectChanges();
 
-      expect(component["showingManaged"]()).toBe(false);
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
-    });
-
-    it("does not move the reader when managed history arrives in the background", () => {
-      canApprove$.next(true);
-      myRows$.next([historyRow({ id: "mine-1" })]);
-      create();
-
-      managedRows$.next([historyRow({ id: "managed-1" })]);
-      fixture.detectChanges();
-
-      expect(component["scope"]()).toBe("mine");
-      expect(component["showingManaged"]()).toBe(false);
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
-    });
-
-    it("shows the managed rows once switched", () => {
-      myRows$.next([historyRow({ id: "mine-1" })]);
-      managedRows$.next([historyRow({ id: "managed-1" })]);
-      create();
-
-      showManaged();
-
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
-    });
-
-    // A non-approver whose managed rows go away loses the toggle, so their pinned scope stops
-    // applying.
-    it("falls back to the caller's own rows if the managed side empties out", () => {
-      managedRows$.next([historyRow({ id: "managed-1" })]);
-      myRows$.next([historyRow({ id: "mine-1" })]);
-      create();
-      showManaged();
-
-      managedRows$.next([]);
-      fixture.detectChanges();
-
-      expect(component["showingManaged"]()).toBe(false);
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
+      expect(query('[data-testid="history-loading"]')).toBeNull();
+      expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
     });
   });
 
@@ -316,12 +382,63 @@ describe("HistoryTabComponent", () => {
       managedIds$.next(new Set(["managed-1", "managed-2"]));
     });
 
-    it("offers no actions on the caller's own rows", () => {
-      myRows$.next([activeGrant]);
+    it("offers no actions on a row the caller only raised", () => {
+      managedIds$.next(new Set());
+      myRows$.next([activeGrant, unstartedApproval]);
       create();
 
       expect(component["canRevoke"](activeGrant)).toBe(false);
       expect(component["canCancelApproval"](unstartedApproval)).toBe(false);
+      expect(query('[data-testid="history-revoke-managed-1"]')).toBeNull();
+      expect(query('[data-testid="history-cancel-approval-managed-2"]')).toBeNull();
+    });
+
+    // The merged list carries rows from both sources, so the Actions column has to answer per row.
+    it("offers actions under All only on the rows the caller manages", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      managedRows$.next([activeGrant]);
+      create();
+
+      expect(component["scope"]()).toBe("all");
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1", "mine-1"]);
+      expect(query('[data-testid="history-revoke-managed-1"]')).not.toBeNull();
+      expect(query('[data-testid="history-revoke-mine-1"]')).toBeNull();
+      expect(component["canRevoke"](historyRow({ id: "mine-1" }))).toBe(false);
+    });
+
+    it("hides the Actions column when nothing in the current list can be acted on", () => {
+      canApprove$.next(true);
+      managedIds$.next(new Set());
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      create();
+
+      const headers = [...fixture.nativeElement.querySelectorAll("th")].map((th: HTMLElement) =>
+        th.textContent?.trim(),
+      );
+      expect(headers).not.toContain("pamColumnActions");
+    });
+
+    it("shows the Actions column once a listed row is one the caller manages", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      managedRows$.next([activeGrant]);
+      create();
+
+      const headers = [...fixture.nativeElement.querySelectorAll("th")].map((th: HTMLElement) =>
+        th.textContent?.trim(),
+      );
+      expect(headers).toContain("pamColumnActions");
+    });
+
+    it("keeps a managed row's actions when the caller filters down to All's subsets", () => {
+      canApprove$.next(true);
+      managedRows$.next([activeGrant]);
+      create();
+
+      expect(component["canRevoke"](activeGrant)).toBe(true);
+      showManaged();
+      expect(component["canRevoke"](activeGrant)).toBe(true);
     });
 
     it("offers Revoke for a live lease the caller granted", () => {
@@ -487,14 +604,14 @@ describe("HistoryTabComponent", () => {
     });
   });
 
-  it("says which side is empty", () => {
-    managedRows$.next([historyRow({ id: "managed-1" })]);
+  it("says which slice is empty", () => {
+    canApprove$.next(true);
     create();
-    expect(fixture.nativeElement.textContent).not.toContain("pamInboxHistoryEmpty");
-
-    managedRows$.next([]);
-    fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain("pamMyRequestsHistoryEmpty");
+
+    showManaged();
+
+    expect(fixture.nativeElement.textContent).toContain("pamInboxHistoryEmpty");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -77,13 +77,27 @@ describe("HistoryTabComponent", () => {
     return fixture.nativeElement.querySelector(selector) as HTMLElement | null;
   }
 
+  /** The ids of the rows the table actually renders, in the order the table renders them. */
+  function renderedRowIds(): string[] {
+    return [...fixture.nativeElement.querySelectorAll("tr[data-testid]")].map((row: HTMLElement) =>
+      (row.getAttribute("data-testid") ?? "").replace("my-access-history-", ""),
+    );
+  }
+
   /** Switch to the approver-side scope and re-render. */
   function showManaged(): void {
     component["selectScope"]("managed");
     fixture.detectChanges();
   }
 
+  /** Run past the skeleton's show delay and re-render. */
+  function passSkeletonDelay(): void {
+    jest.advanceTimersByTime(1000);
+    fixture.detectChanges();
+  }
+
   beforeEach(async () => {
+    jest.useFakeTimers();
     myRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
     managedRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
     managedIds$ = new BehaviorSubject<Set<string>>(new Set());
@@ -129,6 +143,11 @@ describe("HistoryTabComponent", () => {
     })
       .overrideComponent(HistoryTabComponent, { add: { schemas: [NO_ERRORS_SCHEMA] } })
       .compileComponents();
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    jest.useRealTimers();
   });
 
   describe("scope toggle", () => {
@@ -197,6 +216,29 @@ describe("HistoryTabComponent", () => {
       expect(component["historyRows"]().map((r) => r.id)).toEqual(["both-1"]);
     });
 
+    // Only the caller's own read folds an approved extension onto the grant it extended, so the
+    // managed copy of the same request has no "Extended" badge to show.
+    it("keeps the richer copy of a request both reads return", () => {
+      canApprove$.next(true);
+      myRows$.next([
+        historyRow({
+          id: "both-1",
+          extendedBySeconds: 3600,
+          extendedUntil: "2026-08-17T14:00:00.000Z",
+        }),
+      ]);
+      managedRows$.next([historyRow({ id: "both-1" })]);
+
+      create();
+
+      expect(component["historyRows"]().map((r) => r.extendedUntil)).toEqual([
+        "2026-08-17T14:00:00.000Z",
+      ]);
+      expect(query('[data-testid="my-access-history-extended-both-1"]')).not.toBeNull();
+    });
+
+    // Asserted on the rendered rows: the table re-orders whatever it is handed, so the merge's own
+    // sort proves nothing about what the reader sees.
     it("sorts a row with no decision by when it was raised", () => {
       canApprove$.next(true);
       myRows$.next([
@@ -206,7 +248,20 @@ describe("HistoryTabComponent", () => {
 
       create();
 
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1", "managed-1"]);
+      expect(renderedRowIds()).toEqual(["mine-1", "managed-1"]);
+    });
+
+    it("renders the merged list newest first", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1", resolvedAt: "2026-08-17T10:00:00.000Z" })]);
+      managedRows$.next([
+        historyRow({ id: "managed-1", resolvedAt: "2026-08-17T12:00:00.000Z" }),
+        historyRow({ id: "managed-2", resolvedAt: "2026-08-17T09:00:00.000Z" }),
+      ]);
+
+      create();
+
+      expect(renderedRowIds()).toEqual(["managed-1", "mine-1", "managed-2"]);
     });
 
     it("narrows to the caller's own rows, then restores the union", () => {
@@ -280,17 +335,21 @@ describe("HistoryTabComponent", () => {
   });
 
   describe("loading", () => {
-    it("shows the skeleton until the managed history has loaded", () => {
+    it("shows the skeleton once the load has run for a second, then the managed history", () => {
       canApprove$.next(true);
       managedLoading$.next(true);
       myRows$.next([historyRow({ id: "mine-1" })]);
 
       create();
 
+      expect(query('[data-testid="history-loading"]')).toBeNull();
+
+      passSkeletonDelay();
+
       const skeleton = query('[data-testid="history-loading"]');
       expect(skeleton).not.toBeNull();
+      expect(skeleton?.getAttribute("aria-hidden")).toBe("true");
       expect(skeleton?.querySelectorAll("bit-skeleton").length).toBeGreaterThan(0);
-      expect(skeleton?.querySelector('[role="status"]')?.textContent).toContain("loading");
 
       managedRows$.next([historyRow({ id: "managed-1" })]);
       managedLoading$.next(false);
@@ -298,6 +357,52 @@ describe("HistoryTabComponent", () => {
 
       expect(query('[data-testid="history-loading"]')).toBeNull();
       expect(query('[data-testid="my-access-history-managed-1"]')).not.toBeNull();
+    });
+
+    it("never shows the skeleton when the history arrives inside a second", () => {
+      canApprove$.next(true);
+      managedLoading$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+
+      create();
+
+      jest.advanceTimersByTime(500);
+      fixture.detectChanges();
+
+      expect(query("bit-skeleton")).toBeNull();
+
+      managedLoading$.next(false);
+      passSkeletonDelay();
+
+      expect(query("bit-skeleton")).toBeNull();
+      expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
+      expect(query('[data-testid="history-loading-status"]')?.textContent?.trim()).toBe("");
+    });
+
+    // A live region has to be in the DOM before its text changes for assistive tech to announce
+    // them, and emptying it announces nothing on its own.
+    it("keeps one live region mounted and announces both halves of the load", () => {
+      canApprove$.next(true);
+      managedLoading$.next(true);
+
+      create();
+
+      const status = query('[data-testid="history-loading-status"]');
+      expect(status?.getAttribute("role")).toBe("status");
+      expect(status?.getAttribute("aria-live")).toBe("polite");
+      expect(status?.textContent?.trim()).toBe("");
+
+      passSkeletonDelay();
+
+      expect(query('[data-testid="history-loading-status"]')).toBe(status);
+      expect(status?.textContent).toContain("loading");
+
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      managedLoading$.next(false);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="history-loading-status"]')).toBe(status);
+      expect(status?.textContent).toContain("pamHistoryLoaded");
     });
 
     // The shell never loads the inbox for a member who cannot approve, so its loading flag stays
@@ -322,6 +427,7 @@ describe("HistoryTabComponent", () => {
       myRows$.next([historyRow({ id: "mine-1" })]);
 
       create();
+      passSkeletonDelay();
 
       expect(query('[data-testid="history-loading"]')).not.toBeNull();
       expect(query('[data-testid="my-access-history-mine-1"]')).toBeNull();
@@ -339,6 +445,7 @@ describe("HistoryTabComponent", () => {
       myLoading$.next(true);
 
       create();
+      passSkeletonDelay();
 
       expect(query('[data-testid="history-loading"]')).not.toBeNull();
       expect(fixture.nativeElement.textContent).not.toContain("pamMyRequestsHistoryEmpty");
@@ -355,7 +462,7 @@ describe("HistoryTabComponent", () => {
       create();
 
       myLoading$.next(true);
-      fixture.detectChanges();
+      passSkeletonDelay();
 
       expect(query('[data-testid="history-loading"]')).toBeNull();
       expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
@@ -401,7 +508,10 @@ describe("HistoryTabComponent", () => {
       create();
 
       expect(component["scope"]()).toBe("all");
-      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1", "mine-1"]);
+      expect([...component["historyRows"]().map((r) => r.id)].sort()).toEqual([
+        "managed-1",
+        "mine-1",
+      ]);
       expect(query('[data-testid="history-revoke-managed-1"]')).not.toBeNull();
       expect(query('[data-testid="history-revoke-mine-1"]')).toBeNull();
       expect(component["canRevoke"](historyRow({ id: "mine-1" }))).toBe(false);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -7,6 +7,7 @@ import { BehaviorSubject } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
@@ -52,6 +53,8 @@ describe("HistoryTabComponent", () => {
   let managedRows$: BehaviorSubject<MyAccessRequestRow[]>;
   let managedIds$: BehaviorSubject<Set<string>>;
   let managedLoading$: BehaviorSubject<boolean>;
+  let myLoading$: BehaviorSubject<boolean>;
+  let lastSync$: BehaviorSubject<Date | null>;
   let inbox: {
     historyRows$: BehaviorSubject<MyAccessRequestRow[]>;
     managedIds$: BehaviorSubject<Set<string>>;
@@ -85,6 +88,8 @@ describe("HistoryTabComponent", () => {
     managedRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
     managedIds$ = new BehaviorSubject<Set<string>>(new Set());
     managedLoading$ = new BehaviorSubject(false);
+    myLoading$ = new BehaviorSubject(false);
+    lastSync$ = new BehaviorSubject<Date | null>(new Date("2026-08-20T09:00:00.000Z"));
     inbox = {
       historyRows$: managedRows$,
       managedIds$,
@@ -107,10 +112,12 @@ describe("HistoryTabComponent", () => {
           useValue: {
             historyRows$: myRows$,
             cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
+            loading$: myLoading$,
           },
         },
         { provide: ApproverInboxService, useValue: inbox },
         { provide: ApprovalPrivilegeService, useValue: { canApprove$ } },
+        { provide: SyncService, useValue: { activeUserLastSync$: () => lastSync$ } },
         { provide: DialogService, useValue: dialogService },
         { provide: ToastService, useValue: toastService },
         { provide: LogService, useValue: mock<LogService>() },
@@ -181,6 +188,44 @@ describe("HistoryTabComponent", () => {
       expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
     });
 
+    // On a cold load — a bookmark, or a hard refresh straight onto /pam/history — `canApprove$`
+    // answers false for a genuine approver: it is derived from organization and collection state the
+    // first sync has not delivered yet. The sync writes that state before stamping its date, so a
+    // non-null last-sync date is what makes a `false` here trustworthy.
+    it("waits for the first sync before reading a false approval privilege as settled", () => {
+      lastSync$.next(null);
+      managedLoading$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+
+      create();
+
+      expect(query('[data-testid="history-loading"]')).not.toBeNull();
+      expect(query('[data-testid="my-access-history-mine-1"]')).toBeNull();
+
+      canApprove$.next(true);
+      lastSync$.next(new Date("2026-08-20T09:05:00.000Z"));
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      managedLoading$.next(false);
+      fixture.detectChanges();
+
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
+    });
+
+    it("waits on the caller's own history too, so its empty state cannot flash", () => {
+      myLoading$.next(true);
+
+      create();
+
+      expect(query('[data-testid="history-loading"]')).not.toBeNull();
+      expect(fixture.nativeElement.textContent).not.toContain("pamMyRequestsHistoryEmpty");
+
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      myLoading$.next(false);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
+    });
+
     it("lands on the managed side when there is managed history", () => {
       myRows$.next([historyRow({ id: "mine-1" })]);
       managedRows$.next([historyRow({ id: "managed-1" })]);
@@ -208,6 +253,19 @@ describe("HistoryTabComponent", () => {
       managedRows$.next([historyRow({ id: "managed-1" })]);
       fixture.detectChanges();
 
+      expect(component["showingManaged"]()).toBe(false);
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
+    });
+
+    it("does not move the reader when managed history arrives in the background", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      create();
+
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      fixture.detectChanges();
+
+      expect(component["scope"]()).toBe("mine");
       expect(component["showingManaged"]()).toBe(false);
       expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -10,6 +10,7 @@ import { LogService } from "@bitwarden/common/platform/abstractions/log.service"
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { DialogService, ToastService } from "@bitwarden/components";
 
+import { ApprovalPrivilegeService } from "../approvals/approval-privilege.service";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 
 import { HistoryTabComponent } from "./history-tab.component";
@@ -50,13 +51,16 @@ describe("HistoryTabComponent", () => {
   let myRows$: BehaviorSubject<MyAccessRequestRow[]>;
   let managedRows$: BehaviorSubject<MyAccessRequestRow[]>;
   let managedIds$: BehaviorSubject<Set<string>>;
+  let managedLoading$: BehaviorSubject<boolean>;
   let inbox: {
     historyRows$: BehaviorSubject<MyAccessRequestRow[]>;
     managedIds$: BehaviorSubject<Set<string>>;
     cipherById$: BehaviorSubject<Map<string, CipherView>>;
+    loading$: BehaviorSubject<boolean>;
     revokeLease: jest.Mock;
     cancelApproval: jest.Mock;
   };
+  let canApprove$: BehaviorSubject<boolean>;
   let dialogService: MockProxy<DialogService>;
   let toastService: MockProxy<ToastService>;
 
@@ -72,7 +76,7 @@ describe("HistoryTabComponent", () => {
 
   /** Switch to the approver-side scope and re-render. */
   function showManaged(): void {
-    component["scope"].set("managed");
+    component["selectScope"]("managed");
     fixture.detectChanges();
   }
 
@@ -80,13 +84,16 @@ describe("HistoryTabComponent", () => {
     myRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
     managedRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
     managedIds$ = new BehaviorSubject<Set<string>>(new Set());
+    managedLoading$ = new BehaviorSubject(false);
     inbox = {
       historyRows$: managedRows$,
       managedIds$,
       cipherById$: new BehaviorSubject(new Map<string, CipherView>()),
+      loading$: managedLoading$,
       revokeLease: jest.fn().mockResolvedValue(undefined),
       cancelApproval: jest.fn().mockResolvedValue(undefined),
     };
+    canApprove$ = new BehaviorSubject(false);
     dialogService = mock<DialogService>();
     toastService = mock<ToastService>();
     dialogService.openSimpleDialog.mockResolvedValue(true);
@@ -103,6 +110,7 @@ describe("HistoryTabComponent", () => {
           },
         },
         { provide: ApproverInboxService, useValue: inbox },
+        { provide: ApprovalPrivilegeService, useValue: { canApprove$ } },
         { provide: DialogService, useValue: dialogService },
         { provide: ToastService, useValue: toastService },
         { provide: LogService, useValue: mock<LogService>() },
@@ -133,12 +141,74 @@ describe("HistoryTabComponent", () => {
       expect(query('[data-testid="history-scope-managed"]')).not.toBeNull();
     });
 
-    it("shows the caller's own rows by default", () => {
+    it("offers the toggle to an approver with no managed history yet", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+
+      create();
+
+      expect(query('[data-testid="history-scope-managed"]')).not.toBeNull();
+    });
+
+    it("shows nothing until the managed history has loaded, so the scope cannot swap under the reader", () => {
+      canApprove$.next(true);
+      managedLoading$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+
+      create();
+
+      const skeleton = query('[data-testid="history-loading"]');
+      expect(skeleton).not.toBeNull();
+      expect(skeleton?.querySelectorAll("bit-skeleton").length).toBeGreaterThan(0);
+      expect(skeleton?.querySelector('[role="status"]')?.textContent).toContain("loading");
+      expect(query('[data-testid="my-access-history-mine-1"]')).toBeNull();
+
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      managedLoading$.next(false);
+      fixture.detectChanges();
+
+      expect(query('[data-testid="my-access-history-managed-1"]')).not.toBeNull();
+    });
+
+    // The shell never loads the inbox for a member who cannot approve, so its loading flag stays
+    // raised for the life of the page.
+    it("does not wait on the inbox for a member who cannot approve", () => {
+      managedLoading$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+
+      create();
+
+      expect(query('[data-testid="my-access-history-mine-1"]')).not.toBeNull();
+    });
+
+    it("lands on the managed side when there is managed history", () => {
       myRows$.next([historyRow({ id: "mine-1" })]);
       managedRows$.next([historyRow({ id: "managed-1" })]);
 
       create();
 
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
+    });
+
+    it("lands on the caller's own rows when there is no managed history", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+
+      create();
+
+      expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
+    });
+
+    it("keeps the viewer on the scope they picked when managed history arrives", () => {
+      canApprove$.next(true);
+      myRows$.next([historyRow({ id: "mine-1" })]);
+      create();
+
+      component["selectScope"]("mine");
+      managedRows$.next([historyRow({ id: "managed-1" })]);
+      fixture.detectChanges();
+
+      expect(component["showingManaged"]()).toBe(false);
       expect(component["historyRows"]().map((r) => r.id)).toEqual(["mine-1"]);
     });
 
@@ -152,6 +222,8 @@ describe("HistoryTabComponent", () => {
       expect(component["historyRows"]().map((r) => r.id)).toEqual(["managed-1"]);
     });
 
+    // A non-approver whose managed rows go away loses the toggle, so their pinned scope stops
+    // applying.
     it("falls back to the caller's own rows if the managed side empties out", () => {
       managedRows$.next([historyRow({ id: "managed-1" })]);
       myRows$.next([historyRow({ id: "mine-1" })]);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
@@ -28,6 +28,8 @@ import { MyAccessService } from "./my-access.service";
 
 const names = storyNames();
 
+const MINE_TOGGLE = '[data-testid="history-scope-mine"] label';
+
 const request = (overrides: Record<string, unknown>) =>
   toRequestRow(accessRequest(overrides), names);
 
@@ -175,7 +177,7 @@ type Story = StoryObj<HistoryTabComponent>;
 
 /**
  * The caller's own history, for a member who cannot approve. With no managed rows and no approval
- * privilege the Mine/Managed toggle is not rendered at all — a scope switch with one option is noise.
+ * privilege the toggle is not rendered at all: every filter would narrow the same one list.
  */
 export const Default: Story = {
   decorators: [history()],
@@ -187,28 +189,35 @@ export const Empty: Story = {
 };
 
 /**
- * An approver's view: the table opens on the managed scope because there is history behind it, with
- * the revoke and withdraw actions that only exist there. Switch the toggle for the rows the
- * approver raised themselves.
+ * An approver's view. The table opens on All — both the rows they raised and the ones they decided,
+ * newest first — with revoke and withdraw offered only on the rows they manage. The toggle narrows
+ * that list to either source.
  */
 export const WithManagedHistory: Story = {
   decorators: [history({ managed: managedRows })],
 };
 
-/** An approver with nothing decided yet: the scope toggle is offered before it has content. */
+/** An approver with nothing decided yet: the filters are offered before there is anything to narrow. */
 export const ApproverWithoutManagedHistory: Story = {
   decorators: [history({ canApprove: true })],
 };
 
 /**
- * An approver whose own history is empty but who has decided other people's requests. Opens on the
- * managed scope: the Actions column exists nowhere else, so this is the only story that renders the
- * revoke and withdraw buttons.
+ * An approver whose own history is empty but who has decided other people's requests, filtered down
+ * to the managed rows.
  */
 export const ManagedOnly: Story = {
   decorators: [history({ mine: [], managed: managedRows })],
   play: async ({ canvasElement }) => {
     const managed = await within(canvasElement).findByTestId("history-scope-managed");
     await userEvent.click(within(managed).getByRole("radio"));
+  },
+};
+
+/** The "Raised by me" filter applied over a history that has both sources. */
+export const MineFilter: Story = {
+  decorators: [history({ managed: managedRows })],
+  play: async ({ canvasElement }) => {
+    await userEvent.click(canvasElement.querySelector<HTMLLabelElement>(MINE_TOGGLE)!);
   },
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
@@ -3,6 +3,7 @@ import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/an
 import { of } from "rxjs";
 import { userEvent, within } from "storybook/test";
 
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
@@ -148,6 +149,7 @@ function history(
         },
       },
       { provide: ApprovalPrivilegeService, useValue: { canApprove$: of(canApprove) } },
+      { provide: SyncService, useValue: { activeUserLastSync$: () => of(new Date()) } },
       { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
       { provide: ToastService, useValue: { showToast: () => {} } },
     ],

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.stories.ts
@@ -6,6 +6,7 @@ import { userEvent, within } from "storybook/test";
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
+import { ApprovalPrivilegeService } from "../approvals/approval-privilege.service";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import {
   DAY,
@@ -111,8 +112,14 @@ function managedRows() {
   ];
 }
 
-function history(options: { mine?: typeof MY_ROWS; managed?: () => typeof MY_ROWS } = {}) {
-  const { mine = MY_ROWS, managed } = options;
+function history(
+  options: {
+    mine?: typeof MY_ROWS;
+    managed?: () => typeof MY_ROWS;
+    canApprove?: boolean;
+  } = {},
+) {
+  const { mine = MY_ROWS, managed, canApprove = managed != null } = options;
   return moduleMetadata({
     imports: [HistoryTabComponent],
     providers: [
@@ -140,6 +147,7 @@ function history(options: { mine?: typeof MY_ROWS; managed?: () => typeof MY_ROW
           };
         },
       },
+      { provide: ApprovalPrivilegeService, useValue: { canApprove$: of(canApprove) } },
       { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
       { provide: ToastService, useValue: { showToast: () => {} } },
     ],
@@ -164,8 +172,8 @@ export default {
 type Story = StoryObj<HistoryTabComponent>;
 
 /**
- * The caller's own history. With no managed rows the Mine/Managed toggle is not rendered at all —
- * a scope switch with one option is noise.
+ * The caller's own history, for a member who cannot approve. With no managed rows and no approval
+ * privilege the Mine/Managed toggle is not rendered at all — a scope switch with one option is noise.
  */
 export const Default: Story = {
   decorators: [history()],
@@ -177,12 +185,17 @@ export const Empty: Story = {
 };
 
 /**
- * An approver's view: the Mine/Managed toggle appears because there is managed history behind it.
- * The table still opens on Mine — switch the toggle to see the revoke and withdraw actions, which
- * only exist on the managed scope.
+ * An approver's view: the table opens on the managed scope because there is history behind it, with
+ * the revoke and withdraw actions that only exist there. Switch the toggle for the rows the
+ * approver raised themselves.
  */
 export const WithManagedHistory: Story = {
   decorators: [history({ managed: managedRows })],
+};
+
+/** An approver with nothing decided yet: the scope toggle is offered before it has content. */
+export const ApproverWithoutManagedHistory: Story = {
+  decorators: [history({ canApprove: true })],
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -14,6 +14,7 @@ import { combineLatest, filter, map, take } from "rxjs";
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { SyncService } from "@bitwarden/common/platform/sync";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeComponent,
@@ -55,9 +56,10 @@ type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
  *
  * An untouched toggle lands on Managed whenever that side has rows, since this tab is aimed at the
  * approver and answering them with an empty table hides the history they came for behind a control
- * they have no reason to press. Nothing is rendered until the managed side has answered: that
- * default cannot be read off rows which have not arrived without painting the wrong half first and
- * swapping it out from under the reader.
+ * they have no reason to press. Nothing is rendered until both sides have answered, and the default
+ * is fixed at that one moment rather than tracked: read off rows as they arrive, it would paint the
+ * wrong half first, and a later background reload would swap the table — and the toggle's own
+ * selection — out from under whoever is reading it.
  *
  * A toggle rather than one merged table. Merging them would put "a request I raised" and "a request I
  * decided" in the same list with the same columns but different available actions, so a row's
@@ -98,6 +100,7 @@ export class HistoryTabComponent {
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
   private readonly approvalPrivileges = inject(ApprovalPrivilegeService);
+  private readonly syncService = inject(SyncService);
 
   protected readonly HistoryScope = HistoryScope;
 
@@ -129,29 +132,43 @@ export class HistoryTabComponent {
   });
 
   /**
-   * Whether the managed side has answered, latched at the first answer so a later refresh cannot
-   * take the table away again. `ApproverInboxService.loading$` starts true and clears only once
-   * `load()` has run, which the shell defers until the approval privilege resolves and skips
-   * entirely for a member who cannot approve — so neither stream settles this on its own.
+   * The half to open on, decided once both sides have answered and latched there — null until then,
+   * which is what the skeleton renders on.
+   *
+   * Each service's `loading$` starts true and clears when its `load()` resolves, but the shell only
+   * loads the inbox for a caller who can approve, so for everyone else that flag stays raised for
+   * the life of the page and cannot be waited on.
+   *
+   * Hence the sync date. `canApprove$` is derived from synced organization and collection state, so
+   * before the first sync lands it answers `false` for a genuine approver too, and taking that for a
+   * settled "not an approver" is what opened this tab on the wrong half. Nothing else on this path
+   * awaits the sync — the history route has no guard; `canViewApprovalsGuard` waits the same way for
+   * the same reason on the sibling tab.
    */
-  protected readonly historyReady = toSignal(
-    combineLatest([this.approvalPrivileges.canApprove$, this.inbox.loading$]).pipe(
-      filter(([canApprove, loading]) => !canApprove || !loading),
+  private readonly openingScope = toSignal(
+    combineLatest([
+      this.syncService.activeUserLastSync$(),
+      this.approvalPrivileges.canApprove$,
+      this.inbox.loading$,
+      this.myAccess.loading$,
+      this.inbox.historyRows$,
+    ]).pipe(
+      filter(
+        ([lastSync, canApprove, inboxLoading, myLoading]) =>
+          !myLoading && (canApprove ? !inboxLoading : lastSync != null),
+      ),
       take(1),
-      map(() => true),
+      map(([, , , , managed]) => (managed.length > 0 ? HistoryScope.Managed : HistoryScope.Mine)),
     ),
-    { initialValue: false },
+    { initialValue: null as HistoryScope | null },
   );
+
+  protected readonly historyReady = computed(() => this.openingScope() != null);
 
   private readonly hasManagedHistory = computed(() => this.managedRows().length > 0);
 
-  /**
-   * The default half is derived rather than latched on first load, so it keeps tracking the managed
-   * rows until the viewer pins a scope of their own.
-   */
   protected readonly scope = computed<HistoryScope>(
-    () =>
-      this.chosenScope() ?? (this.hasManagedHistory() ? HistoryScope.Managed : HistoryScope.Mine),
+    () => this.chosenScope() ?? this.openingScope() ?? HistoryScope.Mine,
   );
 
   /**

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -3,11 +3,13 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   signal,
+  untracked,
 } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { RouterModule } from "@angular/router";
 import {
   combineLatest,
@@ -54,6 +56,13 @@ import { MyAccessService } from "./my-access.service";
 /** Which slice of the history the table is showing. */
 const HistoryScope = Object.freeze({ All: "all", Mine: "mine", Managed: "managed" } as const);
 type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
+
+/**
+ * How long the "loaded" announcement is left in the live region. Long enough for a polite
+ * announcement to be taken, short enough that what is left behind is the empty region rather than a
+ * stale claim about a load.
+ */
+const announcementHoldMs = 2000;
 
 /** Newest first, by the moment the request was decided — falling back to when it was raised. */
 function resolvedOrSubmittedMs(row: MyAccessRequestRow): number {
@@ -116,6 +125,7 @@ export class HistoryTabComponent {
   private readonly logService = inject(LogService);
   private readonly approvalPrivileges = inject(ApprovalPrivilegeService);
   private readonly syncService = inject(SyncService);
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly HistoryScope = HistoryScope;
 
@@ -175,6 +185,7 @@ export class HistoryTabComponent {
     take(1),
     map(() => true),
     startWith(false),
+    takeUntilDestroyed(this.destroyRef),
     shareReplay({ bufferSize: 1, refCount: false }),
   );
 
@@ -197,10 +208,19 @@ export class HistoryTabComponent {
   /**
    * Whether the skeleton table is on screen. Drives the `role="status"` announcement as well, so
    * that a load finishing inside the delay never announces a screen the user was not shown.
+   *
+   * The `historyLoaded()` term buys nothing for the skeleton markup — the template gates that on the
+   * same flag, and so ends the skeleton as soon as the rows are in hand rather than holding it for
+   * whatever the operator has left of its minimum display time. It is the live region, which sits
+   * outside that block, that needs the term: without it the region goes on announcing "loading" over
+   * an already rendered table.
    */
   protected readonly skeletonVisible = computed(() => this.showSkeleton() && !this.historyLoaded());
 
-  /** Latched once the skeleton has been on screen, so its removal can be announced in turn. */
+  /**
+   * Raised once the skeleton has been on screen, so its removal can be announced in turn, and
+   * lowered again once that announcement has had its moment in the live region.
+   */
   private readonly skeletonShown = signal(false);
 
   /**
@@ -208,6 +228,9 @@ export class HistoryTabComponent {
    * nothing on its own, so the "loading" announcement needs a counterpart once the rows land. Gated
    * on the skeleton having been shown, so a load that finishes inside the delay announces neither
    * half.
+   *
+   * The announcement is transient: assistive tech that re-reads a region's contents on demand would
+   * otherwise be handed a load that finished minutes ago as though it were current.
    */
   protected readonly announceLoaded = computed(
     () => this.skeletonShown() && !this.skeletonVisible(),
@@ -223,7 +246,11 @@ export class HistoryTabComponent {
    */
   protected readonly canSwitchScope = computed(() => this.canApprove() || this.hasManagedHistory());
 
-  /** Falls back to All if the toggle goes away while a filter is applied. */
+  /**
+   * Falls back to All if the toggle goes away while a filter is applied — synchronously here, and
+   * forgotten by the effect that clears the pick, so a toggle that returns cannot silently narrow
+   * the table back to a filter the reader last chose under different circumstances.
+   */
   protected readonly scope = computed<HistoryScope>(() =>
     this.canSwitchScope() ? this.selectedScope() : HistoryScope.All,
   );
@@ -270,9 +297,21 @@ export class HistoryTabComponent {
     return this.historyRows().some((row) => managed.has(String(row.id)));
   });
 
-  protected readonly emptyMessageKey = computed(() =>
-    this.scope() === HistoryScope.Managed ? "pamInboxHistoryEmpty" : "pamMyRequestsHistoryEmpty",
-  );
+  /**
+   * Each scope answers for the slice it lists. All spans both sources, so borrowing either side's
+   * wording tells a reader with no history at all that they have raised nothing — which is only
+   * half of what the empty table means.
+   */
+  protected readonly emptyMessageKey = computed(() => {
+    switch (this.scope()) {
+      case HistoryScope.Managed:
+        return "pamInboxHistoryEmpty";
+      case HistoryScope.Mine:
+        return "pamMyRequestsHistoryEmpty";
+      default:
+        return "pamHistoryEmpty";
+    }
+  });
 
   protected readonly historyDataSource = new TableDataSource<MyAccessRequestRow>();
 
@@ -291,9 +330,20 @@ export class HistoryTabComponent {
     effect(() => {
       this.historyDataSource.data = this.historyRows();
     });
-    effect(() => {
+    effect((onCleanup) => {
       if (this.skeletonVisible()) {
         this.skeletonShown.set(true);
+        return;
+      }
+      if (!untracked(this.skeletonShown)) {
+        return;
+      }
+      const handle = setTimeout(() => this.skeletonShown.set(false), announcementHoldMs);
+      onCleanup(() => clearTimeout(handle));
+    });
+    effect(() => {
+      if (!this.canSwitchScope()) {
+        this.selectedScope.set(HistoryScope.All);
       }
     });
   }
@@ -322,9 +372,7 @@ export class HistoryTabComponent {
    * A lease still marked `active` past its window is therefore revocable here and absent there.
    */
   protected canRevoke(row: MyAccessRequestRow): boolean {
-    return (
-      this.managedIds().has(String(row.id)) && isLiveManagedLease(row)
-    );
+    return this.managedIds().has(String(row.id)) && isLiveManagedLease(row);
   }
 
   /** An approval the requester has not started yet, so it can still be withdrawn. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -9,13 +9,22 @@ import {
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { RouterModule } from "@angular/router";
-import { combineLatest, filter, map, take } from "rxjs";
+import {
+  combineLatest,
+  distinctUntilChanged,
+  filter,
+  map,
+  shareReplay,
+  startWith,
+  take,
+} from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { SyncService } from "@bitwarden/common/platform/sync";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { skeletonLoadingDelay } from "@bitwarden/common/vault/utils/skeleton-loading.operator";
 import {
   BadgeComponent,
   ButtonModule,
@@ -68,7 +77,8 @@ function resolvedOrSubmittedMs(row: MyAccessRequestRow): number {
  * differs is what a row permits: `managedIds` is the per-row authority, so a row carries the same
  * actions under All as under the filter it came from, and a row the caller merely raised carries
  * none. A request the caller raised against a collection they also manage is returned by both reads,
- * so All de-duplicates by request id.
+ * so All de-duplicates by request id, keeping the caller's own copy — only that side fills in the
+ * extension the grant was given.
  *
  * Own rows are read-only, so a caller with no approval privilege has no managed rows, gets no
  * Actions column, and is shown no toggle — every option would be a filter over the same one list.
@@ -138,7 +148,7 @@ export class HistoryTabComponent {
 
   /**
    * Latched true the first time every source the table draws from has finished loading — which is
-   * all the skeleton is waiting for, now that nothing about the opening view is read off the rows.
+   * all the skeleton is waiting for: nothing about the opening view is read off the rows.
    *
    * Latched rather than tracked so a background reload cannot pull the table out from under whoever
    * is reading it. Sampling the whole first load, rather than clearing as soon as any one source
@@ -152,21 +162,55 @@ export class HistoryTabComponent {
    * the history route has no guard; `canViewApprovalsGuard` waits the same way for the same reason
    * on the sibling tab.
    */
-  private readonly historyLoaded = toSignal(
-    combineLatest([
-      this.myAccess.loading$,
-      this.inbox.loading$,
-      this.approvalPrivileges.canApprove$,
-      this.syncService.activeUserLastSync$(),
-    ]).pipe(
-      filter(
-        ([myLoading, inboxLoading, canApprove, lastSync]) =>
-          !myLoading && !((canApprove || lastSync == null) && inboxLoading),
-      ),
-      take(1),
-      map(() => true),
+  private readonly historyLoaded$ = combineLatest([
+    this.myAccess.loading$,
+    this.inbox.loading$,
+    this.approvalPrivileges.canApprove$,
+    this.syncService.activeUserLastSync$(),
+  ]).pipe(
+    filter(
+      ([myLoading, inboxLoading, canApprove, lastSync]) =>
+        !myLoading && !((canApprove || lastSync == null) && inboxLoading),
+    ),
+    take(1),
+    map(() => true),
+    startWith(false),
+    shareReplay({ bufferSize: 1, refCount: false }),
+  );
+
+  protected readonly historyLoaded = toSignal(this.historyLoaded$, { initialValue: false });
+
+  /**
+   * The skeleton is held back until the load has run for a second, per the component library's
+   * display guidance, so a history that arrives quickly never flashes it — arriving at this tab
+   * from a sibling, both reads have usually already answered.
+   */
+  private readonly showSkeleton = toSignal(
+    this.historyLoaded$.pipe(
+      map((loaded) => !loaded),
+      distinctUntilChanged(),
+      skeletonLoadingDelay(),
     ),
     { initialValue: false },
+  );
+
+  /**
+   * Whether the skeleton table is on screen. Drives the `role="status"` announcement as well, so
+   * that a load finishing inside the delay never announces a screen the user was not shown.
+   */
+  protected readonly skeletonVisible = computed(() => this.showSkeleton() && !this.historyLoaded());
+
+  /** Latched once the skeleton has been on screen, so its removal can be announced in turn. */
+  private readonly skeletonShown = signal(false);
+
+  /**
+   * Whether the live region announces that the content has arrived. Emptying the region announces
+   * nothing on its own, so the "loading" announcement needs a counterpart once the rows land. Gated
+   * on the skeleton having been shown, so a load that finishes inside the delay announces neither
+   * half.
+   */
+  protected readonly announceLoaded = computed(
+    () => this.skeletonShown() && !this.skeletonVisible(),
   );
 
   private readonly hasManagedHistory = computed(() => this.managedRows().length > 0);
@@ -184,10 +228,15 @@ export class HistoryTabComponent {
     this.canSwitchScope() ? this.selectedScope() : HistoryScope.All,
   );
 
-  /** Both sources in one list, de-duplicated by request id and re-sorted on the shared key. */
+  /**
+   * Both sources in one list, de-duplicated by request id and re-sorted on the shared key. A row
+   * both reads return keeps the caller's own copy: `buildMyAccessRequestRows` folds an approved
+   * extension onto the grant it extended and fills in the "Extended" badge, which the inbox's
+   * straight row mapping leaves null.
+   */
   private readonly allRows = computed(() => {
-    const rowsById = new Map(this.managedRows().map((row) => [String(row.id), row]));
-    for (const row of this.myRows()) {
+    const rowsById = new Map(this.myRows().map((row) => [String(row.id), row]));
+    for (const row of this.managedRows()) {
       const key = String(row.id);
       if (!rowsById.has(key)) {
         rowsById.set(key, row);
@@ -209,8 +258,6 @@ export class HistoryTabComponent {
     }
   });
 
-  protected readonly showSkeleton = computed(() => !this.historyLoaded());
-
   /**
    * Shown exactly when something in the current list can be acted on. Keyed off the listed rows
    * rather than the viewer's privilege because an approver who has decided nothing yet, and the
@@ -229,12 +276,25 @@ export class HistoryTabComponent {
 
   protected readonly historyDataSource = new TableDataSource<MyAccessRequestRow>();
 
+  /**
+   * The Resolved column's sort, which is what actually orders the rendered table. Sorting on
+   * `resolvedAt` alone would send a row that was never decided to the end of the descending sort
+   * rather than to its submitted-at place. Ascending: `bitSortable` applies the direction itself.
+   */
+  protected readonly byResolvedOrSubmitted = (a: MyAccessRequestRow, b: MyAccessRequestRow) =>
+    resolvedOrSubmittedMs(a) - resolvedOrSubmittedMs(b);
+
   /** Five fills the space the table occupies without implying a row count the history may not have. */
   protected readonly skeletonRows = [0, 1, 2, 3, 4];
 
   constructor() {
     effect(() => {
       this.historyDataSource.data = this.historyRows();
+    });
+    effect(() => {
+      if (this.skeletonVisible()) {
+        this.skeletonShown.set(true);
+      }
     });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -50,7 +50,7 @@ import { isLiveManagedLease } from "../approvals/managed-lease-row";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { RelativeTimePipe } from "../date/relative-time.pipe";
 
-import { MyAccessRequestRow } from "./my-access-row";
+import { MyAccessRequestRow, resolvedOrSubmittedMs } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
 
 /** Which slice of the history the table is showing. */
@@ -63,11 +63,6 @@ type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
  * stale claim about a load.
  */
 const announcementHoldMs = 2000;
-
-/** Newest first, by the moment the request was decided — falling back to when it was raised. */
-function resolvedOrSubmittedMs(row: MyAccessRequestRow): number {
-  return Date.parse(row.resolvedAt ?? row.submittedAt);
-}
 
 /**
  * "History" tab — decided requests, drawn from two sources:
@@ -156,6 +151,18 @@ export class HistoryTabComponent {
     initialValue: new Map<string, CipherView>(),
   });
 
+  private readonly myLoadError = toSignal(this.myAccess.loadError$, { initialValue: null });
+  private readonly managedLoadError = toSignal(this.inbox.loadError$, { initialValue: null });
+
+  /**
+   * Whether either read the table draws from failed. Either one is enough: a failure on one side
+   * leaves the merged list short by everything that side holds, which the table cannot say for
+   * itself.
+   */
+  private readonly loadFailed = computed(
+    () => this.myLoadError() != null || this.managedLoadError() != null,
+  );
+
   /**
    * Latched true the first time every source the table draws from has finished loading — which is
    * all the skeleton is waiting for: nothing about the opening view is read off the rows.
@@ -227,13 +234,17 @@ export class HistoryTabComponent {
    * Whether the live region announces that the content has arrived. Emptying the region announces
    * nothing on its own, so the "loading" announcement needs a counterpart once the rows land. Gated
    * on the skeleton having been shown, so a load that finishes inside the delay announces neither
-   * half.
+   * half, and on both reads having succeeded — a failed read resolves the latch exactly like a
+   * successful one and leaves the same empty table behind, so without the guard the region claims a
+   * history has loaded while the shell is toasting the error for the very same load. A sighted user
+   * reads the toast against the empty table; the announcement is the reading that cannot be
+   * corrected.
    *
    * The announcement is transient: assistive tech that re-reads a region's contents on demand would
    * otherwise be handed a load that finished minutes ago as though it were current.
    */
   protected readonly announceLoaded = computed(
-    () => this.skeletonShown() && !this.skeletonVisible(),
+    () => this.skeletonShown() && !this.skeletonVisible() && !this.loadFailed(),
   );
 
   private readonly hasManagedHistory = computed(() => this.managedRows().length > 0);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -286,16 +286,19 @@ export class HistoryTabComponent {
   });
 
   /**
-   * Shown exactly when something in the current list can be acted on. Keyed off the listed rows
-   * rather than the viewer's privilege because an approver who has decided nothing yet, and the
-   * caller's own rows under "Raised by me", would otherwise get a column of nothing but dashes —
-   * and keyed off the rows rather than the scope because a request the caller raised against a
-   * collection they manage is actionable under every filter it appears in.
+   * Shown exactly when something in the current list can be acted on, asked with the same two
+   * predicates the cells answer to — so the column cannot outlive the buttons it exists to hold.
+   * Managed-ness alone is the weaker question: it holds for every request the caller manages,
+   * decided-and-done included, which is most of what a history accumulates.
+   *
+   * Keyed off the listed rows rather than the viewer's privilege because an approver who has
+   * decided nothing yet, and the caller's own rows under "Raised by me", would otherwise get a
+   * column of nothing but dashes — and off the rows rather than the scope because a request the
+   * caller raised against a collection they manage is actionable under every filter it appears in.
    */
-  protected readonly showActionsColumn = computed(() => {
-    const managed = this.managedIds();
-    return this.historyRows().some((row) => managed.has(String(row.id)));
-  });
+  protected readonly showActionsColumn = computed(() =>
+    this.historyRows().some((row) => this.canRevoke(row) || this.canCancelApproval(row)),
+  );
 
   /**
    * Each scope answers for the slice it lists. All spans both sources, so borrowing either side's

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -42,33 +42,38 @@ import { RelativeTimePipe } from "../date/relative-time.pipe";
 import { MyAccessRequestRow } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
 
-/** Which side of the history the table is showing. */
-const HistoryScope = Object.freeze({ Mine: "mine", Managed: "managed" } as const);
+/** Which slice of the history the table is showing. */
+const HistoryScope = Object.freeze({ All: "all", Mine: "mine", Managed: "managed" } as const);
 type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
 
+/** Newest first, by the moment the request was decided — falling back to when it was raised. */
+function resolvedOrSubmittedMs(row: MyAccessRequestRow): number {
+  return Date.parse(row.resolvedAt ?? row.submittedAt);
+}
+
 /**
- * "History" tab — decided requests, from two perspectives the viewer can switch between:
+ * "History" tab — decided requests, drawn from two sources:
  *
  *  - Mine: the caller's own terminal requests (everything but pending/approved, which live on the My
  *    requests tab).
- *  - Managed: the decided requests for the collections the caller manages — offered to anyone who
- *    can approve, and the only place they can undo a decision.
+ *  - Managed: the decided requests for the collections the caller manages — the only rows they can
+ *    undo a decision on.
  *
- * An untouched toggle lands on Managed whenever that side has rows, since this tab is aimed at the
- * approver and answering them with an empty table hides the history they came for behind a control
- * they have no reason to press. Nothing is rendered until both sides have answered, and the default
- * is fixed at that one moment rather than tracked: read off rows as they arrive, it would paint the
- * wrong half first, and a later background reload would swap the table — and the toggle's own
- * selection — out from under whoever is reading it.
+ * The tab opens on All, which lists both sources merged, and the toggle narrows that list to one
+ * source. Landing on everything means the reader is never answered with an empty table while their
+ * history sits behind a control they had no reason to press, and — unlike a default read off which
+ * side happens to have rows — the selection cannot move under them when a background load arrives.
  *
- * A toggle rather than one merged table. Merging them would put "a request I raised" and "a request I
- * decided" in the same list with the same columns but different available actions, so a row's
- * capabilities would depend on something invisible. Splitting keeps "what can I do to this row?"
- * answerable from what is on screen.
+ * Merging is safe because both sources are already the same row model, sorted on the same key. What
+ * differs is what a row permits: `managedIds` is the per-row authority, so a row carries the same
+ * actions under All as under the filter it came from, and a row the caller merely raised carries
+ * none. A request the caller raised against a collection they also manage is returned by both reads,
+ * so All de-duplicates by request id.
  *
- * Own rows are read-only, so `Mine` has no action column and no clock. `Managed` adds revoke (end a
- * lease the caller granted) and withdraw (take back an approval the requester has not started), both
- * of which the SDK serves.
+ * Own rows are read-only, so a caller with no approval privilege has no managed rows, gets no
+ * Actions column, and is shown no toggle — every option would be a filter over the same one list.
+ * `Managed` adds revoke (end a lease the caller granted) and withdraw (take back an approval the
+ * requester has not started), both of which the SDK serves.
  */
 @Component({
   selector: "pam-history-tab",
@@ -108,8 +113,8 @@ export class HistoryTabComponent {
     initialValue: false,
   });
 
-  /** The scope the viewer picked from the toggle, or null while the default below still applies. */
-  private readonly chosenScope = signal<HistoryScope | null>(null);
+  /** The filter the viewer picked from the toggle. */
+  private readonly selectedScope = signal<HistoryScope>(HistoryScope.All);
 
   /** Request ids currently being acted on, so a second click on the same row is a no-op. */
   private readonly acting = signal<Set<string>>(new Set());
@@ -132,59 +137,94 @@ export class HistoryTabComponent {
   });
 
   /**
-   * The half to open on, decided once both sides have answered and latched there — null until then,
-   * which is what the skeleton renders on.
+   * Latched true the first time every source the table draws from has finished loading — which is
+   * all the skeleton is waiting for, now that nothing about the opening view is read off the rows.
    *
-   * Each service's `loading$` starts true and clears when its `load()` resolves, but the shell only
-   * loads the inbox for a caller who can approve, so for everyone else that flag stays raised for
-   * the life of the page and cannot be waited on.
+   * Latched rather than tracked so a background reload cannot pull the table out from under whoever
+   * is reading it. Sampling the whole first load, rather than clearing as soon as any one source
+   * answers, also keeps All from rendering half its rows as though they were all of them.
    *
-   * Hence the sync date. `canApprove$` is derived from synced organization and collection state, so
-   * before the first sync lands it answers `false` for a genuine approver too, and taking that for a
-   * settled "not an approver" is what opened this tab on the wrong half. Nothing else on this path
-   * awaits the sync — the history route has no guard; `canViewApprovalsGuard` waits the same way for
-   * the same reason on the sibling tab.
+   * The shell only loads the inbox for a caller who can approve, so for everyone else that flag
+   * stays raised for the life of the page and cannot be waited on. `canApprove$` is derived from
+   * synced organization and collection state, so before the first sync lands it answers `false` for
+   * a genuine approver too; until a sync date exists a `false` there is not a settled "not an
+   * approver", and the inbox still has to be waited on. Nothing else on this path awaits the sync —
+   * the history route has no guard; `canViewApprovalsGuard` waits the same way for the same reason
+   * on the sibling tab.
    */
-  private readonly openingScope = toSignal(
+  private readonly historyLoaded = toSignal(
     combineLatest([
-      this.syncService.activeUserLastSync$(),
-      this.approvalPrivileges.canApprove$,
-      this.inbox.loading$,
       this.myAccess.loading$,
-      this.inbox.historyRows$,
+      this.inbox.loading$,
+      this.approvalPrivileges.canApprove$,
+      this.syncService.activeUserLastSync$(),
     ]).pipe(
       filter(
-        ([lastSync, canApprove, inboxLoading, myLoading]) =>
-          !myLoading && (canApprove ? !inboxLoading : lastSync != null),
+        ([myLoading, inboxLoading, canApprove, lastSync]) =>
+          !myLoading && !((canApprove || lastSync == null) && inboxLoading),
       ),
       take(1),
-      map(([, , , , managed]) => (managed.length > 0 ? HistoryScope.Managed : HistoryScope.Mine)),
+      map(() => true),
     ),
-    { initialValue: null as HistoryScope | null },
+    { initialValue: false },
   );
-
-  protected readonly historyReady = computed(() => this.openingScope() != null);
 
   private readonly hasManagedHistory = computed(() => this.managedRows().length > 0);
 
-  protected readonly scope = computed<HistoryScope>(
-    () => this.chosenScope() ?? this.openingScope() ?? HistoryScope.Mine,
-  );
-
   /**
    * The toggle is offered to anyone who can approve, rows or not — gating it on rows hides the
-   * second scope until it has content, which is exactly when the reader no longer needs telling it
-   * exists. The `hasManagedHistory()` term keeps it for a viewer who has managed rows but whom the
-   * privilege predicate does not recognise as an approver.
+   * filters until there is something to filter, which is exactly when the reader no longer needs
+   * telling they exist. The `hasManagedHistory()` term keeps it for a viewer who has managed rows
+   * but whom the privilege predicate does not recognise as an approver.
    */
   protected readonly canSwitchScope = computed(() => this.canApprove() || this.hasManagedHistory());
 
-  protected readonly showingManaged = computed(
-    () => this.scope() === HistoryScope.Managed && this.canSwitchScope(),
+  /** Falls back to All if the toggle goes away while a filter is applied. */
+  protected readonly scope = computed<HistoryScope>(() =>
+    this.canSwitchScope() ? this.selectedScope() : HistoryScope.All,
   );
 
-  protected readonly historyRows = computed(() =>
-    this.showingManaged() ? this.managedRows() : this.myRows(),
+  /** Both sources in one list, de-duplicated by request id and re-sorted on the shared key. */
+  private readonly allRows = computed(() => {
+    const rowsById = new Map(this.managedRows().map((row) => [String(row.id), row]));
+    for (const row of this.myRows()) {
+      const key = String(row.id);
+      if (!rowsById.has(key)) {
+        rowsById.set(key, row);
+      }
+    }
+    return [...rowsById.values()].sort(
+      (a, b) => resolvedOrSubmittedMs(b) - resolvedOrSubmittedMs(a),
+    );
+  });
+
+  protected readonly historyRows = computed(() => {
+    switch (this.scope()) {
+      case HistoryScope.Mine:
+        return this.myRows();
+      case HistoryScope.Managed:
+        return this.managedRows();
+      default:
+        return this.allRows();
+    }
+  });
+
+  protected readonly showSkeleton = computed(() => !this.historyLoaded());
+
+  /**
+   * Shown exactly when something in the current list can be acted on. Keyed off the listed rows
+   * rather than the viewer's privilege because an approver who has decided nothing yet, and the
+   * caller's own rows under "Raised by me", would otherwise get a column of nothing but dashes —
+   * and keyed off the rows rather than the scope because a request the caller raised against a
+   * collection they manage is actionable under every filter it appears in.
+   */
+  protected readonly showActionsColumn = computed(() => {
+    const managed = this.managedIds();
+    return this.historyRows().some((row) => managed.has(String(row.id)));
+  });
+
+  protected readonly emptyMessageKey = computed(() =>
+    this.scope() === HistoryScope.Managed ? "pamInboxHistoryEmpty" : "pamMyRequestsHistoryEmpty",
   );
 
   protected readonly historyDataSource = new TableDataSource<MyAccessRequestRow>();
@@ -198,15 +238,13 @@ export class HistoryTabComponent {
     });
   }
 
-  /** Pin the scope to the viewer's choice, so a later load cannot move them off it. */
   protected selectScope(scope: HistoryScope): void {
-    this.chosenScope.set(scope);
+    this.selectedScope.set(scope);
   }
 
   /** The decrypted cipher for a row, or undefined when it isn't in the caller's vault. */
   protected cipherFor(cipherId: string): CipherView | undefined {
-    const source = this.showingManaged() ? this.managedCiphers() : this.myCiphers();
-    return source.get(cipherId);
+    return this.myCiphers().get(cipherId) ?? this.managedCiphers().get(cipherId);
   }
 
   protected isActing(row: MyAccessRequestRow): boolean {
@@ -225,14 +263,13 @@ export class HistoryTabComponent {
    */
   protected canRevoke(row: MyAccessRequestRow): boolean {
     return (
-      this.showingManaged() && this.managedIds().has(String(row.id)) && isLiveManagedLease(row)
+      this.managedIds().has(String(row.id)) && isLiveManagedLease(row)
     );
   }
 
   /** An approval the requester has not started yet, so it can still be withdrawn. */
   protected canCancelApproval(row: MyAccessRequestRow): boolean {
     return (
-      this.showingManaged() &&
       this.managedIds().has(String(row.id)) &&
       row.status === "approved" &&
       row.producedLeaseId == null

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.ts
@@ -9,6 +9,7 @@ import {
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { RouterModule } from "@angular/router";
+import { combineLatest, filter, map, take } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -19,6 +20,8 @@ import {
   ButtonModule,
   DialogService,
   NoItemsModule,
+  SkeletonComponent,
+  SkeletonTextComponent,
   TableDataSource,
   TableModule,
   ToastService,
@@ -29,6 +32,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 
 import type { AccessLeaseId, AccessRequestId } from "../abstractions/access-lease";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
+import { ApprovalPrivilegeService } from "../approvals/approval-privilege.service";
 import { ApproverInboxService } from "../approvals/approver-inbox.service";
 import { isLiveManagedLease } from "../approvals/managed-lease-row";
 import { DurationShortPipe } from "../date/duration-short.pipe";
@@ -46,8 +50,14 @@ type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
  *
  *  - Mine: the caller's own terminal requests (everything but pending/approved, which live on the My
  *    requests tab).
- *  - Managed: the decided requests for the collections the caller manages — visible only to
- *    approvers, and the only place they can undo a decision.
+ *  - Managed: the decided requests for the collections the caller manages — offered to anyone who
+ *    can approve, and the only place they can undo a decision.
+ *
+ * An untouched toggle lands on Managed whenever that side has rows, since this tab is aimed at the
+ * approver and answering them with an empty table hides the history they came for behind a control
+ * they have no reason to press. Nothing is rendered until the managed side has answered: that
+ * default cannot be read off rows which have not arrived without painting the wrong half first and
+ * swapping it out from under the reader.
  *
  * A toggle rather than one merged table. Merging them would put "a request I raised" and "a request I
  * decided" in the same list with the same columns but different available actions, so a row's
@@ -70,6 +80,8 @@ type HistoryScope = (typeof HistoryScope)[keyof typeof HistoryScope];
     ButtonModule,
     IconComponent,
     NoItemsModule,
+    SkeletonComponent,
+    SkeletonTextComponent,
     TableModule,
     ToggleGroupModule,
     TypographyModule,
@@ -85,9 +97,16 @@ export class HistoryTabComponent {
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
+  private readonly approvalPrivileges = inject(ApprovalPrivilegeService);
 
   protected readonly HistoryScope = HistoryScope;
-  protected readonly scope = signal<HistoryScope>(HistoryScope.Mine);
+
+  private readonly canApprove = toSignal(this.approvalPrivileges.canApprove$, {
+    initialValue: false,
+  });
+
+  /** The scope the viewer picked from the toggle, or null while the default below still applies. */
+  private readonly chosenScope = signal<HistoryScope | null>(null);
 
   /** Request ids currently being acted on, so a second click on the same row is a no-op. */
   private readonly acting = signal<Set<string>>(new Set());
@@ -109,11 +128,42 @@ export class HistoryTabComponent {
     initialValue: new Map<string, CipherView>(),
   });
 
-  /** The Managed toggle only appears once there is managed history to show. */
-  protected readonly hasManagedHistory = computed(() => this.managedRows().length > 0);
+  /**
+   * Whether the managed side has answered, latched at the first answer so a later refresh cannot
+   * take the table away again. `ApproverInboxService.loading$` starts true and clears only once
+   * `load()` has run, which the shell defers until the approval privilege resolves and skips
+   * entirely for a member who cannot approve — so neither stream settles this on its own.
+   */
+  protected readonly historyReady = toSignal(
+    combineLatest([this.approvalPrivileges.canApprove$, this.inbox.loading$]).pipe(
+      filter(([canApprove, loading]) => !canApprove || !loading),
+      take(1),
+      map(() => true),
+    ),
+    { initialValue: false },
+  );
+
+  private readonly hasManagedHistory = computed(() => this.managedRows().length > 0);
+
+  /**
+   * The default half is derived rather than latched on first load, so it keeps tracking the managed
+   * rows until the viewer pins a scope of their own.
+   */
+  protected readonly scope = computed<HistoryScope>(
+    () =>
+      this.chosenScope() ?? (this.hasManagedHistory() ? HistoryScope.Managed : HistoryScope.Mine),
+  );
+
+  /**
+   * The toggle is offered to anyone who can approve, rows or not — gating it on rows hides the
+   * second scope until it has content, which is exactly when the reader no longer needs telling it
+   * exists. The `hasManagedHistory()` term keeps it for a viewer who has managed rows but whom the
+   * privilege predicate does not recognise as an approver.
+   */
+  protected readonly canSwitchScope = computed(() => this.canApprove() || this.hasManagedHistory());
 
   protected readonly showingManaged = computed(
-    () => this.scope() === HistoryScope.Managed && this.hasManagedHistory(),
+    () => this.scope() === HistoryScope.Managed && this.canSwitchScope(),
   );
 
   protected readonly historyRows = computed(() =>
@@ -122,10 +172,18 @@ export class HistoryTabComponent {
 
   protected readonly historyDataSource = new TableDataSource<MyAccessRequestRow>();
 
+  /** Five fills the space the table occupies without implying a row count the history may not have. */
+  protected readonly skeletonRows = [0, 1, 2, 3, 4];
+
   constructor() {
     effect(() => {
       this.historyDataSource.data = this.historyRows();
     });
+  }
+
+  /** Pin the scope to the viewer's choice, so a later load cannot move them off it. */
+  protected selectScope(scope: HistoryScope): void {
+    this.chosenScope.set(scope);
   }
 
   /** The decrypted cipher for a row, or undefined when it isn't in the caller's vault. */

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.spec.ts
@@ -10,6 +10,7 @@ import {
   extensionsByLeaseId,
   historyDisplayStatus,
   resolveResolver,
+  resolvedOrSubmittedMs,
   terminalStatusBadge,
   toLeaseRow,
   toRequestRow,
@@ -74,6 +75,23 @@ function lease(id: string, overrides: Record<string, unknown> = {}): AccessLease
 function names(overrides: Partial<ResolvedNames> = {}): ResolvedNames {
   return { ...emptyResolvedNames(), ...overrides };
 }
+
+describe("resolvedOrSubmittedMs", () => {
+  it("keys a decided request on when it was decided", () => {
+    expect(
+      resolvedOrSubmittedMs({
+        submittedAt: "2024-01-01T00:00:00.000Z",
+        resolvedAt: "2024-01-02T00:00:00.000Z",
+      }),
+    ).toBe(Date.parse("2024-01-02T00:00:00.000Z"));
+  });
+
+  it("falls back to when an undecided request was raised", () => {
+    expect(
+      resolvedOrSubmittedMs({ submittedAt: "2024-01-01T00:00:00.000Z", resolvedAt: null }),
+    ).toBe(Date.parse("2024-01-01T00:00:00.000Z"));
+  });
+});
 
 describe("terminalStatusBadge", () => {
   it.each([

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -102,6 +102,18 @@ type TerminalRequestStatus = Exclude<AccessRequestStatus, "pending" | "approved"
 /** Time an extension (or sum of extensions) added to a lease, and the resulting end (ms). */
 export type LeaseExtensionSummary = { addedSeconds: number; latestEndMs: number };
 
+/**
+ * The one sort key every history list is ordered by: when the request was decided, falling back to
+ * when it was raised so a row that was never decided keeps its place rather than being sent to the
+ * end. Shared by both sources and by the tab that merges them — a merge can only preserve an order
+ * its sources also used, so this has to be a single definition.
+ */
+export function resolvedOrSubmittedMs(
+  row: Pick<MyAccessRequestRow, "resolvedAt" | "submittedAt">,
+): number {
+  return Date.parse(row.resolvedAt ?? row.submittedAt);
+}
+
 /** Map a terminal status to its badge. Exported for tests + storybook fidelity. */
 export function terminalStatusBadge(status: TerminalRequestStatus): TerminalStatusBadge {
   switch (status) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
@@ -26,6 +26,7 @@ import {
   MyAccessRequestRow,
   buildMyAccessRequestRows,
   extensionsByLeaseId,
+  resolvedOrSubmittedMs,
   toLeaseRow,
   toRequestRow,
 } from "./my-access-row";
@@ -139,7 +140,7 @@ export class MyAccessService {
             !(r.status === "approved" && r.producedLeaseId == null) &&
             !(r.producedLeaseId != null && activeLeaseIds.has(r.producedLeaseId)),
         )
-        .sort((a, b) => timeOf(b) - timeOf(a))
+        .sort((a, b) => resolvedOrSubmittedMs(b) - resolvedOrSubmittedMs(a))
         .slice(0, MY_ACCESS_PAGE_LIMIT);
     }),
   );
@@ -253,11 +254,6 @@ export class MyAccessService {
     await this.requestsApi.activateAccessRequest(id);
     await this.load();
   }
-}
-
-/** Sort key for history: resolution time, falling back to submit time. */
-function timeOf(row: MyAccessRequestRow): number {
-  return Date.parse(row.resolvedAt ?? row.submittedAt);
 }
 
 /** The distinct cipher/collection refs across a set of requests + leases, for name resolution. */

--- a/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/approvals/approver-inbox.service.ts
@@ -35,6 +35,7 @@ import {
 import {
   MyAccessRequestRow,
   extensionsByLeaseId,
+  resolvedOrSubmittedMs,
   toRequestRow,
 } from "../access-requests/my-access-row";
 
@@ -291,13 +292,6 @@ function patchRequest(
   return requests.map((request) =>
     uuidAsString(request.id) === uuidAsString(id) ? { ...request, ...patch } : request,
   );
-}
-
-/** Sort key for history: when it was resolved, falling back to when it was submitted. */
-function resolvedOrSubmittedMs(
-  row: Pick<MyAccessRequestRow, "resolvedAt" | "submittedAt">,
-): number {
-  return Date.parse(row.resolvedAt ?? row.submittedAt);
 }
 
 /** The distinct cipher/collection refs across a set of requests, for name resolution. */


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-06-88122152`.

## 📔 Objective

Open History on **All**, and turn the two scopes into filters over that list.

- What was wrong: History opened on one of two scopes picked by inspecting the data — it landed on "For my collections" whenever that side had rows, otherwise on "Raised by me". The reviewer asked for an All option, for All to be the default, and for the two scopes to be filters the user applies rather than the landing state.
- What changed: the toggle is now `All | Raised by me | For my collections`, fixed to All on open. All lists both sources merged, de-duplicated by request id (a request the caller raised against a collection they manage comes back from both reads) and sorted newest first on the key both sources already sort by — `resolvedAt`, falling back to `submittedAt`.
- Actions stay per row, not per scope: `managedIds` decides whether a row offers Revoke / Withdraw approval, so a row carries the same actions under every filter it appears in, and a row the caller merely raised carries none. The Actions column renders only when something in the current list is actually actionable.
- The data-driven default is gone rather than left inert — the `openingScope` signal, its sampled `combineLatest`, and the comments describing that behaviour are deleted. The loading skeleton now keys off a first-load latch over the sources' own `loading$` flags instead of "a default has been chosen".
- Surface: `Password Manager -> Access requests -> History (scope toggle)`.
- Size: 5 files, 314 insertions(+), 148 deletions(-).
- Stack: sits on `pam/uat-t-history-withdraw-approval-confirm`; `my-requests-approved-to-active-access` sits on it.

"All" is proposed copy, not approved by a designer.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

Both shots captured at 1440x1024: before on `pam/uat`, after on this branch (`pam/uat-t-history-default-scope`).

The approver's own history was seeded for these shots, so both sources are non-empty and the merge is visible: the rows are QA fixtures, not organic data. Under All the table shows 45 rows — 43 managed + 5 raised by the approver, less the 3 a single de-duplication removes.

### Password Manager -> Access requests -> History (scope toggle)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/074b05d238daa213e72a4d192533a066f612e794/before-uat-FLW-06-88122152.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/a33b0be96a324bcc54296d8fee56defd89bab610/after-uat-FLW-06-88122152.png" alt="after" width="460"> |
