### PR TITLE
fix(pam): move an approved request out of Pending on My requests

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -114,6 +114,32 @@ export function resolvedOrSubmittedMs(
   return Date.parse(row.resolvedAt ?? row.submittedAt);
 }
 
+/**
+ * An approved request that can still be turned into access: not activated yet, and its activation
+ * window has not closed. The server refuses to activate a request past `leaseNotAfter`, so once
+ * that passes the grant can produce nothing and is no longer something the requester acts on.
+ */
+export function isRedeemableGrant(
+  row: Pick<MyAccessRequestRow, "status" | "producedLeaseId" | "leaseNotAfter">,
+  nowMs: number,
+): boolean {
+  return (
+    row.status === "approved" &&
+    row.producedLeaseId == null &&
+    Date.parse(row.leaseNotAfter) > nowMs
+  );
+}
+
+/**
+ * The status of a grant whose activation window closed before it was used. {@link
+ * historyDisplayStatus} is caller-agnostic and cannot see the clock, so it keeps reading "Approved"
+ * for a grant that can no longer produce access.
+ */
+export const lapsedGrantBadge: TerminalStatusBadge = {
+  labelKey: "pamStatusExpired",
+  variant: "warning",
+};
+
 /** Map a terminal status to its badge. Exported for tests + storybook fidelity. */
 export function terminalStatusBadge(status: TerminalRequestStatus): TerminalStatusBadge {
   switch (status) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
@@ -122,7 +122,7 @@ describe("MyAccessService", () => {
       it("puts pending and approved requests in pendingRows$", async () => {
         requestsApi.listMyAccessRequests.mockResolvedValue([
           request("req-1", { status: "pending" }),
-          request("req-2", { status: "approved" }),
+          request("req-2", { status: "approved", leaseNotAfter: "2999-01-01T00:00:00.000Z" }),
           request("req-3", { status: "denied" }),
         ]);
 
@@ -130,6 +130,31 @@ describe("MyAccessService", () => {
 
         const rows = await firstValueFrom(service.pendingRows$);
         expect(rows.map((r) => r.id)).toEqual(["req-1", "req-2"]);
+      });
+
+      it("moves a grant whose activation window has lapsed out of pendingRows$ and into history", async () => {
+        requestsApi.listMyAccessRequests.mockResolvedValue([
+          request("req-live", { status: "approved", leaseNotAfter: "2999-01-01T00:00:00.000Z" }),
+          request("req-lapsed", { status: "approved", leaseNotAfter: "2000-01-01T00:00:00.000Z" }),
+        ]);
+
+        await service.load();
+
+        expect((await firstValueFrom(service.pendingRows$)).map((r) => r.id)).toEqual(["req-live"]);
+        expect((await firstValueFrom(service.historyRows$)).map((r) => r.id)).toEqual([
+          "req-lapsed",
+        ]);
+      });
+
+      it("badges a grant that lapsed unactivated Expired rather than Approved", async () => {
+        requestsApi.listMyAccessRequests.mockResolvedValue([
+          request("req-lapsed", { status: "approved", leaseNotAfter: "2000-01-01T00:00:00.000Z" }),
+        ]);
+
+        await service.load();
+
+        const [row] = await firstValueFrom(service.historyRows$);
+        expect(row.statusBadge).toEqual({ labelKey: "pamStatusExpired", variant: "warning" });
       });
 
       it("includes only active leases in leases$", async () => {
@@ -148,7 +173,8 @@ describe("MyAccessService", () => {
       it("excludes pending/approved requests and one whose lease is still active from historyRows$", async () => {
         requestsApi.listMyAccessRequests.mockResolvedValue([
           request("req-1", { status: "denied" }), // terminal, no lease -> included
-          request("req-2", { status: "approved" }), // still actionable -> excluded (in Pending)
+          // still actionable -> excluded (in Pending)
+          request("req-2", { status: "approved", leaseNotAfter: "2999-01-01T00:00:00.000Z" }),
           request("req-3", { status: "pending" }), // still actionable -> excluded (in Pending)
           request("req-4", {
             status: "approved",

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
@@ -26,6 +26,8 @@ import {
   MyAccessRequestRow,
   buildMyAccessRequestRows,
   extensionsByLeaseId,
+  isRedeemableGrant,
+  lapsedGrantBadge,
   resolvedOrSubmittedMs,
   toLeaseRow,
   toRequestRow,
@@ -85,18 +87,23 @@ export class MyAccessService {
   );
 
   /**
-   * Requests the requester can still act on: still pending a decision, or approved and awaiting
-   * activation. Extension requests are surfaced separately (see {@link extensionRows$}), so
-   * {@link rows$} — which already folds them away — never mixes them in here.
+   * Requests the requester can still act on: still pending a decision, or approved and awaiting an
+   * activation that can still happen ({@link isRedeemableGrant}). A grant whose window lapsed
+   * unused is not one of them — it can mint nothing and offers no action, so it settles in
+   * {@link historyRows$} rather than being carried here forever. The window is read once per
+   * emission; a grant that lapses while the page is open moves on the next load, and the tab's own
+   * clock withholds its actions in the meantime.
+   *
+   * Extension requests are surfaced separately (see {@link extensionRows$}), so {@link rows$} —
+   * which already folds them away — never mixes them in here.
    */
   readonly pendingRows$: Observable<MyAccessRequestRow[]> = this.rows$.pipe(
-    map((rows) =>
-      rows
-        .filter(
-          (r) => r.status === "pending" || (r.status === "approved" && r.producedLeaseId == null),
-        )
-        .slice(0, MY_ACCESS_PAGE_LIMIT),
-    ),
+    map((rows) => {
+      const nowMs = Date.now();
+      return rows
+        .filter((r) => r.status === "pending" || isRedeemableGrant(r, nowMs))
+        .slice(0, MY_ACCESS_PAGE_LIMIT);
+    }),
   );
 
   /**
@@ -120,9 +127,13 @@ export class MyAccessService {
   );
 
   /**
-   * Terminal requests (everything but pending, and approved-but-not-yet-activated), newest first. A grant whose lease is
-   * still active is excluded — it belongs in Active leases, not both places — and returns here
-   * once the lease ends.
+   * Terminal requests (everything but pending, and a grant still awaiting an activation that can
+   * happen), newest first — the exact complement of {@link pendingRows$}, so a request is always in
+   * one of the two. A grant whose lease is still active is excluded on top of that: it belongs in
+   * Active leases, not both places, and returns here once the lease ends.
+   *
+   * An unactivated grant can only reach here by its window lapsing, which is not a state the
+   * caller-agnostic {@link historyDisplayStatus} can name, so its badge is corrected on the way in.
    *
    * Includes a denied extension, which {@link rows$} deliberately does not fold onto its grant: it
    * added nothing to the lease, so this is the only place the requester can see it (PM-42632).
@@ -132,13 +143,19 @@ export class MyAccessService {
     this.leases$,
   ]).pipe(
     map(([rows, leases]) => {
+      const nowMs = Date.now();
       const activeLeaseIds = new Set(leases.map((l) => uuidAsString(l.id)));
       return rows
         .filter(
           (r) =>
             r.status !== "pending" &&
-            !(r.status === "approved" && r.producedLeaseId == null) &&
+            !isRedeemableGrant(r, nowMs) &&
             !(r.producedLeaseId != null && activeLeaseIds.has(r.producedLeaseId)),
+        )
+        .map((r) =>
+          r.status === "approved" && r.producedLeaseId == null
+            ? { ...r, statusBadge: lapsedGrantBadge }
+            : r,
         )
         .sort((a, b) => resolvedOrSubmittedMs(b) - resolvedOrSubmittedMs(a))
         .slice(0, MY_ACCESS_PAGE_LIMIT);

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -191,7 +191,7 @@
         <ng-container header>
           <tr>
             <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-            <th bitCell bitSortable="notAfter" default="asc">{{ "pamColumnWindow" | i18n }}</th>
+            <th bitCell bitSortable="notAfter">{{ "pamColumnWindow" | i18n }}</th>
             <th bitCell>{{ "pamColumnStatus" | i18n }}</th>
             <th bitCell class="tw-w-32">
               <span class="tw-sr-only">{{ "pamColumnActions" | i18n }}</span>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -199,7 +199,7 @@
           </tr>
         </ng-container>
         <ng-template body let-rows$>
-          <tr bitRow *ngFor="let row of rows$ | async" [attr.data-testid]="rowTestId(row)">
+          <tr bitRow *ngFor="let row of rows$ | async" [attr.data-testid]="row.testId">
             <td bitCell>
               <div class="tw-flex tw-items-center tw-gap-3">
                 @if (cipherFor(row.cipherId); as cipher) {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -16,7 +16,9 @@
 <bit-accordion-group>
   <!-- Pending -->
   <bit-accordion [title]="'pamMyRequestsPendingSection' | i18n" [open]="true">
-    <span slot="end" bitBadge variant="secondary">{{ pendingRows().length }}</span>
+    <span slot="end" bitBadge variant="secondary" data-testid="my-access-pending-count">{{
+      pendingRows().length
+    }}</span>
 
     @if (pendingRows().length === 0) {
       <p bitTypography="body2" class="tw-mb-0 tw-text-muted" data-testid="my-access-pending-empty">
@@ -86,26 +88,6 @@
             <td bitCell>{{ row.submittedAt | date: "short" }}</td>
             <td bitCell>
               <div class="tw-flex tw-items-start tw-gap-2">
-                @if (canStart(row)) {
-                  <div class="tw-flex tw-flex-col tw-items-start tw-gap-1">
-                    <button
-                      type="button"
-                      bitButton
-                      buttonType="primary"
-                      size="small"
-                      class="tw-whitespace-nowrap"
-                      [loading]="isStarting(row.id)"
-                      [disabled]="isStarting(row.id)"
-                      (click)="activate(row)"
-                      [attr.data-testid]="'my-access-pending-start-' + row.id"
-                    >
-                      {{ "pamStartLeaseButton" | i18n }}
-                    </button>
-                    <span class="tw-text-xs tw-text-muted tw-whitespace-nowrap">
-                      {{ "pamActivateWithin" | i18n: (row.leaseNotAfter | remainingTime: nowMs()) }}
-                    </span>
-                  </div>
-                }
                 @if (canCancel(row)) {
                   <button
                     type="button"
@@ -195,82 +177,140 @@
   }
 
   <!-- Currently checked out (active leases) -->
-  <bit-accordion [title]="'pamMyRequestsGroupCheckedOut' | i18n">
-    <span slot="end" bitBadge variant="secondary">{{ leases().length }}</span>
+  <bit-accordion [title]="'pamMyRequestsGroupCheckedOut' | i18n" [open]="true">
+    <span slot="end" bitBadge variant="secondary" data-testid="my-access-active-count">{{
+      activeAccessRows().length
+    }}</span>
 
-    @if (leases().length === 0) {
+    @if (activeAccessRows().length === 0) {
       <p bitTypography="body2" class="tw-mb-0 tw-text-muted" data-testid="my-access-leases-empty">
         {{ "pamMyLeasesActiveEmpty" | i18n }}
       </p>
     } @else {
-      <bit-table [dataSource]="leasesDataSource">
+      <bit-table [dataSource]="activeAccessDataSource">
         <ng-container header>
           <tr>
             <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-            <th bitCell>{{ "pamColumnWindow" | i18n }}</th>
-            <th bitCell bitSortable="notAfter" default="asc">{{ "pamColumnRemaining" | i18n }}</th>
+            <th bitCell bitSortable="notAfter" default="asc">{{ "pamColumnWindow" | i18n }}</th>
+            <th bitCell>{{ "pamColumnStatus" | i18n }}</th>
             <th bitCell class="tw-w-32">
               <span class="tw-sr-only">{{ "pamColumnActions" | i18n }}</span>
             </th>
           </tr>
         </ng-container>
         <ng-template body let-rows$>
-          <tr
-            bitRow
-            *ngFor="let lease of rows$ | async"
-            [attr.data-testid]="'my-access-lease-' + lease.id"
-          >
+          <tr bitRow *ngFor="let row of rows$ | async" [attr.data-testid]="rowTestId(row)">
             <td bitCell>
               <div class="tw-flex tw-items-center tw-gap-3">
-                @if (cipherFor(lease.cipherId); as cipher) {
+                @if (cipherFor(row.cipherId); as cipher) {
                   <app-vault-icon [cipher]="cipher" />
                 }
                 <div>
-                  <a [routerLink]="['/pam/requests', lease.requestId]">{{
-                    lease.cipherName ?? lease.cipherId
+                  <a [routerLink]="['/pam/requests', row.requestId]">{{
+                    row.cipherName ?? row.cipherId
                   }}</a>
-                  @if (lease.collectionName) {
+                  @if (row.collectionName) {
                     <div class="tw-text-xs tw-text-muted">
-                      {{ "pamInboxInCollection" | i18n: lease.collectionName }}
+                      {{ "pamInboxInCollection" | i18n: row.collectionName }}
                     </div>
                   }
-                  @if (lease.extendedUntil) {
-                    <span
-                      bitBadge
-                      variant="secondary"
-                      class="tw-mt-1 tw-inline-block"
-                      [attr.data-testid]="'my-access-lease-extended-' + lease.id"
-                    >
-                      {{
-                        "pamExtendedBadge"
-                          | i18n
-                            : (lease.extendedBySeconds | durationShort)
-                            : (lease.extendedUntil | date: "short")
-                      }}
-                    </span>
+                  @if (row.lease; as lease) {
+                    @if (lease.extendedUntil) {
+                      <span
+                        bitBadge
+                        variant="secondary"
+                        class="tw-mt-1 tw-inline-block"
+                        [attr.data-testid]="'my-access-lease-extended-' + lease.id"
+                      >
+                        {{
+                          "pamExtendedBadge"
+                            | i18n
+                              : (lease.extendedBySeconds | durationShort)
+                              : (lease.extendedUntil | date: "short")
+                        }}
+                      </span>
+                    }
                   }
                 </div>
               </div>
             </td>
             <td bitCell>
-              {{ lease.notBefore | date: "short" }} &ndash; {{ lease.notAfter | date: "short" }}
+              @if (row.request != null && startsNow(row.request)) {
+                {{ "pamWindowUntil" | i18n: (row.notAfter | date: "short") }}
+              } @else {
+                {{ row.notBefore | date: "short" }} &ndash; {{ row.notAfter | date: "short" }}
+              }
             </td>
             <td bitCell>
-              <app-pam-access-state-badge [state]="leaseBadgeState(lease.id)" />
+              @if (row.lease; as lease) {
+                <app-pam-access-state-badge [state]="leaseBadgeState(lease.id)" />
+              } @else if (row.request; as request) {
+                @if (isReadyNow(request)) {
+                  <app-pam-access-state-badge [state]="readyBadge" />
+                } @else if (request.statusBadge; as badge) {
+                  <span
+                    bitBadge
+                    [variant]="badge.variant"
+                    [attr.data-testid]="'my-access-approved-status-' + request.id"
+                  >
+                    {{ badge.labelKey | i18n }}
+                  </span>
+                }
+                @if (canStart(request)) {
+                  <div class="tw-mt-1 tw-text-xs tw-text-muted tw-whitespace-nowrap">
+                    {{
+                      "pamActivateWithin" | i18n: (request.leaseNotAfter | remainingTime: nowMs())
+                    }}
+                  </div>
+                }
+              }
             </td>
             <td bitCell>
-              <button
-                type="button"
-                bitButton
-                buttonType="secondary"
-                size="small"
-                [loading]="isEnding(lease.id)"
-                [disabled]="isEnding(lease.id)"
-                (click)="endLease(lease)"
-                [attr.data-testid]="'my-access-end-' + lease.id"
-              >
-                {{ "pamEndLeaseButton" | i18n }}
-              </button>
+              @if (row.lease; as lease) {
+                <button
+                  type="button"
+                  bitButton
+                  buttonType="secondary"
+                  size="small"
+                  [loading]="isEnding(lease.id)"
+                  [disabled]="isEnding(lease.id)"
+                  (click)="endLease(lease)"
+                  [attr.data-testid]="'my-access-end-' + lease.id"
+                >
+                  {{ "pamEndLeaseButton" | i18n }}
+                </button>
+              } @else if (row.request; as request) {
+                <div class="tw-flex tw-items-start tw-gap-2">
+                  @if (canStart(request)) {
+                    <button
+                      type="button"
+                      bitButton
+                      buttonType="primary"
+                      size="small"
+                      class="tw-whitespace-nowrap"
+                      [loading]="isStarting(request.id)"
+                      [disabled]="isStarting(request.id)"
+                      (click)="activate(request)"
+                      [attr.data-testid]="'my-access-approved-start-' + request.id"
+                    >
+                      {{ "pamStartLeaseButton" | i18n }}
+                    </button>
+                  }
+                  @if (canCancel(request)) {
+                    <button
+                      type="button"
+                      bitButton
+                      buttonType="secondary"
+                      size="small"
+                      [disabled]="isCancelling(request.id)"
+                      (click)="cancel(request)"
+                      [attr.data-testid]="'my-access-approved-cancel-' + request.id"
+                    >
+                      {{ "cancel" | i18n }}
+                    </button>
+                  }
+                </div>
+              }
             </td>
           </tr>
         </ng-template>

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -160,7 +160,7 @@
     </bit-accordion>
   }
 
-  <!-- Currently checked out (active leases) -->
+  <!-- Your access: the leases held now, plus grants awaiting activation -->
   <bit-accordion [title]="'pamMyRequestsGroupCheckedOut' | i18n" [open]="true">
     <span slot="end" bitBadge variant="secondary" data-testid="my-access-active-count">{{
       activeAccessRows().length
@@ -174,7 +174,9 @@
       <bit-table [dataSource]="activeAccessDataSource">
         <ng-container header>
           <tr>
-            <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
+            <th bitCell bitSortable="cipherName" [fn]="byItemName">
+              {{ "pamColumnItem" | i18n }}
+            </th>
             <th bitCell>{{ "pamColumnWindow" | i18n }}</th>
             <th bitCell>{{ "pamColumnStatus" | i18n }}</th>
             <th bitCell class="tw-w-32">
@@ -241,7 +243,10 @@
                   </span>
                 }
                 @if (canStart(request)) {
-                  <div class="tw-mt-1 tw-text-xs tw-text-muted tw-whitespace-nowrap">
+                  <div
+                    class="tw-mt-1 tw-text-xs tw-text-muted tw-whitespace-nowrap"
+                    [id]="'my-access-approved-deadline-' + request.id"
+                  >
                     {{
                       "pamActivateWithin" | i18n: (request.leaseNotAfter | remainingTime: nowMs())
                     }}
@@ -275,6 +280,7 @@
                       [loading]="isStarting(request.id)"
                       [disabled]="isStarting(request.id)"
                       (click)="activate(request)"
+                      [attr.aria-describedby]="'my-access-approved-deadline-' + request.id"
                       [attr.data-testid]="'my-access-approved-start-' + request.id"
                     >
                       {{ "pamStartLeaseButton" | i18n }}

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -29,7 +29,6 @@
         <ng-container header>
           <tr>
             <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-            <th bitCell>{{ "pamColumnStatus" | i18n }}</th>
             <th bitCell>{{ "pamColumnRequestedWindow" | i18n }}</th>
             <th bitCell bitSortable="submittedAt" default="desc">
               {{ "pamColumnSubmitted" | i18n }}
@@ -61,21 +60,6 @@
                   }
                 </div>
               </div>
-            </td>
-            <td bitCell>
-              @if (pendingStatus(row); as status) {
-                @if (status.badgeState; as state) {
-                  <app-pam-access-state-badge [state]="state" />
-                } @else if (status.statusBadge; as badge) {
-                  <span
-                    bitBadge
-                    [variant]="badge.variant"
-                    [attr.data-testid]="'my-access-pending-status-' + row.id"
-                  >
-                    {{ badge.labelKey | i18n }}
-                  </span>
-                }
-              }
             </td>
             <td bitCell>
               @if (startsNow(row)) {
@@ -191,7 +175,7 @@
         <ng-container header>
           <tr>
             <th bitCell bitSortable="cipherName">{{ "pamColumnItem" | i18n }}</th>
-            <th bitCell bitSortable="notAfter">{{ "pamColumnWindow" | i18n }}</th>
+            <th bitCell>{{ "pamColumnWindow" | i18n }}</th>
             <th bitCell>{{ "pamColumnStatus" | i18n }}</th>
             <th bitCell class="tw-w-32">
               <span class="tw-sr-only">{{ "pamColumnActions" | i18n }}</span>
@@ -235,7 +219,7 @@
               </div>
             </td>
             <td bitCell>
-              @if (row.request != null && startsNow(row.request)) {
+              @if (row.request != null && isReadyNow(row.request)) {
                 {{ "pamWindowUntil" | i18n: (row.notAfter | date: "short") }}
               } @else {
                 {{ row.notBefore | date: "short" }} &ndash; {{ row.notAfter | date: "short" }}
@@ -247,7 +231,7 @@
               } @else if (row.request; as request) {
                 @if (isReadyNow(request)) {
                   <app-pam-access-state-badge [state]="readyBadge" />
-                } @else if (request.statusBadge; as badge) {
+                } @else if (grantBadge(request); as badge) {
                   <span
                     bitBadge
                     [variant]="badge.variant"

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -43,8 +43,6 @@ function requestRow(overrides: Record<string, unknown> = {}): MyAccessRequestRow
     cipherName: "Prod database",
     collectionName: "Production",
     status: "approved",
-    statusVariant: "info",
-    statusLabelKey: "pamStatusApproved",
     badgeState: null,
     statusBadge: { labelKey: "pamStatusApproved", variant: "success" },
     submittedAt: "2026-08-17T11:00:00.000Z",

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -16,6 +16,16 @@ import { MyRequestsTabComponent } from "./my-requests-tab.component";
 
 const LEASE_END = "2026-08-20T12:00:00.000Z";
 
+/**
+ * The ids of the once-a-second clocks a spied `setInterval` created, told apart from the
+ * zero-delay timers Angular's own scheduler queues during change detection.
+ */
+function secondlyIntervalIds(spy: jest.SpyInstance): unknown[] {
+  return spy.mock.results
+    .filter((_, index) => spy.mock.calls[index][1] === 1000)
+    .map((result) => result.value);
+}
+
 // Overrides are loosely typed rather than `Partial<MyAccessLeaseRow>`: the row's ids are opaque
 // branded types, so tests stand in plain strings and rely on the single cast below — the same
 // convention as `history-tab.component.spec.ts`.
@@ -93,6 +103,18 @@ describe("MyRequestsTabComponent", () => {
     return [...rows].map((row) => row.getAttribute("data-testid"));
   }
 
+  /** Click the active-access table's Item header, toggling its sort the way a user would. */
+  function sortActiveAccessByItem(): void {
+    const anyRow = fixture.nativeElement.querySelector(
+      'tr[data-testid^="my-access-lease-"], tr[data-testid^="my-access-approved-"]',
+    ) as HTMLElement;
+    const header = anyRow
+      .closest("table")!
+      .querySelector("th[bitSortable] button") as HTMLButtonElement;
+    header.click();
+    fixture.detectChanges();
+  }
+
   beforeEach(async () => {
     jest.useFakeTimers();
     pendingRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
@@ -130,6 +152,7 @@ describe("MyRequestsTabComponent", () => {
   afterEach(() => {
     fixture?.destroy();
     jest.useRealTimers();
+    jest.restoreAllMocks();
   });
 
   describe("active lease countdown", () => {
@@ -394,6 +417,78 @@ describe("MyRequestsTabComponent", () => {
 
       expect(query('[data-testid="my-access-pending-empty"]')).not.toBeNull();
       expect(query('[data-testid="my-access-approved-req-1"]')).not.toBeNull();
+    });
+  });
+
+  describe("sorting the active access by item", () => {
+    beforeEach(() => {
+      jest.setSystemTime(new Date("2026-08-20T11:30:00.000Z"));
+      pendingRows$.next([
+        requestRow({ id: "req-alpha", cipherName: "Alpha DB" }),
+        requestRow({ id: "req-zebra", cipherName: "Zebra DB" }),
+      ]);
+      leases$.next([leaseRow({ id: "lease-1", cipherName: "Prod database" })]);
+    });
+
+    it("keeps held access ahead of grants when sorted A to Z", () => {
+      create();
+
+      sortActiveAccessByItem();
+
+      expect(activeAccessRowIds()).toEqual([
+        "my-access-lease-lease-1",
+        "my-access-approved-req-alpha",
+        "my-access-approved-req-zebra",
+      ]);
+    });
+
+    it("keeps held access ahead of grants when the sort is reversed", () => {
+      create();
+
+      sortActiveAccessByItem();
+      sortActiveAccessByItem();
+
+      expect(activeAccessRowIds()).toEqual([
+        "my-access-lease-lease-1",
+        "my-access-approved-req-zebra",
+        "my-access-approved-req-alpha",
+      ]);
+    });
+  });
+
+  describe("the countdown clock", () => {
+    it("runs no clock at all when nothing on the tab has a window to lapse", () => {
+      const setIntervalSpy = jest.spyOn(global, "setInterval");
+      leases$.next([leaseRow()]);
+
+      create();
+
+      expect(secondlyIntervalIds(setIntervalSpy)).toHaveLength(1); // the badge's own, not a second
+    });
+
+    it("shares one clock with the badges it renders, and tears it down on destroy", () => {
+      const setIntervalSpy = jest.spyOn(global, "setInterval");
+      const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+      pendingRows$.next([requestRow()]);
+      leases$.next([leaseRow()]);
+
+      create();
+
+      const [intervalId] = secondlyIntervalIds(setIntervalSpy);
+      expect(secondlyIntervalIds(setIntervalSpy)).toHaveLength(1);
+      expect(clearIntervalSpy).not.toHaveBeenCalledWith(intervalId);
+
+      fixture.destroy();
+
+      expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId);
+    });
+
+    it("holds no clock when there is neither a request nor a lease to watch", () => {
+      const setIntervalSpy = jest.spyOn(global, "setInterval");
+
+      create();
+
+      expect(secondlyIntervalIds(setIntervalSpy)).toHaveLength(0);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -86,6 +86,13 @@ describe("MyRequestsTabComponent", () => {
     return fixture.nativeElement.querySelector(selector) as HTMLElement | null;
   }
 
+  function activeAccessRowIds(): (string | null)[] {
+    const rows = fixture.nativeElement.querySelectorAll(
+      'tr[data-testid^="my-access-lease-"], tr[data-testid^="my-access-approved-"]',
+    ) as NodeListOf<HTMLElement>;
+    return [...rows].map((row) => row.getAttribute("data-testid"));
+  }
+
   beforeEach(async () => {
     jest.useFakeTimers();
     pendingRows$ = new BehaviorSubject<MyAccessRequestRow[]>([]);
@@ -394,6 +401,24 @@ describe("MyRequestsTabComponent", () => {
       expect(query('[data-testid="access-state-badge-ready"]')).toBeNull();
       expect(query('[data-testid="my-access-approved-start-req-1"]')).toBeNull();
       expect(query('[data-testid="my-access-approved-cancel-req-1"]')).toBeNull();
+    });
+
+    it("orders held access soonest-ending first, ahead of grants awaiting activation", () => {
+      pendingRows$.next([
+        requestRow({ id: "req-lapsed", leaseNotAfter: "2026-08-19T11:30:00.000Z" }),
+      ]);
+      leases$.next([
+        leaseRow({ id: "lease-late", notAfter: "2026-08-20T18:00:00.000Z" }),
+        leaseRow({ id: "lease-soon" }),
+      ]);
+
+      create();
+
+      expect(activeAccessRowIds()).toEqual([
+        "my-access-lease-lease-soon",
+        "my-access-lease-lease-late",
+        "my-access-approved-req-lapsed",
+      ]);
     });
 
     it("shows the Pending empty state when the only request is approved", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -277,59 +277,6 @@ describe("MyRequestsTabComponent", () => {
     });
   });
 
-  describe("Pending table status column", () => {
-    // The section mixes both statuses, so placement under the "Pending" heading cannot state which
-    // one a row is (PM-41841).
-    it("badges a request still awaiting a decision as pending", () => {
-      pendingRows$.next([
-        requestRow({ id: "req-p", status: "pending", badgeState: { kind: "pending" } }),
-      ]);
-
-      create();
-
-      expect(query('[data-testid="access-state-badge-pending"]')).not.toBeNull();
-      expect(query('[data-testid="my-access-pending-status-req-p"]')).toBeNull();
-    });
-
-    it("badges an approved request awaiting activation as approved", () => {
-      pendingRows$.next([
-        requestRow({
-          id: "req-a",
-          status: "approved",
-          badgeState: null,
-          statusBadge: { labelKey: "pamStatusApproved", variant: "success" },
-        }),
-      ]);
-
-      create();
-
-      const badge = query('[data-testid="my-access-pending-status-req-a"]');
-      expect(badge?.textContent?.trim()).toBe("pamStatusApproved");
-    });
-
-    it("badges an approved request whose window has lapsed as expired, not approved", () => {
-      jest.setSystemTime(new Date("2026-08-20T12:00:00.000Z"));
-      pendingRows$.next([
-        requestRow({
-          id: "req-l",
-          status: "approved",
-          leaseNotAfter: "2026-08-20T11:00:00.000Z",
-          badgeState: null,
-          statusBadge: { labelKey: "pamStatusApproved", variant: "success" },
-        }),
-      ]);
-
-      create();
-
-      // Start and Cancel are both withheld once the window lapses, so the badge is the only thing
-      // left that can explain why the row has no actions.
-      const badge = query('[data-testid="my-access-pending-status-req-l"]');
-      expect(badge?.textContent?.trim()).toBe("pamStatusExpired");
-      expect(query('[data-testid="my-access-pending-start-req-l"]')).toBeNull();
-      expect(query('[data-testid="my-access-pending-cancel-req-l"]')).toBeNull();
-    });
-  });
-
   describe("Pending section empty state", () => {
     it("shows the empty-state message when there is nothing pending", () => {
       create();
@@ -401,6 +348,25 @@ describe("MyRequestsTabComponent", () => {
       expect(query('[data-testid="access-state-badge-ready"]')).toBeNull();
       expect(query('[data-testid="my-access-approved-start-req-1"]')).toBeNull();
       expect(query('[data-testid="my-access-approved-cancel-req-1"]')).toBeNull();
+    });
+
+    it("badges a grant whose window has lapsed Expired rather than Approved", () => {
+      pendingRows$.next([requestRow({ leaseNotAfter: "2026-08-19T11:30:00.000Z" })]);
+
+      create();
+
+      const status = query('[data-testid="my-access-approved-status-req-1"]')!;
+      expect(status.textContent).toContain("pamStatusExpired");
+      expect(status.textContent).not.toContain("pamStatusApproved");
+    });
+
+    it("drops the open-ended 'Until' window once a grant can no longer be started", () => {
+      pendingRows$.next([requestRow({ leaseNotAfter: "2026-08-19T11:30:00.000Z" })]);
+
+      create();
+
+      const row = query('[data-testid="my-access-approved-req-1"]')!;
+      expect(row.textContent).not.toContain("pamWindowUntil");
     });
 
     it("orders held access soonest-ending first, ahead of grants awaiting activation", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -45,6 +45,8 @@ function requestRow(overrides: Record<string, unknown> = {}): MyAccessRequestRow
     status: "approved",
     statusVariant: "info",
     statusLabelKey: "pamStatusApproved",
+    badgeState: null,
+    statusBadge: { labelKey: "pamStatusApproved", variant: "success" },
     submittedAt: "2026-08-17T11:00:00.000Z",
     resolvedAt: "2026-08-17T11:05:00.000Z",
     leaseNotBefore: "2026-08-17T11:00:00.000Z",
@@ -329,6 +331,80 @@ describe("MyRequestsTabComponent", () => {
 
       expect(query('[data-testid="my-access-pending-empty"]')).not.toBeNull();
       expect(fixture.nativeElement.textContent).toContain("pamMyRequestsPendingEmpty");
+    });
+  });
+
+  describe("grouping an approved request", () => {
+    beforeEach(() => {
+      jest.setSystemTime(new Date("2026-08-20T11:30:00.000Z"));
+    });
+
+    it("renders an approved, unactivated request with the active access rather than Pending", () => {
+      pendingRows$.next([requestRow(), requestRow({ id: "req-pending", status: "pending" })]);
+
+      create();
+
+      expect(query('[data-testid="my-access-approved-req-1"]')).not.toBeNull();
+      expect(query('[data-testid="my-access-pending-req-1"]')).toBeNull();
+      expect(query('[data-testid="my-access-pending-req-pending"]')).not.toBeNull();
+    });
+
+    it("counts undecided rows under Pending and approved rows with the active access", () => {
+      pendingRows$.next([requestRow(), requestRow({ id: "req-pending", status: "pending" })]);
+      leases$.next([leaseRow()]);
+
+      create();
+
+      expect(query('[data-testid="my-access-pending-count"]')!.textContent).toContain("1");
+      expect(query('[data-testid="my-access-active-count"]')!.textContent).toContain("2");
+    });
+
+    it("never renders a Start button inside the Pending table", () => {
+      pendingRows$.next([requestRow(), requestRow({ id: "req-pending", status: "pending" })]);
+
+      create();
+
+      expect(query('[data-testid^="my-access-pending-start-"]')).toBeNull();
+      expect(query('[data-testid="my-access-approved-start-req-1"]')).not.toBeNull();
+    });
+
+    it("badges a grant inside its window 'Ready to use'", () => {
+      pendingRows$.next([requestRow()]);
+
+      create();
+
+      expect(query('[data-testid="access-state-badge-ready"]')).not.toBeNull();
+    });
+
+    it("does not claim readiness before the window opens", () => {
+      pendingRows$.next([requestRow({ leaseNotBefore: "2026-08-21T11:30:00.000Z" })]);
+
+      create();
+
+      expect(query('[data-testid="access-state-badge-ready"]')).toBeNull();
+      expect(query('[data-testid="my-access-approved-status-req-1"]')!.textContent).toContain(
+        "pamStatusApproved",
+      );
+    });
+
+    it("keeps a grant whose window has lapsed visible, with nothing to start or cancel", () => {
+      pendingRows$.next([requestRow({ leaseNotAfter: "2026-08-19T11:30:00.000Z" })]);
+
+      create();
+
+      expect(query('[data-testid="my-access-approved-req-1"]')).not.toBeNull();
+      expect(query('[data-testid="access-state-badge-ready"]')).toBeNull();
+      expect(query('[data-testid="my-access-approved-start-req-1"]')).toBeNull();
+      expect(query('[data-testid="my-access-approved-cancel-req-1"]')).toBeNull();
+    });
+
+    it("shows the Pending empty state when the only request is approved", () => {
+      pendingRows$.next([requestRow()]);
+
+      create();
+
+      expect(query('[data-testid="my-access-pending-empty"]')).not.toBeNull();
+      expect(query('[data-testid="my-access-approved-req-1"]')).not.toBeNull();
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
@@ -218,7 +218,8 @@ export const ApprovedNotYetRedeemable: Story = {
 
 /**
  * An approved grant nobody activated before its window lapsed. It still has to be visible
- * somewhere, so it stays with the active access, badged "Approved" with no action offered.
+ * somewhere, so it stays with the active access, badged "Approved" with no action offered — below
+ * the lease the caller actually holds, even though its window ended first.
  */
 export const ApprovedWindowLapsed: Story = {
   decorators: [
@@ -237,7 +238,15 @@ export const ApprovedWindowLapsed: Story = {
           ),
         ],
         extensions: [],
-        leases: [],
+        leases: [
+          toLeaseRow(
+            accessLease({
+              notBefore: liveFromNow(-15 * MINUTE),
+              notAfter: liveFromNow(20 * MINUTE),
+            }),
+            names,
+          ),
+        ],
       }),
     }),
   ],

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
@@ -217,9 +217,9 @@ export const ApprovedNotYetRedeemable: Story = {
 };
 
 /**
- * An approved grant nobody activated before its window lapsed. It still has to be visible
- * somewhere, so it stays with the active access, badged "Expired" with no action offered — below
- * the lease the caller actually holds, even though its window ended first.
+ * An approved grant whose window lapsed while the tab was open — the next load moves it to History.
+ * Until then it stays with the active access, badged "Expired" with no action offered, below the
+ * lease the caller actually holds even though its own window ended first.
  */
 export const ApprovedWindowLapsed: Story = {
   decorators: [

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
@@ -218,7 +218,7 @@ export const ApprovedNotYetRedeemable: Story = {
 
 /**
  * An approved grant nobody activated before its window lapsed. It still has to be visible
- * somewhere, so it stays with the active access, badged "Approved" with no action offered — below
+ * somewhere, so it stays with the active access, badged "Expired" with no action offered — below
  * the lease the caller actually holds, even though its window ended first.
  */
 export const ApprovedWindowLapsed: Story = {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
@@ -30,7 +30,7 @@ const names = storyNames();
  */
 function content() {
   const pending = [
-    // Approved and ready to activate: the Start button is live.
+    // Approved and ready to activate: renders in the active-access section, badged "Ready to use".
     toRequestRow(
       accessRequest({
         id: "req-approved",
@@ -151,7 +151,10 @@ export default {
 
 type Story = StoryObj<MyRequestsTabComponent>;
 
-/** All three sections populated: a startable grant, a pending request, an extension, two leases. */
+/**
+ * All three sections populated. The startable grant sits with the two leases under the last
+ * heading, not under Pending, which holds only the request still awaiting a decision.
+ */
 export const Default: Story = {
   decorators: [myAccess()],
 };
@@ -186,8 +189,9 @@ export const ActiveLeaseOnly: Story = {
 };
 
 /**
- * An approved grant whose window has not opened yet: it cannot be started, so the row shows when it
- * becomes redeemable rather than an inert Start button.
+ * An approved grant whose window has not opened yet. It is badged "Approved" rather than "Ready to
+ * use", but Start access is still offered — `canStart` does not read `leaseNotBefore`, and the
+ * product deliberately lets the requester try and surfaces the server's refusal.
  */
 export const ApprovedNotYetRedeemable: Story = {
   decorators: [
@@ -201,6 +205,33 @@ export const ApprovedNotYetRedeemable: Story = {
               leaseNotBefore: liveFromNow(DAY),
               leaseNotAfter: liveFromNow(DAY + 2 * HOUR),
               resolvedAt: liveFromNow(-MINUTE),
+            }),
+            names,
+          ),
+        ],
+        extensions: [],
+        leases: [],
+      }),
+    }),
+  ],
+};
+
+/**
+ * An approved grant nobody activated before its window lapsed. It still has to be visible
+ * somewhere, so it stays with the active access, badged "Approved" with no action offered.
+ */
+export const ApprovedWindowLapsed: Story = {
+  decorators: [
+    myAccess({
+      content: () => ({
+        pending: [
+          toRequestRow(
+            accessRequest({
+              id: "req-lapsed",
+              status: "approved",
+              leaseNotBefore: liveFromNow(-2 * HOUR),
+              leaseNotAfter: liveFromNow(-HOUR),
+              resolvedAt: liveFromNow(-3 * HOUR),
             }),
             names,
           ),

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -174,12 +174,12 @@ export class MyRequestsTabComponent implements OnInit {
    * `status` alone: a clock-dependent split (`canStart`) would drop a grant whose activation
    * window has lapsed out of both sections.
    */
-  protected readonly approvedRows = computed(() =>
+  private readonly approvedRows = computed(() =>
     this.filteredPending().filter((row) => row.status !== "pending"),
   );
 
   protected readonly extensionRows = computed(() => this.applyFilters(this.allExtensions()));
-  protected readonly leases = computed(() => this.applyFilters(this.allLeases()));
+  private readonly leases = computed(() => this.applyFilters(this.allLeases()));
 
   /**
    * Deliberately depends on `approvedRows` and `leases` only, never on `nowMs()`: a per-tick

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -2,17 +2,15 @@ import { CommonModule } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
-  NgZone,
-  OnInit,
   computed,
   effect,
   inject,
   signal,
 } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { RouterModule } from "@angular/router";
+import { EMPTY, switchMap } from "rxjs";
 
 import { IconComponent } from "@bitwarden/angular/vault/components/icon.component";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -28,6 +26,8 @@ import {
   DialogService,
   NoItemsModule,
   SearchModule,
+  SortDirection,
+  SortFn,
   TableDataSource,
   TableModule,
   ToastService,
@@ -37,11 +37,18 @@ import { I18nPipe } from "@bitwarden/ui-common";
 
 import { AccessLeaseId, AccessRequestId, activateAccessErrorMessageKey } from "..";
 import { AccessBadgeState } from "../access-state-badge/access-badge-state";
+import { AccessBadgeTickerService } from "../access-state-badge/access-badge-ticker.service";
 import { AccessStateBadgeComponent } from "../access-state-badge/access-state-badge.component";
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { RemainingTimePipe } from "../date/remaining-time.pipe";
 
-import { MyAccessLeaseRow, MyAccessRequestRow, TerminalStatusBadge } from "./my-access-row";
+import {
+  MyAccessLeaseRow,
+  MyAccessRequestRow,
+  TerminalStatusBadge,
+  isRedeemableGrant,
+  lapsedGrantBadge,
+} from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
 
 /** A row carrying the id + collection fields the toolbar filters against. */
@@ -71,13 +78,6 @@ type ActiveAccessRow = {
 /** Ascending by window end; meaningful only within one row kind. */
 const byWindowEnd = (a: ActiveAccessRow, b: ActiveAccessRow): number =>
   Date.parse(a.notAfter) - Date.parse(b.notAfter);
-
-/**
- * Substituted for the row model's badge once a grant's activation window has lapsed. The model's
- * badge is caller-agnostic and cannot see the clock, so it keeps reading "Approved" for a grant that
- * can no longer produce access.
- */
-const lapsedGrantBadge: TerminalStatusBadge = { labelKey: "pamStatusExpired", variant: "warning" };
 
 /**
  * "My requests" tab — the caller's own PAM access, grouped into three accordion sections mirroring
@@ -115,22 +115,19 @@ const lapsedGrantBadge: TerminalStatusBadge = { labelKey: "pamStatusExpired", va
     RemainingTimePipe,
   ],
 })
-export class MyRequestsTabComponent implements OnInit {
+export class MyRequestsTabComponent {
   private readonly myAccess = inject(MyAccessService);
   private readonly i18nService = inject(I18nService);
   private readonly toastService = inject(ToastService);
   private readonly logService = inject(LogService);
   private readonly dialogService = inject(DialogService);
-  private readonly destroyRef = inject(DestroyRef);
-  private readonly ngZone = inject(NgZone);
+  private readonly ticker = inject(AccessBadgeTickerService);
 
   protected readonly cancelling = signal<Set<AccessRequestId>>(new Set());
   /** Ids of approved requests currently being activated (prevents double-click). */
   protected readonly starting = signal<Set<AccessRequestId>>(new Set());
   /** Ids of active leases currently being ended (prevents double-click). */
   protected readonly ending = signal<Set<AccessLeaseId>>(new Set());
-  /** Ticks once a second so the redemption/remaining countdowns stay live. */
-  protected readonly nowMs = signal(Date.now());
 
   /** Free-text search across item + collection names; the Collection filter selects one collection. */
   protected readonly searchControl = new FormControl<string>("", { nonNullable: true });
@@ -150,6 +147,22 @@ export class MyRequestsTabComponent implements OnInit {
   private readonly allLeases = toSignal(this.myAccess.leases$, {
     initialValue: [] as MyAccessLeaseRow[],
   });
+
+  /**
+   * Ticks once a second so the redemption/remaining countdowns stay live. Shares the one clock the
+   * badges already run on, and only observes it while a request is listed — the leases on this tab
+   * carry their own countdowns, so a tab showing nothing but held access leaves that clock torn
+   * down rather than scheduling a round of change detection every second that can change nothing.
+   *
+   * Gated on the unfiltered requests rather than on anything downstream of the clock, which would
+   * feed the clock back into itself.
+   */
+  protected readonly nowMs = toSignal(
+    toObservable(computed(() => this.allPending().length > 0)).pipe(
+      switchMap((anyRequests) => (anyRequests ? this.ticker.ticks$ : EMPTY)),
+    ),
+    { initialValue: Date.now() },
+  );
 
   /** Decrypted gated ciphers keyed by id; the template reads these to render an item's favicon. */
   private readonly cipherById = toSignal(this.myAccess.cipherById$, {
@@ -194,10 +207,10 @@ export class MyRequestsTabComponent implements OnInit {
    * (see {@link leaseBadgeStates}).
    *
    * Held leases come first, and the Window column is not sortable, because `notAfter` means "when
-   * held access ends" on a lease but "activation deadline" on a grant. Ordering the merged set by it
-   * alone floats a grant whose window has already lapsed — one that grants nothing and offers no
-   * action — above live access, and nothing ever clears such a row: `MyAccessService.pendingRows$`
-   * keeps it and `historyRows$` excludes it.
+   * held access ends" on a lease but "activation deadline" on a grant. Ordering the merged set by
+   * it alone floats a grant the caller has not started — including, until the next load drops it,
+   * one whose window has already lapsed — above the access they actually hold. The Item column is
+   * sortable but keeps the same grouping; see {@link byItemName}.
    */
   protected readonly activeAccessRows = computed<ActiveAccessRow[]>(() => {
     const held: ActiveAccessRow[] = this.leases().map((lease) => ({
@@ -245,6 +258,23 @@ export class MyRequestsTabComponent implements OnInit {
   protected readonly readyBadge: AccessBadgeState = { kind: "ready" };
 
   /**
+   * The Item column's sort. `bit-table` multiplies a custom comparator's result by its own
+   * direction modifier, so the "held access first" term is pre-multiplied to cancel that out and
+   * hold in both directions; the item name only decides within a group.
+   */
+  protected readonly byItemName: SortFn = (
+    a: ActiveAccessRow,
+    b: ActiveAccessRow,
+    direction?: SortDirection,
+  ): number => {
+    const grouping = (a.lease == null ? 1 : 0) - (b.lease == null ? 1 : 0);
+    if (grouping !== 0) {
+      return direction === "desc" ? -grouping : grouping;
+    }
+    return (a.cipherName ?? "").localeCompare(b.cipherName ?? "");
+  };
+
+  /**
    * Each table renders from its own data source so `bit-table` can sort the rows independently.
    */
   protected readonly pendingDataSource = new TableDataSource<MyAccessRequestRow>();
@@ -260,16 +290,6 @@ export class MyRequestsTabComponent implements OnInit {
     });
     effect(() => {
       this.activeAccessDataSource.data = this.activeAccessRows();
-    });
-  }
-
-  ngOnInit(): void {
-    // Keep the countdown clock outside the Angular zone: a periodic in-zone timer never lets NgZone
-    // settle, which would hang `fixture.whenStable()` for any host that embeds this view. The signal
-    // write still drives change detection on its own.
-    this.ngZone.runOutsideAngular(() => {
-      const intervalId = setInterval(() => this.nowMs.set(Date.now()), 1000);
-      this.destroyRef.onDestroy(() => clearInterval(intervalId));
     });
   }
 
@@ -331,11 +351,7 @@ export class MyRequestsTabComponent implements OnInit {
     if (row.status === "pending") {
       return true;
     }
-    return (
-      row.status === "approved" &&
-      row.producedLeaseId == null &&
-      Date.parse(row.leaseNotAfter) > this.nowMs()
-    );
+    return isRedeemableGrant(row, this.nowMs());
   }
 
   /**
@@ -343,11 +359,7 @@ export class MyRequestsTabComponent implements OnInit {
    * lapses the server rejects activation, so the Start button must not be offered.
    */
   protected canStart(row: MyAccessRequestRow): boolean {
-    return (
-      row.status === "approved" &&
-      row.producedLeaseId == null &&
-      Date.parse(row.leaseNotAfter) > this.nowMs()
-    );
+    return isRedeemableGrant(row, this.nowMs());
   }
 
   /**

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -57,6 +57,7 @@ type FilterableRow = {
  * are flattened onto the row because `bit-table` sorts on top-level row properties.
  */
 type ActiveAccessRow = {
+  readonly testId: string;
   readonly requestId: AccessRequestId;
   readonly cipherId: string;
   readonly cipherName: string | null;
@@ -157,18 +158,20 @@ export class MyRequestsTabComponent implements OnInit {
       .sort((a, b) => a.label.localeCompare(b.label));
   });
 
+  private readonly filteredPending = computed(() => this.applyFilters(this.allPending()));
+
   /** Rows still awaiting an approver's decision — the only thing "Pending" holds. */
   protected readonly pendingRows = computed(() =>
-    this.applyFilters(this.allPending()).filter((row) => row.status === "pending"),
+    this.filteredPending().filter((row) => row.status === "pending"),
   );
 
   /**
-   * Approved and awaiting activation. The exact complement of {@link pendingRows} over the
-   * service's `pendingRows$`, split on `status` alone: a clock-dependent split (`canStart`) would
-   * drop a grant whose activation window has lapsed out of both sections.
+   * Approved and awaiting activation. The exact complement of {@link pendingRows}, split on
+   * `status` alone: a clock-dependent split (`canStart`) would drop a grant whose activation
+   * window has lapsed out of both sections.
    */
   protected readonly approvedRows = computed(() =>
-    this.applyFilters(this.allPending()).filter((row) => row.status !== "pending"),
+    this.filteredPending().filter((row) => row.status !== "pending"),
   );
 
   protected readonly extensionRows = computed(() => this.applyFilters(this.allExtensions()));
@@ -181,6 +184,7 @@ export class MyRequestsTabComponent implements OnInit {
    */
   protected readonly activeAccessRows = computed<ActiveAccessRow[]>(() => [
     ...this.approvedRows().map((request) => ({
+      testId: `my-access-approved-${request.id}`,
       requestId: request.id,
       cipherId: request.cipherId,
       cipherName: request.cipherName,
@@ -191,6 +195,7 @@ export class MyRequestsTabComponent implements OnInit {
       request,
     })),
     ...this.leases().map((lease) => ({
+      testId: `my-access-lease-${lease.id}`,
       requestId: lease.requestId,
       cipherId: lease.cipherId,
       cipherName: lease.cipherName,
@@ -276,12 +281,6 @@ export class MyRequestsTabComponent implements OnInit {
 
   protected leaseBadgeState(id: AccessLeaseId): AccessBadgeState | null {
     return this.leaseBadgeStates().get(id) ?? null;
-  }
-
-  protected rowTestId(row: ActiveAccessRow): string {
-    return row.lease == null
-      ? `my-access-approved-${row.requestId}`
-      : `my-access-lease-${row.lease.id}`;
   }
 
   protected isCancelling(id: AccessRequestId): boolean {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -41,7 +41,7 @@ import { AccessStateBadgeComponent } from "../access-state-badge/access-state-ba
 import { DurationShortPipe } from "../date/duration-short.pipe";
 import { RemainingTimePipe } from "../date/remaining-time.pipe";
 
-import { MyAccessLeaseRow, MyAccessRequestRow, terminalStatusBadge } from "./my-access-row";
+import { MyAccessLeaseRow, MyAccessRequestRow, TerminalStatusBadge } from "./my-access-row";
 import { MyAccessService } from "./my-access.service";
 
 /** A row carrying the id + collection fields the toolbar filters against. */
@@ -71,6 +71,13 @@ type ActiveAccessRow = {
 /** Ascending by window end; meaningful only within one row kind. */
 const byWindowEnd = (a: ActiveAccessRow, b: ActiveAccessRow): number =>
   Date.parse(a.notAfter) - Date.parse(b.notAfter);
+
+/**
+ * Substituted for the row model's badge once a grant's activation window has lapsed. The model's
+ * badge is caller-agnostic and cannot see the clock, so it keeps reading "Approved" for a grant that
+ * can no longer produce access.
+ */
+const lapsedGrantBadge: TerminalStatusBadge = { labelKey: "pamStatusExpired", variant: "warning" };
 
 /**
  * "My requests" tab — the caller's own PAM access, grouped into three accordion sections mirroring
@@ -186,10 +193,10 @@ export class MyRequestsTabComponent implements OnInit {
    * rebuild would hand every badge a fresh input object every second and restart its countdown
    * (see {@link leaseBadgeStates}).
    *
-   * Held leases come first, and the Window column carries no default sort, because `notAfter` means
-   * "when held access ends" on a lease but "activation deadline" on a grant. Ordering the merged set
-   * by it alone floats a grant whose window has already lapsed — one that grants nothing and offers
-   * no action — above live access, and nothing ever clears such a row: `MyAccessService.pendingRows$`
+   * Held leases come first, and the Window column is not sortable, because `notAfter` means "when
+   * held access ends" on a lease but "activation deadline" on a grant. Ordering the merged set by it
+   * alone floats a grant whose window has already lapsed — one that grants nothing and offers no
+   * action — above live access, and nothing ever clears such a row: `MyAccessService.pendingRows$`
    * keeps it and `historyRows$` excludes it.
    */
   protected readonly activeAccessRows = computed<ActiveAccessRow[]>(() => {
@@ -332,25 +339,6 @@ export class MyRequestsTabComponent implements OnInit {
   }
 
   /**
-   * The status badge for a row in the Pending table, which holds two statuses: still awaiting a
-   * decision, and approved but not yet activated.
-   *
-   * Reads the row model's own badge, except for an approved request whose window has already
-   * lapsed. The row model is deliberately time-agnostic because it also feeds the approver
-   * surfaces, while this table withholds both Start and Cancel from a lapsed row — so badging it
-   * "Approved" would promise access the row can no longer produce. It reads as Expired instead,
-   * the label History gives it once the server expires it.
-   */
-  protected pendingStatus(
-    row: MyAccessRequestRow,
-  ): Pick<MyAccessRequestRow, "badgeState" | "statusBadge"> {
-    if (row.status === "approved" && row.producedLeaseId == null && !this.canStart(row)) {
-      return { badgeState: null, statusBadge: terminalStatusBadge("expired") };
-    }
-    return { badgeState: row.badgeState, statusBadge: row.statusBadge };
-  }
-
-  /**
    * An approved request is startable only while its window can still produce access; once the window
    * lapses the server rejects activation, so the Start button must not be offered.
    */
@@ -368,6 +356,14 @@ export class MyRequestsTabComponent implements OnInit {
    */
   protected isReadyNow(row: MyAccessRequestRow): boolean {
     return this.canStart(row) && this.startsNow(row);
+  }
+
+  /**
+   * The Status badge for a grant awaiting activation. A lapsed grant sits in the same section as the
+   * access the caller holds, so it must not keep the model's green "Approved".
+   */
+  protected grantBadge(row: MyAccessRequestRow): TerminalStatusBadge | null {
+    return this.canStart(row) ? row.statusBadge : lapsedGrantBadge;
   }
 
   protected async cancel(row: MyAccessRequestRow): Promise<void> {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -213,7 +213,7 @@ export class MyRequestsTabComponent {
    * sortable but keeps the same grouping; see {@link byItemName}.
    */
   protected readonly activeAccessRows = computed<ActiveAccessRow[]>(() => {
-    const held: ActiveAccessRow[] = this.leases().map((lease) => ({
+    const held: ActiveAccessRow[] = this.leases().map((lease): ActiveAccessRow => ({
       testId: `my-access-lease-${lease.id}`,
       requestId: lease.requestId,
       cipherId: lease.cipherId,
@@ -224,7 +224,7 @@ export class MyRequestsTabComponent {
       lease,
       request: null,
     }));
-    const granted: ActiveAccessRow[] = this.approvedRows().map((request) => ({
+    const granted: ActiveAccessRow[] = this.approvedRows().map((request): ActiveAccessRow => ({
       testId: `my-access-approved-${request.id}`,
       requestId: request.id,
       cipherId: request.cipherId,

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -52,11 +52,28 @@ type FilterableRow = {
 };
 
 /**
+ * A row of the active-access table. Exactly one of `lease` / `request` is set: a lease the caller
+ * holds right now, or an approved request they have not activated yet. `cipherName` / `notAfter`
+ * are flattened onto the row because `bit-table` sorts on top-level row properties.
+ */
+type ActiveAccessRow = {
+  readonly requestId: AccessRequestId;
+  readonly cipherId: string;
+  readonly cipherName: string | null;
+  readonly collectionName: string | null;
+  readonly notBefore: string;
+  readonly notAfter: string;
+  readonly lease: MyAccessLeaseRow | null;
+  readonly request: MyAccessRequestRow | null;
+};
+
+/**
  * "My requests" tab — the caller's own PAM access, grouped into three accordion sections mirroring
  * the design:
- *  - Pending — requests still awaiting a decision, or approved and awaiting activation.
+ *  - Pending — requests still awaiting an approver's decision.
  *  - Extension requests — open requests to extend a lease already held.
- *  - Currently checked out — the leases the caller holds right now.
+ *  - Currently checked out — the leases the caller holds right now, together with approved grants
+ *    the caller has not activated yet.
  *
  * Data, name resolution, and optimistic cancel/end live in {@link MyAccessService} (provided on the
  * shell route and shared across tabs); this component owns only the view: the live countdown clock,
@@ -140,9 +157,50 @@ export class MyRequestsTabComponent implements OnInit {
       .sort((a, b) => a.label.localeCompare(b.label));
   });
 
-  protected readonly pendingRows = computed(() => this.applyFilters(this.allPending()));
+  /** Rows still awaiting an approver's decision — the only thing "Pending" holds. */
+  protected readonly pendingRows = computed(() =>
+    this.applyFilters(this.allPending()).filter((row) => row.status === "pending"),
+  );
+
+  /**
+   * Approved and awaiting activation. The exact complement of {@link pendingRows} over the
+   * service's `pendingRows$`, split on `status` alone: a clock-dependent split (`canStart`) would
+   * drop a grant whose activation window has lapsed out of both sections.
+   */
+  protected readonly approvedRows = computed(() =>
+    this.applyFilters(this.allPending()).filter((row) => row.status !== "pending"),
+  );
+
   protected readonly extensionRows = computed(() => this.applyFilters(this.allExtensions()));
   protected readonly leases = computed(() => this.applyFilters(this.allLeases()));
+
+  /**
+   * Deliberately depends on `approvedRows` and `leases` only, never on `nowMs()`: a per-tick
+   * rebuild would hand every badge a fresh input object every second and restart its countdown
+   * (see {@link leaseBadgeStates}). `bit-table`'s default sort orders the merged set by `notAfter`.
+   */
+  protected readonly activeAccessRows = computed<ActiveAccessRow[]>(() => [
+    ...this.approvedRows().map((request) => ({
+      requestId: request.id,
+      cipherId: request.cipherId,
+      cipherName: request.cipherName,
+      collectionName: request.collectionName,
+      notBefore: request.leaseNotBefore,
+      notAfter: request.leaseNotAfter,
+      lease: null,
+      request,
+    })),
+    ...this.leases().map((lease) => ({
+      requestId: lease.requestId,
+      cipherId: lease.cipherId,
+      cipherName: lease.cipherName,
+      collectionName: lease.collectionName,
+      notBefore: lease.notBefore,
+      notAfter: lease.notAfter,
+      lease,
+      request: null,
+    })),
+  ]);
 
   /**
    * Badge state is memoised per lease so the shared badge component sees a stable input across the
@@ -160,12 +218,15 @@ export class MyRequestsTabComponent implements OnInit {
       ),
   );
 
+  /** A stable identity so the badge input does not churn; the `ready` state carries no payload. */
+  protected readonly readyBadge: AccessBadgeState = { kind: "ready" };
+
   /**
    * Each table renders from its own data source so `bit-table` can sort the rows independently.
    */
   protected readonly pendingDataSource = new TableDataSource<MyAccessRequestRow>();
   protected readonly extensionDataSource = new TableDataSource<MyAccessRequestRow>();
-  protected readonly leasesDataSource = new TableDataSource<MyAccessLeaseRow>();
+  protected readonly activeAccessDataSource = new TableDataSource<ActiveAccessRow>();
 
   constructor() {
     effect(() => {
@@ -175,7 +236,7 @@ export class MyRequestsTabComponent implements OnInit {
       this.extensionDataSource.data = this.extensionRows();
     });
     effect(() => {
-      this.leasesDataSource.data = this.leases();
+      this.activeAccessDataSource.data = this.activeAccessRows();
     });
   }
 
@@ -215,6 +276,12 @@ export class MyRequestsTabComponent implements OnInit {
 
   protected leaseBadgeState(id: AccessLeaseId): AccessBadgeState | null {
     return this.leaseBadgeStates().get(id) ?? null;
+  }
+
+  protected rowTestId(row: ActiveAccessRow): string {
+    return row.lease == null
+      ? `my-access-approved-${row.requestId}`
+      : `my-access-lease-${row.lease.id}`;
   }
 
   protected isCancelling(id: AccessRequestId): boolean {
@@ -283,6 +350,14 @@ export class MyRequestsTabComponent implements OnInit {
       row.producedLeaseId == null &&
       Date.parse(row.leaseNotAfter) > this.nowMs()
     );
+  }
+
+  /**
+   * The grant can be started right now: approved, unactivated, and inside its window. Only then is
+   * "Ready to use" a true statement about the access the viewer holds.
+   */
+  protected isReadyNow(row: MyAccessRequestRow): boolean {
+    return this.canStart(row) && this.startsNow(row);
   }
 
   protected async cancel(row: MyAccessRequestRow): Promise<void> {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -68,6 +68,10 @@ type ActiveAccessRow = {
   readonly request: MyAccessRequestRow | null;
 };
 
+/** Ascending by window end; meaningful only within one row kind. */
+const byWindowEnd = (a: ActiveAccessRow, b: ActiveAccessRow): number =>
+  Date.parse(a.notAfter) - Date.parse(b.notAfter);
+
 /**
  * "My requests" tab — the caller's own PAM access, grouped into three accordion sections mirroring
  * the design:
@@ -180,21 +184,16 @@ export class MyRequestsTabComponent implements OnInit {
   /**
    * Deliberately depends on `approvedRows` and `leases` only, never on `nowMs()`: a per-tick
    * rebuild would hand every badge a fresh input object every second and restart its countdown
-   * (see {@link leaseBadgeStates}). `bit-table`'s default sort orders the merged set by `notAfter`.
+   * (see {@link leaseBadgeStates}).
+   *
+   * Held leases come first, and the Window column carries no default sort, because `notAfter` means
+   * "when held access ends" on a lease but "activation deadline" on a grant. Ordering the merged set
+   * by it alone floats a grant whose window has already lapsed — one that grants nothing and offers
+   * no action — above live access, and nothing ever clears such a row: `MyAccessService.pendingRows$`
+   * keeps it and `historyRows$` excludes it.
    */
-  protected readonly activeAccessRows = computed<ActiveAccessRow[]>(() => [
-    ...this.approvedRows().map((request) => ({
-      testId: `my-access-approved-${request.id}`,
-      requestId: request.id,
-      cipherId: request.cipherId,
-      cipherName: request.cipherName,
-      collectionName: request.collectionName,
-      notBefore: request.leaseNotBefore,
-      notAfter: request.leaseNotAfter,
-      lease: null,
-      request,
-    })),
-    ...this.leases().map((lease) => ({
+  protected readonly activeAccessRows = computed<ActiveAccessRow[]>(() => {
+    const held: ActiveAccessRow[] = this.leases().map((lease) => ({
       testId: `my-access-lease-${lease.id}`,
       requestId: lease.requestId,
       cipherId: lease.cipherId,
@@ -204,8 +203,20 @@ export class MyRequestsTabComponent implements OnInit {
       notAfter: lease.notAfter,
       lease,
       request: null,
-    })),
-  ]);
+    }));
+    const granted: ActiveAccessRow[] = this.approvedRows().map((request) => ({
+      testId: `my-access-approved-${request.id}`,
+      requestId: request.id,
+      cipherId: request.cipherId,
+      cipherName: request.cipherName,
+      collectionName: request.collectionName,
+      notBefore: request.leaseNotBefore,
+      notAfter: request.leaseNotAfter,
+      lease: null,
+      request,
+    }));
+    return [...held.sort(byWindowEnd), ...granted.sort(byWindowEnd)];
+  });
 
   /**
    * Badge state is memoised per lease so the shared badge component sees a stable input across the


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-05-7bf3e221`.

## 📔 Objective

Move an approved request out of Pending on My requests.

- What was wrong: Verified at pam/uat, my-requests-tab.component.html:17-110: the "Pending" accordion holds every row that is not yet a live lease, including approved ones - the rows that render the Start access button
- Surface: `Web vault -> Access requests -> My requests`.
- Size: 4 files, 375 insertions(+), 77 deletions(-).
- Stack: sits on `pam/uat-t-history-default-scope`; `active-access-section-copy` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

Captured at 1440x1024 (the column-ladder pair at 1024x836, its defect width). Before is `pam/uat`; after is the assembled stack tip, so the after side shows this change alongside the rest of the stack.

### Web vault -> Access requests -> My requests

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/4fdf2669fb82a13cb573deced765db9f4cf7f47f/before-uat-FLW-05-7bf3e221.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/1a11f8d4d5f8db059df4c75b1f8d1a75284325fe/after-uat-FLW-05-7bf3e221.png" alt="after" width="460"> |


## Known gaps

- CI here inherits failures already on `pam/uat` (`Run tests`, `Rust lint`, two cloud builds) plus a pre-existing `tsc-strict` error in `access-rule-edit.component.spec.ts` from #22635. None originate in this stack: the PAM suite passes on the assembled tip, 67 suites and 792 tests.

## Supersedes the Pending Status column from PM-41841

This PR removes the `pamColumnStatus` column, `pendingStatus()`, and the accompanying
`Pending table status column` spec block that `0650d731af` ([PM-41841] Show a per-row status in the
My requests pending table) added to `pam/uat`.

That is deliberate, and it was decided by the UAT reviewer rather than inferred.

The two changes answer the same problem in incompatible ways. PM-41841 keeps approved requests in the
Pending table and adds a Status column so a reader can tell "awaiting decision" from "approved,
awaiting activation". This PR removes approved requests from Pending altogether, into Active access
beside the leases the caller already holds. PM-41841's own test states its premise: "The section mixes
both statuses, so placement under the 'Pending' heading cannot state which one a row is." This PR
removes that mixing, which makes the column redundant: after the split every Pending row has the same
status, so the column renders one identical chip on every row under a heading that already says
Pending, and `pendingStatus()`'s approved branch is unreachable.

Nothing PM-41841 conveys is lost. The status follows its rows into Active access, which carries its
own Status column, and the "lapsed approved grant reads Expired, not Approved" rule it introduced is
preserved there through `grantBadge()`. Before PM-41841 the Pending table had no status column at all,
so this restores that shape rather than inventing one.

Rendered Pending columns after this change: `Item`, `Requested window`, `Submitted`, `Actions`.

PM-41841's author should still sanity-check this, since it removes a column they shipped.


[PM-41841]: https://bitwarden.atlassian.net/browse/PM-41841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ