### PR TITLE
fix(pam): retitle the My requests checked-out section "Active access"

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17061,9 +17061,6 @@
   "pamAccessRuleDeactivateConfirmContent": {
     "message": "This rule will stop applying to new access requests."
   },
-  "pamAccessRuleSaveErrorBody": {
-    "message": "Something went wrong. Your rule wasn't saved, but your information is still here. Try again."
-  },
   "pamAccessRuleSaveErrorGeneric": {
     "message": "Something went wrong. Your rule wasn't saved, but your information is still here."
   },
@@ -17247,23 +17244,11 @@
   "pamMyRequestsLoadError": {
     "message": "Could not load your requests"
   },
-  "pamMyRequestsEmptyTitle": {
-    "message": "No requests yet"
-  },
-  "pamMyRequestsEmptyDescription": {
-    "message": "You haven't submitted any access requests."
-  },
-  "pamMyLeasesActiveSection": {
-    "message": "Active leases"
-  },
   "pamMyRequestsPendingSection": {
     "message": "Pending"
   },
   "pamMyRequestsPendingEmpty": {
     "message": "No pending requests"
-  },
-  "pamMyRequestsHistorySection": {
-    "message": "History"
   },
   "pamMyRequestsHistoryEmpty": {
     "message": "No request history"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17238,8 +17238,11 @@
   "pamMyRequestsGroupExtensions": {
     "message": "Extension requests"
   },
-  "pamMyRequestsGroupCheckedOut": {
-    "message": "Currently checked out"
+  "pamMyRequestsActiveAccessSection": {
+    "message": "Active access"
+  },
+  "pamMyRequestsActiveAccessEmpty": {
+    "message": "No active access"
   },
   "pamMyRequestsLoadError": {
     "message": "Could not load your requests"
@@ -17252,9 +17255,6 @@
   },
   "pamMyLeasesActiveSection": {
     "message": "Active leases"
-  },
-  "pamMyLeasesActiveEmpty": {
-    "message": "No active leases"
   },
   "pamMyRequestsPendingSection": {
     "message": "Pending"

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access-row.ts
@@ -51,7 +51,7 @@ export type MyAccessRequestRow = {
   /**
    * The raw id of the lease this request minted when activated, or null if it never produced one.
    * Used to fold an extension onto its original and to exclude the row from History while that
-   * lease is still active (shown in Active leases instead).
+   * lease is still active (shown in Active access instead).
    */
   producedLeaseId: string | null;
   /**
@@ -168,7 +168,7 @@ export function terminalStatusBadge(status: TerminalRequestStatus): TerminalStat
  * `canceled` and `revoked` are distinct lease statuses, so the label reads straight off
  * `producedLeaseStatus`: the requester ending their own lease is "Canceled", an operator ending it
  * out from under them is "Revoked". An `active` produced lease is labelled like a live grant — callers exclude it from History (it
- * belongs in Active leases) but the detail page's top status field can still render it correctly.
+ * belongs in Active access) but the detail page's top status field can still render it correctly.
  */
 export function historyDisplayStatus(
   request: Pick<AccessRequestView, "status" | "producedLeaseId" | "producedLeaseStatus">,

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.spec.ts
@@ -180,7 +180,7 @@ describe("MyAccessService", () => {
             status: "approved",
             producedLeaseId: "lease-1",
             producedLeaseStatus: "active",
-          }), // lease still active -> excluded (in Active leases)
+          }), // lease still active -> excluded (in Active access)
           request("req-5", {
             status: "approved",
             producedLeaseId: "lease-2",

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-access.service.ts
@@ -130,7 +130,7 @@ export class MyAccessService {
    * Terminal requests (everything but pending, and a grant still awaiting an activation that can
    * happen), newest first — the exact complement of {@link pendingRows$}, so a request is always in
    * one of the two. A grant whose lease is still active is excluded on top of that: it belongs in
-   * Active leases, not both places, and returns here once the lease ends.
+   * Active access, not both places, and returns here once the lease ends.
    *
    * An unactivated grant can only reach here by its window lapsing, which is not a state the
    * caller-agnostic {@link historyDisplayStatus} can name, so its badge is corrected on the way in.
@@ -230,7 +230,7 @@ export class MyAccessService {
   }
 
   /**
-   * End the caller's own active lease early. Optimistically drops the lease from Active leases and
+   * End the caller's own active lease early. Optimistically drops the lease from Active access and
    * marks its originating request's produced lease `canceled` — the status the server records for a
    * self-service end, as against `revoked` for an operator ending it — so the grant reappears in
    * History labelled "Canceled" straight away; then calls the API and, on failure, restores both

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -167,7 +167,7 @@
     }}</span>
 
     @if (activeAccessRows().length === 0) {
-      <p bitTypography="body2" class="tw-mb-0 tw-text-muted" data-testid="my-access-leases-empty">
+      <p bitTypography="body2" class="tw-mb-0 tw-text-muted" data-testid="my-access-active-empty">
         {{ "pamMyRequestsActiveAccessEmpty" | i18n }}
       </p>
     } @else {

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.html
@@ -160,15 +160,15 @@
     </bit-accordion>
   }
 
-  <!-- Your access: the leases held now, plus grants awaiting activation -->
-  <bit-accordion [title]="'pamMyRequestsGroupCheckedOut' | i18n" [open]="true">
+  <!-- Active access -->
+  <bit-accordion [title]="'pamMyRequestsActiveAccessSection' | i18n" [open]="true">
     <span slot="end" bitBadge variant="secondary" data-testid="my-access-active-count">{{
       activeAccessRows().length
     }}</span>
 
     @if (activeAccessRows().length === 0) {
       <p bitTypography="body2" class="tw-mb-0 tw-text-muted" data-testid="my-access-leases-empty">
-        {{ "pamMyLeasesActiveEmpty" | i18n }}
+        {{ "pamMyRequestsActiveAccessEmpty" | i18n }}
       </p>
     } @else {
       <bit-table [dataSource]="activeAccessDataSource">

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -309,11 +309,17 @@ describe("MyRequestsTabComponent", () => {
     });
   });
 
-  describe("Active access section empty state", () => {
+  describe("Active access section", () => {
+    it("renders the section title", () => {
+      create();
+
+      expect(fixture.nativeElement.textContent).toContain("pamMyRequestsActiveAccessSection");
+    });
+
     it("shows the empty-state message when no access is active", () => {
       create();
 
-      expect(query('[data-testid="my-access-leases-empty"]')).not.toBeNull();
+      expect(query('[data-testid="my-access-active-empty"]')).not.toBeNull();
       expect(fixture.nativeElement.textContent).toContain("pamMyRequestsActiveAccessEmpty");
     });
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.spec.ts
@@ -309,6 +309,15 @@ describe("MyRequestsTabComponent", () => {
     });
   });
 
+  describe("Active access section empty state", () => {
+    it("shows the empty-state message when no access is active", () => {
+      create();
+
+      expect(query('[data-testid="my-access-leases-empty"]')).not.toBeNull();
+      expect(fixture.nativeElement.textContent).toContain("pamMyRequestsActiveAccessEmpty");
+    });
+  });
+
   describe("grouping an approved request", () => {
     beforeEach(() => {
       jest.setSystemTime(new Date("2026-08-20T11:30:00.000Z"));

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.stories.ts
@@ -160,8 +160,8 @@ export const Default: Story = {
 };
 
 /**
- * Nothing outstanding. Pending and Currently checked out carry their own empty state; Extension
- * requests renders nothing at all — it never shows once `extensionRows()` is empty.
+ * Nothing outstanding. Pending and Active access carry their own empty state; Extension requests
+ * renders nothing at all — it never shows once `extensionRows()` is empty.
  */
 export const Empty: Story = {
   decorators: [myAccess({ content: empty })],

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -84,8 +84,8 @@ const byWindowEnd = (a: ActiveAccessRow, b: ActiveAccessRow): number =>
  * the design:
  *  - Pending — requests still awaiting an approver's decision.
  *  - Extension requests — open requests to extend a lease already held.
- *  - Active access — the leases the caller holds right now, together with approved grants
- *    the caller has not activated yet.
+ *  - Active access — the leases the caller holds right now, together with approved grants the
+ *    caller has not activated yet.
  *
  * Data, name resolution, and optimistic cancel/end live in {@link MyAccessService} (provided on the
  * shell route and shared across tabs); this component owns only the view: the live countdown clock,

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/my-requests-tab.component.ts
@@ -84,7 +84,7 @@ const byWindowEnd = (a: ActiveAccessRow, b: ActiveAccessRow): number =>
  * the design:
  *  - Pending — requests still awaiting an approver's decision.
  *  - Extension requests — open requests to extend a lease already held.
- *  - Currently checked out — the leases the caller holds right now, together with approved grants
+ *  - Active access — the leases the caller holds right now, together with approved grants
  *    the caller has not activated yet.
  *
  * Data, name resolution, and optimistic cancel/end live in {@link MyAccessService} (provided on the

--- a/bitwarden_license/bit-web/src/app/pam/pam.allium
+++ b/bitwarden_license/bit-web/src/app/pam/pam.allium
@@ -1466,8 +1466,8 @@ surface ActiveLeasesPage {
     -- Caller's currently-active leases with per-row revoke (used by lease
     -- holders to end their own access early) and extension.
     --
-    -- No page of its own. Both actions it provides ARE reachable: the "Active
-    -- access" section of my-requests-tab.component ends a lease, and
+    -- No page of its own. Both actions it provides ARE reachable: the
+    -- "Active access" section of my-requests-tab.component ends a lease, and
     -- cipher-view-banner.component ends or extends the lease on the item itself
     -- (through extend-lease-dialog.component). This surface is kept as the domain
     -- statement of what a lease holder may do to their own lease, independently of

--- a/bitwarden_license/bit-web/src/app/pam/pam.allium
+++ b/bitwarden_license/bit-web/src/app/pam/pam.allium
@@ -1466,8 +1466,8 @@ surface ActiveLeasesPage {
     -- Caller's currently-active leases with per-row revoke (used by lease
     -- holders to end their own access early) and extension.
     --
-    -- No page of its own. Both actions it provides ARE reachable: the "Currently
-    -- checked out" section of my-requests-tab.component ends a lease, and
+    -- No page of its own. Both actions it provides ARE reachable: the "Active
+    -- access" section of my-requests-tab.component ends a lease, and
     -- cipher-view-banner.component ends or extends the lease on the item itself
     -- (through extend-lease-dialog.component). This surface is kept as the domain
     -- statement of what a lease holder may do to their own lease, independently of


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-02-943b8fee`.

## 📔 Objective

Retitle the My requests checked-out section "Active access".

- What was wrong: Verified at pam/uat: pamMyRequestsGroupCheckedOut is "Currently checked out" and its empty state pamMyLeasesActiveEmpty is "No active leases" - two different vocabularies for one concept, on one scree
- Surface: `Web vault -> Access requests -> My requests (section headers)`.
- Size: 6 files, 23 insertions(+), 14 deletions(-).
- Stack: sits on `pam/uat-t-my-requests-approved-to-active-access`; `request-window-error-field-association` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

Captured at 1440x1024 (the column-ladder pair at 1024x836, its defect width). Before is `pam/uat`; after is the assembled stack tip, so the after side shows this change alongside the rest of the stack.

### Web vault -> Access requests -> My requests (section headers)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/44dbe9d1f26ba9fdeeb47c4c140fe320a04c812e/before-uat-FLW-02-943b8fee.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/33dd25e5fdbab6ca73a98abf0dd810ac14d65805/after-uat-FLW-02-943b8fee.png" alt="after" width="460"> |


## Known gaps

- CI here inherits failures already on `pam/uat` (`Run tests`, `Rust lint`, two cloud builds) plus a pre-existing `tsc-strict` error in `access-rule-edit.component.spec.ts` from #22635. None originate in this stack: the PAM suite passes on the assembled tip, 67 suites and 792 tests.
