### PR TITLE
fix(pam): render the request-window errors on the End time field

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -229,7 +229,7 @@
                     id="pam-cipher-view-banner_input_start"
                   />
                 </bit-form-field>
-                <bit-form-field>
+                <bit-form-field [attr.data-testid]="windowErrorTestId()">
                   <bit-label>{{ "requestAccessModalEnd" | i18n }}</bit-label>
                   <input
                     bitInput
@@ -239,22 +239,6 @@
                   />
                 </bit-form-field>
               </div>
-
-              @if (windowEndBeforeStart()) {
-                <p
-                  bitTypography="helper"
-                  class="tw-text-danger"
-                  data-testid="window-end-before-start"
-                >
-                  {{ "requestAccessModalEndBeforeStart" | i18n }}
-                </p>
-              } @else if (windowExceedsMax()) {
-                <p bitTypography="helper" class="tw-text-danger" data-testid="window-exceeds-max">
-                  {{
-                    "requestAccessModalWindowExceedsMax" | i18n: (maxWindowSeconds() | durationLong)
-                  }}
-                </p>
-              }
 
               <bit-form-field>
                 <bit-label>{{ "requestAccessModalReasonRequired" | i18n }}</bit-label>

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -229,7 +229,7 @@
                     id="pam-cipher-view-banner_input_start"
                   />
                 </bit-form-field>
-                <bit-form-field>
+                <bit-form-field [attr.data-testid]="windowErrorTestId()">
                   <bit-label>{{ "requestAccessModalEnd" | i18n }}</bit-label>
                   <input
                     bitInput

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -229,7 +229,7 @@
                     id="pam-cipher-view-banner_input_start"
                   />
                 </bit-form-field>
-                <bit-form-field [attr.data-testid]="windowErrorTestId()">
+                <bit-form-field>
                   <bit-label>{{ "requestAccessModalEnd" | i18n }}</bit-label>
                   <input
                     bitInput

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -155,12 +155,6 @@ describe("CipherViewBannerComponent", () => {
       ?.querySelector("bit-error") ?? null) as HTMLElement | null;
   }
 
-  // The hooks sit on the End `bit-form-field`: `bit-error` is created inside the design system's
-  // own template, so it cannot carry one itself.
-  function windowError(testId: string): HTMLElement | null {
-    return query(`[data-testid="${testId}"] bit-error`);
-  }
-
   beforeEach(() => {
     enabled$ = new BehaviorSubject<boolean>(true);
     requestsApi = mock<AccessRequestSdkService>();
@@ -674,9 +668,8 @@ describe("CipherViewBannerComponent", () => {
 
       expect(component["humanForm"].invalid).toBe(true);
       const maxWindow = formatDuration("en-US", 1800, "long");
-      const error = windowError("window-exceeds-max");
+      const error = endFieldError();
       expect(error).not.toBeNull();
-      expect(error).toBe(endFieldError());
       expect(error?.textContent).toContain(maxWindow);
     });
 
@@ -807,9 +800,8 @@ describe("CipherViewBannerComponent", () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const error = windowError("window-end-before-start");
+      const error = endFieldError();
       expect(error).not.toBeNull();
-      expect(error).toBe(endFieldError());
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
       expect(error?.getAttribute("aria-live")).toBe("assertive");
       const endInput = query("#pam-cipher-view-banner_input_end");
@@ -830,7 +822,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(component["humanForm"].controls.end.touched).toBe(true);
-      const error = windowError("window-end-before-start");
+      const error = endFieldError();
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
     });
@@ -854,8 +846,6 @@ describe("CipherViewBannerComponent", () => {
 
       expect(component["humanForm"].controls.end.errors).toBeNull();
       expect(endFieldError()).toBeNull();
-      expect(query('[data-testid="window-end-before-start"]')).toBeNull();
-      expect(query('[data-testid="window-exceeds-max"]')).toBeNull();
     });
 
     it("reveals the window error on submit rather than submitting", async () => {
@@ -877,7 +867,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(requestsApi.submitAccessRequest).not.toHaveBeenCalled();
-      const error = windowError("window-end-before-start");
+      const error = endFieldError();
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
     });

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -655,19 +655,17 @@ describe("CipherViewBannerComponent", () => {
 
       // A 2h window is well inside the global 24h ceiling but past this rule's 30m cap.
       component["humanForm"].patchValue({ date: "2026-08-17", start: "09:00", end: "11:00" });
+      component["humanForm"].controls.end.markAsTouched();
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
 
-      expect(component["windowExceedsMax"]()).toBe(true);
       expect(component["humanForm"].invalid).toBe(true);
-      // Asserted on what the requester actually sees. The error lives on the form GROUP, so
-      // `bit-form-field`'s slot (which reads `end`'s own status) never renders it; the visible
-      // paragraph is the only thing that does.
       const maxWindow = formatDuration("en-US", 1800, "long");
       const error = query('[data-testid="window-exceeds-max"]');
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain(maxWindow);
+      expect(error?.querySelector("bit-error")).not.toBeNull();
     });
 
     it("re-resolves the bounds when the fold-out is re-opened against a different rule", async () => {
@@ -792,11 +790,82 @@ describe("CipherViewBannerComponent", () => {
       await fixture.whenStable();
 
       component["humanForm"].patchValue({ date: "2026-08-17", start: "10:00", end: "09:00" });
+      component["humanForm"].controls.end.markAsTouched();
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
 
-      expect(component["windowEndBeforeStart"]()).toBe(true);
+      const error = query('[data-testid="window-end-before-start"]');
+      expect(error).not.toBeNull();
+      expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
+
+      const endInput = query("#pam-cipher-view-banner_input_end");
+      const bitError = error?.querySelector("bit-error");
+      expect(bitError).not.toBeNull();
+      expect(bitError?.getAttribute("aria-live")).toBe("assertive");
+      expect(endInput?.getAttribute("aria-invalid")).toBe("true");
+    });
+
+    it("reveals the window error when a start edit breaks a window the requester never touched", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
+      await create(gatedCipher());
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      component["humanForm"].patchValue({ date: "2026-08-17", start: "09:00", end: "10:00" });
+      component["humanForm"].controls.start.setValue("11:00");
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["humanForm"].controls.end.touched).toBe(true);
+      const error = query('[data-testid="window-end-before-start"]');
+      expect(error).not.toBeNull();
+      expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
+    });
+
+    it("clears the window error once the window is valid again", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
+      await create(gatedCipher());
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      component["humanForm"].patchValue({ date: "2026-08-17", start: "11:00", end: "10:00" });
+      component["humanForm"].controls.end.markAsTouched();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      component["humanForm"].controls.start.setValue("09:00");
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["humanForm"].controls.end.errors).toBeNull();
+      expect(query('[data-testid="window-end-before-start"]')).toBeNull();
+      expect(query('[data-testid="window-exceeds-max"]')).toBeNull();
+    });
+
+    it("reveals the window error on submit rather than submitting", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
+      await create(gatedCipher());
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      component["humanForm"].patchValue({
+        date: "2026-08-17",
+        start: "10:00",
+        end: "09:00",
+        reason: "prod incident",
+      });
+      await component["submitRequest"]();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(requestsApi.submitAccessRequest).not.toHaveBeenCalled();
       const error = query('[data-testid="window-end-before-start"]');
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -155,6 +155,12 @@ describe("CipherViewBannerComponent", () => {
       ?.querySelector("bit-error") ?? null) as HTMLElement | null;
   }
 
+  // The hooks sit on the End `bit-form-field`: `bit-error` is created inside the design system's
+  // own template, so it cannot carry one itself.
+  function windowError(testId: string): HTMLElement | null {
+    return query(`[data-testid="${testId}"] bit-error`);
+  }
+
   beforeEach(() => {
     enabled$ = new BehaviorSubject<boolean>(true);
     requestsApi = mock<AccessRequestSdkService>();
@@ -668,8 +674,9 @@ describe("CipherViewBannerComponent", () => {
 
       expect(component["humanForm"].invalid).toBe(true);
       const maxWindow = formatDuration("en-US", 1800, "long");
-      const error = endFieldError();
+      const error = windowError("window-exceeds-max");
       expect(error).not.toBeNull();
+      expect(error).toBe(endFieldError());
       expect(error?.textContent).toContain(maxWindow);
     });
 
@@ -800,11 +807,13 @@ describe("CipherViewBannerComponent", () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const error = endFieldError();
+      const error = windowError("window-end-before-start");
       expect(error).not.toBeNull();
+      expect(error).toBe(endFieldError());
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
       expect(error?.getAttribute("aria-live")).toBe("assertive");
-      expect(query("#pam-cipher-view-banner_input_end")?.getAttribute("aria-invalid")).toBe("true");
+      const endInput = query("#pam-cipher-view-banner_input_end");
+      expect(endInput?.getAttribute("aria-invalid")).toBe("true");
     });
 
     it("reveals the window error when a start edit breaks a window the requester never touched", async () => {
@@ -821,7 +830,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(component["humanForm"].controls.end.touched).toBe(true);
-      const error = endFieldError();
+      const error = windowError("window-end-before-start");
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
     });
@@ -845,6 +854,8 @@ describe("CipherViewBannerComponent", () => {
 
       expect(component["humanForm"].controls.end.errors).toBeNull();
       expect(endFieldError()).toBeNull();
+      expect(query('[data-testid="window-end-before-start"]')).toBeNull();
+      expect(query('[data-testid="window-exceeds-max"]')).toBeNull();
     });
 
     it("reveals the window error on submit rather than submitting", async () => {
@@ -866,7 +877,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(requestsApi.submitAccessRequest).not.toHaveBeenCalled();
-      const error = endFieldError();
+      const error = windowError("window-end-before-start");
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
     });

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -149,6 +149,12 @@ describe("CipherViewBannerComponent", () => {
     return Array.from(fixture.nativeElement.querySelectorAll(selector)) as HTMLElement[];
   }
 
+  function endFieldError(): HTMLElement | null {
+    return (query("#pam-cipher-view-banner_input_end")
+      ?.closest("bit-form-field")
+      ?.querySelector("bit-error") ?? null) as HTMLElement | null;
+  }
+
   beforeEach(() => {
     enabled$ = new BehaviorSubject<boolean>(true);
     requestsApi = mock<AccessRequestSdkService>();
@@ -662,10 +668,9 @@ describe("CipherViewBannerComponent", () => {
 
       expect(component["humanForm"].invalid).toBe(true);
       const maxWindow = formatDuration("en-US", 1800, "long");
-      const error = query('[data-testid="window-exceeds-max"]');
+      const error = endFieldError();
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain(maxWindow);
-      expect(error?.querySelector("bit-error")).not.toBeNull();
     });
 
     it("re-resolves the bounds when the fold-out is re-opened against a different rule", async () => {
@@ -795,15 +800,11 @@ describe("CipherViewBannerComponent", () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const error = query('[data-testid="window-end-before-start"]');
+      const error = endFieldError();
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
-
-      const endInput = query("#pam-cipher-view-banner_input_end");
-      const bitError = error?.querySelector("bit-error");
-      expect(bitError).not.toBeNull();
-      expect(bitError?.getAttribute("aria-live")).toBe("assertive");
-      expect(endInput?.getAttribute("aria-invalid")).toBe("true");
+      expect(error?.getAttribute("aria-live")).toBe("assertive");
+      expect(query("#pam-cipher-view-banner_input_end")?.getAttribute("aria-invalid")).toBe("true");
     });
 
     it("reveals the window error when a start edit breaks a window the requester never touched", async () => {
@@ -820,7 +821,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(component["humanForm"].controls.end.touched).toBe(true);
-      const error = query('[data-testid="window-end-before-start"]');
+      const error = endFieldError();
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
     });
@@ -843,8 +844,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(component["humanForm"].controls.end.errors).toBeNull();
-      expect(query('[data-testid="window-end-before-start"]')).toBeNull();
-      expect(query('[data-testid="window-exceeds-max"]')).toBeNull();
+      expect(endFieldError()).toBeNull();
     });
 
     it("reveals the window error on submit rather than submitting", async () => {
@@ -866,7 +866,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(requestsApi.submitAccessRequest).not.toHaveBeenCalled();
-      const error = query('[data-testid="window-end-before-start"]');
+      const error = endFieldError();
       expect(error).not.toBeNull();
       expect(error?.textContent).toContain("requestAccessModalEndBeforeStart");
     });

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -63,7 +63,6 @@ import { AccessRequestCancelService } from "../services/access-request-cancel.se
 
 import {
   REQUEST_WINDOW_ERROR_KEY,
-  type RequestWindowError,
   requestWindowEndValidator,
 } from "./request-access-window.validators";
 
@@ -342,34 +341,6 @@ export class CipherViewBannerComponent implements OnInit {
       ],
     ],
     reason: ["", [Validators.required, nonBlank]],
-  });
-
-  /**
-   * The End control's event stream as a signal. Reactive forms are not signal-based, so this is the
-   * change source that lets {@link windowErrorTestId} re-evaluate under OnPush — the same
-   * `ControlEvent` stream `BitFormFieldControlDirective` uses to repaint the field itself.
-   */
-  private readonly endControlEvents = toSignal(this.humanForm.controls.end.events, {
-    initialValue: null,
-  });
-
-  /**
-   * The `data-testid` the End field carries while it is SHOWING a window problem — null otherwise,
-   * so the hook marks a rendered message rather than a latent error. It cannot go on `bit-error`,
-   * which the design system creates inside its own template.
-   */
-  protected readonly windowErrorTestId = computed<string | null>(() => {
-    this.endControlEvents();
-    const end = this.humanForm.controls.end;
-    const error = end.errors?.[REQUEST_WINDOW_ERROR_KEY] as RequestWindowError | undefined;
-    switch (end.touched ? (error?.problem ?? null) : null) {
-      case "endBeforeStart":
-        return "window-end-before-start";
-      case "exceedsMaxWindow":
-        return "window-exceeds-max";
-      default:
-        return null;
-    }
   });
 
   ngOnInit(): void {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  LOCALE_ID,
   NgZone,
   OnInit,
   computed,
@@ -10,7 +11,7 @@ import {
   input,
   signal,
 } from "@angular/core";
-import { toObservable, toSignal } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
 import { catchError, combineLatest, firstValueFrom, from, map, merge, of, switchMap } from "rxjs";
 
@@ -43,6 +44,7 @@ import {
   MAX_REQUEST_ACCESS_WINDOW_SECONDS,
   REQUEST_ACCESS_DURATION_PRESETS,
   type RequestDurationOption,
+  type RequestWindowProblem,
   activateAccessErrorMessageKey,
   apiErrorBodyMessage,
   classifyRequestAccessError,
@@ -54,13 +56,15 @@ import {
 import { ExtendLeaseDialogComponent } from "../access-requests/extend-lease-dialog/extend-lease-dialog.component";
 import { DurationLongPipe } from "../date/duration-long.pipe";
 import { DurationShortPipe } from "../date/duration-short.pipe";
+import { formatDuration } from "../date/format-duration";
 import { formatRemaining } from "../date/format-remaining";
 import { isGovernedCipher } from "../helpers/governed-cipher";
 import { AccessRequestCancelService } from "../services/access-request-cancel.service";
 
 import {
   REQUEST_WINDOW_ERROR_KEY,
-  requestWindowValidator,
+  type RequestWindowError,
+  requestWindowEndValidator,
 } from "./request-access-window.validators";
 
 /**
@@ -121,6 +125,7 @@ export class CipherViewBannerComponent implements OnInit {
   private readonly formBuilder = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
+  private readonly locale = inject(LOCALE_ID);
 
   /** Ticks once a second so the live countdown and a scheduled window's opening stay current. */
   private readonly nowMs = signal(Date.now());
@@ -320,37 +325,71 @@ export class CipherViewBannerComponent implements OnInit {
     reason: [""],
   });
 
-  protected readonly humanForm = this.formBuilder.nonNullable.group(
-    {
-      date: ["", Validators.required],
-      start: ["", Validators.required],
-      end: ["", Validators.required],
-      reason: ["", [Validators.required, nonBlank]],
-    },
-    // Reads the cap through the signal on every run, so a fold-out re-opened against a different
-    // rule validates against that rule's maximum rather than the one in force when the form was
-    // built.
-    { validators: [requestWindowValidator(() => this.maxWindowSeconds())] },
-  );
-
-  protected readonly windowEndBeforeStart = computed(
-    () => this.humanFormErrors()?.[REQUEST_WINDOW_ERROR_KEY] === "endBeforeStart",
-  );
-  protected readonly windowExceedsMax = computed(
-    () => this.humanFormErrors()?.[REQUEST_WINDOW_ERROR_KEY] === "exceedsMaxWindow",
-  );
+  protected readonly humanForm = this.formBuilder.nonNullable.group({
+    date: ["", Validators.required],
+    start: ["", Validators.required],
+    end: [
+      "",
+      [
+        Validators.required,
+        // Reads the cap through the signal on every run, so a fold-out re-opened against a
+        // different rule validates against that rule's maximum rather than the one in force when
+        // the form was built.
+        requestWindowEndValidator(
+          () => this.maxWindowSeconds(),
+          (problem, max) => this.windowProblemMessage(problem, max),
+        ),
+      ],
+    ],
+    reason: ["", [Validators.required, nonBlank]],
+  });
 
   /**
-   * The human form's group-level errors as a signal, so the two window messages above re-evaluate
-   * under OnPush. Reactive forms are not signal-based, so the value stream is the change source;
-   * `valueChanges` fires after the validators have run, so `errors` is already current.
+   * The End control's event stream as a signal. Reactive forms are not signal-based, so this is the
+   * change source that lets {@link windowErrorTestId} re-evaluate under OnPush — the same
+   * `ControlEvent` stream `BitFormFieldControlDirective` uses to repaint the field itself.
    */
-  private readonly humanFormErrors = toSignal(
-    this.humanForm.valueChanges.pipe(map(() => this.humanForm.errors)),
-    { initialValue: null },
-  );
+  private readonly endControlEvents = toSignal(this.humanForm.controls.end.events, {
+    initialValue: null,
+  });
+
+  /**
+   * The `data-testid` the End field carries while it is SHOWING a window problem — null otherwise,
+   * so the hook marks a rendered message rather than a latent error. It cannot go on `bit-error`,
+   * which the design system creates inside its own template.
+   */
+  protected readonly windowErrorTestId = computed<string | null>(() => {
+    this.endControlEvents();
+    const end = this.humanForm.controls.end;
+    const error = end.errors?.[REQUEST_WINDOW_ERROR_KEY] as RequestWindowError | undefined;
+    switch (end.touched ? (error?.problem ?? null) : null) {
+      case "endBeforeStart":
+        return "window-end-before-start";
+      case "exceedsMaxWindow":
+        return "window-exceeds-max";
+      default:
+        return null;
+    }
+  });
 
   ngOnInit(): void {
+    // A control validator only re-runs on its own control, so without this a window fixed — or
+    // broken — by editing Date or Start would leave End's status behind. Subscribed to the two
+    // siblings rather than the group, because `updateValueAndValidity` re-emits the group's
+    // `valueChanges` and a group subscription would re-enter.
+    const { date, start, end } = this.humanForm.controls;
+    merge(date.valueChanges, start.valueChanges)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        end.updateValueAndValidity();
+        // Narrow on purpose: only a fresh window error, and only from a sibling edit, so this
+        // never nags a blank End the requester has not reached and never races
+        // `BitInputDirective.onInput`'s `markAsUntouched` on End itself.
+        if (end.errors?.[REQUEST_WINDOW_ERROR_KEY] != null) {
+          end.markAsTouched();
+        }
+      });
+
     // Kept outside the Angular zone: a periodic in-zone timer never lets NgZone settle, which would
     // hang `fixture.whenStable()` for any host embedding the cipher view. The signal write still
     // drives change detection on its own.
@@ -421,6 +460,15 @@ export class CipherViewBannerComponent implements OnInit {
     } finally {
       this.loadingRequestForm.set(false);
     }
+  }
+
+  private windowProblemMessage(problem: RequestWindowProblem, maxWindowSeconds: number): string {
+    return problem === "endBeforeStart"
+      ? this.i18nService.t("requestAccessModalEndBeforeStart")
+      : this.i18nService.t(
+          "requestAccessModalWindowExceedsMax",
+          formatDuration(this.locale, maxWindowSeconds, "long"),
+        );
   }
 
   // `[bitAction]` owns the button's busy state and serialises re-entrant clicks, so this only has to

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -63,6 +63,7 @@ import { AccessRequestCancelService } from "../services/access-request-cancel.se
 
 import {
   REQUEST_WINDOW_ERROR_KEY,
+  type RequestWindowError,
   requestWindowEndValidator,
 } from "./request-access-window.validators";
 
@@ -341,6 +342,34 @@ export class CipherViewBannerComponent implements OnInit {
       ],
     ],
     reason: ["", [Validators.required, nonBlank]],
+  });
+
+  /**
+   * The End control's event stream as a signal. Reactive forms are not signal-based, so this is the
+   * change source that lets {@link windowErrorTestId} re-evaluate under OnPush — the same
+   * `ControlEvent` stream `BitFormFieldControlDirective` uses to repaint the field itself.
+   */
+  private readonly endControlEvents = toSignal(this.humanForm.controls.end.events, {
+    initialValue: null,
+  });
+
+  /**
+   * The `data-testid` the End field carries while it is SHOWING a window problem — null otherwise,
+   * so the hook marks a rendered message rather than a latent error. It cannot go on `bit-error`,
+   * which the design system creates inside its own template.
+   */
+  protected readonly windowErrorTestId = computed<string | null>(() => {
+    this.endControlEvents();
+    const end = this.humanForm.controls.end;
+    const error = end.errors?.[REQUEST_WINDOW_ERROR_KEY] as RequestWindowError | undefined;
+    switch (end.touched ? (error?.problem ?? null) : null) {
+      case "endBeforeStart":
+        return "window-end-before-start";
+      case "exceedsMaxWindow":
+        return "window-exceeds-max";
+      default:
+        return null;
+    }
   });
 
   ngOnInit(): void {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/request-access-window.validators.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/request-access-window.validators.ts
@@ -1,8 +1,12 @@
 import { AbstractControl, ValidationErrors } from "@angular/forms";
 
-import { type RequestWindowProblem, requestWindowProblem } from "../helpers/request-access-window";
+import {
+  type RequestWindowFormValue,
+  type RequestWindowProblem,
+  requestWindowProblem,
+} from "../helpers/request-access-window";
 
-/** The key the window validator reports under, so the template can branch on the problem. */
+/** The key the window validator reports its {@link RequestWindowError} under. */
 export const REQUEST_WINDOW_ERROR_KEY = "requestWindow";
 
 /**
@@ -37,15 +41,17 @@ export function requestWindowEndValidator(
     // Read off the sibling CONTROLS, never `group.value`: `updateValueAndValidity` emits the
     // child's `valueChanges` before it propagates to the parent, so inside a sibling's handler the
     // group's cached value snapshot is still the previous one.
-    const date = group.get("date")?.value as string | null | undefined;
-    const start = group.get("start")?.value as string | null | undefined;
+    const requested: RequestWindowFormValue = {
+      date: group.get("date")?.value,
+      start: group.get("start")?.value,
+      end: control.value,
+    };
     const max = maxWindowSeconds();
-    const problem = requestWindowProblem(
-      { date, start, end: control.value as string | null | undefined },
-      max,
-    );
-    return problem == null
-      ? null
-      : { [REQUEST_WINDOW_ERROR_KEY]: { problem, message: message(problem, max) } };
+    const problem = requestWindowProblem(requested, max);
+    if (problem == null) {
+      return null;
+    }
+    const error: RequestWindowError = { problem, message: message(problem, max) };
+    return { [REQUEST_WINDOW_ERROR_KEY]: error };
   };
 }

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/request-access-window.validators.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/request-access-window.validators.ts
@@ -1,35 +1,51 @@
 import { AbstractControl, ValidationErrors } from "@angular/forms";
 
-import {
-  MAX_REQUEST_ACCESS_WINDOW_SECONDS,
-  requestWindowProblem,
-} from "../helpers/request-access-window";
+import { type RequestWindowProblem, requestWindowProblem } from "../helpers/request-access-window";
 
-/** The key the window validators report under, so the template can branch on the problem. */
+/** The key the window validator reports under, so the template can branch on the problem. */
 export const REQUEST_WINDOW_ERROR_KEY = "requestWindow";
 
 /**
- * Group-level validator for the human-path window: rejects an end at or before the start, and a
- * span past the cap the governing rule allows. The rules themselves live in
+ * The shape reported under {@link REQUEST_WINDOW_ERROR_KEY}. `message` is already localized so
+ * `bit-error` renders it through its `error[1].message` fall-through.
+ */
+export type RequestWindowError = { problem: RequestWindowProblem; message: string };
+
+/**
+ * End-time validator for the human-path window: rejects an end at or before the start, and a span
+ * past the cap the governing rule allows. The rules themselves live in
  * `helpers/request-access-window` (`requestWindowProblem`) so they stay Angular-free and
  * unit-testable without a form; this is only the reactive-forms adapter. Stays quiet while the
  * window is incomplete.
  *
+ * Field-level rather than group-level so `bit-form-field` renders it in the End time slot, which is
+ * what carries the control association, the invalid styling and the live announcement.
+ *
  * A factory rather than a bare validator because the cap is per-rule and is not known until the
- * pre-check lands: the component rebinds this on the form once it has the bounds. `maxWindowSeconds`
- * is read through a callback rather than captured, so re-opening the fold-out against a different
- * rule does not leave a stale cap behind.
+ * pre-check lands. `maxWindowSeconds` is read through a callback rather than captured, so
+ * re-opening the fold-out against a different rule does not leave a stale cap behind.
  */
-export function requestWindowValidator(
-  maxWindowSeconds: () => number = () => MAX_REQUEST_ACCESS_WINDOW_SECONDS,
+export function requestWindowEndValidator(
+  maxWindowSeconds: () => number,
+  message: (problem: RequestWindowProblem, maxWindowSeconds: number) => string,
 ): (control: AbstractControl) => ValidationErrors | null {
   return (control) => {
-    const { date, start, end } = control.value as {
-      date?: string | null;
-      start?: string | null;
-      end?: string | null;
-    };
-    const problem = requestWindowProblem({ date, start, end }, maxWindowSeconds());
-    return problem == null ? null : { [REQUEST_WINDOW_ERROR_KEY]: problem };
+    const group = control.parent;
+    if (group == null) {
+      return null;
+    }
+    // Read off the sibling CONTROLS, never `group.value`: `updateValueAndValidity` emits the
+    // child's `valueChanges` before it propagates to the parent, so inside a sibling's handler the
+    // group's cached value snapshot is still the previous one.
+    const date = group.get("date")?.value as string | null | undefined;
+    const start = group.get("start")?.value as string | null | undefined;
+    const max = maxWindowSeconds();
+    const problem = requestWindowProblem(
+      { date, start, end: control.value as string | null | undefined },
+      max,
+    );
+    return problem == null
+      ? null
+      : { [REQUEST_WINDOW_ERROR_KEY]: { problem, message: message(problem, max) } };
   };
 }


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-02-4c7e0409`.

## 📔 Objective

Render the request-window errors on the End time field.

- What was wrong: STILL OPEN at pam/uat despite the tracker calling it merged.
- Surface: `Web vault -> gated cipher -> inline request form (invalid window)`.
- Size: 4 files, 200 insertions(+), 66 deletions(-).
- Stack: sits on `pam/uat-t-active-access-section-copy`; `cidr-duplicate-field-errors` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

After only; no before pair. The before state (a PAM-gated cipher showing the access banner's inline request form) could not be reproduced in the QA environment: the requester holds direct read access to the governed ciphers, so the banner never renders and the request form is unreachable. The after image is included below for reference.

| After |
|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/1d3af662c0f8ab7185e1aac9becfe29d1e880bba/after-uat-FLW-02-4c7e0409.png" alt="after" width="460"> |


## Known gaps

- No before/after screenshots (see above).
- CI here inherits failures already on `pam/uat` (`Run tests`, `Rust lint`, two cloud builds) plus a pre-existing `tsc-strict` error in `access-rule-edit.component.spec.ts` from #22635. None originate in this stack: the PAM suite passes on the assembled tip, 67 suites and 792 tests.
