### PR TITLE
fix(pam): mark the duplicate CIDR rows and render the error through bit-error

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/cidr.validator.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/cidr.validator.spec.ts
@@ -3,6 +3,7 @@ import { FormArray, FormControl } from "@angular/forms";
 import {
   atLeastOneNonEmptyCidrValidator,
   cidrValidator,
+  duplicateCidrValues,
   noDuplicateCidrsValidator,
 } from "./cidr.validator";
 
@@ -38,6 +39,22 @@ describe("cidrValidator", () => {
 
   it("returns null for a whitespace-only string (treated as empty)", () => {
     expect(validate("   ")).toBeNull();
+  });
+});
+
+describe("duplicateCidrValues", () => {
+  it("returns an empty set when all values are distinct", () => {
+    expect(duplicateCidrValues(["10.0.0.0/8", "192.168.0.0/16"])).toEqual(new Set());
+  });
+
+  it("returns the repeated value, trimmed, once per distinct range", () => {
+    expect(duplicateCidrValues(["10.0.0.0/8", " 10.0.0.0/8 ", "10.0.0.0/8"])).toEqual(
+      new Set(["10.0.0.0/8"]),
+    );
+  });
+
+  it("ignores empty and whitespace-only rows", () => {
+    expect(duplicateCidrValues(["", "   ", "10.0.0.0/8"])).toEqual(new Set());
   });
 });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/cidr.validator.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/cidr.validator.ts
@@ -33,6 +33,31 @@ export function cidrValidator(invalidMessage: string, isValid: CidrPredicate): V
 }
 
 /**
+ * The trimmed values that appear on more than one row. Empty rows are ignored.
+ *
+ * Single source of truth for "which ranges repeat": the array-level
+ * {@link noDuplicateCidrsValidator} decides from it whether Save is blocked, and the editor marks
+ * its rows from it. Deriving both from one function is what stops them disagreeing — were one side
+ * to gain a normalisation the other lacked (case-folding IPv6, canonicalising equivalent ranges),
+ * the array could reject a rule while no row showed the admin why.
+ */
+export function duplicateCidrValues(values: readonly string[]): Set<string> {
+  const seen = new Set<string>();
+  const duplicated = new Set<string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    if (seen.has(trimmed)) {
+      duplicated.add(trimmed);
+    }
+    seen.add(trimmed);
+  }
+  return duplicated;
+}
+
+/**
  * Cross-array validator: rejects with `{ duplicateCidrs: true }` if any two
  * row controls share the same trimmed value. Empty rows are ignored. Attach to
  * the CIDR {@link FormArray}.
@@ -42,18 +67,8 @@ export function noDuplicateCidrsValidator(): ValidatorFn {
     if (!(control instanceof FormArray)) {
       return null;
     }
-    const values = (control.controls as FormControl<string>[]).map((c) => c.value.trim());
-    const seen = new Set<string>();
-    for (const v of values) {
-      if (v === "") {
-        continue;
-      }
-      if (seen.has(v)) {
-        return { duplicateCidrs: true };
-      }
-      seen.add(v);
-    }
-    return null;
+    const values = (control.controls as FormControl<string>[]).map((c) => c.value);
+    return duplicateCidrValues(values).size > 0 ? { duplicateCidrs: true } : null;
   };
 }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.html
@@ -27,12 +27,6 @@
   }
 </div>
 
-@if (cidrArray().touched && cidrArray().hasError("duplicateCidrs")) {
-  <p class="tw-text-danger" bitTypography="helper">
-    {{ "accessRuleIpAllowlistDuplicateCidr" | i18n }}
-  </p>
-}
-
 @if (cidrArray().touched && cidrArray().hasError("atLeastOneCidr")) {
   <p class="tw-text-danger" bitTypography="helper">
     {{ "accessRuleIpAllowlistAtLeastOne" | i18n }}

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
@@ -7,6 +7,7 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import { CidrValidationService } from "./cidr-validation.service";
+import { noDuplicateCidrsValidator } from "./cidr.validator";
 import {
   cidrRowControl,
   IpAllowlistCidrsArray,
@@ -26,6 +27,7 @@ describe("IpAllowlistEditorComponent", () => {
   function hostArray(...cidrs: string[]): IpAllowlistCidrsArray {
     return new FormArray<FormControl<string>>(
       cidrs.map((c) => cidrRowControl(c, "invalid", isValidCidr)),
+      { validators: [noDuplicateCidrsValidator()] },
     );
   }
 
@@ -191,6 +193,15 @@ describe("IpAllowlistEditorComponent", () => {
       );
     }
 
+    /**
+     * Indices of the rows carrying the row-level `duplicateCidr` mark. Asserted alongside
+     * {@link errorsByRow}, which reads the DOM and can still show a stale `bit-error` when the
+     * host mutates the array without emitting.
+     */
+    function markedRows(): number[] {
+      return cidrArray.controls.flatMap((c, i) => (c.hasError("duplicateCidr") ? [i] : []));
+    }
+
     function clickRemove(index: number): void {
       rows()[index].query(By.css("button[bitIconButton]")).nativeElement.click();
     }
@@ -202,6 +213,7 @@ describe("IpAllowlistEditorComponent", () => {
 
       expect(errorsByRow()).toEqual([[DUPLICATE], [], [DUPLICATE]]);
       expect(cidrArray.at(1).hasError("duplicateCidr")).toBe(false);
+      expect(cidrArray.hasError("duplicateCidrs")).toBe(true);
     });
 
     it("marks both rows of a duplicate pair when only one of them is blurred", () => {
@@ -211,6 +223,7 @@ describe("IpAllowlistEditorComponent", () => {
       inputAt(1).dispatchEvent(new Event("blur"));
 
       expect(errorsByRow()).toEqual([[DUPLICATE], [DUPLICATE]]);
+      expect(cidrArray.hasError("duplicateCidrs")).toBe(true);
     });
 
     it("keeps the duplicate marks on the surviving rows when a row between them is removed", () => {
@@ -219,12 +232,14 @@ describe("IpAllowlistEditorComponent", () => {
       clickRemove(1);
 
       expect(errorsByRow()).toEqual([[DUPLICATE], [DUPLICATE]]);
+      expect(cidrArray.hasError("duplicateCidrs")).toBe(true);
     });
 
     it("shows the format error rather than the duplicate one on a row that is both", () => {
       create(hostArray("not-a-cidr", "not-a-cidr"));
 
       expect(errorsByRow()).toEqual([["invalid"], ["invalid"]]);
+      expect(cidrArray.hasError("duplicateCidrs")).toBe(true);
     });
 
     it("clears the duplicate mark from both rows once the values differ", () => {
@@ -233,6 +248,33 @@ describe("IpAllowlistEditorComponent", () => {
       type(1, "192.168.0.0/16");
 
       expect(errorsByRow()).toEqual([[], []]);
+      expect(cidrArray.hasError("duplicateCidrs")).toBe(false);
+    });
+
+    it("marks the rows when the host replaces the array without emitting", () => {
+      create(hostArray("10.0.0.0/8"));
+
+      cidrArray.clear({ emitEvent: false });
+      for (const cidr of ["10.0.0.0/8", "192.168.0.0/16", "10.0.0.0/8"]) {
+        cidrArray.push(cidrRowControl(cidr, "invalid", isValidCidr), { emitEvent: false });
+      }
+      cidrArray.updateValueAndValidity({ emitEvent: false });
+      fixture.detectChanges();
+
+      expect(cidrArray.hasError("duplicateCidrs")).toBe(true);
+      expect(markedRows()).toEqual([0, 2]);
+    });
+
+    it("marks the rows when the host re-enables the array without emitting", () => {
+      create(hostArray("10.0.0.0/8", "10.0.0.0/8"));
+
+      cidrArray.disable({ emitEvent: false });
+      cidrArray.enable({ emitEvent: false });
+      fixture.detectChanges();
+
+      expect(cidrArray.hasError("duplicateCidrs")).toBe(true);
+      expect(markedRows()).toEqual([0, 1]);
+      expect(errorsByRow()).toEqual([[DUPLICATE], [DUPLICATE]]);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
@@ -172,8 +172,6 @@ describe("IpAllowlistEditorComponent", () => {
       input.dispatchEvent(new Event("input"));
     }
 
-    // Counts what the admin actually sees. Asserting on the model instead — or reaching for
-    // markAllAsTouched() — is what hid the earlier attempts' failure to mark the partner row.
     function renderedErrors(): string[] {
       fixture.detectChanges();
       return fixture.debugElement

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
@@ -1,3 +1,4 @@
+import { DebugElement } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormArray, FormControl } from "@angular/forms";
 import { By } from "@angular/platform-browser";
@@ -172,20 +173,34 @@ describe("IpAllowlistEditorComponent", () => {
       input.dispatchEvent(new Event("input"));
     }
 
-    function renderedErrors(): string[] {
-      fixture.detectChanges();
-      return fixture.debugElement
-        .queryAll(By.css("bit-error"))
-        .map((e) => (e.nativeElement as HTMLElement).textContent!.trim());
+    function rows(): DebugElement[] {
+      return fixture.debugElement.queryAll(By.css("bit-form-field"));
     }
+
+    /**
+     * The `bit-error` text rendered inside each row's own `bit-form-field`, in row order. Scoped
+     * per row rather than counted across the component, so a mark landing under the wrong input
+     * fails instead of passing on a matching total.
+     */
+    function errorsByRow(): string[][] {
+      fixture.detectChanges();
+      return rows().map((row) =>
+        row
+          .queryAll(By.css("bit-error"))
+          .map((e) => (e.nativeElement as HTMLElement).textContent!.trim()),
+      );
+    }
+
+    function clickRemove(index: number): void {
+      rows()[index].query(By.css("button[bitSuffix]")).nativeElement.click();
+    }
+
+    const DUPLICATE = "accessRuleIpAllowlistDuplicateCidr";
 
     it("renders a bit-error on both duplicate rows when an already-duplicated rule mounts untouched", () => {
       create(hostArray("10.0.0.0/8", "192.168.0.0/16", "10.0.0.0/8"));
 
-      expect(renderedErrors()).toEqual([
-        "accessRuleIpAllowlistDuplicateCidr",
-        "accessRuleIpAllowlistDuplicateCidr",
-      ]);
+      expect(errorsByRow()).toEqual([[DUPLICATE], [], [DUPLICATE]]);
       expect(cidrArray.at(1).hasError("duplicateCidr")).toBe(false);
     });
 
@@ -195,15 +210,21 @@ describe("IpAllowlistEditorComponent", () => {
       type(1, "10.0.0.0/8");
       inputAt(1).dispatchEvent(new Event("blur"));
 
-      expect(renderedErrors().length).toBe(2);
+      expect(errorsByRow()).toEqual([[DUPLICATE], [DUPLICATE]]);
     });
 
     it("keeps the duplicate marks on the surviving rows when a row between them is removed", () => {
       create(hostArray("10.0.0.0/8", "192.168.0.0/16", "10.0.0.0/8"));
 
-      component["removeRow"](1);
+      clickRemove(1);
 
-      expect(renderedErrors().length).toBe(2);
+      expect(errorsByRow()).toEqual([[DUPLICATE], [DUPLICATE]]);
+    });
+
+    it("shows the format error rather than the duplicate one on a row that is both", () => {
+      create(hostArray("not-a-cidr", "not-a-cidr"));
+
+      expect(errorsByRow()).toEqual([["invalid"], ["invalid"]]);
     });
 
     it("clears the duplicate mark from both rows once the values differ", () => {
@@ -211,7 +232,7 @@ describe("IpAllowlistEditorComponent", () => {
 
       type(1, "192.168.0.0/16");
 
-      expect(renderedErrors()).toEqual([]);
+      expect(errorsByRow()).toEqual([[], []]);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormArray, FormControl } from "@angular/forms";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -157,6 +158,62 @@ describe("IpAllowlistEditorComponent", () => {
       component["markTouched"]();
 
       expect(cidrArray.touched).toBe(true);
+    });
+  });
+
+  describe("duplicate rows", () => {
+    function inputAt(index: number): HTMLInputElement {
+      return fixture.debugElement.queryAll(By.css("input[bitInput]"))[index].nativeElement;
+    }
+
+    function type(index: number, value: string): void {
+      const input = inputAt(index);
+      input.value = value;
+      input.dispatchEvent(new Event("input"));
+    }
+
+    // Counts what the admin actually sees. Asserting on the model instead — or reaching for
+    // markAllAsTouched() — is what hid the earlier attempts' failure to mark the partner row.
+    function renderedErrors(): string[] {
+      fixture.detectChanges();
+      return fixture.debugElement
+        .queryAll(By.css("bit-error"))
+        .map((e) => (e.nativeElement as HTMLElement).textContent!.trim());
+    }
+
+    it("renders a bit-error on both duplicate rows when an already-duplicated rule mounts untouched", () => {
+      create(hostArray("10.0.0.0/8", "192.168.0.0/16", "10.0.0.0/8"));
+
+      expect(renderedErrors()).toEqual([
+        "accessRuleIpAllowlistDuplicateCidr",
+        "accessRuleIpAllowlistDuplicateCidr",
+      ]);
+      expect(cidrArray.at(1).hasError("duplicateCidr")).toBe(false);
+    });
+
+    it("marks both rows of a duplicate pair when only one of them is blurred", () => {
+      create(hostArray("10.0.0.0/8", "192.168.0.0/16"));
+
+      type(1, "10.0.0.0/8");
+      inputAt(1).dispatchEvent(new Event("blur"));
+
+      expect(renderedErrors().length).toBe(2);
+    });
+
+    it("keeps the duplicate marks on the surviving rows when a row between them is removed", () => {
+      create(hostArray("10.0.0.0/8", "192.168.0.0/16", "10.0.0.0/8"));
+
+      component["removeRow"](1);
+
+      expect(renderedErrors().length).toBe(2);
+    });
+
+    it("clears the duplicate mark from both rows once the values differ", () => {
+      create(hostArray("10.0.0.0/8", "10.0.0.0/8"));
+
+      type(1, "192.168.0.0/16");
+
+      expect(renderedErrors()).toEqual([]);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.spec.ts
@@ -192,7 +192,7 @@ describe("IpAllowlistEditorComponent", () => {
     }
 
     function clickRemove(index: number): void {
-      rows()[index].query(By.css("button[bitSuffix]")).nativeElement.click();
+      rows()[index].query(By.css("button[bitIconButton]")).nativeElement.click();
     }
 
     const DUPLICATE = "accessRuleIpAllowlistDuplicateCidr";

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.stories.ts
@@ -92,7 +92,7 @@ export const InvalidRow: Story = editorStory(
   cidrArray(["10.0.0.0/8", "not-a-cidr"], { touched: true }),
 );
 
-/** Duplicate ranges surface the array-level duplicate error. */
+/** Two rows sharing a range: each offending row carries its own error, with no prior interaction. */
 export const DuplicateRanges: Story = editorStory(
-  cidrArray(["10.0.0.0/8", "10.0.0.0/8"], { withArrayValidators: true, touched: true }),
+  cidrArray(["10.0.0.0/8", "10.0.0.0/8"], { withArrayValidators: true }),
 );

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
@@ -22,7 +22,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { CidrValidationService } from "./cidr-validation.service";
-import { CidrPredicate, cidrValidator } from "./cidr.validator";
+import { CidrPredicate, cidrValidator, duplicateCidrValues } from "./cidr.validator";
 
 /** A single CIDR row control, carrying the per-row {@link cidrValidator}. */
 export type CidrRowControl = FormControl<string>;
@@ -122,10 +122,13 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
   }
 
   /**
-   * Marks every row whose trimmed value is shared with another row, so `bit-form-field` renders
+   * Marks every row {@link duplicateCidrValues} reports as repeated, so `bit-form-field` renders
    * `accessRuleIpAllowlistDuplicateCidr` through `bit-error` under each offending row — the same
    * mechanism {@link cidrValidator} already gets for `invalidCidr`. A row can be both malformed and
    * repeated; `invalidCidr` stays first in insertion order so the format error is what shows.
+   *
+   * The rows marked here and the array's own `duplicateCidrs` error come from that one function, so
+   * the array can never be rejected with no row saying why.
    *
    * Marking the row touched is part of the contract, not a nicety:
    * `BitFormFieldControlDirective.hasError` gates on the row's own `touched`, and neither an
@@ -134,18 +137,7 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
   private syncDuplicateErrors(): void {
     const controls = this.cidrArray().controls;
     const values = controls.map((control) => control.value.trim());
-
-    const seen = new Set<string>();
-    const duplicated = new Set<string>();
-    for (const value of values) {
-      if (value === "") {
-        continue;
-      }
-      if (seen.has(value)) {
-        duplicated.add(value);
-      }
-      seen.add(value);
-    }
+    const duplicated = duplicateCidrValues(values);
 
     const message = this.i18n.t("accessRuleIpAllowlistDuplicateCidr");
     controls.forEach((control, index) => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
@@ -52,8 +52,9 @@ export function cidrRowControl(
  *
  * Renders a repeatable list of CIDR inputs over a {@link FormArray} owned by the host form and
  * passed in via {@link cidrArray}. The host keeps value and validity on its own control — this
- * component only manages the row UI (add/remove) and surfaces the array's validation errors.
- * Empty rows stay in the value; the host trims and drops them when serialising the rule.
+ * component manages the row UI (add/remove), surfaces the array's validation errors, and marks
+ * each row that repeats another row's range. Empty rows stay in the value; the host trims and
+ * drops them when serialising the rule.
  */
 @Component({
   selector: "app-pam-ip-allowlist-editor",
@@ -115,7 +116,7 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
     this.markTouched();
   }
 
-  /** Surface the array-level errors (duplicate / at-least-one) once the user interacts. */
+  /** Surface the array-level at-least-one error once the user interacts. */
   protected markTouched(): void {
     this.cidrArray().markAsTouched();
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
@@ -94,10 +94,6 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    // Not ngOnInit: each row's `[formControl]` directive revalidates its control as its binding
-    // initialises, replacing `control.errors` wholesale and wiping any mark set earlier. Not
-    // valueChanges alone either: the host seeds an existing rule's rows with `{ emitEvent: false }`
-    // (`AccessRuleEditComponent.setIpAllowlistCidrs`), so nothing is emitted on load.
     this.syncDuplicateErrors();
   }
 
@@ -129,10 +125,6 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
    *
    * The rows marked here and the array's own `duplicateCidrs` error come from that one function, so
    * the array can never be rejected with no row saying why.
-   *
-   * Marking the row touched is part of the contract, not a nicety:
-   * `BitFormFieldControlDirective.hasError` gates on the row's own `touched`, and neither an
-   * untouched initial load nor a blur on one row of a pair ever sets it on the partner row.
    */
   private syncDuplicateErrors(): void {
     const controls = this.cidrArray().controls;
@@ -142,15 +134,10 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
     const message = this.i18n.t("accessRuleIpAllowlistDuplicateCidr");
     controls.forEach((control, index) => {
       const isDuplicate = duplicated.has(values[index]);
-      // Every `setErrors` revalidates the whole array through its ancestors, so only write to the
-      // rows whose mark actually changes.
       if (isDuplicate === control.hasError("duplicateCidr")) {
         return;
       }
       if (isDuplicate) {
-        // No `{ emitEvent: false }` on either call: `hasError` only recomputes on a
-        // StatusChangeEvent / TouchedChangeEvent, so suppressing them would change the errors
-        // without rendering them.
         control.setErrors({ ...control.errors, duplicateCidr: { message } });
         control.markAsTouched();
       } else {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
@@ -96,7 +96,7 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
     // Not ngOnInit: each row's `[formControl]` directive revalidates its control as its binding
     // initialises, replacing `control.errors` wholesale and wiping any mark set earlier. Not
     // valueChanges alone either: the host seeds an existing rule's rows with `{ emitEvent: false }`
-    // (access-rule-edit.component.ts:426-438), so nothing is emitted on load.
+    // (`AccessRuleEditComponent.setIpAllowlistCidrs`), so nothing is emitted on load.
     this.syncDuplicateErrors();
   }
 
@@ -134,16 +134,21 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
     const controls = this.cidrArray().controls;
     const values = controls.map((control) => control.value.trim());
 
-    const counts = new Map<string, number>();
+    const seen = new Set<string>();
+    const duplicated = new Set<string>();
     for (const value of values) {
-      if (value !== "") {
-        counts.set(value, (counts.get(value) ?? 0) + 1);
+      if (value === "") {
+        continue;
       }
+      if (seen.has(value)) {
+        duplicated.add(value);
+      }
+      seen.add(value);
     }
 
     const message = this.i18n.t("accessRuleIpAllowlistDuplicateCidr");
     controls.forEach((control, index) => {
-      const isDuplicate = (counts.get(values[index]) ?? 0) > 1;
+      const isDuplicate = duplicated.has(values[index]);
       // Every `setErrors` revalidates the whole array through its ancestors, so only write to the
       // rows whose mark actually changes.
       if (isDuplicate === control.hasError("duplicateCidr")) {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
@@ -1,5 +1,14 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, OnInit, inject, input } from "@angular/core";
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  inject,
+  input,
+} from "@angular/core";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormArray, FormControl, ReactiveFormsModule } from "@angular/forms";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -61,7 +70,7 @@ export function cidrRowControl(
     IconButtonModule,
   ],
 })
-export class IpAllowlistEditorComponent implements OnInit {
+export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
   /** The host-owned CIDR array this editor renders and mutates. */
   readonly cidrArray = input.required<IpAllowlistCidrsArray>();
 
@@ -70,12 +79,25 @@ export class IpAllowlistEditorComponent implements OnInit {
 
   private readonly i18n = inject(I18nService);
   private readonly cidrValidation = inject(CidrValidationService);
+  private readonly destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
     // Start with a single blank row to type into when the host seeds no value.
     if (this.cidrArray().length === 0) {
       this.appendRow();
     }
+
+    this.cidrArray()
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.syncDuplicateErrors());
+  }
+
+  ngAfterViewInit(): void {
+    // Not ngOnInit: each row's `[formControl]` directive revalidates its control as its binding
+    // initialises, replacing `control.errors` wholesale and wiping any mark set earlier. Not
+    // valueChanges alone either: the host seeds an existing rule's rows with `{ emitEvent: false }`
+    // (access-rule-edit.component.ts:426-438), so nothing is emitted on load.
+    this.syncDuplicateErrors();
   }
 
   protected addRow(): void {
@@ -96,6 +118,49 @@ export class IpAllowlistEditorComponent implements OnInit {
   /** Surface the array-level errors (duplicate / at-least-one) once the user interacts. */
   protected markTouched(): void {
     this.cidrArray().markAsTouched();
+  }
+
+  /**
+   * Marks every row whose trimmed value is shared with another row, so `bit-form-field` renders
+   * `accessRuleIpAllowlistDuplicateCidr` through `bit-error` under each offending row — the same
+   * mechanism {@link cidrValidator} already gets for `invalidCidr`. A row can be both malformed and
+   * repeated; `invalidCidr` stays first in insertion order so the format error is what shows.
+   *
+   * Marking the row touched is part of the contract, not a nicety:
+   * `BitFormFieldControlDirective.hasError` gates on the row's own `touched`, and neither an
+   * untouched initial load nor a blur on one row of a pair ever sets it on the partner row.
+   */
+  private syncDuplicateErrors(): void {
+    const controls = this.cidrArray().controls;
+    const values = controls.map((control) => control.value.trim());
+
+    const counts = new Map<string, number>();
+    for (const value of values) {
+      if (value !== "") {
+        counts.set(value, (counts.get(value) ?? 0) + 1);
+      }
+    }
+
+    const message = this.i18n.t("accessRuleIpAllowlistDuplicateCidr");
+    controls.forEach((control, index) => {
+      const isDuplicate = (counts.get(values[index]) ?? 0) > 1;
+      // Every `setErrors` revalidates the whole array through its ancestors, so only write to the
+      // rows whose mark actually changes.
+      if (isDuplicate === control.hasError("duplicateCidr")) {
+        return;
+      }
+      if (isDuplicate) {
+        // No `{ emitEvent: false }` on either call: `hasError` only recomputes on a
+        // StatusChangeEvent / TouchedChangeEvent, so suppressing them would change the errors
+        // without rendering them.
+        control.setErrors({ ...control.errors, duplicateCidr: { message } });
+        control.markAsTouched();
+      } else {
+        const rest = { ...control.errors };
+        delete rest.duplicateCidr;
+        control.setErrors(Object.keys(rest).length > 0 ? rest : null);
+      }
+    });
   }
 
   private appendRow(value = ""): void {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/ip-allowlist/ip-allowlist-editor.component.ts
@@ -1,14 +1,5 @@
 import { CommonModule } from "@angular/common";
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  DestroyRef,
-  OnInit,
-  inject,
-  input,
-} from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { ChangeDetectionStrategy, Component, DoCheck, OnInit, inject, input } from "@angular/core";
 import { FormArray, FormControl, ReactiveFormsModule } from "@angular/forms";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -71,7 +62,7 @@ export function cidrRowControl(
     IconButtonModule,
   ],
 })
-export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
+export class IpAllowlistEditorComponent implements OnInit, DoCheck {
   /** The host-owned CIDR array this editor renders and mutates. */
   readonly cidrArray = input.required<IpAllowlistCidrsArray>();
 
@@ -80,20 +71,21 @@ export class IpAllowlistEditorComponent implements OnInit, AfterViewInit {
 
   private readonly i18n = inject(I18nService);
   private readonly cidrValidation = inject(CidrValidationService);
-  private readonly destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
     // Start with a single blank row to type into when the host seeds no value.
     if (this.cidrArray().length === 0) {
       this.appendRow();
     }
-
-    this.cidrArray()
-      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.syncDuplicateErrors());
   }
 
-  ngAfterViewInit(): void {
+  /**
+   * The row marks have to track the array's own duplicate validator, which the host can re-run
+   * without any notification: it replaces the rows and toggles the array's enabled state under
+   * `emitEvent: false`, so neither `valueChanges` nor `statusChanges` fires. Checking each cycle
+   * is what keeps the two in step; {@link syncDuplicateErrors} writes nothing once they agree.
+   */
+  ngDoCheck(): void {
     this.syncDuplicateErrors();
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-SCR-05-733eb8dc`.

## 📔 Objective

Mark the duplicate CIDR rows and render the error through bit-error.

- What was wrong: Verified at pam/uat, ip-allowlist-editor.component.html:34-38: the duplicate error is a bare <p class="tw-text-danger" bitTypography="helper"> at the very bottom of the editor, below the per-line hint
- Surface: `Admin Console -> PAM -> Access rules -> New -> Optional conditions -> Restrict by IP address`.
- Size: 6 files, 179 insertions(+), 27 deletions(-).
- Stack: sits on `pam/uat-t-request-window-error-field-association`; `rule-form-active-access-hint` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

Captured at 1440x1024 (the column-ladder pair at 1024x836, its defect width). Before is `pam/uat`; after is the assembled stack tip, so the after side shows this change alongside the rest of the stack.

### Admin Console -> PAM -> Access rules -> New -> Optional conditions -> Restrict by IP address

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/cf5b13ec6e11ce1fe89140b86897a17f358dc187/before-uat-SCR-05-733eb8dc.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/f5386584c4028eca44b4fdc1c896db9fde4bca7c/after-uat-SCR-05-733eb8dc.png" alt="after" width="460"> |


## Known gaps

- CI here inherits failures already on `pam/uat` (`Run tests`, `Rust lint`, two cloud builds) plus a pre-existing `tsc-strict` error in `access-rule-edit.component.spec.ts` from #22635. None originate in this stack: the PAM suite passes on the assembled tip, 67 suites and 792 tests.
