### PR TITLE
fix(pam): say "access" instead of "session" in the single-active-user hint

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -16972,8 +16972,8 @@
   "pamAccessRuleSingleActiveUser": {
     "message": "Only 1 user can have active access at a time"
   },
-  "pamAccessRuleSingleActiveUserHint": {
-    "message": "Others with approval can attempt to start access once the current session ends or is revoked."
+  "pamAccessRuleSingleActiveAccessHint": {
+    "message": "Others with approval can attempt to start access once the current access ends or is revoked."
   },
   "pamAccessRuleAllowExtensions": {
     "message": "Allow lease extensions"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17503,8 +17503,8 @@
       }
     }
   },
-  "pamAccessBadgeSessionEnded": {
-    "message": "Session ended"
+  "pamAccessBadgeEnded": {
+    "message": "Access ended"
   },
   "pamAuditKindLeaseEndedByHolder": {
     "message": "Lease ended by holder"

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -233,7 +233,7 @@
               formControlName="singleActiveLease"
             />
             <bit-label>{{ "pamAccessRuleSingleActiveUser" | i18n }}</bit-label>
-            <bit-hint>{{ "pamAccessRuleSingleActiveUserHint" | i18n }}</bit-hint>
+            <bit-hint>{{ "pamAccessRuleSingleActiveAccessHint" | i18n }}</bit-hint>
           </bit-form-control>
         </bit-card>
       </bit-section>

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -275,6 +275,22 @@ describe("AccessRuleEditComponent — page furniture", () => {
     );
   });
 
+  it("hangs the single-active-access hint off the single-active-user checkbox", async () => {
+    const fixture = await render({});
+    const control = (
+      fixture.nativeElement.querySelector(
+        "#access-rule-edit_checkbox_single-active-lease",
+      ) as HTMLInputElement
+    ).closest("bit-form-control") as HTMLElement;
+
+    expect(control.querySelector("bit-label")!.textContent!.trim()).toBe(
+      "pamAccessRuleSingleActiveUser",
+    );
+    expect(control.querySelector("bit-hint")!.textContent!.trim()).toBe(
+      "pamAccessRuleSingleActiveAccessHint",
+    );
+  });
+
   it("links the event log notice at the organization's PAM audit route", async () => {
     const fixture = await render({});
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -277,11 +277,9 @@ describe("AccessRuleEditComponent — page furniture", () => {
 
   it("hangs the single-active-access hint off the single-active-user checkbox", async () => {
     const fixture = await render({});
-    const control = (
-      fixture.nativeElement.querySelector(
-        "#access-rule-edit_checkbox_single-active-lease",
-      ) as HTMLInputElement
-    ).closest("bit-form-control") as HTMLElement;
+    const control = fixture.nativeElement
+      .querySelector("#access-rule-edit_checkbox_single-active-lease")
+      .closest("bit-form-control") as HTMLElement;
 
     expect(control.querySelector("bit-label")!.textContent!.trim()).toBe(
       "pamAccessRuleSingleActiveUser",

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.spec.ts
@@ -48,7 +48,7 @@ describe("AccessStateBadgeComponent", () => {
     ["pending", "warning", "bwi-clock", "pamAccessBadgePending"],
     ["unavailable", "subtle", "bwi-lock", "pamAccessBadgeUnavailable"],
     ["ready", "success", "bwi-check", "pamAccessBadgeReady"],
-    ["expired", "subtle", "bwi-lock", "pamAccessBadgeSessionEnded"],
+    ["expired", "subtle", "bwi-lock", "pamAccessBadgeEnded"],
   ])("maps the %s state to its badge recipe", (kind, variant, icon, label) => {
     create({ kind } as AccessBadgeState);
 
@@ -81,7 +81,7 @@ describe("AccessStateBadgeComponent", () => {
 
     const recipe = component["recipe"]()!;
     expect(recipe.variant).toBe("subtle");
-    expect(recipe.label).toBe("pamAccessBadgeSessionEnded");
+    expect(recipe.label).toBe("pamAccessBadgeEnded");
   });
 });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.stories.ts
@@ -12,7 +12,7 @@ const HOUR = 60 * MINUTE;
 /**
  * `active` is the only state whose recipe depends on the clock, so `expiresAt` is built at render
  * time rather than at module load — a story left open would otherwise drift past its own expiry and
- * silently fall back to the "Session ended" recipe.
+ * silently fall back to the "Access ended" recipe.
  */
 function expiringIn(ms: number): AccessBadgeState {
   return { kind: "active", expiresAt: new Date(Date.now() + ms) };
@@ -34,7 +34,7 @@ export default {
               pamAccessBadgePending: "Pending approval",
               pamAccessBadgeUnavailable: "Unavailable",
               pamAccessBadgeReady: "Ready to use",
-              pamAccessBadgeSessionEnded: "Session ended",
+              pamAccessBadgeEnded: "Access ended",
               pamAccessBadgeTimeLeft: (duration) => `${duration} left`,
               pamAccessBadgeEndingSoon: (duration) => `Ending soon • ${duration} left`,
             }),
@@ -90,7 +90,7 @@ export const EndingSoonSeconds: Story = {
 };
 
 /**
- * A finished session. Not currently reachable through `cipherAccessBadgeState` — the SDK has no
+ * A finished lease. Not currently reachable through `cipherAccessBadgeState` — the SDK has no
  * field to derive it from — but part of the badge model, so the recipe is pinned here.
  */
 export const Expired: Story = {
@@ -107,7 +107,7 @@ export const Unavailable: Story = {
 
 /**
  * An `active` lease whose `expiresAt` has already passed locally, before any refetch. The component
- * falls back to the resting "Session ended" recipe rather than rendering a negative countdown.
+ * falls back to the resting "Access ended" recipe rather than rendering a negative countdown.
  */
 export const LapsedLease: Story = {
   render: () => ({ props: { state: expiringIn(-1 * MINUTE) } }),

--- a/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-state-badge/access-state-badge.component.ts
@@ -64,7 +64,7 @@ export class AccessStateBadgeComponent {
     if (state.kind === "active") {
       const remainingMs = state.expiresAt.getTime() - this.now();
       if (remainingMs <= 0) {
-        // The lease lapsed locally before a refetch — show the resting "Session ended" badge.
+        // The lease lapsed locally before a refetch — show the resting "Access ended" badge.
         return this.staticRecipe("expired");
       }
       const remaining = formatRemaining(remainingMs);
@@ -121,7 +121,7 @@ export class AccessStateBadgeComponent {
         return {
           variant: "subtle",
           icon: "bwi-lock",
-          label: this.i18nService.t("pamAccessBadgeSessionEnded"),
+          label: this.i18nService.t("pamAccessBadgeEnded"),
           testId: "access-state-badge-expired",
         };
     }

--- a/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/vault-row-lease-badge/vault-row-lease-badge.component.stories.ts
@@ -40,7 +40,7 @@ function ungatedCipher(): CipherView {
 
 /**
  * `state` is a factory, not a value, so an active lease's `expiresAt` is relative to when the story
- * renders rather than when this module loaded — a stale one would resolve straight to "Session
+ * renders rather than when this module loaded — a stale one would resolve straight to "Access
  * ended".
  *
  * `organizations` stands in for the account's PAM-eligible organizations, which the component


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-FLW-01-4269ea26`.

## 📔 Objective

Say "access" instead of "session" in the single-active-user hint.

- What was wrong: Verified at pam/uat: pamAccessRuleSingleActiveUserHint reads "Others with approval can attempt to start access once the current session ends or is revoked." It sits directly under the label pamAccessR
- Surface: `Admin Console -> PAM -> Access rules -> New access rule (Optional conditions)`.
- Size: 3 files, 17 insertions(+), 3 deletions(-).
- Stack: sits on `pam/uat-t-cidr-duplicate-field-errors`; `access-rule-error-sdk-sentence-guard` sits on it.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

Captured at 1440x1024 (the column-ladder pair at 1024x836, its defect width). Before is `pam/uat`; after is the assembled stack tip, so the after side shows this change alongside the rest of the stack.

### Admin Console -> PAM -> Access rules -> New access rule (Optional conditions)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/f9485c9ffa8907c6ff6b2310f6e4bd761c45296f/before-uat-FLW-01-4269ea26.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/c356c3a0d3da748f58ef9d2dd67df691fa702888/after-uat-FLW-01-4269ea26.png" alt="after" width="460"> |


## Known gaps

- CI here inherits failures already on `pam/uat` (`Run tests`, `Rust lint`, two cloud builds) plus a pre-existing `tsc-strict` error in `access-rule-edit.component.spec.ts` from #22635. None originate in this stack: the PAM suite passes on the assembled tip, 67 suites and 792 tests.
