### PR TITLE
test(pam): pin the SDK sentence the blank-name error mapping matches on

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
@@ -127,7 +127,7 @@ describe("accessRuleErrorMessageKey", () => {
  * from ACCESS_RULE_NAME_MAX_LENGTH — either would pass against a reword the catalog had absorbed.
  */
 describe("ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally", () => {
-  it("still matches the SDK's own wording", () => {
+  it("still holds the wording last verified against the SDK", () => {
     expect(ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally.serverMessage).toBe(
       "Name must be between 1 and 256 characters",
     );

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
@@ -120,30 +120,16 @@ describe("accessRuleErrorMessageKey", () => {
   });
 });
 
+/**
+ * The SDK builds this sentence itself, before any request goes out, and offers no code to switch
+ * on, so the mapping onto the Name field survives only while the catalog repeats it verbatim. The
+ * expectation spells the sentence out rather than reading it back from the catalog or rebuilding it
+ * from ACCESS_RULE_NAME_MAX_LENGTH — either would pass against a reword the catalog had absorbed.
+ */
 describe("ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally", () => {
-  /**
-   * The SDK builds this sentence itself, before any request goes out, and offers no code to switch
-   * on — so the mapping onto the Name field survives only while these two strings stay identical.
-   * Typed out in full on purpose: reading it back from the catalog, or rebuilding it from
-   * ACCESS_RULE_NAME_MAX_LENGTH, would pass against any reword the catalog had already absorbed.
-   */
-  const SDK_BLANK_NAME_REJECTION = "Name must be between 1 and 256 characters";
-
   it("still matches the SDK's own wording", () => {
     expect(ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally.serverMessage).toBe(
-      SDK_BLANK_NAME_REJECTION,
+      "Name must be between 1 and 256 characters",
     );
-  });
-
-  it("still routes that exact sentence to the Name field", () => {
-    const outcome = classifyAccessRuleError(
-      accessRuleError("Validation", SDK_BLANK_NAME_REJECTION),
-    );
-
-    expect(outcome).toEqual({
-      kind: "mapped",
-      messageKey: "pamAccessRuleNameRequired",
-      field: "name",
-    });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from "fs";
+
 import {
   ACCESS_RULE_SERVER_ERRORS,
   accessRuleErrorMessageKey,
   classifyAccessRuleError,
 } from "./access-rule-error";
+import { ACCESS_RULE_NAME_MAX_LENGTH } from "./access-rule-request";
 
 /** The SDK's flat access-rule error: a `name`-tagged Error carrying a `variant`. */
 const accessRuleError = (variant: string, message: string) =>
@@ -123,13 +126,31 @@ describe("accessRuleErrorMessageKey", () => {
 /**
  * The SDK builds this sentence itself, before any request goes out, and offers no code to switch
  * on, so the mapping onto the Name field survives only while the catalog repeats it verbatim. The
- * expectation spells the sentence out rather than reading it back from the catalog or rebuilding it
- * from ACCESS_RULE_NAME_MAX_LENGTH — either would pass against a reword the catalog had absorbed.
+ * first expectation spells the sentence out rather than reading it back from the catalog or
+ * rebuilding it from ACCESS_RULE_NAME_MAX_LENGTH — either would pass against a reword the catalog
+ * had absorbed — but on its own it can only catch an edit to the catalog, so the rest hold it to
+ * the SDK. The wasm never spells the sentence out whole: it stores the literal pieces either side
+ * of the maximum and formats the number in at runtime, which is why the number is pinned to
+ * ACCESS_RULE_NAME_MAX_LENGTH while the pieces are matched against the binary.
  */
 describe("ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally", () => {
+  const { serverMessage } = ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally;
+  const wasm = readFileSync(
+    require.resolve("@bitwarden/commercial-sdk-internal/bitwarden_wasm_internal_bg.wasm"),
+  );
+
   it("still holds the wording last verified against the SDK", () => {
-    expect(ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally.serverMessage).toBe(
-      "Name must be between 1 and 256 characters",
-    );
+    expect(serverMessage).toBe("Name must be between 1 and 256 characters");
   });
+
+  it("names the maximum a name is held to before it is sent", () => {
+    expect(serverMessage).toContain(String(ACCESS_RULE_NAME_MAX_LENGTH));
+  });
+
+  it.each(serverMessage.split(String(ACCESS_RULE_NAME_MAX_LENGTH)))(
+    "is still built from %p in the SDK's wasm",
+    (piece) => {
+      expect(wasm.includes(Buffer.from(piece, "utf8"))).toBe(true);
+    },
+  );
 });

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.spec.ts
@@ -119,3 +119,31 @@ describe("accessRuleErrorMessageKey", () => {
     );
   });
 });
+
+describe("ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally", () => {
+  /**
+   * The SDK builds this sentence itself, before any request goes out, and offers no code to switch
+   * on — so the mapping onto the Name field survives only while these two strings stay identical.
+   * Typed out in full on purpose: reading it back from the catalog, or rebuilding it from
+   * ACCESS_RULE_NAME_MAX_LENGTH, would pass against any reword the catalog had already absorbed.
+   */
+  const SDK_BLANK_NAME_REJECTION = "Name must be between 1 and 256 characters";
+
+  it("still matches the SDK's own wording", () => {
+    expect(ACCESS_RULE_SERVER_ERRORS.NameRequiredLocally.serverMessage).toBe(
+      SDK_BLANK_NAME_REJECTION,
+    );
+  });
+
+  it("still routes that exact sentence to the Name field", () => {
+    const outcome = classifyAccessRuleError(
+      accessRuleError("Validation", SDK_BLANK_NAME_REJECTION),
+    );
+
+    expect(outcome).toEqual({
+      kind: "mapped",
+      messageKey: "pamAccessRuleNameRequired",
+      field: "name",
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
@@ -16,10 +16,9 @@ export type AccessRuleErrorField = "name" | "collections" | "maxExtensionDuratio
  * deliberately absent: the edit form builds that document itself, so any of them is a client bug
  * the admin cannot act on, and the generic system-error copy is the honest thing to show.
  * `NameRequiredLocally` is the one exception to "sourced from the server": it's the SDK's own
- * local (pre-HTTP) validation message, never a wire body. Nothing on the wire carries it and there
- * is no code to switch on, so that entry's `serverMessage` is pinned to the literal sentence in
- * `access-rule-error.spec.ts`: an SDK reword has to turn that test red and be re-decided, rather
- * than silently dropping the blank-name case back onto the generic banner.
+ * local (pre-HTTP) validation message, never a wire body. `access-rule-error.spec.ts` pins that
+ * entry's `serverMessage` to the literal sentence, so an SDK reword turns the test red and gets
+ * re-decided rather than silently dropping the blank-name case back onto the generic banner.
  */
 export const ACCESS_RULE_SERVER_ERRORS = Object.freeze({
   NameRequired: {

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
@@ -16,7 +16,10 @@ export type AccessRuleErrorField = "name" | "collections" | "maxExtensionDuratio
  * deliberately absent: the edit form builds that document itself, so any of them is a client bug
  * the admin cannot act on, and the generic system-error copy is the honest thing to show.
  * `NameRequiredLocally` is the one exception to "sourced from the server": it's the SDK's own
- * local (pre-HTTP) validation message, never a wire body.
+ * local (pre-HTTP) validation message, never a wire body. Nothing on the wire carries it and there
+ * is no code to switch on, so that entry's `serverMessage` is pinned to the literal sentence in
+ * `access-rule-error.spec.ts`: an SDK reword has to turn that test red and be re-decided, rather
+ * than silently dropping the blank-name case back onto the generic banner.
  */
 export const ACCESS_RULE_SERVER_ERRORS = Object.freeze({
   NameRequired: {

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
@@ -17,11 +17,12 @@ export type AccessRuleErrorField = "name" | "collections" | "maxExtensionDuratio
  * the admin cannot act on, and the generic system-error copy is the honest thing to show.
  * `NameRequiredLocally` is the one exception to "sourced from the server": it's the SDK's own
  * local (pre-HTTP) validation message, never a wire body. Nothing here reads that sentence from the
- * SDK — the wasm interpolates the maximum into it at runtime — so the pin in
- * `access-rule-error.spec.ts` only holds this entry to the wording last verified by hand against
- * the SDK; it cannot see a reword on the SDK's side. That reword would leave every test green while
- * dropping the blank-name case back onto the generic banner, so re-verify it on each
- * `@bitwarden/commercial-sdk-internal` bump.
+ * SDK — the wasm interpolates the maximum into it at runtime — so `access-rule-error.spec.ts`
+ * holds this entry to the SDK instead, matching the literal pieces either side of the maximum
+ * against the wasm, and the maximum itself against `ACCESS_RULE_NAME_MAX_LENGTH`. A reword on the
+ * SDK's side fails that spec rather than quietly dropping the blank-name case back onto the
+ * generic banner; a cap the SDK lowered without rewording stays invisible to it, so re-read the
+ * maximum on each `@bitwarden/commercial-sdk-internal` bump.
  */
 export const ACCESS_RULE_SERVER_ERRORS = Object.freeze({
   NameRequired: {

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-error.ts
@@ -16,9 +16,12 @@ export type AccessRuleErrorField = "name" | "collections" | "maxExtensionDuratio
  * deliberately absent: the edit form builds that document itself, so any of them is a client bug
  * the admin cannot act on, and the generic system-error copy is the honest thing to show.
  * `NameRequiredLocally` is the one exception to "sourced from the server": it's the SDK's own
- * local (pre-HTTP) validation message, never a wire body. `access-rule-error.spec.ts` pins that
- * entry's `serverMessage` to the literal sentence, so an SDK reword turns the test red and gets
- * re-decided rather than silently dropping the blank-name case back onto the generic banner.
+ * local (pre-HTTP) validation message, never a wire body. Nothing here reads that sentence from the
+ * SDK — the wasm interpolates the maximum into it at runtime — so the pin in
+ * `access-rule-error.spec.ts` only holds this entry to the wording last verified by hand against
+ * the SDK; it cannot see a reword on the SDK's side. That reword would leave every test green while
+ * dropping the blank-name case back onto the generic banner, so re-verify it on each
+ * `@bitwarden/commercial-sdk-internal` bump.
  */
 export const ACCESS_RULE_SERVER_ERRORS = Object.freeze({
   NameRequired: {


### PR DESCRIPTION
## 🎟️ Tracking

PAM UAT review finding `uat-SCR-06-f05dc675`.

## 📔 Objective

Pin the SDK sentence the blank-name error mapping matches on.

- What was wrong: The behaviour half of this finding is ALREADY on pam/uat: 4dcb8d664d (PM-42426, #22635) added NameRequiredLocally to ACCESS_RULE_SERVER_ERRORS, so a whitespace-only name maps to pamAccessRuleNameRequi
- Surface: `Admin Console -> PAM -> Access rules -> New (save failure banner)`.
- Size: 2 files, 20 insertions(+), 1 deletion(-).
- Stack: sits on `pam/uat-t-rule-form-active-access-hint`; top of the stack.

One pull request per PAM UAT backlog ticket, rooted on `pam/uat`. Merge in stack order.

## 📸 Screenshots

Captured at 1440x1024 (the column-ladder pair at 1024x836, its defect width). Before is `pam/uat`; after is the assembled stack tip, so the after side shows this change alongside the rest of the stack.

### Admin Console -> PAM -> Access rules -> New (save failure banner)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/e841054f8525116dd21956e1eedf0dc9fa321ee1/before-uat-SCR-06-f05dc675.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/e54aeead2d95be4e8382ea7eb12cb92a/raw/e841054f8525116dd21956e1eedf0dc9fa321ee1/after-uat-SCR-06-f05dc675.png" alt="after" width="460"> |


## Known gaps

- CI here inherits failures already on `pam/uat` (`Run tests`, `Rust lint`, two cloud builds) plus a pre-existing `tsc-strict` error in `access-rule-edit.component.spec.ts` from #22635. None originate in this stack: the PAM suite passes on the assembled tip, 67 suites and 792 tests.
