### PR TITLE
[PM-42443] Include member items when fetching org ciphers in Access Intelligence

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
@@ -181,7 +181,7 @@ describe("DefaultAccessIntelligenceDataService", () => {
       expect(report?.id).toBe("report-id-123" as OrganizationReportId);
       expect(report?.organizationId).toBe(orgId);
 
-      expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId);
+      expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId, true);
       expect(organizationUserApiService.getAllUsers).toHaveBeenCalledWith(orgId, {
         includeGroups: true,
       });

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
@@ -439,7 +439,7 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
   }
 
   private loadCiphersOnly$(orgId: OrganizationId): Observable<CipherView[]> {
-    return from(this.cipherService.getAllFromApiForOrganization(orgId)).pipe(
+    return from(this.cipherService.getAllFromApiForOrganization(orgId, true)).pipe(
       catchError((err: unknown) => {
         this.logService.error("[DefaultAccessIntelligenceDataService] Cipher load failed", err);
         return of([] as CipherView[]);
@@ -455,7 +455,7 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
     collections: ListResponse<CollectionAccessDetailsResponse>;
   }> {
     return forkJoin({
-      ciphers: from(this.cipherService.getAllFromApiForOrganization(orgId)),
+      ciphers: from(this.cipherService.getAllFromApiForOrganization(orgId, true)),
       apiUsers: from(
         this.organizationUserApiService.getAllUsers(orgId, {
           includeGroups: true,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42443](https://bitwarden.atlassian.net/browse/PM-42443)

## 📔 Objective

Items in a member's My Items collection stopped appearing in Access Intelligence reports. Moving an item into a regular collection made it appear again.

Access Intelligence has two implementations swapped by the `pm-31936-access-intelligence-new-architecture` flag. The V1 orchestrator passes `includeMemberItems: true` when fetching organization ciphers; the V2 data service did not. Without it, `GET /ciphers/organization-details` omits the `&includeMemberItems=true` query param and the server falls back to `GetAllOrganizationCiphersExcludingDefaultUserCollections`, filtering out any cipher whose only collection is a `DefaultUserCollection`. No code change in 2026.8.0 caused this — the regression surfaced when the flag rolled organizations onto V2.

This passes `true` at the two V2 call sites, matching the V1 orchestrator and every other organization-scope DIRT report. The spec assertion is updated in the same commit because `toHaveBeenCalledWith` matches arguments exactly and would otherwise fail.

Notes for reviewers:

- This is intended to be cherry-picked to `rc` for 2026.8.1.
- New test coverage is deliberately excluded here and will follow in a separate PR to `main` only, to keep the cherry-pick free of spec conflicts.
- After this fix the application row appears with its at-risk password counted, but resolves to **0 members**. That is a second, separate V1/V2 discrepancy: V2 builds its collection-to-member map from `/collections/details`, which only returns `Type = 0` shared collections, so the My Items collection is never in the map. It requires a server change and is being scoped separately. Please don't file it as a new defect.

[PM-42443]: https://bitwarden.atlassian.net/browse/PM-42443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ