### PR TITLE
🍒 [PM-42443] Include member items when fetching org ciphers in Access Intelligence

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
@@ -181,7 +181,7 @@ describe("DefaultAccessIntelligenceDataService", () => {
       expect(report?.id).toBe("report-id-123" as OrganizationReportId);
       expect(report?.organizationId).toBe(orgId);
 
-      expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId);
+      expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId, true);
       expect(organizationUserApiService.getAllUsers).toHaveBeenCalledWith(orgId, {
         includeGroups: true,
       });

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
@@ -439,7 +439,7 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
   }
 
   private loadCiphersOnly$(orgId: OrganizationId): Observable<CipherView[]> {
-    return from(this.cipherService.getAllFromApiForOrganization(orgId)).pipe(
+    return from(this.cipherService.getAllFromApiForOrganization(orgId, true)).pipe(
       catchError((err: unknown) => {
         this.logService.error("[DefaultAccessIntelligenceDataService] Cipher load failed", err);
         return of([] as CipherView[]);
@@ -455,7 +455,7 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
     collections: ListResponse<CollectionAccessDetailsResponse>;
   }> {
     return forkJoin({
-      ciphers: from(this.cipherService.getAllFromApiForOrganization(orgId)),
+      ciphers: from(this.cipherService.getAllFromApiForOrganization(orgId, true)),
       apiUsers: from(
         this.organizationUserApiService.getAllUsers(orgId, {
           includeGroups: true,


### PR DESCRIPTION
## 🎟️ Tracking

Cherry pick into rc: [PM-42443](https://bitwarden.atlassian.net/browse/PM-42443)

## 📔 Objective

Cherry pick #22749 into rc



[PM-42443]: https://bitwarden.atlassian.net/browse/PM-42443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ