### PR TITLE
fix(pam): move the request form's Cancel beside Request access

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -147,6 +147,7 @@
         @if (!requestFormExpanded()) {
           <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
             <button
+              #requestToggleButton
               type="button"
               bitButton
               buttonType="primary"
@@ -162,7 +163,7 @@
     </div>
 
     @if (requestFormExpanded()) {
-      <div class="tw-text-fg-body">
+      <div class="tw-text-fg-body" #requestFoldOut tabindex="-1">
         <hr class="tw-my-4 tw-border-t tw-border-border-base" />
 
         @if (loadingRequestForm()) {
@@ -267,8 +268,8 @@
           </p>
         }
 
-        @if (requestMode() !== null) {
-          <div class="tw-mt-4 tw-flex tw-items-center tw-justify-end tw-gap-2">
+        <div class="tw-mt-4 tw-flex tw-items-center tw-justify-end tw-gap-2">
+          @if (requestMode() !== null) {
             <button
               type="button"
               bitButton
@@ -279,18 +280,18 @@
             >
               {{ "requestAccessModalSubmit" | i18n }}
             </button>
-            <button
-              type="button"
-              bitButton
-              buttonType="secondary"
-              size="small"
-              (click)="toggleRequestForm()"
-              id="pam-cipher-view-banner_button_request-cancel"
-            >
-              {{ "cancel" | i18n }}
-            </button>
-          </div>
-        }
+          }
+          <button
+            type="button"
+            bitButton
+            buttonType="secondary"
+            size="small"
+            (click)="toggleRequestForm()"
+            id="pam-cipher-view-banner_button_request-cancel"
+          >
+            {{ "cancel" | i18n }}
+          </button>
+        </div>
       </div>
     }
   </bit-card>

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -144,18 +144,20 @@
           </p>
         }
 
-        <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
-          <button
-            type="button"
-            bitButton
-            buttonType="primary"
-            size="small"
-            (click)="toggleRequestForm()"
-            id="pam-cipher-view-banner_button_request-toggle"
-          >
-            {{ (requestFormExpanded() ? "cancel" : "pamRequestAccessButton") | i18n }}
-          </button>
-        </div>
+        @if (!requestFormExpanded()) {
+          <div class="tw-flex tw-flex-col tw-items-start tw-gap-2">
+            <button
+              type="button"
+              bitButton
+              buttonType="primary"
+              size="small"
+              (click)="toggleRequestForm()"
+              id="pam-cipher-view-banner_button_request-toggle"
+            >
+              {{ "pamRequestAccessButton" | i18n }}
+            </button>
+          </div>
+        }
       </div>
     </div>
 
@@ -266,7 +268,7 @@
         }
 
         @if (requestMode() !== null) {
-          <div class="tw-mt-4 tw-flex tw-justify-end">
+          <div class="tw-mt-4 tw-flex tw-items-center tw-justify-end tw-gap-2">
             <button
               type="button"
               bitButton
@@ -276,6 +278,16 @@
               id="pam-cipher-view-banner_button_request-submit"
             >
               {{ "requestAccessModalSubmit" | i18n }}
+            </button>
+            <button
+              type="button"
+              bitButton
+              buttonType="secondary"
+              size="small"
+              (click)="toggleRequestForm()"
+              id="pam-cipher-view-banner_button_request-cancel"
+            >
+              {{ "cancel" | i18n }}
             </button>
           </div>
         }

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -163,7 +163,13 @@
     </div>
 
     @if (requestFormExpanded()) {
-      <div class="tw-text-fg-body" #requestFoldOut tabindex="-1">
+      <div
+        class="tw-text-fg-body"
+        #requestFoldOut
+        tabindex="-1"
+        role="group"
+        [attr.aria-label]="'pamRequestAccessButton' | i18n"
+      >
         <hr class="tw-my-4 tw-border-t tw-border-border-base" />
 
         @if (loadingRequestForm()) {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -149,6 +149,19 @@ describe("CipherViewBannerComponent", () => {
     return Array.from(fixture.nativeElement.querySelectorAll(selector)) as HTMLElement[];
   }
 
+  /**
+   * Move the banner to its next access state the way a real change does — announce on
+   * {@link AccessRefreshService} and let the re-read drive the template.
+   */
+  async function refreshTo(next: CipherAccessStateView): Promise<void> {
+    requestsApi.getCipherAccessState.mockResolvedValue(next);
+    TestBed.inject(AccessRefreshService).notifyAccessChanged("cipher-1");
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
   function endFieldError(): HTMLElement | null {
     return (query("#pam-cipher-view-banner_input_end")
       ?.closest("bit-form-field")
@@ -632,6 +645,48 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       expect(document.activeElement).toBe(query("#pam-cipher-view-banner_button_request-toggle"));
+    });
+
+    it("leaves focus where it is when the toggle remounts on its own", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      const elsewhere = document.createElement("input");
+      document.body.appendChild(elsewhere);
+      elsewhere.focus();
+
+      // The request is approved and started, so the resting card and its toggle unmount...
+      await refreshTo(accessState({ activeLease: leaseView() }));
+      expect(query("#pam-cipher-view-banner_button_request-toggle")).toBeNull();
+
+      // ...and the lapsing lease brings both back, with the requester editing somewhere else.
+      await refreshTo(accessState());
+      expect(query("#pam-cipher-view-banner_button_request-toggle")).not.toBeNull();
+
+      expect(document.activeElement).toBe(elsewhere);
+      elsewhere.remove();
+    });
+
+    it("still moves focus on a toggle made after the banner changed state", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      await refreshTo(accessState({ activeLease: leaseView() }));
+      await refreshTo(accessState());
+
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      const focused = document.activeElement as HTMLElement | null;
+      expect(focused?.contains(query("#pam-cipher-view-banner_button_request-cancel"))).toBe(true);
     });
 
     it("shapes the form from the pre-check's human path and seeds the window", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -562,6 +562,38 @@ describe("CipherViewBannerComponent", () => {
       expect(query("#pam-cipher-view-banner_input_date")).toBeNull();
     });
 
+    it("moves Cancel down beside Request access once the form is open", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      expect(query("#pam-cipher-view-banner_button_request-toggle")).toBeNull();
+      const cancel = query("#pam-cipher-view-banner_button_request-cancel");
+      expect(cancel).not.toBeNull();
+      expect(cancel?.closest("div")).toBe(
+        query("#pam-cipher-view-banner_button_request-submit")?.closest("div"),
+      );
+    });
+
+    it("collapses the form from the Cancel beside Request access", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      query("#pam-cipher-view-banner_button_request-cancel")?.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component["requestFormExpanded"]()).toBe(false);
+      expect(query("#pam-cipher-view-banner_button_request-toggle")).not.toBeNull();
+      expect(query("#pam-cipher-view-banner_button_request-cancel")).toBeNull();
+    });
+
     it("shapes the form from the pre-check's human path and seeds the window", async () => {
       requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
       await create(gatedCipher());

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -586,8 +586,6 @@ describe("CipherViewBannerComponent", () => {
 
       query("#pam-cipher-view-banner_button_request-cancel")?.click();
       fixture.detectChanges();
-      await fixture.whenStable();
-      fixture.detectChanges();
 
       expect(component["requestFormExpanded"]()).toBe(false);
       expect(query("#pam-cipher-view-banner_button_request-toggle")).not.toBeNull();

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -592,6 +592,48 @@ describe("CipherViewBannerComponent", () => {
       expect(query("#pam-cipher-view-banner_button_request-cancel")).toBeNull();
     });
 
+    it("still offers Cancel when the pre-check leaves the fold-out without a form", async () => {
+      requestsApi.preCheck.mockRejectedValue(new Error("boom"));
+      await create(gatedCipher());
+
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      expect(query("#pam-cipher-view-banner_button_request-submit")).toBeNull();
+      expect(query('[data-testid="request-error"]')).not.toBeNull();
+
+      query("#pam-cipher-view-banner_button_request-cancel")?.click();
+      fixture.detectChanges();
+
+      expect(component["requestFormExpanded"]()).toBe(false);
+      expect(query("#pam-cipher-view-banner_button_request-toggle")).not.toBeNull();
+    });
+
+    it("moves focus into the fold-out when opening unmounts the toggle", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      const focused = document.activeElement as HTMLElement | null;
+      expect(focused).not.toBe(document.body);
+      expect(focused?.contains(query("#pam-cipher-view-banner_button_request-cancel"))).toBe(true);
+    });
+
+    it("returns focus to the toggle when Cancel unmounts itself", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      query("#pam-cipher-view-banner_button_request-cancel")?.click();
+      fixture.detectChanges();
+
+      expect(document.activeElement).toBe(query("#pam-cipher-view-banner_button_request-toggle"));
+    });
+
     it("shapes the form from the pre-check's human path and seeds the window", async () => {
       requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "human" }));
       await create(gatedCipher());

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -632,6 +632,9 @@ describe("CipherViewBannerComponent", () => {
       const focused = document.activeElement as HTMLElement | null;
       expect(focused).not.toBe(document.body);
       expect(focused?.contains(query("#pam-cipher-view-banner_button_request-cancel"))).toBe(true);
+      // The move is only announceable if what it lands on names itself.
+      expect(focused?.getAttribute("role")).toBe("group");
+      expect(focused?.getAttribute("aria-label")?.trim()).toBe("pamRequestAccessButton");
     });
 
     it("returns focus to the toggle when Cancel unmounts itself", async () => {
@@ -687,6 +690,46 @@ describe("CipherViewBannerComponent", () => {
 
       const focused = document.activeElement as HTMLElement | null;
       expect(focused?.contains(query("#pam-cipher-view-banner_button_request-cancel"))).toBe(true);
+    });
+
+    it("drops a toggle's pending focus when the card unmounts before either target renders", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+
+      // Cancel in the fold-out, with an access change landing in the same pass: the whole request
+      // card unmounts, so neither the toggle nor the fold-out is ever on screen to take the focus.
+      await component["toggleRequestForm"]();
+      await refreshTo(accessState({ activeLease: leaseView() }));
+      expect(query('[data-testid="cipher-view-banner-request"]')).toBeNull();
+
+      const elsewhere = document.createElement("input");
+      document.body.appendChild(elsewhere);
+      elsewhere.focus();
+
+      await refreshTo(accessState());
+      expect(query("#pam-cipher-view-banner_button_request-toggle")).not.toBeNull();
+
+      expect(document.activeElement).toBe(elsewhere);
+      elsewhere.remove();
+    });
+
+    it("does not render the fold-out back open when the card cycles away and returns", async () => {
+      requestsApi.preCheck.mockResolvedValue(preCheck({ approvalMode: "automatic" }));
+      await create(gatedCipher());
+      await component["toggleRequestForm"]();
+      fixture.detectChanges();
+      expect(query("#pam-cipher-view-banner_button_request-submit")).not.toBeNull();
+
+      await refreshTo(accessState({ activeLease: leaseView() }));
+      expect(query('[data-testid="cipher-view-banner-request"]')).toBeNull();
+
+      await refreshTo(accessState());
+
+      expect(component["requestFormExpanded"]()).toBe(false);
+      expect(query("#pam-cipher-view-banner_button_request-toggle")).not.toBeNull();
+      expect(query("#pam-cipher-view-banner_button_request-submit")).toBeNull();
     });
 
     it("shapes the form from the pre-check's human path and seeds the window", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -689,6 +689,7 @@ describe("CipherViewBannerComponent", () => {
       fixture.detectChanges();
 
       const focused = document.activeElement as HTMLElement | null;
+      expect(focused).not.toBe(document.body);
       expect(focused?.contains(query("#pam-cipher-view-banner_button_request-cancel"))).toBe(true);
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -847,7 +847,6 @@ describe("CipherViewBannerComponent", () => {
       await create(gatedCipher());
       await component["toggleRequestForm"]();
 
-      // End before start, and no reason.
       component["humanForm"].patchValue({
         date: "2026-08-17",
         start: "10:00",

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -4,15 +4,16 @@ import {
   Component,
   DestroyRef,
   ElementRef,
+  Injector,
   LOCALE_ID,
   NgZone,
   OnInit,
+  afterNextRender,
   computed,
   effect,
   inject,
   input,
   signal,
-  untracked,
   viewChild,
 } from "@angular/core";
 import { takeUntilDestroyed, toObservable, toSignal } from "@angular/core/rxjs-interop";
@@ -128,6 +129,7 @@ export class CipherViewBannerComponent implements OnInit {
   private readonly formBuilder = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
+  private readonly injector = inject(Injector);
   private readonly locale = inject(LOCALE_ID);
 
   /** Ticks once a second so the live countdown and a scheduled window's opening stay current. */
@@ -297,7 +299,6 @@ export class CipherViewBannerComponent implements OnInit {
   private readonly requestFoldOut = viewChild("requestFoldOut", {
     read: ElementRef<HTMLElement>,
   });
-  private readonly requestFormToggled = signal(false);
   /** Approval path resolved by the pre-check; `null` until the fold-out lands it. */
   protected readonly requestMode = signal<AccessApprovalMode | null>(null);
   protected readonly loadingRequestForm = signal(false);
@@ -354,19 +355,13 @@ export class CipherViewBannerComponent implements OnInit {
   });
 
   constructor() {
-    // Opening unmounts the "Request access" button and collapsing unmounts Cancel, so each
-    // direction destroys the element the requester just activated and focus falls to <body>.
-    // Latched by a toggle and spent on the first mounted target, so neither the initial render nor
-    // a later remount — the toggle returning when a lease lapses, say — pulls focus on its own. The
-    // latch is read untracked so spending it cannot re-enter; `requestFormExpanded` is written by
-    // every toggle and still drives the re-run.
+    // The resting request card is the only thing that renders the fold-out, so an access change
+    // that retires the card — a lease granted from another surface, say — has to close it too.
+    // Left open, it would unfold itself again when the card returns, with no user action and
+    // seeded from a pre-check run against whichever rule was in force before.
     effect(() => {
-      const target = this.requestFormExpanded()
-        ? this.requestFoldOut()
-        : this.requestToggleButton();
-      if (target != null && untracked(this.requestFormToggled)) {
-        this.requestFormToggled.set(false);
-        target.nativeElement.focus();
+      if (!this.canRequestAccess()) {
+        this.requestFormExpanded.set(false);
       }
     });
   }
@@ -409,8 +404,15 @@ export class CipherViewBannerComponent implements OnInit {
    */
   protected async toggleRequestForm(): Promise<void> {
     const next = !this.requestFormExpanded();
-    this.requestFormToggled.set(true);
     this.requestFormExpanded.set(next);
+    // Opening unmounts the "Request access" button and collapsing unmounts Cancel, so each
+    // direction destroys the element the requester just activated and focus falls to <body>. Bound
+    // to the render this toggle causes, so the intent expires with it: a card retired before
+    // either target mounts leaves nothing behind to pull focus on a later remount.
+    afterNextRender(
+      () => (next ? this.requestFoldOut() : this.requestToggleButton())?.nativeElement.focus(),
+      { injector: this.injector },
+    );
     if (!next) {
       return;
     }

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -289,7 +289,6 @@ export class CipherViewBannerComponent implements OnInit {
       (this.approvedRequest() != null && !this.approvedRequestStartsNow()),
   );
 
-  /** Whether the "Request access" entry point has folded out its form. */
   protected readonly requestFormExpanded = signal(false);
   private readonly requestToggleButton = viewChild("requestToggleButton", {
     read: ElementRef<HTMLElement>,

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -3,13 +3,16 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  ElementRef,
   LOCALE_ID,
   NgZone,
   OnInit,
   computed,
+  effect,
   inject,
   input,
   signal,
+  viewChild,
 } from "@angular/core";
 import { takeUntilDestroyed, toObservable, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
@@ -288,6 +291,13 @@ export class CipherViewBannerComponent implements OnInit {
 
   /** Whether the "Request access" entry point has folded out its form. */
   protected readonly requestFormExpanded = signal(false);
+  private readonly requestToggleButton = viewChild("requestToggleButton", {
+    read: ElementRef<HTMLElement>,
+  });
+  private readonly requestFoldOut = viewChild("requestFoldOut", {
+    read: ElementRef<HTMLElement>,
+  });
+  private readonly requestFormToggled = signal(false);
   /** Approval path resolved by the pre-check; `null` until the fold-out lands it. */
   protected readonly requestMode = signal<AccessApprovalMode | null>(null);
   protected readonly loadingRequestForm = signal(false);
@@ -343,6 +353,20 @@ export class CipherViewBannerComponent implements OnInit {
     reason: ["", [Validators.required, nonBlank]],
   });
 
+  constructor() {
+    // Opening unmounts the "Request access" button and collapsing unmounts Cancel, so each
+    // direction destroys the element the requester just activated and focus falls to <body>.
+    // Latched on the first toggle, so the initial render never pulls focus.
+    effect(() => {
+      const target = this.requestFormExpanded()
+        ? this.requestFoldOut()
+        : this.requestToggleButton();
+      if (this.requestFormToggled()) {
+        target?.nativeElement.focus();
+      }
+    });
+  }
+
   ngOnInit(): void {
     // A control validator only re-runs on its own control, so without this a window fixed — or
     // broken — by editing Date or Start would leave End's status behind. Subscribed to the two
@@ -381,6 +405,7 @@ export class CipherViewBannerComponent implements OnInit {
    */
   protected async toggleRequestForm(): Promise<void> {
     const next = !this.requestFormExpanded();
+    this.requestFormToggled.set(true);
     this.requestFormExpanded.set(next);
     if (!next) {
       return;

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -12,6 +12,7 @@ import {
   inject,
   input,
   signal,
+  untracked,
   viewChild,
 } from "@angular/core";
 import { takeUntilDestroyed, toObservable, toSignal } from "@angular/core/rxjs-interop";
@@ -355,13 +356,17 @@ export class CipherViewBannerComponent implements OnInit {
   constructor() {
     // Opening unmounts the "Request access" button and collapsing unmounts Cancel, so each
     // direction destroys the element the requester just activated and focus falls to <body>.
-    // Latched on the first toggle, so the initial render never pulls focus.
+    // Latched by a toggle and spent on the first mounted target, so neither the initial render nor
+    // a later remount — the toggle returning when a lease lapses, say — pulls focus on its own. The
+    // latch is read untracked so spending it cannot re-enter; `requestFormExpanded` is written by
+    // every toggle and still drives the re-run.
     effect(() => {
       const target = this.requestFormExpanded()
         ? this.requestFoldOut()
         : this.requestToggleButton();
-      if (this.requestFormToggled()) {
-        target?.nativeElement.focus();
+      if (target != null && untracked(this.requestFormToggled)) {
+        this.requestFormToggled.set(false);
+        target.nativeElement.focus();
       }
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket. Raised in PAM UAT review: the request fold-out's Cancel sat above the form rather than beside its submit, and used the primary button style.

## 📔 Objective

Moves Cancel out of the card header and into the fold-out's action row, beside `Request access`, as a `secondary` button.

- The header button no longer doubles as Cancel. It unmounts while the form is open and always reads `Request access`.
- The action row pairs the primary submit with a `secondary` Cancel, matching `extend-lease-dialog` and `access-rule-edit`.
- That row renders for the whole fold-out, not only once `requestMode` resolves. Gating it on `requestMode() !== null` strands the user in an open form with an error and no way out when the pre-check rejects.
- Focus follows the change: opening moves focus into the fold-out, cancelling returns it to the header button, since each button now unmounts itself on click.

Five tests cover the placement, the collapse, the failed pre-check, and both focus directions.

This PR targets `pam/uat-t-access-rule-error-sdk-sentence-guard`, not the default branch. It is the top of the stack rooted on `pam/uat`, so read and merge the PRs below it first.

## 📸 Screenshots

`Web/PAM/Cipher View Banner` story `PrivilegedHumanApproval`, dark theme, fold-out expanded.

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/9b968c75c0934d8d4ec53a87c4fedb42/raw/cancel-placement-before.png" alt="Cancel sits above the form as a primary button" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/9b968c75c0934d8d4ec53a87c4fedb42/raw/cancel-placement-after.png" alt="Cancel sits beside Request access as a secondary button" width="460"> |

Before: the header button has relabelled itself to `Cancel` and renders in the primary style, with `Request access` alone at the bottom. After: the header button is gone while the form is open, and `Cancel` sits beside the submit in the `secondary` style.

Captured from Storybook on this branch. The base has since been rebased onto the rewritten stack, with no change to this PR's diff or to `cipher-view-banner/`, so both frames still depict the current base and head.

Verified in the browser rather than read off the source. With the fold-out open, `#pam-cipher-view-banner_button_request-toggle` is absent from the DOM, `#..._request-cancel` and `#..._request-submit` share a parent element, and their computed backgrounds differ (`rgb(29, 41, 61)` against `rgb(107, 174, 250)`).

## Known gaps

- `npm run test:types` reports 3 pre-existing strict errors, in `history-tab.component.ts`, `access-audit.component.spec.ts` and `access-rule-edit.component.spec.ts`. None are in files this PR touches and none are reachable from the changed component.
