### PR TITLE
[PM-42443] Test cases for including My Items in Access Intelligence

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
@@ -121,6 +121,20 @@ describe("DefaultAccessIntelligenceDataService", () => {
       expect(report?.id).toBe(newId);
     });
 
+    it("requests member items so ciphers in a member's My Items collection are loaded", async () => {
+      reportPersistenceService.loadLastReport$.mockReturnValue(
+        of({ report: testReport, hadLegacyBlobs: false }),
+      );
+      cipherService.getAllFromApiForOrganization.mockResolvedValue(testCiphers);
+
+      await firstValueFrom(service.initializeForOrganization$(orgId));
+
+      // Without the second argument the server omits ciphers whose only
+      // collection is a member's default "My Items" collection.
+      expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId, true);
+      expect(await firstValueFrom(service.ciphers$)).toEqual(testCiphers);
+    });
+
     it("should handle load errors gracefully", async () => {
       reportPersistenceService.loadLastReport$.mockReturnValue(
         throwError(() => new Error("Load failed")),
@@ -218,6 +232,20 @@ describe("DefaultAccessIntelligenceDataService", () => {
 
       const ciphers = await firstValueFrom(service.ciphers$);
       expect(ciphers).toEqual(testCiphers);
+    });
+
+    it("requests member items so ciphers in a member's My Items collection are reported on", async () => {
+      await firstValueFrom(service.generateNewReport$(orgId));
+
+      // Without the second argument the server omits ciphers whose only
+      // collection is a member's default "My Items" collection.
+      expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId, true);
+    });
+
+    it("requests member items when refreshing an existing report", async () => {
+      await firstValueFrom(service.refreshReport$(orgId));
+
+      expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId, true);
     });
 
     it("should handle generation errors and keep previous report", async () => {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42443](https://bitwarden.atlassian.net/browse/PM-42443)

## 📔 Objective

Follow-up test coverage for _PM-42443_. The fix itself shipped in #22749 and was cherry-picked to `rc` in #22751; test cases were deliberately held back so the cherry-pick stayed free of spec conflicts. This adds them to `main` only.

The bug: the V2 Access Intelligence data service fetched organization ciphers without `includeMemberItems`, so the server omitted any cipher whose only collection was a member's default My Items collection and those items never appeared in reports.

No production code changes — spec file only.


[PM-42443]: https://bitwarden.atlassian.net/browse/PM-42443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ