### PR TITLE
[PM-42493] fix: move focus off the Add folder button after creating a folder

### DIFF
--- a/libs/vault/src/components/my-folders/my-folders.component.html
+++ b/libs/vault/src/components/my-folders/my-folders.component.html
@@ -1,75 +1,83 @@
 <!-- Slot for the client-specific page header (e.g. web/desktop <app-header>). -->
 <ng-content></ng-content>
 
-<bit-table-v2
-  [tableDef]="table"
-  [filter]="filter"
-  [selection]="selection"
-  [loading]="loading()"
-  [trackBy]="trackById"
+<div
+  #tableRegion
+  tabindex="-1"
+  role="region"
+  [attr.aria-label]="'myFolders' | i18n"
+  class="focus-visible:tw-outline-none"
 >
-  <bit-table-toolbar>
-    <bit-search
-      id="my-folders_input_search"
-      class="tw-flex-1"
-      [placeholder]="'search' | i18n"
-      [attr.aria-label]="'search' | i18n"
-    ></bit-search>
-    <button
-      bitButton
-      type="button"
-      buttonType="primary"
-      startIcon="bwi-plus"
-      slot="end"
-      id="my-folders_button_add-folder"
-      (click)="addFolder()"
-    >
-      {{ "addFolder" | i18n }}
-    </button>
-  </bit-table-toolbar>
-
-  <bit-bulk-actions-bar>
-    <bit-bulk-action
-      [action]="deleteSelected"
-      icon="bwi-trash"
-      [label]="'delete' | i18n"
-    ></bit-bulk-action>
-  </bit-bulk-actions-bar>
-
-  <bit-column sortable defaultSort="asc" width="minmax(12rem, 20rem)">
-    <bit-header-cell>{{ "name" | i18n }}</bit-header-cell>
-    <bit-cell *bitCellDef="table.columns.name; let row">{{ row.displayName }}</bit-cell>
-  </bit-column>
-
-  <bit-column sortable width="120px">
-    <bit-header-cell>{{ "items" | i18n }}</bit-header-cell>
-    <bit-cell *bitCellDef="table.columns.itemCount; let row">{{ row.itemCount }}</bit-cell>
-  </bit-column>
-
-  <bit-column>
-    <bit-header-cell>
-      <span class="tw-w-full tw-text-end">{{ "options" | i18n }}</span>
-    </bit-header-cell>
-    <bit-cell *bitCellDef="table.columns.options; let row">
+  <bit-table-v2
+    [tableDef]="table"
+    [filter]="filter"
+    [selection]="selection"
+    [loading]="loading()"
+    [trackBy]="trackById"
+  >
+    <bit-table-toolbar>
+      <bit-search
+        id="my-folders_input_search"
+        class="tw-flex-1"
+        [placeholder]="'search' | i18n"
+        [attr.aria-label]="'search' | i18n"
+      ></bit-search>
       <button
-        slot="end"
+        bitButton
         type="button"
-        bitIconButton="bwi-pencil-square"
-        size="small"
-        [id]="'my-folders_button_edit-' + row.id"
-        [label]="'editFolderNamed' | i18n: row.displayName"
-        (click)="editFolder(row)"
-      ></button>
-      <button
+        buttonType="primary"
+        startIcon="bwi-plus"
         slot="end"
-        type="button"
-        bitIconButton="bwi-trash"
-        buttonType="dangerGhost"
-        size="small"
-        [id]="'my-folders_button_delete-' + row.id"
-        [label]="'deleteFolderNamed' | i18n: row.displayName"
-        (click)="deleteFolder(row)"
-      ></button>
-    </bit-cell>
-  </bit-column>
-</bit-table-v2>
+        id="my-folders_button_add-folder"
+        (click)="addFolder()"
+      >
+        {{ "addFolder" | i18n }}
+      </button>
+    </bit-table-toolbar>
+
+    <bit-bulk-actions-bar>
+      <bit-bulk-action
+        [action]="deleteSelected"
+        icon="bwi-trash"
+        [label]="'delete' | i18n"
+      ></bit-bulk-action>
+    </bit-bulk-actions-bar>
+
+    <bit-column sortable defaultSort="asc" width="minmax(12rem, 20rem)">
+      <bit-header-cell>{{ "name" | i18n }}</bit-header-cell>
+      <bit-cell *bitCellDef="table.columns.name; let row">{{ row.displayName }}</bit-cell>
+    </bit-column>
+
+    <bit-column sortable width="120px">
+      <bit-header-cell>{{ "items" | i18n }}</bit-header-cell>
+      <bit-cell *bitCellDef="table.columns.itemCount; let row">{{ row.itemCount }}</bit-cell>
+    </bit-column>
+
+    <bit-column>
+      <bit-header-cell>
+        <span class="tw-w-full tw-text-end">{{ "options" | i18n }}</span>
+      </bit-header-cell>
+      <bit-cell *bitCellDef="table.columns.options; let row">
+        <button
+          slot="end"
+          type="button"
+          bitIconButton="bwi-pencil-square"
+          size="small"
+          [id]="'my-folders_button_edit-' + row.id"
+          [label]="'editFolderNamed' | i18n: row.displayName"
+          (click)="editFolder(row)"
+        ></button>
+        <button
+          slot="end"
+          type="button"
+          bitIconButton="bwi-trash"
+          buttonType="dangerGhost"
+          size="small"
+          [id]="'my-folders_button_delete-' + row.id"
+          [label]="'deleteFolderNamed' | i18n: row.displayName"
+          (click)="deleteFolder(row)"
+        ></button>
+      </bit-cell>
+    </bit-column>
+  </bit-table-v2>
+</div>

--- a/libs/vault/src/components/my-folders/my-folders.component.spec.ts
+++ b/libs/vault/src/components/my-folders/my-folders.component.spec.ts
@@ -126,7 +126,7 @@ describe("MyFoldersComponent", () => {
     beforeEach(() => {
       open = jest
         .spyOn(AddEditFolderDialogComponent, "open")
-        .mockReturnValue({ closed: new BehaviorSubject(undefined) } as never);
+        .mockReturnValue({ closed: of(undefined) } as never);
     });
 
     it("opens the dialog with no folder from the add button", async () => {

--- a/libs/vault/src/components/my-folders/my-folders.component.ts
+++ b/libs/vault/src/components/my-folders/my-folders.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   TrackByFunction,
   computed,
   effect,
@@ -39,7 +40,10 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { buildFolderRows, FolderTableRow } from "../../models/folder-table-row";
-import { AddEditFolderDialogComponent } from "../add-edit-folder-dialog/add-edit-folder-dialog.component";
+import {
+  AddEditFolderDialogComponent,
+  AddEditFolderDialogResult,
+} from "../add-edit-folder-dialog/add-edit-folder-dialog.component";
 import { openDeleteFolderDialog } from "../delete-folder-dialog/delete-folder-dialog.component";
 
 /**
@@ -79,6 +83,8 @@ export class MyFoldersComponent {
   private readonly toastService = inject(ToastService);
 
   private readonly tableRef = viewChild(BitTableV2Component<FolderTableRow>);
+
+  private readonly tableRegion = viewChild<ElementRef<HTMLElement>>("tableRegion");
 
   private readonly loadedRows = toSignal(
     this.accountService.activeAccount$.pipe(
@@ -131,7 +137,15 @@ export class MyFoldersComponent {
     !values.search || row.name.toLowerCase().includes(values.search.toLowerCase());
 
   protected async addFolder(): Promise<void> {
-    await lastValueFrom(AddEditFolderDialogComponent.open(this.dialogService).closed);
+    const result = await lastValueFrom(
+      AddEditFolderDialogComponent.open(this.dialogService).closed,
+    );
+
+    if (result !== AddEditFolderDialogResult.Created) {
+      return;
+    }
+
+    this.tableRegion()?.nativeElement.focus({ preventScroll: true });
   }
 
   protected async editFolder(row: FolderTableRow): Promise<void> {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42493

## 📔 Objective

After creating a folder from the My folders page, the `Add folder` button stayed visually highlighted.

The dialog returns focus to the trigger on close (`DialogService.setRestoreFocusEl` hands the button to CDK as `config.restoreFocus`). The button then matches `:focus-visible`, which for `buttonType="primary"` applies `focus-visible:tw-bg-bg-brand-strong` plus the focus ring — reading as a stuck highlight.

`addFolder()` now lands focus on a labelled region wrapping the table once the dialog reports `Created`, instead of leaving it on the trigger. Dismissing the dialog is unaffected.

Shared component, so this covers both web and desktop.

## 📸 Screenshots

<!-- TODO: attach before/after -->