### PR TITLE
[PM-42585] feat: Add Single org prerequisite to fill assist policy

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/fill-assist.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/fill-assist.component.spec.ts
@@ -47,6 +47,8 @@ describe("FillAssistPolicy", () => {
     expect(policy.description).toBe("fillAssistPolicyDesc");
     expect(policy.type).toBe(PolicyType.FillAssist);
     expect(policy.component).toBe(FillAssistPolicyComponent);
+    expect(policy.prerequisiteKey).toBe("requireSsoPolicyReqV2");
+    expect(policy.prerequisiteKeyVfo1).toBe("requireSsoPolicyReqV2Vfo1");
   });
 
   it("gates display$ on the FillAssistTargetingRules feature flag when enabled", async () => {

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/fill-assist.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/fill-assist.component.spec.ts
@@ -47,8 +47,8 @@ describe("FillAssistPolicy", () => {
     expect(policy.description).toBe("fillAssistPolicyDesc");
     expect(policy.type).toBe(PolicyType.FillAssist);
     expect(policy.component).toBe(FillAssistPolicyComponent);
-    expect(policy.prerequisiteKey).toBe("requireSsoPolicyReqV2");
-    expect(policy.prerequisiteKeyVfo1).toBe("requireSsoPolicyReqV2Vfo1");
+    expect(policy.prerequisiteKey).toBe("requireSingleOrganizationPolicy");
+    expect(policy.prerequisiteKeyVfo1).toBe("requireSingleOrganizationPolicyVfo1");
   });
 
   it("gates display$ on the FillAssistTargetingRules feature flag when enabled", async () => {

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/fill-assist.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/fill-assist.component.ts
@@ -103,8 +103,8 @@ export class FillAssistPolicy extends BasePolicyEditDefinition {
   // The component renders its own description paragraph so the "Learn more"
   // link can be inlined; suppress the framework's plain-text rendering.
   showDescription = false;
-  prerequisiteKey = "requireSsoPolicyReqV2";
-  prerequisiteKeyVfo1 = "requireSsoPolicyReqV2Vfo1";
+  prerequisiteKey = "requireSingleOrganizationPolicy";
+  prerequisiteKeyVfo1 = "requireSingleOrganizationPolicyVfo1";
 
   override display$(organization: Organization, configService: ConfigService): Observable<boolean> {
     return configService.getFeatureFlag$(FeatureFlag.FillAssistTargetingRules);

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/fill-assist.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/fill-assist.component.ts
@@ -103,6 +103,8 @@ export class FillAssistPolicy extends BasePolicyEditDefinition {
   // The component renders its own description paragraph so the "Learn more"
   // link can be inlined; suppress the framework's plain-text rendering.
   showDescription = false;
+  prerequisiteKey = "requireSsoPolicyReqV2";
+  prerequisiteKeyVfo1 = "requireSsoPolicyReqV2Vfo1";
 
   override display$(organization: Organization, configService: ConfigService): Observable<boolean> {
     return configService.getFeatureFlag$(FeatureFlag.FillAssistTargetingRules);

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -8014,6 +8014,13 @@
     "message": "You must enable the single organization membership policy before enabling this one.",
     "description": "VFO1 terminology variant of 'requireSsoPolicyReqV2'"
   },
+  "requireSingleOrganizationPolicy": {
+    "message": "You must enable the single organization policy before enabling this one."
+  },
+  "requireSingleOrganizationPolicyVfo1": {
+    "message": "You must enable the single organization membership policy before enabling this one.",
+    "description": "VFO1 terminology variant of 'requireSingleOrganizationPolicy'"
+  },
   "requireSsoPolicyReqError": {
     "message": "Single organization policy not set up."
   },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-42585

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add a "Prerequisite" callout to the "Activate fill assist" policy edit drawer, informing admins that the "Single organization membership" policy must be enabled first. 

### Why require Single Org?
 
Fill assist rule URLs are org-scoped, and when a user is a member of multiple orgs with the policy on, only the first policy resolved applies — requiring single organization prevents this unintended cross-org behavior.

### Note about server changes

Server-side enforcement is handled by [bitwarden/server#8266](https://github.com/bitwarden/server/pull/8266) (merged). This client change is display-only, mirroring the existing UriMatchDefaultPolicy — reuses the generic requireSsoPolicyReqV2 / requireSsoPolicyReqV2Vfo1 i18n keys. No new strings, no template changes, no client-side blocking logic.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

### Callout is always present in the drawer:

<img width="1142" height="464" alt="image" src="https://github.com/user-attachments/assets/8b485f8e-a82c-42b8-b09d-83b8dc713d01" />

### Error toast - try enabling "Activate fill assist" while "Single organization membership" is disabled:

<img width="700" height="290" alt="image" src="https://github.com/user-attachments/assets/5032ebc2-5276-40b8-a795-7370349831a3" />

### Error toast -- try disabling "Single organization membership" while "Activate fill assist" is enabled:

<img width="714" height="254" alt="image" src="https://github.com/user-attachments/assets/20a85ab1-fd25-4625-a528-eb93c59237f1" />
