### PR TITLE
[PM-42631] Fix flaky storybook tests for shared folder card grid

### DIFF
--- a/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.html
+++ b/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.html
@@ -4,7 +4,7 @@
   <bit-accordion
     [title]="'sharedFoldersInParent' | i18n: parentName()"
     variant="subtle"
-    [open]="true"
+    [open]="open()"
   >
     @let countText = countSegments();
     <span bitTypography="body2" class="tw-shrink-0 tw-text-muted" slot="end"

--- a/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.spec.ts
+++ b/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.spec.ts
@@ -57,10 +57,17 @@ describe("SharedFolderCardGridComponent", () => {
     return folderTree(PARENT, count);
   }
 
-  function createComponent(collections: CollectionView[], scope: VaultScope = scopeTo(PARENT.id)) {
+  function createComponent(
+    collections: CollectionView[],
+    scope: VaultScope = scopeTo(PARENT.id),
+    startingState: { open?: boolean; initiallyExpanded?: boolean } = {},
+  ) {
     fixture = TestBed.createComponent(SharedFolderCardGridComponent);
     fixture.componentRef.setInput("collections", collections);
     fixture.componentRef.setInput("scope", scope);
+    Object.entries(startingState).forEach(([input, value]) =>
+      fixture.componentRef.setInput(input, value),
+    );
     fixture.detectChanges();
   }
 
@@ -74,6 +81,12 @@ describe("SharedFolderCardGridComponent", () => {
     return fixture.nativeElement
       .querySelector('[data-accordion-trigger] span:not([slot="end"])')
       ?.textContent?.trim();
+  }
+
+  function accordionOpen(): string | null | undefined {
+    return fixture.nativeElement
+      .querySelector("[data-accordion-trigger]")
+      ?.getAttribute("aria-expanded");
   }
 
   /** The cards themselves, distinguished from the overflow trigger by their `bit-item-content`. */
@@ -296,6 +309,15 @@ describe("SharedFolderCardGridComponent", () => {
       expect(trigger()?.querySelector("i")?.classList).toContain("bwi-angle-up");
     });
 
+    it("reveals the overflow from the first render when the host asks for it", () => {
+      createComponent(children(COLLAPSED_CARD_COUNT + 3), scopeTo(PARENT.id), {
+        initiallyExpanded: true,
+      });
+
+      expect(cards()).toHaveLength(COLLAPSED_CARD_COUNT + 3);
+      expect(trigger()?.getAttribute("aria-expanded")).toBe("true");
+    });
+
     it("re-collapses when the scope moves to a folder with different children", () => {
       const design = { id: "design" as CollectionId, name: "Design" };
       createComponent([
@@ -329,6 +351,28 @@ describe("SharedFolderCardGridComponent", () => {
 
     it("does not announce on the initial collapsed render", () => {
       createComponent(children(COLLAPSED_CARD_COUNT + 4));
+
+      expect(liveAnnouncer.announce).not.toHaveBeenCalled();
+    });
+
+    // Nothing was revealed, so there is nothing to point the user back at.
+    it("does not announce when the host renders the grid expanded", () => {
+      createComponent(children(COLLAPSED_CARD_COUNT + 4), scopeTo(PARENT.id), {
+        initiallyExpanded: true,
+      });
+
+      expect(liveAnnouncer.announce).not.toHaveBeenCalled();
+    });
+
+    it("does not announce when the trigger collapses the grid again", () => {
+      createComponent(children(COLLAPSED_CARD_COUNT + 4));
+
+      trigger()?.click();
+      fixture.detectChanges();
+      liveAnnouncer.announce.mockClear();
+
+      trigger()?.click();
+      fixture.detectChanges();
 
       expect(liveAnnouncer.announce).not.toHaveBeenCalled();
     });
@@ -370,6 +414,21 @@ describe("SharedFolderCardGridComponent", () => {
 
       expect(cards()).toHaveLength(COLLAPSED_CARD_COUNT);
       expect(countLabel()).toBe(`sharedFolderCount:${COLLAPSED_CARD_COUNT + 7}`);
+    });
+
+    it("opens the section by default", () => {
+      createComponent(children(2));
+
+      expect(accordionOpen()).toBe("true");
+    });
+
+    it("starts the section closed when the host asks for it", () => {
+      createComponent(children(2), scopeTo(PARENT.id), { open: false });
+
+      expect(accordionOpen()).toBe("false");
+      // The header still carries the folder's name and child count while the cards are hidden.
+      expect(accordionTitle()).toBe("sharedFoldersInParent:Engineering");
+      expect(countLabel()).toBe("sharedFolderCount:2");
     });
 
     it("names the region holding the cards with the titled accordion trigger", () => {

--- a/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.stories.ts
+++ b/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.stories.ts
@@ -1,6 +1,5 @@
 import { RouterTestingModule } from "@angular/router/testing";
 import { Meta, StoryObj, componentWrapperDecorator, moduleMetadata } from "@storybook/angular";
-import { getByRole, userEvent } from "storybook/test";
 
 import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -108,36 +107,12 @@ export default {
   },
 } as Meta<SharedFolderCardGridComponent>;
 
+/**
+ * Both the accordion's open state and the overflow's are the component's own, but each takes its
+ * starting value from an input — so a story renders the state it documents on its first frame
+ * rather than painting a default and then clicking its way out of it.
+ */
 type Story = StoryObj<SharedFolderCardGridComponent>;
-
-/**
- * Reveals the cards held behind the trigger. Both the accordion's open state and the overflow's live
- * inside the component, so stories reach them by driving the same controls a user would — which means
- * a story paints in its default state for a frame before its play function lands.
- */
-const expandOverflow: Story["play"] = async (context) => {
-  const trigger = getByRole(context.canvasElement, "button", { name: "Show all" });
-  await userEvent.click(trigger);
-};
-
-/** Collapses the whole section by clicking the accordion's own header. */
-const collapseAccordion: Story["play"] = async (context) => {
-  const header = getByRole(context.canvasElement, "button", { name: /in Departments/ });
-  await userEvent.click(header);
-};
-
-/**
- * Docs pages skip play functions by default, which would leave every story driven by one above
- * showing its default state — the exact opposite of what it is there to document. Stories with a
- * play function opt into running it inline on the docs page too.
- */
-const autoplayInDocs: Story["parameters"] = {
-  docs: {
-    story: {
-      autoplay: true,
-    },
-  },
-};
 
 /** Five children — one full row of three plus a partial row, no overflow. */
 export const Default: Story = {};
@@ -164,21 +139,19 @@ export const ManyChildrenCollapsed: Story = {
 export const ManyChildrenExpanded: Story = {
   args: {
     collections: MANY_FOLDERS,
+    initiallyExpanded: true,
   },
-  play: expandOverflow,
-  parameters: autoplayInDocs,
 };
 
 /**
- * The section closed. `bit-accordion` opens by default, so this collapses it the way a user would —
- * the header stays readable, count and all, with every card hidden behind it.
+ * The section closed — the header stays readable, count and all, with every card hidden behind it.
+ * Users can still open it from the header; only the starting state differs.
  */
 export const AccordionCollapsed: Story = {
   args: {
     collections: MANY_FOLDERS,
+    open: false,
   },
-  play: collapseAccordion,
-  parameters: autoplayInDocs,
 };
 
 /**
@@ -205,9 +178,8 @@ export const NarrowContainerExpanded: Story = {
   ],
   args: {
     collections: MANY_FOLDERS,
+    initiallyExpanded: true,
   },
-  play: expandOverflow,
-  parameters: autoplayInDocs,
 };
 
 /** Names truncate rather than blowing out the track width. */

--- a/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.ts
+++ b/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.ts
@@ -4,11 +4,9 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
-  effect,
   inject,
   input,
   linkedSignal,
-  untracked,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
 
@@ -114,6 +112,15 @@ export class SharedFolderCardGridComponent {
    */
   readonly scope = input.required<VaultScope>();
 
+  /** Whether the section starts open. Users can still collapse and reopen it from its header. */
+  readonly open = input(true);
+
+  /**
+   * Whether the overflow cards start revealed, before the trigger below the grid has been used.
+   * Reset along with {@link expanded} whenever the set of children changes.
+   */
+  readonly initiallyExpanded = input(false);
+
   protected readonly gridTemplateColumns = GRID_TEMPLATE_COLUMNS;
 
   /**
@@ -149,10 +156,16 @@ export class SharedFolderCardGridComponent {
       .join(","),
   );
 
-  /** Whether the overflow cards have been revealed. Toggled by the trigger below the grid. */
-  protected readonly expanded = linkedSignal<string, boolean>({
-    source: this.folderIds,
-    computation: () => false,
+  /**
+   * Whether the overflow cards have been revealed. Toggled by the trigger below the grid, and reset
+   * to {@link initiallyExpanded} whenever the set of children changes.
+   */
+  protected readonly expanded = linkedSignal({
+    source: () => ({
+      folderIds: this.folderIds(),
+      initiallyExpanded: this.initiallyExpanded(),
+    }),
+    computation: ({ initiallyExpanded }) => initiallyExpanded,
   });
 
   /**
@@ -215,25 +228,20 @@ export class SharedFolderCardGridComponent {
 
   protected toggleExpanded() {
     this.expanded.update((expanded) => !expanded);
-  }
 
-  constructor() {
-    effect(() => {
-      if (!this.expanded()) {
-        return;
-      }
+    if (!this.expanded()) {
+      return;
+    }
 
-      // The grid sits above its own trigger, so the cards that just appeared are behind the user's
-      // focus and would otherwise go unnoticed by a screen reader.
-      const message = untracked(() => {
-        const overflowCardsCount = this.overflowCards().length;
-        if (overflowCardsCount === 1) {
-          return this.i18nService.t("moreSharedFoldersShownAboveSingular");
-        }
-        return this.i18nService.t("moreSharedFoldersShownAbove", overflowCardsCount);
-      });
+    // The grid sits above its own trigger, so the cards that just appeared are behind the user's
+    // focus and would otherwise go unnoticed by a screen reader. Only the toggle announces: a grid
+    // the host renders expanded has revealed nothing, so there is nothing to point back at.
+    const overflowCardsCount = this.overflowCards().length;
+    const message =
+      overflowCardsCount === 1
+        ? this.i18nService.t("moreSharedFoldersShownAboveSingular")
+        : this.i18nService.t("moreSharedFoldersShownAbove", overflowCardsCount);
 
-      void this.liveAnnouncer.announce(message, "polite");
-    });
+    void this.liveAnnouncer.announce(message, "polite");
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-42631)

## 📔 Objective

Fix the flaky storybook tests for the shared folder card grid most likely caused by the click actions. 
Adds inputs to determine the initial state of the accordion and the card list.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
