### PR TITLE
[PM-41308] Web: Passkey login report table updates

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
@@ -95,7 +95,6 @@
                 <a
                   bitButton
                   endIcon="bwi-external-link"
-                  variant="subtle"
                   [href]="row.instructions"
                   target="_blank"
                   rel="noreferrer"

--- a/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
@@ -42,65 +42,65 @@
         </bit-callout>
         <bit-table-scroll [dataSource]="dataSource" [rowSize]="75" layout="fixed">
           <ng-container header>
-            <th bitCell class="tw-w-12"></th>
-            <th bitCell>{{ "name" | i18n }}</th>
+            <th bitCell class="tw-w-2/3">{{ "name" | i18n }}</th>
             <th bitCell class="tw-w-1/6">{{ "type" | i18n }}</th>
-            <th bitCell class="tw-w-1/4"></th>
+            <th bitCell class="tw-w-1/6 tw-text-right">{{ "options" | i18n }}</th>
           </ng-container>
           <ng-template bitRowDef let-row>
             <td bitCell>
-              <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
-            </td>
-            <td bitCell class="tw-truncate tw-max-w-0">
-              @if (canManageCipher(row.cipher)) {
-                <a
-                  bitLink
-                  href="#"
-                  appStopClick
-                  (click)="selectCipher(row.cipher)"
-                  title="{{ 'editItemWithName' | i18n: row.cipher.name }}"
-                  >{{ row.cipher.name }}</a
-                >
-              } @else {
-                <span title="{{ row.cipher.name }}">{{ row.cipher.name }}</span>
-              }
-              @if (row.cipher.hasAttachments) {
-                <bit-icon
-                  name="bwi-paperclip"
-                  class="tw-ml-1"
-                  appStopProp
-                  title="{{ 'attachments' | i18n }}"
-                  aria-hidden="true"
-                ></bit-icon>
-                <span class="tw-sr-only">{{ "attachments" | i18n }}</span>
-              }
-              <br />
-              <small>{{ row.cipher.subTitle }}</small>
+              <div class="tw-flex tw-items-center tw-gap-4 tw-truncate">
+                <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
+                <span>
+                  @if (canManageCipher(row.cipher)) {
+                    <a
+                      bitLink
+                      href="#"
+                      appStopClick
+                      (click)="selectCipher(row.cipher)"
+                      title="{{ 'editItemWithName' | i18n: row.cipher.name }}"
+                      >{{ row.cipher.name }}</a
+                    >
+                  } @else {
+                    <span title="{{ row.cipher.name }}">{{ row.cipher.name }}</span>
+                  }
+                  @if (row.cipher.hasAttachments) {
+                    <bit-icon
+                      name="bwi-paperclip"
+                      class="tw-ml-1"
+                      appStopProp
+                      title="{{ 'attachments' | i18n }}"
+                      aria-hidden="true"
+                    ></bit-icon>
+                    <span class="tw-sr-only">{{ "attachments" | i18n }}</span>
+                  }
+                  <br />
+                  <small>{{ row.cipher.subTitle }}</small>
+                </span>
+              </div>
             </td>
             <td bitCell>
-              @if (row.supportsPasskeyLogin) {
-                <bit-icon
-                  name="bwi-passkey"
-                  class="tw-mr-1"
-                  title="{{ 'passwordlessLogin' | i18n }}"
-                  aria-hidden="true"
-                ></bit-icon>
-                <span class="tw-sr-only">{{ "passwordlessLogin" | i18n }}</span>
-              }
-              @if (row.supportsPasskeyMfa) {
-                <bit-icon
-                  name="bwi-lock-encrypted"
-                  class="tw-mr-1"
-                  title="{{ 'multifactorAuthentication' | i18n }}"
-                  aria-hidden="true"
-                ></bit-icon>
-                <span class="tw-sr-only">{{ "multifactorAuthentication" | i18n }}</span>
-              }
+              <div class="tw-flex tw-gap-2 tw-items-center">
+                @if (row.supportsPasskeyLogin) {
+                  <span bitBadge size="small" variant="subtle">
+                    {{ "login" | i18n }}
+                  </span>
+                }
+                @if (row.supportsPasskeyMfa) {
+                  <span bitBadge size="small" variant="subtle">2FA</span>
+                }
+              </div>
             </td>
-            <td bitCell class="tw-text-right">
+            <td bitCell>
               @if (row.instructions) {
-                <a [href]="row.instructions" target="_blank" rel="noreferrer">
-                  <span bitBadge variant="primary">{{ "instructions" | i18n }}</span>
+                <a
+                  bitButton
+                  endIcon="bwi-external-link"
+                  variant="subtle"
+                  [href]="row.instructions"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {{ "instructions" | i18n }}
                 </a>
               }
             </td>

--- a/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.html
@@ -48,9 +48,9 @@
           </ng-container>
           <ng-template bitRowDef let-row>
             <td bitCell>
-              <div class="tw-flex tw-items-center tw-gap-4 tw-truncate">
+              <div class="tw-flex tw-items-center tw-gap-4">
                 <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
-                <span>
+                <span class="tw-truncate tw-min-w-0">
                   @if (canManageCipher(row.cipher)) {
                     <a
                       bitLink

--- a/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/org-passkey-report.component.ts
@@ -26,6 +26,7 @@ import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-repromp
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeComponent,
+  ButtonModule,
   CalloutComponent,
   ContainerComponent,
   DialogService,
@@ -79,6 +80,7 @@ import {
     LinkComponent,
     TableModule,
     BadgeComponent,
+    ButtonModule,
   ],
 })
 export class OrgPasskeyReportComponent {

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
@@ -66,47 +66,56 @@
         }
         <bit-table-scroll [dataSource]="dataSource" [rowSize]="75" layout="fixed">
           <ng-container header>
-            <th bitCell class="tw-w-12"></th>
-            <th bitCell>{{ "name" | i18n }}</th>
+            <th bitCell class="tw-w-2/4">{{ "name" | i18n }}</th>
+            <th bitCell class="tw-w-2/6">{{ "vault" | i18n }}</th>
             <th bitCell class="tw-w-1/6">{{ "type" | i18n }}</th>
-            <th bitCell class="tw-w-1/4">{{ "owner" | i18n }}</th>
-            <th bitCell class="tw-w-1/4"></th>
+            <th bitCell class="tw-w-1/6 tw-text-right">{{ "options" | i18n }}</th>
           </ng-container>
           <ng-template bitRowDef let-row>
-            <td bitCell>
+            <td bitCell class="tw-truncate tw-flex tw-items-center tw-gap-4">
               <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
+              <span>
+                <a
+                  bitLink
+                  href="#"
+                  appStopClick
+                  (click)="selectCipher(row.cipher)"
+                  title="{{ 'editItemWithName' | i18n: row.cipher.name }}"
+                  >{{ row.cipher.name }}</a
+                >
+                @if (row.cipher.organizationId) {
+                  <bit-icon
+                    [name]="'bwi-collection-shared' | vfo1Icon"
+                    class="tw-ml-1"
+                    appStopProp
+                    title="{{ 'shared' | i18n }}"
+                    aria-hidden="true"
+                  ></bit-icon>
+                  <span class="tw-sr-only">{{ "shared" | i18n }}</span>
+                }
+                @if (row.cipher.hasAttachments) {
+                  <bit-icon
+                    name="bwi-paperclip"
+                    class="tw-ml-1"
+                    appStopProp
+                    title="{{ 'attachments' | i18n }}"
+                    aria-hidden="true"
+                  ></bit-icon>
+                  <span class="tw-sr-only">{{ "attachments" | i18n }}</span>
+                }
+                <br />
+                <small>{{ row.cipher.subTitle }}</small>
+              </span>
             </td>
-            <td bitCell class="tw-truncate tw-max-w-0">
-              <a
-                bitLink
-                href="#"
-                appStopClick
-                (click)="selectCipher(row.cipher)"
-                title="{{ 'editItemWithName' | i18n: row.cipher.name }}"
-                >{{ row.cipher.name }}</a
-              >
-              @if (row.cipher.organizationId) {
-                <bit-icon
-                  [name]="'bwi-collection-shared' | vfo1Icon"
-                  class="tw-ml-1"
-                  appStopProp
-                  title="{{ 'shared' | i18n }}"
-                  aria-hidden="true"
-                ></bit-icon>
-                <span class="tw-sr-only">{{ "shared" | i18n }}</span>
-              }
-              @if (row.cipher.hasAttachments) {
-                <bit-icon
-                  name="bwi-paperclip"
-                  class="tw-ml-1"
-                  appStopProp
-                  title="{{ 'attachments' | i18n }}"
-                  aria-hidden="true"
-                ></bit-icon>
-                <span class="tw-sr-only">{{ "attachments" | i18n }}</span>
-              }
-              <br />
-              <small>{{ row.cipher.subTitle }}</small>
+            <td bitCell>
+              <app-org-badge
+                [disabled]="true"
+                [organizationId]="row.cipher.organizationId"
+                [organizationName]="
+                  (row.cipher.organizationId | orgNameFromId: organizations() ?? []) ?? ''
+                "
+                appStopProp
+              />
             </td>
             <td bitCell>
               @if (row.supportsPasskeyLogin) {
@@ -127,16 +136,6 @@
                 ></bit-icon>
                 <span class="tw-sr-only">{{ "multifactorAuthentication" | i18n }}</span>
               }
-            </td>
-            <td bitCell>
-              <app-org-badge
-                [disabled]="true"
-                [organizationId]="row.cipher.organizationId"
-                [organizationName]="
-                  (row.cipher.organizationId | orgNameFromId: organizations() ?? []) ?? ''
-                "
-                appStopProp
-              />
             </td>
             <td bitCell class="tw-text-right">
               @if (row.instructions) {

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
@@ -73,9 +73,9 @@
           </ng-container>
           <ng-template bitRowDef let-row>
             <td bitCell>
-              <div class="tw-truncate tw-flex tw-items-center tw-gap-4">
+              <div class="tw-flex tw-items-center tw-gap-4">
                 <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
-                <span>
+                <span class="tw-truncate tw-min-w-0">
                   <a
                     bitLink
                     href="#"
@@ -112,7 +112,7 @@
             <td bitCell class="tw-truncate">
               @if (row.cipher.organizationId) {
                 @let orgName = row.cipher.organizationId | orgNameFromId: organizations() ?? [];
-                {{ "orgNameVault" | i18n: orgName }}
+                {{ "orgNameVault" | i18n: orgName ?? "" }}
               } @else {
                 {{ "myVault" | i18n }}
               }

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
@@ -66,8 +66,8 @@
         }
         <bit-table-scroll [dataSource]="dataSource" [rowSize]="75" layout="fixed">
           <ng-container header>
-            <th bitCell class="tw-w-2/4">{{ "name" | i18n }}</th>
-            <th bitCell class="tw-w-2/6">{{ "vault" | i18n }}</th>
+            <th bitCell class="tw-w-1/2">{{ "name" | i18n }}</th>
+            <th bitCell class="tw-w-1/6">{{ "vault" | i18n }}</th>
             <th bitCell class="tw-w-1/6">{{ "type" | i18n }}</th>
             <th bitCell class="tw-w-1/6 tw-text-right">{{ "options" | i18n }}</th>
           </ng-container>
@@ -107,40 +107,35 @@
                 <small>{{ row.cipher.subTitle }}</small>
               </span>
             </td>
-            <td bitCell>
-              <app-org-badge
-                [disabled]="true"
-                [organizationId]="row.cipher.organizationId"
-                [organizationName]="
-                  (row.cipher.organizationId | orgNameFromId: organizations() ?? []) ?? ''
-                "
-                appStopProp
-              />
+            <td bitCell class="tw-truncate">
+              @if (row.cipher.organizationId) {
+                @let orgName = row.cipher.organizationId | orgNameFromId: organizations() ?? [];
+                {{ "orgNameVault" | i18n: orgName }}
+              } @else {
+                {{ "myVault" | i18n }}
+              }
             </td>
-            <td bitCell>
+            <td bitCell class="tw-flex tw-gap-2 tw-items-center">
               @if (row.supportsPasskeyLogin) {
-                <bit-icon
-                  name="bwi-passkey"
-                  class="tw-mr-1"
-                  title="{{ 'passwordlessLogin' | i18n }}"
-                  aria-hidden="true"
-                ></bit-icon>
-                <span class="tw-sr-only">{{ "passwordlessLogin" | i18n }}</span>
+                <span bitBadge size="small" variant="subtle">
+                  {{ "login" | i18n }}
+                </span>
               }
               @if (row.supportsPasskeyMfa) {
-                <bit-icon
-                  name="bwi-lock-encrypted"
-                  class="tw-mr-1"
-                  title="{{ 'multifactorAuthentication' | i18n }}"
-                  aria-hidden="true"
-                ></bit-icon>
-                <span class="tw-sr-only">{{ "multifactorAuthentication" | i18n }}</span>
+                <span bitBadge size="small" variant="subtle">2FA</span>
               }
             </td>
             <td bitCell class="tw-text-right">
               @if (row.instructions) {
-                <a [href]="row.instructions" target="_blank" rel="noreferrer">
-                  <span bitBadge variant="primary">{{ "instructions" | i18n }}</span>
+                <a
+                  bitButton
+                  endIcon="bwi-external-link"
+                  variant="subtle"
+                  [href]="row.instructions"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {{ "instructions" | i18n }}
                 </a>
               }
             </td>

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
@@ -66,46 +66,48 @@
         }
         <bit-table-scroll [dataSource]="dataSource" [rowSize]="75" layout="fixed">
           <ng-container header>
-            <th bitCell class="tw-w-1/2">{{ "name" | i18n }}</th>
-            <th bitCell class="tw-w-1/6">{{ "vault" | i18n }}</th>
+            <th bitCell class="tw-w-5/12">{{ "name" | i18n }}</th>
+            <th bitCell class="tw-w-3/12">{{ "vault" | i18n }}</th>
             <th bitCell class="tw-w-1/6">{{ "type" | i18n }}</th>
             <th bitCell class="tw-w-1/6 tw-text-right">{{ "options" | i18n }}</th>
           </ng-container>
           <ng-template bitRowDef let-row>
-            <td bitCell class="tw-truncate tw-flex tw-items-center tw-gap-4">
-              <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
-              <span>
-                <a
-                  bitLink
-                  href="#"
-                  appStopClick
-                  (click)="selectCipher(row.cipher)"
-                  title="{{ 'editItemWithName' | i18n: row.cipher.name }}"
-                  >{{ row.cipher.name }}</a
-                >
-                @if (row.cipher.organizationId) {
-                  <bit-icon
-                    [name]="'bwi-collection-shared' | vfo1Icon"
-                    class="tw-ml-1"
-                    appStopProp
-                    title="{{ 'shared' | i18n }}"
-                    aria-hidden="true"
-                  ></bit-icon>
-                  <span class="tw-sr-only">{{ "shared" | i18n }}</span>
-                }
-                @if (row.cipher.hasAttachments) {
-                  <bit-icon
-                    name="bwi-paperclip"
-                    class="tw-ml-1"
-                    appStopProp
-                    title="{{ 'attachments' | i18n }}"
-                    aria-hidden="true"
-                  ></bit-icon>
-                  <span class="tw-sr-only">{{ "attachments" | i18n }}</span>
-                }
-                <br />
-                <small>{{ row.cipher.subTitle }}</small>
-              </span>
+            <td bitCell>
+              <div class="tw-truncate tw-flex tw-items-center tw-gap-4">
+                <app-vault-icon [cipher]="row.cipher"></app-vault-icon>
+                <span>
+                  <a
+                    bitLink
+                    href="#"
+                    appStopClick
+                    (click)="selectCipher(row.cipher)"
+                    title="{{ 'editItemWithName' | i18n: row.cipher.name }}"
+                    >{{ row.cipher.name }}</a
+                  >
+                  @if (row.cipher.organizationId) {
+                    <bit-icon
+                      [name]="'bwi-collection-shared' | vfo1Icon"
+                      class="tw-ml-1"
+                      appStopProp
+                      title="{{ 'shared' | i18n }}"
+                      aria-hidden="true"
+                    ></bit-icon>
+                    <span class="tw-sr-only">{{ "shared" | i18n }}</span>
+                  }
+                  @if (row.cipher.hasAttachments) {
+                    <bit-icon
+                      name="bwi-paperclip"
+                      class="tw-ml-1"
+                      appStopProp
+                      title="{{ 'attachments' | i18n }}"
+                      aria-hidden="true"
+                    ></bit-icon>
+                    <span class="tw-sr-only">{{ "attachments" | i18n }}</span>
+                  }
+                  <br />
+                  <small>{{ row.cipher.subTitle }}</small>
+                </span>
+              </div>
             </td>
             <td bitCell class="tw-truncate">
               @if (row.cipher.organizationId) {
@@ -115,17 +117,19 @@
                 {{ "myVault" | i18n }}
               }
             </td>
-            <td bitCell class="tw-flex tw-gap-2 tw-items-center">
-              @if (row.supportsPasskeyLogin) {
-                <span bitBadge size="small" variant="subtle">
-                  {{ "login" | i18n }}
-                </span>
-              }
-              @if (row.supportsPasskeyMfa) {
-                <span bitBadge size="small" variant="subtle">2FA</span>
-              }
+            <td bitCell>
+              <div class="tw-flex tw-gap-2 tw-items-center">
+                @if (row.supportsPasskeyLogin) {
+                  <span bitBadge size="small" variant="subtle">
+                    {{ "login" | i18n }}
+                  </span>
+                }
+                @if (row.supportsPasskeyMfa) {
+                  <span bitBadge size="small" variant="subtle">2FA</span>
+                }
+              </div>
             </td>
-            <td bitCell class="tw-text-right">
+            <td bitCell>
               @if (row.instructions) {
                 <a
                   bitButton

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
@@ -134,7 +134,6 @@
                 <a
                   bitButton
                   endIcon="bwi-external-link"
-                  variant="subtle"
                   [href]="row.instructions"
                   target="_blank"
                   rel="noreferrer"

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.ts
@@ -17,6 +17,7 @@ import { CipherRepromptType } from "@bitwarden/common/vault/enums/cipher-repromp
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeModule,
+  ButtonModule,
   CalloutModule,
   ChipFilterComponent,
   ContainerComponent,
@@ -69,6 +70,7 @@ import {
     GetOrgNameFromIdPipe,
     OrganizationNameBadgeComponent,
     Vfo1IconPipe,
+    ButtonModule,
   ],
   providers: [PasskeyReportService],
 })

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -4199,12 +4199,6 @@
   "instructions": {
     "message": "Instructions"
   },
-  "passwordlessLogin": {
-    "message": "Passwordless login"
-  },
-  "multifactorAuthentication": {
-    "message": "Multifactor authentication"
-  },
   "exposedPasswordsReport": {
     "message": "Exposed passwords"
   },
@@ -17574,6 +17568,18 @@
       "label": {
         "content": "$1",
         "example": "Login"
+      }
+    }
+  },
+  "login": {
+    "message": "Login"
+  },
+  "orgNameVault": {
+    "message": "$ORGNAME$ vault",
+    "placeholders": {
+      "orgname": {
+        "content": "$1",
+        "example": "Unknown organization"
       }
     }
   }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-41308

## 📔 Objective
Changes to the Passkey login reports (both individual and organization versions) stemming from design review. Includes:
- Table headers updated 
- Link to instructions for setting up passkey use changed to a button
- And more...

## 📸 Screenshots
**Individual passkey report**

<img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/f5dc8e8f-6662-4fdb-8d26-9a32c0272fed" />


**Organization passkey report**

<img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/d541fb60-64fd-404d-a1a2-22b08acdddef" />
