### PR TITLE
[PM-41307] Web: Passkey report filter option label updates

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.html
@@ -50,7 +50,7 @@
               @for (status of filterStatus(); track status) {
                 <bit-toggle [value]="status">
                   {{ getName(status) }}
-                  <span bitBadge variant="info"> {{ getCount(status) }} </span>
+                  <bit-berry [value]="getCount(status)" />
                 </bit-toggle>
               }
             </bit-toggle-group>

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.ts
@@ -27,6 +27,7 @@ import {
   TableDataSource,
   TableModule,
   ToggleGroupModule,
+  BerryComponent,
 } from "@bitwarden/components";
 import {
   CipherFormConfig,
@@ -69,6 +70,7 @@ import {
     GetOrgNameFromIdPipe,
     Vfo1IconPipe,
     ButtonModule,
+    BerryComponent,
   ],
   providers: [PasskeyReportService],
 })

--- a/apps/web/src/app/dirt/reports/pages/passkey-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/passkey-report.component.ts
@@ -32,7 +32,6 @@ import {
   CipherFormConfig,
   CipherFormConfigService,
   GetOrgNameFromIdPipe,
-  OrganizationNameBadgeComponent,
   PasswordRepromptService,
   VaultItemDialogComponent,
   VaultItemDialogMode,
@@ -68,7 +67,6 @@ import {
     TableModule,
     ToggleGroupModule,
     GetOrgNameFromIdPipe,
-    OrganizationNameBadgeComponent,
     Vfo1IconPipe,
     ButtonModule,
   ],
@@ -182,10 +180,13 @@ export class PasskeyReportComponent implements OnInit {
       return this.i18nService.t("all");
     }
     if (filterId === 1) {
-      return this.i18nService.t("me");
+      return this.i18nService.t("myVault");
     }
 
-    return this.organizations()?.find((org) => org.id === filterId)?.name ?? "";
+    return this.i18nService.t(
+      "orgNameVault",
+      this.organizations()?.find((org) => org.id === filterId)?.name ?? "",
+    );
   }
 
   protected getCount(filterId: string | number): number {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-41307

## 📔 Objective
Updates the filter option copy in the individual Passkey login report to reflect new "Vault" column options. Can be one of "All", "My vault", or "<org_name> vault"

## 📸 Screenshots
**Toggle group without dropdown triggered**

<img width="1678" height="1522" alt="image" src="https://github.com/user-attachments/assets/2d91b749-375a-440d-861b-24baa46712f2" />

**Toggle group dropdown**

<img width="1392" height="1522" alt="image" src="https://github.com/user-attachments/assets/8e291311-078c-4208-bc7b-00d4c2b7f4bf" />


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>