### PR TITLE
[PM-36618] Web: Fix end icon in export button on events pages

### DIFF
--- a/apps/web/src/app/dirt/event-logs/components/organization-events/events.component.html
+++ b/apps/web/src/app/dirt/event-logs/components/organization-events/events.component.html
@@ -55,7 +55,7 @@
         bitFormButton
         [bitAction]="exportEvents"
         [disabled]="dirtyDates || usePlaceHolderEvents"
-        endIcon="bwi-sign-in"
+        endIcon="bwi-import"
       >
         {{ "exportVerb" | i18n }}
       </button>

--- a/bitwarden_license/bit-web/src/app/dirt/provider-events/events.component.html
+++ b/bitwarden_license/bit-web/src/app/dirt/provider-events/events.component.html
@@ -43,7 +43,7 @@
         bitFormButton
         [bitAction]="exportEvents"
         [disabled]="dirtyDates"
-        endIcon="bwi-sign-in"
+        endIcon="bwi-import"
       >
         {{ "exportVerb" | i18n }}
       </button>


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-36618

## 📔 Objective
The incorrect icons were used for the export buttons on the events pages in the web app. This updates both to use the correct icon, matching pattern with the Member access report.

## 📸 Screenshots
<img width="1086" height="246" alt="image" src="https://github.com/user-attachments/assets/e434de53-8789-4e47-9d09-16740689eb5e" />
