### PR TITLE
init runtime before autofill orchestrator

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -1836,8 +1836,8 @@ export default class MainBackground {
     // injection, so the onConnect listener is registered before any frame
     // connects.
     this.autofillLifecycleService.init();
-    this.autofillOrchestrator.init();
     await this.runtimeBackground.init();
+    this.autofillOrchestrator.init();
     await this.notificationBackground.init();
     this.overlayNotificationsBackground.init();
     this.commandsBackground.init();


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26324

## 📔 Objective

The extension reads MDM-managed environment URLs exactly once on install. There is a known race-condition in this logic. The read happens inside a 100ms setTimeout. If chrome.storage.managed is not yet populated when the timer fires, the URL is silently dropped.

We're working on a long term soluion for this on [PM-27719](https://bitwarden.atlassian.net/browse/PM-27719), but have gotten an influx of reports since the 2026.8.0 release last week indicating something got worse.

https://github.com/bitwarden/clients/commit/8a418658bc4e874bc599877b69861fc3a4bbcc48 ([PM-40259](https://bitwarden.atlassian.net/browse/PM-40259)) added `autofillOrchestrator.init()` before `await runtimeBackground.init()` in `main.background.ts`. This is the only relevant change I can find from the last release that has any proximity to this bug. I'm thinking the addition of new steps before the setting is read is causing the race to trip more often.

On this commit I've simply moved the `autofillORchestrator.init()` call down one line, to see if this alleviates the new issues for customers.


[PM-27719]: https://bitwarden.atlassian.net/browse/PM-27719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-40259]: https://bitwarden.atlassian.net/browse/PM-40259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ