### PR TITLE
[PM-42709] Fix forwarded email provider selection

### DIFF
--- a/libs/tools/generator/components/src/credential-generator.component.ts
+++ b/libs/tools/generator/components/src/credential-generator.component.ts
@@ -82,7 +82,7 @@ import { PassphraseSettingsComponent } from "./passphrase-settings.component";
 import { PasswordSettingsComponent } from "./password-settings.component";
 import { SubaddressSettingsComponent } from "./subaddress-settings.component";
 import { UsernameSettingsComponent } from "./username-settings.component";
-import { translate } from "./util";
+import { getUsernameGeneratorSelection, translate } from "./util";
 
 // constants used to identify navigation selections that are not
 // generator algorithms
@@ -490,6 +490,9 @@ export class CredentialGeneratorComponent implements OnInit, OnChanges, OnDestro
         // `is*Algorithm` decides `algorithm`'s type, which flows into `setPreference`
         if (isEmailAlgorithm(algorithm.id)) {
           setPreference("email");
+          if (isForwarderExtensionId(algorithm.id)) {
+            preference.email.forwarder = algorithm.id;
+          }
         } else if (isUsernameAlgorithm(algorithm.id)) {
           setPreference("username");
         } else if (isPasswordAlgorithm(algorithm.id)) {
@@ -508,21 +511,17 @@ export class CredentialGeneratorComponent implements OnInit, OnChanges, OnDestro
     // populate the form with the user's preferences to kick off interactivity
     preferences
       .pipe(
-        map(({ email, username, password }) => {
-          const usernamePref = email.updated > username.updated ? email : username;
-          const forwarderPref = isForwarderExtensionId(usernamePref.algorithm)
-            ? usernamePref
-            : null;
+        map((preferences) => {
+          const { password } = preferences;
+          const { preference, forwarder } = getUsernameGeneratorSelection(preferences);
+          const { algorithm } = preference;
+          const isForwarderSelected = isForwarderExtensionId(algorithm);
 
           // inject drill-down flags
-          const forwarderNav = !forwarderPref
-            ? NONE_SELECTED
-            : JSON.stringify(forwarderPref.algorithm);
-          const userNav = forwarderPref ? FORWARDER : JSON.stringify(usernamePref.algorithm);
+          const forwarderNav = forwarder ? JSON.stringify(forwarder) : NONE_SELECTED;
+          const userNav = isForwarderSelected ? FORWARDER : JSON.stringify(algorithm);
           const rootNav =
-            usernamePref.updated > password.updated
-              ? IDENTIFIER
-              : JSON.stringify(password.algorithm);
+            preference.updated > password.updated ? IDENTIFIER : JSON.stringify(password.algorithm);
 
           // construct cascade metadata
           const cascade = {
@@ -537,14 +536,14 @@ export class CredentialGeneratorComponent implements OnInit, OnChanges, OnDestro
               selection: { nav: userNav },
               active: {
                 nav: userNav,
-                algorithm: forwarderPref ? undefined : usernamePref.algorithm,
+                algorithm: isForwarderSelected ? undefined : algorithm,
               },
             },
             forwarder: {
               selection: { nav: forwarderNav },
               active: {
                 nav: forwarderNav,
-                algorithm: forwarderPref?.algorithm,
+                algorithm: forwarder,
               },
             },
           };

--- a/libs/tools/generator/components/src/username-generator.component.ts
+++ b/libs/tools/generator/components/src/username-generator.component.ts
@@ -78,7 +78,7 @@ import { CatchallSettingsComponent } from "./catchall-settings.component";
 import { ForwarderSettingsComponent } from "./forwarder-settings.component";
 import { SubaddressSettingsComponent } from "./subaddress-settings.component";
 import { UsernameSettingsComponent } from "./username-settings.component";
-import { toAlgorithmInfo, translate } from "./util";
+import { getUsernameGeneratorSelection, toAlgorithmInfo, translate } from "./util";
 
 // constants used to identify navigation selections that are not
 // generator algorithms
@@ -440,6 +440,9 @@ export class UsernameGeneratorComponent implements OnInit, OnChanges, OnDestroy 
         if (isEmailAlgorithm(algorithm.id)) {
           preference.email.algorithm = algorithm.id;
           preference.email.updated = new Date();
+          if (isForwarderExtensionId(algorithm.id)) {
+            preference.email.forwarder = algorithm.id;
+          }
         } else if (isUsernameAlgorithm(algorithm.id)) {
           preference.username.algorithm = algorithm.id;
           preference.username.updated = new Date();
@@ -456,17 +459,14 @@ export class UsernameGeneratorComponent implements OnInit, OnChanges, OnDestroy 
 
     preferences
       .pipe(
-        map(({ email, username }) => {
-          const usernamePref = email.updated > username.updated ? email : username;
-          const forwarderPref = isForwarderExtensionId(usernamePref.algorithm)
-            ? usernamePref
-            : null;
+        map((preferences) => {
+          const { preference, forwarder } = getUsernameGeneratorSelection(preferences);
+          const { algorithm } = preference;
+          const isForwarderSelected = isForwarderExtensionId(algorithm);
 
           // inject drill-down flags
-          const forwarderNav = !forwarderPref
-            ? NONE_SELECTED
-            : JSON.stringify(forwarderPref.algorithm);
-          const userNav = forwarderPref ? FORWARDER : JSON.stringify(usernamePref.algorithm);
+          const forwarderNav = forwarder ? JSON.stringify(forwarder) : NONE_SELECTED;
+          const userNav = isForwarderSelected ? FORWARDER : JSON.stringify(algorithm);
 
           // construct cascade metadata
           const cascade = {
@@ -474,14 +474,14 @@ export class UsernameGeneratorComponent implements OnInit, OnChanges, OnDestroy 
               selection: { nav: userNav },
               active: {
                 nav: userNav,
-                algorithm: forwarderPref ? undefined : usernamePref.algorithm,
+                algorithm: isForwarderSelected ? undefined : algorithm,
               },
             },
             forwarder: {
               selection: { nav: forwarderNav },
               active: {
                 nav: forwarderNav,
-                algorithm: forwarderPref?.algorithm,
+                algorithm: forwarder,
               },
             },
           };

--- a/libs/tools/generator/components/src/util.spec.ts
+++ b/libs/tools/generator/components/src/util.spec.ts
@@ -1,0 +1,39 @@
+/// SDK/WASM code relies on TextEncoder/TextDecoder being available globally
+import { TextEncoder, TextDecoder } from "util";
+Object.assign(global, { TextDecoder, TextEncoder });
+
+import { Vendor } from "@bitwarden/common/tools/extension/vendor/data";
+import { Algorithm, CredentialPreference } from "@bitwarden/generator-core";
+
+import { getUsernameGeneratorSelection } from "./util";
+
+describe("getUsernameGeneratorSelection", () => {
+  const duckDuckGo = { forwarder: Vendor.duckduckgo };
+
+  it.each([
+    ["random word", Algorithm.username, new Date(0), new Date(1)],
+    ["catch-all email", Algorithm.catchall, new Date(1), new Date(0)],
+    ["plus addressed email", Algorithm.plusAddress, new Date(1), new Date(0)],
+  ])(
+    "preserves the forwarder after selecting %s",
+    (_, algorithm, emailUpdated, usernameUpdated) => {
+      const preferences = {
+        email: {
+          algorithm: algorithm === Algorithm.username ? duckDuckGo : algorithm,
+          forwarder: duckDuckGo,
+          updated: emailUpdated,
+        },
+        username: {
+          algorithm: algorithm === Algorithm.username ? algorithm : Algorithm.username,
+          updated: usernameUpdated,
+        },
+        password: { algorithm: Algorithm.password, updated: new Date(0) },
+      } as CredentialPreference;
+
+      expect(getUsernameGeneratorSelection(preferences)).toMatchObject({
+        preference: { algorithm },
+        forwarder: duckDuckGo,
+      });
+    },
+  );
+});

--- a/libs/tools/generator/components/src/util.ts
+++ b/libs/tools/generator/components/src/util.ts
@@ -1,7 +1,21 @@
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { I18nKeyOrLiteral } from "@bitwarden/common/tools/types";
 import { isI18nKey } from "@bitwarden/common/tools/util";
-import { AlgorithmInfo, AlgorithmMetadata } from "@bitwarden/generator-core";
+import {
+  AlgorithmInfo,
+  AlgorithmMetadata,
+  CredentialPreference,
+  isForwarderExtensionId,
+} from "@bitwarden/generator-core";
+
+/** Gets the active username preference and preferred forwarder. */
+export function getUsernameGeneratorSelection({ email, username }: CredentialPreference) {
+  const preference = email.updated > username.updated ? email : username;
+  const forwarder =
+    email.forwarder ?? (isForwarderExtensionId(email.algorithm) ? email.algorithm : undefined);
+
+  return { preference, forwarder };
+}
 
 /** Adapts {@link AlgorithmMetadata} to legacy {@link AlgorithmInfo} structure. */
 export function toAlgorithmInfo(metadata: AlgorithmMetadata, i18n: I18nService) {

--- a/libs/tools/generator/core/src/providers/credential-preferences.spec.ts
+++ b/libs/tools/generator/core/src/providers/credential-preferences.spec.ts
@@ -2,7 +2,9 @@
 import { TextEncoder, TextDecoder } from "util";
 Object.assign(global, { TextDecoder, TextEncoder });
 
-import { AlgorithmsByType, Type } from "../metadata";
+import { Vendor } from "@bitwarden/common/tools/extension/vendor/data";
+
+import { AlgorithmsByType, ForwarderExtensionId, Type } from "../metadata";
 import { CredentialPreference } from "../types";
 
 import { PREFERENCES } from "./credential-preferences";
@@ -78,6 +80,36 @@ describe("PREFERENCES", () => {
           algorithm: AlgorithmsByType[Type.username][0],
         },
       });
+    });
+
+    it("migrates the selected forwarder to the forwarder preference", () => {
+      const input: any = structuredClone(SomeCredentialPreferences);
+      const forwarder = { forwarder: Vendor.duckduckgo } as ForwarderExtensionId;
+      input.email.algorithm = forwarder;
+
+      const result = PREFERENCES.deserializer(input);
+
+      expect(result.email.forwarder).toEqual(forwarder);
+    });
+
+    it("preserves the forwarder preference for other email algorithms", () => {
+      const input: any = structuredClone(SomeCredentialPreferences);
+      const forwarder = { forwarder: Vendor.duckduckgo } as ForwarderExtensionId;
+      input.email.forwarder = forwarder;
+
+      const result = PREFERENCES.deserializer(input);
+
+      expect(result.email.forwarder).toEqual(forwarder);
+    });
+
+    it("updates the forwarder preference from the selected forwarder", () => {
+      const input: any = structuredClone(SomeCredentialPreferences);
+      input.email.forwarder = { forwarder: Vendor.duckduckgo };
+      input.email.algorithm = { forwarder: Vendor.simplelogin };
+
+      const result = PREFERENCES.deserializer(input);
+
+      expect(result.email.forwarder).toEqual(input.email.algorithm);
     });
 
     it("converts string fields to Dates", () => {

--- a/libs/tools/generator/core/src/providers/credential-preferences.ts
+++ b/libs/tools/generator/core/src/providers/credential-preferences.ts
@@ -1,6 +1,6 @@
 import { GENERATOR_DISK, UserKeyDefinition } from "@bitwarden/common/platform/state";
 
-import { AlgorithmsByType, CredentialType } from "../metadata";
+import { AlgorithmsByType, CredentialType, Type, isForwarderExtensionId } from "../metadata";
 import { CredentialPreference } from "../types";
 
 /** plaintext password generation options */
@@ -19,6 +19,11 @@ export const PREFERENCES = new UserKeyDefinition<CredentialPreference>(
           const [algorithm] = AlgorithmsByType[type];
           result[type] = { algorithm, updated: new Date() };
         }
+      }
+
+      const email = result[Type.email];
+      if (isForwarderExtensionId(email.algorithm)) {
+        email.forwarder = email.algorithm;
       }
 
       return result;

--- a/libs/tools/generator/core/src/types/credential-preference.ts
+++ b/libs/tools/generator/core/src/types/credential-preference.ts
@@ -1,10 +1,15 @@
-import { CredentialAlgorithm, CredentialType } from "../metadata";
+import { CredentialAlgorithm, CredentialType, ForwarderExtensionId } from "../metadata";
+
+type AlgorithmPreference = {
+  algorithm: CredentialAlgorithm;
+  updated: Date;
+};
 
 /** The kind of credential to generate using a compound configuration. */
-// FIXME: extend the preferences to include a preferred forwarder
 export type CredentialPreference = {
-  [Key in CredentialType]: {
-    algorithm: CredentialAlgorithm;
-    updated: Date;
+  [Key in CredentialType]: AlgorithmPreference;
+} & {
+  email: AlgorithmPreference & {
+    forwarder?: ForwarderExtensionId;
   };
 };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42709

Discovered in the browser extension; no existing issue covers the provider reset when switching back to Forwarded email alias.

## 📔 Objective

Switching away from Forwarded email alias clears the selected provider when returning to it.

### Reproduction

1. Select Forwarded email alias and choose any provider.
2. Select Random word, Catch-all email, or Plus addressed email.
3. Select Forwarded email alias again.

The provider resets to Select.

This change stores the preferred forwarder separately, preserves it across algorithm changes, and migrates existing preferences.