### PR TITLE
Fix how the PAM audit log renders absence and timestamps

### DIFF
--- a/apps/web/src/app/layouts/user-layout.component.spec.ts
+++ b/apps/web/src/app/layouts/user-layout.component.spec.ts
@@ -5,6 +5,7 @@ import { RouterModule } from "@angular/router";
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -155,6 +156,9 @@ describe("UserLayoutComponent", () => {
         { provide: GlobalStateProvider, useValue: new FakeGlobalStateProvider() },
         { provide: SyncService, useValue: mock<SyncService>() },
         { provide: AccountService, useValue: { activeAccount$: of({ id: userId }) } },
+        // This layout renders PamUserNavSlotComponent, which reads the user's organizations to
+        // decide whether to show the PAM link.
+        { provide: OrganizationService, useValue: { organizations$: () => of([]) } },
         { provide: SendPolicyService, useValue: { disableSend$: of(false) } },
         {
           provide: PremiumSubscriptionRoutingService,

--- a/apps/web/src/app/pam/pam-mount-nav-resolution.spec.ts
+++ b/apps/web/src/app/pam/pam-mount-nav-resolution.spec.ts
@@ -155,7 +155,8 @@ describe("PAM mount / shared nav link resolution", () => {
     configService.getFeatureFlag$.mockReturnValue(flag$);
     policyService.policyAppliesToUser$.mockReturnValue(of(false));
     cipherArchiveService.userCanArchive$.mockReturnValue(canArchive$);
-    Object.defineProperty(vaultNavService, "viewModel$", { value: viewModel$ });
+    // `viewModel$` is a method taking the user id, not a bare stream.
+    Object.defineProperty(vaultNavService, "viewModel$", { value: () => viewModel$ });
 
     await TestBed.configureTestingModule({
       imports: [UserLayoutComponent, NavigationModule],

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18156,6 +18156,18 @@
   "pamRequestAccessButton": {
     "message": "Request access"
   },
+  "pamRequestSlotTaken": {
+    "message": "Someone else has access to this item right now. You can request access, but you won't be able to start it until they're done."
+  },
+  "pamRequestSlotTakenUntil": {
+    "message": "Someone else has access to this item right now. You can request access, but you won't be able to start it until $TIME$.",
+    "placeholders": {
+      "time": {
+        "content": "$1",
+        "example": "8/31/26, 10:52 AM"
+      }
+    }
+  },
   "cipherLeaseExpiresIn": {
     "message": "Leased — expires in $DURATION$",
     "placeholders": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17982,9 +17982,6 @@
   "pamAuditNoMatchesMessage": {
     "message": "No events match the current filters."
   },
-  "pamAuditColumnTime": {
-    "message": "Time"
-  },
   "pamAuditColumnEvent": {
     "message": "Event"
   },

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -26,6 +26,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     cipherName: "prod db",
     cipherId: "cipher-1",
     collectionName: "production",
+    collectionId: "collection-1",
     ruleName: null,
     ruleId: null,
     detail: null,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.spec.ts
@@ -32,6 +32,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     automated: false,
     inDoubt: false,
     requestId: null,
+    leaseId: null,
     duration: null,
     exactWindow: null,
     extendedUntil: null,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -33,6 +33,11 @@ export type AuditRow = {
   cipherId: string | null;
   /** Decrypted collection name from local vault state, or null. */
   collectionName: string | null;
+  /**
+   * The subject collection, when the event names one — the identity behind a collection the drawer can
+   * open the organization vault on.
+   */
+  collectionId: string | null;
   /** The access rule's name (plaintext, provided by the server), for rule administration events; null otherwise. */
   ruleName: string | null;
   /** The subject access rule, when the event names one — the identity behind a rule-named Item cell. */
@@ -153,6 +158,7 @@ export function toAuditRow(
     cipherName,
     cipherId: event.cipherId,
     collectionName,
+    collectionId: event.collectionId,
     ruleName: event.ruleName,
     ruleId: event.ruleId,
     detail: event.detail,
@@ -188,6 +194,18 @@ export function auditItemId(row: AuditRow): string | null {
 /** The label the Item cell renders for a row, or null when it renders no item. */
 export function auditItemLabel(row: AuditRow): string | null {
   return row.cipherName ?? row.ruleName;
+}
+
+/**
+ * Whether the event destroyed the rule it names.
+ *
+ * The audit store snapshots {@link AuditRow.ruleName} at write time, so such a row still reads as a name
+ * long after the rule itself is gone — and the rule editor's route would answer that name with a 404 on
+ * the very event an auditor is most likely to follow. Read off the label key rather than the wire kind
+ * because that is what the row carries once shaped.
+ */
+export function auditRuleDeleted(row: AuditRow): boolean {
+  return row.kindLabelKey === auditKindLabelKey(AccessAuditEventKind.RuleDeleted);
 }
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit-row.ts
@@ -44,11 +44,16 @@ export type AuditRow = {
   /** True when the action's outcome never landed (only the write-ahead attempt) — shown as an in-doubt row. */
   inDoubt: boolean;
   /**
-   * The originating request, when the event has one. Carried but not rendered: the request-detail page
-   * is authorized for the requester or a managing approver, not for AccessEventLogs, so this trail
-   * offers no drill-down (see {@link AccessAuditComponent}).
+   * The originating request, when the event has one. Shown in the details drawer but never as a link:
+   * the request-detail page is authorized for the requester or a managing approver, not for
+   * AccessEventLogs, so this trail offers no drill-down (see {@link AccessAuditComponent}).
    */
   requestId: string | null;
+  /**
+   * The lease the event concerns, when it has one. Like {@link AuditRow.requestId} it opens nothing;
+   * it is carried so the details drawer can hand an auditor the id support would ask them for.
+   */
+  leaseId: string | null;
   /** The length of the granted access window, as an i18n key + value. Null on every other kind. */
   duration: LabelValue | null;
   /** The exact "from – to" window behind {@link duration}, for the cell's tooltip. Null whenever {@link duration} is. */
@@ -154,6 +159,7 @@ export function toAuditRow(
     automated: event.automated,
     inDoubt: event.incomplete,
     requestId: event.requestId,
+    leaseId: event.leaseId,
     duration: grantedWindow == null ? null : durationLabel(grantedWindow),
     exactWindow: grantedWindow == null ? null : exactWindow(grantedWindow),
     extendedUntil,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -229,6 +229,10 @@
                   it rather than all six: a trail is ninety days long, and a tab stop per cell would
                   put hundreds between an auditor and the end of the table. Pointer activation stays
                   on the row itself, so the cell must not repeat it — the click would arrive twice.
+
+                  `button` marks its children presentational, so the in-doubt badge below is not
+                  exposed as a node of its own and only reaches a screen reader through this cell's
+                  accessible name.
                 -->
                 <td
                   bitCell
@@ -237,7 +241,10 @@
                   class="tw-whitespace-nowrap focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-border-focus"
                   id="access-audit_button_details-{{ $index }}"
                   [attr.aria-label]="
-                    (row.kindLabelKey | i18n) + ' ' + (row.occurredAt | date: 'medium')
+                    (row.kindLabelKey | i18n) +
+                    ' ' +
+                    (row.occurredAt | date: 'medium') +
+                    (row.inDoubt ? ' ' + ('pamAuditIncomplete' | i18n) : '')
                   "
                   (keydown.enter)="openDetails(row)"
                   (keydown.space)="openDetails(row); $event.preventDefault()"

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -194,12 +194,28 @@
             <tr>
               <th bitCell class="tw-whitespace-nowrap">{{ "timestamp" | i18n }}</th>
               <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnEvent" | i18n }}</th>
-              <th bitCell>{{ "pamAuditColumnActor" | i18n }}</th>
-              <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
+              <!--
+                Actor, Requester and Duration stand down while the drawer is beside the table. Six
+                columns do not fit the half-width the drawer leaves, and these three are the ones the
+                reader loses least by: the pane they just opened already shows all three for the
+                selected row, actor and requester are a small repeating set of names across the trail,
+                and duration is an em dash on most kinds. Timestamp, Event and Item stay because they
+                are what keeps a place in the list — Item being what separates a run of rows sharing
+                one event label. `tw-hidden` rather than an opacity or width class, so the cells leave
+                the accessibility tree with the layout and no anchor is left focusable but unreadable.
+              -->
+              <th bitCell [class.tw-hidden]="detailsOpen()">
+                {{ "pamAuditColumnActor" | i18n }}
+              </th>
+              <th bitCell [class.tw-hidden]="detailsOpen()">
+                {{ "pamAuditColumnRequester" | i18n }}
+              </th>
               <th bitCell class="tw-min-w-48 tw-max-w-64 tw-break-words">
                 {{ "pamAuditColumnItem" | i18n }}
               </th>
-              <th bitCell>{{ "pamAuditColumnDuration" | i18n }}</th>
+              <th bitCell [class.tw-hidden]="detailsOpen()">
+                {{ "pamAuditColumnDuration" | i18n }}
+              </th>
             </tr>
           </ng-container>
           <ng-template body>
@@ -236,7 +252,7 @@
                     >
                   }
                 </td>
-                <td bitCell>
+                <td bitCell [class.tw-hidden]="detailsOpen()">
                   @if (row.automated) {
                     <span class="tw-text-muted">{{ "pamAuditSystem" | i18n }}</span>
                   } @else if (linkedMember(row.actorId, row.actor); as member) {
@@ -254,7 +270,7 @@
                     <span class="tw-text-muted">—</span>
                   }
                 </td>
-                <td bitCell>
+                <td bitCell [class.tw-hidden]="detailsOpen()">
                   @if (linkedMember(row.requesterId, row.requester); as member) {
                     <a
                       bitLink
@@ -288,7 +304,7 @@
                     <span class="tw-text-muted">—</span>
                   }
                 </td>
-                <td bitCell>
+                <td bitCell [class.tw-hidden]="detailsOpen()">
                   @if (row.duration; as duration) {
                     <span class="tw-whitespace-nowrap" [bitTooltip]="row.exactWindow">{{
                       duration.key | i18n: duration.value

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -172,9 +172,20 @@
     </div>
 
     @if (filteredRows().length === 0) {
-      <bit-callout type="info" [title]="'pamAuditNoMatchesTitle' | i18n">
-        {{ "pamAuditNoMatchesMessage" | i18n }}
-      </bit-callout>
+      <bit-no-items>
+        <span slot="title">{{ "pamAuditNoMatchesTitle" | i18n }}</span>
+        <span slot="description">{{ "pamAuditNoMatchesMessage" | i18n }}</span>
+        <button
+          slot="button"
+          type="button"
+          bitButton
+          buttonType="secondary"
+          id="access-audit_button_no-matches-clear-all"
+          (click)="clearAll()"
+        >
+          {{ "clearAll" | i18n }}
+        </button>
+      </bit-no-items>
     } @else {
       <div class="tw-overflow-x-auto">
         <bit-table>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -222,8 +222,10 @@
                       (click)="openMemberEvents($event, member)"
                       >{{ row.actor }}</a
                     >
-                  } @else {
+                  } @else if (row.actor) {
                     {{ row.actor }}
+                  } @else {
+                    <span class="tw-text-muted">—</span>
                   }
                 </td>
                 <td bitCell>
@@ -236,8 +238,10 @@
                       (click)="openMemberEvents($event, member)"
                       >{{ row.requester }}</a
                     >
-                  } @else {
+                  } @else if (row.requester) {
                     {{ row.requester }}
+                  } @else {
+                    <span class="tw-text-muted">—</span>
                   }
                 </td>
                 <td bitCell class="tw-max-w-64 tw-break-words">
@@ -271,7 +275,13 @@
                     <span class="tw-text-muted">—</span>
                   }
                 </td>
-                <td bitCell class="tw-max-w-64 tw-break-words">{{ row.detail }}</td>
+                <td bitCell class="tw-max-w-64 tw-break-words">
+                  @if (row.detail) {
+                    {{ row.detail }}
+                  } @else {
+                    <span class="tw-text-muted">—</span>
+                  }
+                </td>
               </tr>
             }
           </ng-template>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -172,7 +172,8 @@
     </div>
 
     @if (filteredRows().length === 0) {
-      <bit-no-items>
+      <bit-status-lockup>
+        <bit-svg slot="graphic" [content]="noResultsSvg"></bit-svg>
         <span slot="title">{{ "pamAuditNoMatchesTitle" | i18n }}</span>
         <span slot="description">{{ "pamAuditNoMatchesMessage" | i18n }}</span>
         <button
@@ -185,7 +186,7 @@
         >
           {{ "clearAll" | i18n }}
         </button>
-      </bit-no-items>
+      </bit-status-lockup>
     } @else {
       <div class="tw-overflow-x-auto">
         <bit-table>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -198,16 +198,32 @@
               <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
               <th bitCell class="tw-max-w-64 tw-break-words">{{ "pamAuditColumnItem" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnDuration" | i18n }}</th>
-              <th bitCell class="tw-max-w-64 tw-break-words">
-                {{ "pamAuditColumnDetail" | i18n }}
-              </th>
             </tr>
           </ng-container>
           <ng-template body>
             @for (row of filteredRows(); track $index) {
-              <tr bitRow>
+              <tr bitRow class="tw-cursor-pointer" (click)="openDetails(row)">
                 <td bitCell class="tw-whitespace-nowrap">{{ row.occurredAt | date: "medium" }}</td>
-                <td bitCell class="tw-whitespace-nowrap">
+                <!--
+                  The row's keyboard affordance, following the clickable-row pattern the access
+                  intelligence tables use (`role="button"` + `tabindex` + Enter/Space on the cell
+                  rather than on the `tr`, which is neither focusable nor nameable). One cell carries
+                  it rather than all six: a trail is ninety days long, and a tab stop per cell would
+                  put hundreds between an auditor and the end of the table. Pointer activation stays
+                  on the row itself, so the cell must not repeat it — the click would arrive twice.
+                -->
+                <td
+                  bitCell
+                  role="button"
+                  tabindex="0"
+                  class="tw-whitespace-nowrap focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-border-focus"
+                  id="access-audit_button_details-{{ $index }}"
+                  [attr.aria-label]="
+                    (row.kindLabelKey | i18n) + ' ' + (row.occurredAt | date: 'medium')
+                  "
+                  (keydown.enter)="openDetails(row)"
+                  (keydown.space)="openDetails(row); $event.preventDefault()"
+                >
                   {{ row.kindLabelKey | i18n }}
                   @if (row.inDoubt) {
                     <span
@@ -279,13 +295,6 @@
                     <span class="tw-whitespace-nowrap">{{
                       "pamAuditDurationExtendedTo" | i18n: (row.extendedUntil | date: "short")
                     }}</span>
-                  } @else {
-                    <span class="tw-text-muted">—</span>
-                  }
-                </td>
-                <td bitCell class="tw-max-w-64 tw-break-words">
-                  @if (row.detail) {
-                    {{ row.detail }}
                   } @else {
                     <span class="tw-text-muted">—</span>
                   }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -191,7 +191,7 @@
         <bit-table>
           <ng-container header>
             <tr>
-              <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnTime" | i18n }}</th>
+              <th bitCell class="tw-whitespace-nowrap">{{ "timestamp" | i18n }}</th>
               <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnEvent" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnActor" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
@@ -205,11 +205,7 @@
           <ng-template body>
             @for (row of filteredRows(); track $index) {
               <tr bitRow>
-                <td bitCell class="tw-whitespace-nowrap">
-                  <span [bitTooltip]="row.occurredAt | date: 'medium'">{{
-                    row.occurredAt | date: "short"
-                  }}</span>
-                </td>
+                <td bitCell class="tw-whitespace-nowrap">{{ row.occurredAt | date: "medium" }}</td>
                 <td bitCell class="tw-whitespace-nowrap">
                   {{ row.kindLabelKey | i18n }}
                   @if (row.inDoubt) {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.html
@@ -196,7 +196,9 @@
               <th bitCell class="tw-whitespace-nowrap">{{ "pamAuditColumnEvent" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnActor" | i18n }}</th>
               <th bitCell>{{ "pamAuditColumnRequester" | i18n }}</th>
-              <th bitCell class="tw-max-w-64 tw-break-words">{{ "pamAuditColumnItem" | i18n }}</th>
+              <th bitCell class="tw-min-w-48 tw-max-w-64 tw-break-words">
+                {{ "pamAuditColumnItem" | i18n }}
+              </th>
               <th bitCell>{{ "pamAuditColumnDuration" | i18n }}</th>
             </tr>
           </ng-container>
@@ -268,7 +270,7 @@
                     <span class="tw-text-muted">—</span>
                   }
                 </td>
-                <td bitCell class="tw-max-w-64 tw-break-words">
+                <td bitCell class="tw-min-w-48 tw-max-w-64 tw-break-words">
                   @if (row.cipherName && row.cipherId) {
                     <a
                       bitLink

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -73,7 +73,7 @@ describe("AccessAuditComponent", () => {
   let organizationUserApiService: MockProxy<OrganizationUserApiService>;
   let dialogService: MockProxy<DialogService>;
 
-  const configureTestBed = async (canManageAccessRules = true) => {
+  const configureTestBed = async (canManageAccessRules = true, canViewAllCollections = true) => {
     await TestBed.configureTestingModule({
       imports: [AccessAuditComponent],
       providers: [
@@ -92,7 +92,8 @@ describe("AccessAuditComponent", () => {
         {
           provide: OrganizationService,
           useValue: {
-            organizations$: () => of([{ id: ORGANIZATION_ID, canManageAccessRules }]),
+            organizations$: () =>
+              of([{ id: ORGANIZATION_ID, canManageAccessRules, canViewAllCollections }]),
           },
         },
         {
@@ -1468,6 +1469,28 @@ describe("AccessAuditComponent", () => {
 
       expect(drawerData().actor).toBeNull();
       expect(drawerData().requester).toBeNull();
+    });
+
+    // The page already read the viewer's membership; a pane re-deriving it could offer a link the
+    // page itself would not.
+    it("hands the drawer the permissions its links are gated on", async () => {
+      await render([event()]);
+
+      rows()[0].click();
+
+      expect(drawerData().canManageAccessRules).toBe(true);
+      expect(drawerData().canViewCollections).toBe(true);
+    });
+
+    it("hands the drawer neither permission when the viewer holds neither", async () => {
+      TestBed.resetTestingModule();
+      await configureTestBed(false, false);
+      await render([event()]);
+
+      rows()[0].click();
+
+      expect(drawerData().canManageAccessRules).toBe(false);
+      expect(drawerData().canViewCollections).toBe(false);
     });
 
     // An anchor inside the row already opens something of its own. Letting the click reach the row

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1447,9 +1447,14 @@ describe("AccessAuditComponent", () => {
       fixture.detectChanges();
 
       expect(component().status()).toBe("empty");
-      const noItems = fixture.nativeElement.querySelector("bit-no-items") as HTMLElement;
-      expect(noItems.querySelector("[slot=title]")!.textContent!.trim()).toBe("No audit activity");
-      expect(fixture.nativeElement.querySelector("#access-audit_link_access-rules")).not.toBeNull();
+      const accessRulesLink = fixture.nativeElement.querySelector(
+        "#access-audit_link_access-rules",
+      );
+      expect(accessRulesLink).not.toBeNull();
+      const emptyState = accessRulesLink!.closest("bit-status-lockup")!;
+      expect(emptyState.querySelector("[slot=title]")!.textContent!.trim()).toBe(
+        "No audit activity",
+      );
       expect(emptyStateClearAll()).toBeNull();
     });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1422,7 +1422,7 @@ describe("AccessAuditComponent", () => {
       overFilter();
 
       expect(component().filteredRows()).toHaveLength(0);
-      expect(fixture.nativeElement.querySelector("bit-no-items")).not.toBeNull();
+      expect(fixture.nativeElement.querySelector("bit-status-lockup")).not.toBeNull();
       expect(fixture.nativeElement.querySelector("bit-callout")).toBeNull();
       expect(fixture.nativeElement.querySelector("bit-table")).toBeNull();
     });
@@ -1431,9 +1431,11 @@ describe("AccessAuditComponent", () => {
       await renderReady();
       overFilter();
 
-      const noItems = fixture.nativeElement.querySelector("bit-no-items") as HTMLElement;
-      expect(noItems.querySelector("[slot=title]")!.textContent!.trim()).toBe("No matching events");
-      expect(noItems.querySelector("[slot=description]")!.textContent!.trim()).toBe(
+      const emptyState = emptyStateClearAll()!.closest("bit-status-lockup")!;
+      expect(emptyState.querySelector("[slot=title]")!.textContent!.trim()).toBe(
+        "No matching events",
+      );
+      expect(emptyState.querySelector("[slot=description]")!.textContent!.trim()).toBe(
         "No events match the current filters.",
       );
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1440,6 +1440,20 @@ describe("AccessAuditComponent", () => {
       expect(drawerData().organizationId).toBe(ORGANIZATION_ID);
     });
 
+    // `openDrawer` defaults `closeOnNavigation` to false and `DrawerService` only tears the stack down
+    // when the bottom ref asked for it, so without this the pane stays mounted over whatever page the
+    // auditor navigates to next.
+    it("closes the drawer when the auditor navigates away", async () => {
+      await render([event()]);
+
+      rows()[0].click();
+
+      expect(dialogService.openDrawer).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ closeOnNavigation: true }),
+      );
+    });
+
     // The member lookup ran once for the whole trail; the pane must link exactly what the row under
     // it links, which it can only do if the page hands over the answer it already has.
     it("hands the drawer the identities the row resolved", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1398,6 +1398,90 @@ describe("AccessAuditComponent", () => {
     });
   });
 
+  describe("empty cells", () => {
+    const ACTOR = 2;
+    const REQUESTER = 3;
+    const DETAIL = 6;
+
+    const render = async (events: AccessAuditEventResponse[]) => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue(events);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const cell = (column: number): HTMLElement =>
+      Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll("bit-table tbody tr td"))[
+        column
+      ];
+
+    const text = (column: number) => cell(column).textContent!.trim();
+
+    it("renders the actor's name when the row names one", async () => {
+      await render([event({ ActorId: "user-9", ActorName: "Linus" })]);
+
+      expect(text(ACTOR)).toBe("Linus");
+    });
+
+    it("renders an em dash for a row with no actor", async () => {
+      await render([event({ ActorId: null, ActorName: null, ActorEmail: null })]);
+
+      expect(text(ACTOR)).toBe("—");
+    });
+
+    // "System" is a value, not an absence: an automated row has an actor, it just is not a person.
+    it("keeps the System label rather than a dash for an automated row", async () => {
+      await render([event({ ActorId: null, ActorName: null, ActorEmail: null, Automated: true })]);
+
+      expect(text(ACTOR)).toBe("System");
+    });
+
+    it("renders the requester's name when the row names one", async () => {
+      await render([event({ RequesterId: "user-9", RequesterName: "Linus" })]);
+
+      expect(text(REQUESTER)).toBe("Linus");
+    });
+
+    it("renders an em dash for a row with no requester", async () => {
+      await render([event({ RequesterId: null, RequesterName: null, RequesterEmail: null })]);
+
+      expect(text(REQUESTER)).toBe("—");
+    });
+
+    it("renders the detail when the row carries one", async () => {
+      await render([event({ Detail: "Incident closed early." })]);
+
+      expect(text(DETAIL)).toBe("Incident closed early.");
+    });
+
+    it("renders an em dash for a row with no detail", async () => {
+      await render([event({ Detail: null })]);
+
+      expect(text(DETAIL)).toBe("—");
+    });
+
+    // A blank cell in an audit table reads as a rendering failure rather than as "no value".
+    it("leaves no cell of a bare row blank", async () => {
+      await render([
+        event({
+          ActorId: null,
+          ActorName: null,
+          ActorEmail: null,
+          RequesterId: null,
+          RequesterName: null,
+          RequesterEmail: null,
+          Detail: null,
+        }),
+      ]);
+
+      for (const column of [ACTOR, REQUESTER, DETAIL]) {
+        expect(text(column)).toBe("—");
+        expect(cell(column).querySelector(".tw-text-muted")).not.toBeNull();
+      }
+    });
+  });
+
   describe("column widths", () => {
     /** Time, Event, Actor, Requester, Item, Duration, Detail — the order the template declares. */
     const TIME = 0;

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1816,6 +1816,23 @@ describe("AccessAuditComponent", () => {
       expect(cells[ITEM].classList).toContain("tw-break-words");
     });
 
+    it("floors Item so the auto table overflows instead of collapsing the column", async () => {
+      const { headers, cells } = await renderTable();
+
+      expect(headers[ITEM].classList).toContain("tw-min-w-48");
+      expect(cells[ITEM].classList).toContain("tw-min-w-48");
+    });
+
+    it("keeps the Item floor beneath the cap and beside the bitCell padding", async () => {
+      const { cells } = await renderTable();
+
+      // Same HostBinding merge as above: the floor is inert unless it survives alongside tw-p-3,
+      // and it is only a floor while the cap is still there to bound the other end.
+      expect(cells[ITEM].classList).toContain("tw-p-3");
+      expect(cells[ITEM].classList).toContain("tw-min-w-48");
+      expect(cells[ITEM].classList).toContain("tw-max-w-64");
+    });
+
     it("leaves the unbounded name columns free to wrap", async () => {
       const { cells } = await renderTable();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1399,6 +1399,172 @@ describe("AccessAuditComponent", () => {
     });
   });
 
+  describe("details drawer", () => {
+    const render = async (events: AccessAuditEventResponse[]) => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue(events);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const rows = (): HTMLElement[] =>
+      Array.from(fixture.nativeElement.querySelectorAll("bit-table tbody tr"));
+
+    const activator = (index = 0): HTMLElement =>
+      fixture.nativeElement.querySelector(`#access-audit_button_details-${index}`);
+
+    /** The params the one opened drawer was configured with. */
+    const drawerData = () =>
+      (dialogService.openDrawer.mock.calls[0][1] as { data: Record<string, any> }).data;
+
+    const press = (element: HTMLElement, key: string): KeyboardEvent => {
+      const keydown = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+      element.dispatchEvent(keydown);
+      fixture.detectChanges();
+      return keydown;
+    };
+
+    it("opens the drawer over the row that was activated", async () => {
+      await render([
+        event({ OccurredAt: "2026-08-18T09:00:00.000Z", Detail: "first" }),
+        event({ OccurredAt: "2026-08-18T08:00:00.000Z", Detail: "second" }),
+      ]);
+
+      rows()[1].click();
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(1);
+      expect(drawerData().row.detail).toBe("second");
+      expect(drawerData().organizationId).toBe(ORGANIZATION_ID);
+    });
+
+    // The member lookup ran once for the whole trail; the pane must link exactly what the row under
+    // it links, which it can only do if the page hands over the answer it already has.
+    it("hands the drawer the identities the row resolved", async () => {
+      await render([event({ ActorId: "user-1", RequesterId: "user-2" })]);
+
+      rows()[0].click();
+
+      expect(drawerData().actor).toEqual({
+        name: "Ada",
+        email: "ada@example.com",
+        organizationUserId: "org-user-1",
+      });
+      expect(drawerData().requester.organizationUserId).toBe("org-user-2");
+    });
+
+    it("hands the drawer no actor for an automated row", async () => {
+      await render([event({ Automated: true })]);
+
+      rows()[0].click();
+
+      expect(drawerData().actor).toBeNull();
+    });
+
+    it("leaves an identity the member lookup did not resolve unlinked in the drawer", async () => {
+      await render([event({ ActorId: "user-9", ActorName: "Linus", RequesterId: "user-9" })]);
+
+      rows()[0].click();
+
+      expect(drawerData().actor).toBeNull();
+      expect(drawerData().requester).toBeNull();
+    });
+
+    // An anchor inside the row already opens something of its own. Letting the click reach the row
+    // as well would stack a drawer behind the dialog the auditor actually asked for.
+    it.each([
+      ["actor", { ActorId: "user-1", ActorName: "Ada" }],
+      ["requester", { RequesterId: "user-2", RequesterName: "Grace" }],
+    ])("opens only the entity dialog from the %s link", async (name, overrides) => {
+      await render([event(overrides)]);
+
+      fixture.nativeElement.querySelector(`#access-audit_link_${name}-0`).click();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(1);
+      expect(dialogService.openDrawer).not.toHaveBeenCalled();
+    });
+
+    it("opens only the entity dialog from the item link", async () => {
+      nameResolver.resolveNames.mockResolvedValue({
+        ...emptyResolvedNames(),
+        cipherNameById: new Map([["cipher-1", "Prod database"]]),
+      });
+      await render([event({ CipherId: "cipher-1", CollectionId: "col-1" })]);
+
+      fixture.nativeElement.querySelector("#access-audit_link_item-0").click();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(1);
+      expect(dialogService.openDrawer).not.toHaveBeenCalled();
+    });
+
+    // A `tr` is neither focusable nor nameable, so the affordance lives on a cell — one cell, not
+    // six, or a ninety-day trail would put hundreds of tab stops between an auditor and the table's end.
+    it("gives the row one keyboard activator, with a role and a name", async () => {
+      await render([event()]);
+
+      const cell = activator();
+      expect(cell.getAttribute("role")).toBe("button");
+      expect(cell.getAttribute("tabindex")).toBe("0");
+      expect(cell.getAttribute("aria-label")).toContain("Request approved");
+      expect(cell.className).toContain("focus-visible:tw-ring-2");
+      expect(
+        fixture.nativeElement.querySelectorAll('bit-table tbody [role="button"]'),
+      ).toHaveLength(1);
+    });
+
+    it("opens the drawer on Enter", async () => {
+      await render([event()]);
+
+      press(activator(), "Enter");
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(1);
+    });
+
+    // Space activates the row without also scrolling the page out from under it.
+    it("opens the drawer on Space, and swallows the key", async () => {
+      await render([event()]);
+
+      const keydown = press(activator(), " ");
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(1);
+      expect(keydown.defaultPrevented).toBe(true);
+    });
+
+    // Pointer activation sits on the row, so the activator cell must not repeat it.
+    it("opens the drawer once when the activator itself is clicked", async () => {
+      await render([event()]);
+
+      activator().click();
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(1);
+    });
+
+    it("no longer gives the table a Detail column", async () => {
+      await render([event({ Detail: "Incident closed early." })]);
+
+      const headers = Array.from<HTMLElement>(
+        fixture.nativeElement.querySelectorAll("bit-table thead th"),
+      ).map((header) => header.textContent!.trim());
+      expect(headers).toEqual(["Timestamp", "Event", "Actor", "Requester", "Item", "Duration"]);
+      expect(fixture.nativeElement.querySelector("bit-table tbody").textContent).not.toContain(
+        "Incident closed early.",
+      );
+    });
+
+    // The column is gone from the TABLE, not from the trail: the file an auditor exports is the
+    // record they file, and it still has to carry the free text the column used to show.
+    it("still exports the detail the column gave up", async () => {
+      await render([event({ Detail: "Incident closed early." })]);
+
+      fixture.nativeElement.querySelector("#access-audit_button_export").click();
+
+      const csv = fileDownloadService.download.mock.calls[0][0].blobData as string;
+      const parsed = papa.parse<Record<string, string>>(csv, { header: true });
+      expect(parsed.meta.fields).toContain("detail");
+      expect(parsed.data[0].detail).toBe("Incident closed early.");
+    });
+  });
+
   describe("no matches", () => {
     const emptyStateClearAll = (): HTMLButtonElement | null =>
       fixture.nativeElement.querySelector("#access-audit_button_no-matches-clear-all");
@@ -1487,7 +1653,8 @@ describe("AccessAuditComponent", () => {
   describe("empty cells", () => {
     const ACTOR = 2;
     const REQUESTER = 3;
-    const DETAIL = 6;
+    const ITEM = 4;
+    const DURATION = 5;
 
     const render = async (events: AccessAuditEventResponse[]) => {
       auditApiService.listAccessAuditTrail.mockResolvedValue(events);
@@ -1535,18 +1702,6 @@ describe("AccessAuditComponent", () => {
       expect(text(REQUESTER)).toBe("—");
     });
 
-    it("renders the detail when the row carries one", async () => {
-      await render([event({ Detail: "Incident closed early." })]);
-
-      expect(text(DETAIL)).toBe("Incident closed early.");
-    });
-
-    it("renders an em dash for a row with no detail", async () => {
-      await render([event({ Detail: null })]);
-
-      expect(text(DETAIL)).toBe("—");
-    });
-
     // A blank cell in an audit table reads as a rendering failure rather than as "no value".
     it("leaves no cell of a bare row blank", async () => {
       await render([
@@ -1557,11 +1712,12 @@ describe("AccessAuditComponent", () => {
           RequesterId: null,
           RequesterName: null,
           RequesterEmail: null,
-          Detail: null,
+          CipherId: null,
+          CollectionId: null,
         }),
       ]);
 
-      for (const column of [ACTOR, REQUESTER, DETAIL]) {
+      for (const column of [ACTOR, REQUESTER, ITEM, DURATION]) {
         expect(text(column)).toBe("—");
         expect(cell(column).querySelector(".tw-text-muted")).not.toBeNull();
       }
@@ -1609,13 +1765,12 @@ describe("AccessAuditComponent", () => {
   });
 
   describe("column widths", () => {
-    /** Time, Event, Actor, Requester, Item, Duration, Detail — the order the template declares. */
+    /** Timestamp, Event, Actor, Requester, Item, Duration — the order the template declares. */
     const TIME = 0;
     const EVENT = 1;
     const ACTOR = 2;
     const REQUESTER = 3;
     const ITEM = 4;
-    const DETAIL = 6;
 
     const renderTable = async () => {
       auditApiService.listAccessAuditTrail.mockResolvedValue([event()]);
@@ -1652,15 +1807,13 @@ describe("AccessAuditComponent", () => {
       expect(cells[ITEM].classList).toContain("tw-p-3");
     });
 
-    it("caps Item and Detail and lets their text break inside the cap", async () => {
+    it("caps Item and lets its text break inside the cap", async () => {
       const { headers, cells } = await renderTable();
 
-      for (const column of [ITEM, DETAIL]) {
-        expect(headers[column].classList).toContain("tw-max-w-64");
-        expect(headers[column].classList).toContain("tw-break-words");
-        expect(cells[column].classList).toContain("tw-max-w-64");
-        expect(cells[column].classList).toContain("tw-break-words");
-      }
+      expect(headers[ITEM].classList).toContain("tw-max-w-64");
+      expect(headers[ITEM].classList).toContain("tw-break-words");
+      expect(cells[ITEM].classList).toContain("tw-max-w-64");
+      expect(cells[ITEM].classList).toContain("tw-break-words");
     });
 
     it("leaves the unbounded name columns free to wrap", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1550,6 +1550,15 @@ describe("AccessAuditComponent", () => {
       ).toHaveLength(1);
     });
 
+    // `button` marks its children presentational, so the badge is not exposed as a node of its own and
+    // an in-doubt row would otherwise announce exactly the same as a settled one.
+    it("names the in-doubt badge on the cell that carries the role", async () => {
+      await render([event({ Incomplete: true }), event({ Incomplete: false })]);
+
+      expect(activator(0).getAttribute("aria-label")).toContain("Incomplete");
+      expect(activator(1).getAttribute("aria-label")).not.toContain("Incomplete");
+    });
+
     it("opens the drawer on Enter", async () => {
       await render([event()]);
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -5,7 +5,7 @@ import { By } from "@angular/platform-browser";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 import * as papa from "papaparse";
-import { of } from "rxjs";
+import { Subject, of } from "rxjs";
 
 import {
   OrganizationUserApiService,
@@ -19,6 +19,7 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import {
   DialogService,
+  DrawerRef,
   FilterMenuComponent,
   FilterOptionComponent,
   I18nMockService,
@@ -1869,6 +1870,222 @@ describe("AccessAuditComponent", () => {
 
       const table = fixture.nativeElement.querySelector("bit-table");
       expect(table.parentElement.classList).toContain("tw-overflow-x-auto");
+    });
+  });
+
+  /**
+   * Six columns do not fit the half-width the drawer leaves, so three of them stand down while it is
+   * open. The three that go are the three the drawer itself is already showing for the selected row.
+   */
+  describe("columns while the details drawer is open", () => {
+    const ALL_COLUMNS = ["Timestamp", "Event", "Actor", "Requester", "Item", "Duration"];
+    const WITH_DRAWER = ["Timestamp", "Event", "Item"];
+    const STOOD_DOWN = [2, 3, 5];
+
+    /**
+     * The drawer refs the page opened, newest last.
+     *
+     * `close()` and `forceClose()` are deliberately the same emission: `DrawerRef.close()` (the X
+     * button, Escape, and `openDrawer`'s own teardown of the outgoing stack) and `_forceClose()` (a
+     * route change under `closeOnNavigation`) both push one value onto `closed` and complete it. That
+     * they converge is what lets a single subscription cover every way out of the pane.
+     */
+    type FakeDrawer = { close: () => void; forceClose: () => void };
+
+    let drawers: FakeDrawer[];
+
+    beforeEach(() => {
+      drawers = [];
+      dialogService.openDrawer.mockImplementation(() => {
+        // The real openDrawer closes the open stack before pushing the new ref, so the outgoing
+        // drawer emits on `closed` before this call has the incoming one. Mirrored here, because that
+        // ordering is the whole risk in replacing one drawer with another.
+        drawers.at(-1)?.close();
+        const closed = new Subject<unknown>();
+        const emit = () => {
+          closed.next(undefined);
+          closed.complete();
+        };
+        drawers.push({ close: emit, forceClose: emit });
+        return Promise.resolve({ closed: closed.asObservable() } as unknown as DrawerRef);
+      });
+    });
+
+    const render = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event({ OccurredAt: "2026-08-18T09:00:00.000Z" }),
+        event({ OccurredAt: "2026-08-18T08:00:00.000Z" }),
+      ]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const openRow = async (index = 0) => {
+      const rows: HTMLElement[] = Array.from(
+        fixture.nativeElement.querySelectorAll("bit-table tbody tr"),
+      );
+      rows[index].click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const settle = async () => {
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const headers = (): HTMLElement[] =>
+      Array.from(fixture.nativeElement.querySelectorAll("bit-table thead th"));
+
+    const bodyRows = (): HTMLElement[] =>
+      Array.from(fixture.nativeElement.querySelectorAll("bit-table tbody tr"));
+
+    const hidden = (element: HTMLElement) => element.classList.contains("tw-hidden");
+
+    const visibleColumns = () =>
+      headers()
+        .filter((header) => !hidden(header))
+        .map((header) => header.textContent!.trim());
+
+    it("keeps all six columns while no drawer is open", async () => {
+      await render();
+
+      expect(visibleColumns()).toEqual(ALL_COLUMNS);
+      expect(headers().filter(hidden)).toHaveLength(0);
+    });
+
+    it("stands Actor, Requester and Duration down once the drawer opens", async () => {
+      await render();
+      await openRow();
+
+      expect(component().detailsOpen()).toBe(true);
+      expect(visibleColumns()).toEqual(WITH_DRAWER);
+    });
+
+    // Hidden, not removed: a column dropped from the DOM would re-flow the table and, if the header
+    // and the cells ever disagreed about which one went, silently shift every value one column over.
+    it("leaves the stood-down columns in the DOM, header and cells together", async () => {
+      await render();
+      await openRow();
+
+      expect(headers()).toHaveLength(6);
+      const hiddenHeaders = headers().flatMap((header, index) => (hidden(header) ? [index] : []));
+      expect(hiddenHeaders).toEqual(STOOD_DOWN);
+
+      for (const row of bodyRows()) {
+        const cells: HTMLElement[] = Array.from(row.querySelectorAll("td"));
+        expect(cells).toHaveLength(6);
+        expect(cells.flatMap((cell, index) => (hidden(cell) ? [index] : []))).toEqual(STOOD_DOWN);
+      }
+    });
+
+    // The Actor and Requester anchors are unreachable while their columns are down, which is fine —
+    // the drawer offers the same links. What is not fine is a cell that is invisible but still read
+    // out and still focusable. `tw-hidden` is `display: none`, which takes the subtree out of the
+    // accessibility tree and out of the tab order; a visibility or opacity class would not.
+    it("takes the stood-down cells out of the accessibility tree, not just out of view", async () => {
+      await render();
+      await openRow();
+
+      for (const index of STOOD_DOWN) {
+        const cell = bodyRows()[0].querySelectorAll("td")[index];
+        expect(cell.classList).toContain("tw-hidden");
+        for (const seen of ["tw-invisible", "tw-opacity-0", "tw-sr-only", "tw-w-0"]) {
+          expect(cell.classList).not.toContain(seen);
+        }
+      }
+    });
+
+    // bitCell sets `class` through a HostBinding; the toggled class has to merge with that rather
+    // than replace it, or the padding goes with the column.
+    it("keeps the bitCell padding and the Item bounds under the toggle", async () => {
+      await render();
+      await openRow();
+
+      const item = bodyRows()[0].querySelectorAll("td")[4];
+      expect(item.classList).toContain("tw-p-3");
+      expect(item.classList).toContain("tw-min-w-48");
+      expect(item.classList).toContain("tw-max-w-64");
+      expect(bodyRows()[0].querySelectorAll("td")[2].classList).toContain("tw-p-3");
+    });
+
+    // Every way out of a drawer ends in one of these two, and both emit on `closed`. A drawer has no
+    // backdrop of its own to dismiss — it takes a grid column beside the table rather than covering
+    // the page — so there is no third route to miss.
+    it.each([
+      ["the close button", (drawer: FakeDrawer) => drawer.close()],
+      ["Escape", (drawer: FakeDrawer) => drawer.close()],
+      ["a route change", (drawer: FakeDrawer) => drawer.forceClose()],
+    ])("restores all six columns when the drawer closes by %s", async (_route, close) => {
+      await render();
+      await openRow();
+      expect(visibleColumns()).toEqual(WITH_DRAWER);
+
+      close(drawers.at(-1)!);
+      await settle();
+
+      expect(component().detailsOpen()).toBe(false);
+      expect(visibleColumns()).toEqual(ALL_COLUMNS);
+    });
+
+    // Activating a second row replaces the drawer: the outgoing ref closes on the way, and its close
+    // must not be read as "no drawer" over the one that took its place.
+    it("stays at three columns when a different row replaces the open drawer", async () => {
+      await render();
+      await openRow(0);
+      await openRow(1);
+
+      expect(dialogService.openDrawer).toHaveBeenCalledTimes(2);
+      expect(drawers).toHaveLength(2);
+      expect(component().detailsOpen()).toBe(true);
+      expect(visibleColumns()).toEqual(WITH_DRAWER);
+    });
+
+    it("restores all six columns when the replacement drawer is closed", async () => {
+      await render();
+      await openRow(0);
+      await openRow(1);
+
+      drawers.at(-1)!.close();
+      await settle();
+
+      expect(visibleColumns()).toEqual(ALL_COLUMNS);
+    });
+
+    // A ref that closed while a newer one was being opened has nothing left to report.
+    it("ignores a stale ref closing after it was replaced", async () => {
+      await render();
+      await openRow(0);
+      await openRow(1);
+
+      drawers[0].close();
+      await settle();
+
+      expect(component().detailsOpen()).toBe(true);
+      expect(visibleColumns()).toEqual(WITH_DRAWER);
+    });
+
+    // The wrapper is the safety net for widths nothing can be trimmed to fit; it does not go away
+    // just because the ordinary drawer-open case now has nothing to scroll.
+    it("keeps the horizontal scroll container while the drawer is open", async () => {
+      await render();
+      await openRow();
+
+      const table = fixture.nativeElement.querySelector("bit-table");
+      expect(table.parentElement.classList).toContain("tw-overflow-x-auto");
+    });
+
+    // A drawer that never opened — its predecessor's closePredicate refused — leaves the table alone.
+    it("keeps all six columns when the drawer never opened", async () => {
+      await render();
+      dialogService.openDrawer.mockResolvedValue(undefined);
+
+      await openRow();
+
+      expect(component().detailsOpen()).toBe(false);
+      expect(visibleColumns()).toEqual(ALL_COLUMNS);
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1,3 +1,4 @@
+import { DatePipe } from "@angular/common";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
@@ -125,7 +126,7 @@ describe("AccessAuditComponent", () => {
             clearAll: "Clear all",
             pamAuditNoMatchesTitle: "No matching events",
             pamAuditNoMatchesMessage: "No events match the current filters.",
-            pamAuditColumnTime: "Time",
+            timestamp: "Timestamp",
             pamAuditColumnEvent: "Event",
             pamAuditColumnActor: "Actor",
             pamAuditColumnRequester: "Requester",
@@ -1557,6 +1558,47 @@ describe("AccessAuditComponent", () => {
         expect(text(column)).toBe("—");
         expect(cell(column).querySelector(".tw-text-muted")).not.toBeNull();
       }
+    });
+  });
+
+  // The organization event log heads this column "Timestamp" and renders it `medium`; an auditor
+  // reading both surfaces should not have to translate between two renderings of the same instant.
+  describe("timestamp column", () => {
+    const OCCURRED_AT = "2026-08-18T09:00:00.000Z";
+
+    const renderRow = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([event({ OccurredAt: OCCURRED_AT })]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    const header = (): HTMLElement =>
+      fixture.nativeElement.querySelectorAll("bit-table thead th")[0];
+
+    const cell = (): HTMLElement =>
+      fixture.nativeElement.querySelectorAll("bit-table tbody tr td")[0];
+
+    it("heads the column the way the organization event log heads it", async () => {
+      await renderRow();
+
+      expect(header().textContent!.trim()).toBe("Timestamp");
+    });
+
+    it("renders the whole timestamp rather than an abbreviated one", async () => {
+      await renderRow();
+
+      const medium = new DatePipe("en-US").transform(new Date(OCCURRED_AT), "medium")!;
+      expect(cell().textContent!.trim()).toBe(medium);
+    });
+
+    // The tooltip existed only to recover what `short` left out; a cell that shows the whole
+    // timestamp has nothing left to reveal on hover.
+    it("carries nothing to hover over", async () => {
+      await renderRow();
+
+      expect(cell().querySelector("span")).toBeNull();
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1398,6 +1398,84 @@ describe("AccessAuditComponent", () => {
     });
   });
 
+  describe("no matches", () => {
+    const emptyStateClearAll = (): HTMLButtonElement | null =>
+      fixture.nativeElement.querySelector("#access-audit_button_no-matches-clear-all");
+
+    const renderReady = async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([
+        event({ ActorId: "user-1", ActorName: "Ada" }),
+        event({ ActorId: "user-3", ActorName: "Linus" }),
+      ]);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    };
+
+    /** Narrows to a kind the trail does not carry, which leaves the filtered table empty. */
+    const overFilter = () => selectFilter("kind", ["pamAuditKindRuleCreated"]);
+
+    // Filtering something out is an ordinary outcome, not the unexpected condition a callout announces.
+    it("renders the standard empty state rather than a callout", async () => {
+      await renderReady();
+      overFilter();
+
+      expect(component().filteredRows()).toHaveLength(0);
+      expect(fixture.nativeElement.querySelector("bit-no-items")).not.toBeNull();
+      expect(fixture.nativeElement.querySelector("bit-callout")).toBeNull();
+      expect(fixture.nativeElement.querySelector("bit-table")).toBeNull();
+    });
+
+    it("carries the no-matches title and message into the empty state", async () => {
+      await renderReady();
+      overFilter();
+
+      const noItems = fixture.nativeElement.querySelector("bit-no-items") as HTMLElement;
+      expect(noItems.querySelector("[slot=title]")!.textContent!.trim()).toBe("No matching events");
+      expect(noItems.querySelector("[slot=description]")!.textContent!.trim()).toBe(
+        "No events match the current filters.",
+      );
+    });
+
+    // The trail-with-no-events state is a different empty state, with its own copy and its own action.
+    it("leaves the trail's own empty state alone", async () => {
+      auditApiService.listAccessAuditTrail.mockResolvedValue([]);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component().status()).toBe("empty");
+      const noItems = fixture.nativeElement.querySelector("bit-no-items") as HTMLElement;
+      expect(noItems.querySelector("[slot=title]")!.textContent!.trim()).toBe("No audit activity");
+      expect(fixture.nativeElement.querySelector("#access-audit_link_access-rules")).not.toBeNull();
+      expect(emptyStateClearAll()).toBeNull();
+    });
+
+    // The way out of an over-filtered table has to be where the auditor is looking, not only in the
+    // chip row above it.
+    it("resets every chip from the empty state's Clear all", async () => {
+      await renderReady();
+      selectFilter("actor", ["user-1"]);
+      selectFilter("timePeriod", "today");
+      overFilter();
+      expect(emptyStateClearAll()).not.toBeNull();
+
+      emptyStateClearAll()!.click();
+      fixture.detectChanges();
+
+      expect(
+        component()
+          .chips()
+          .some((chip: any) => chip.active()),
+      ).toBe(false);
+      expect(component().selectedPeriod()).toBeNull();
+      expect(component().filteredRows()).toHaveLength(2);
+      expect(fixture.nativeElement.querySelector("bit-table")).not.toBeNull();
+      expect(emptyStateClearAll()).toBeNull();
+    });
+  });
+
   describe("empty cells", () => {
     const ACTOR = 2;
     const REQUESTER = 3;

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -2090,8 +2090,7 @@ describe("AccessAuditComponent", () => {
       expect(visibleColumns()).toEqual(WITH_DRAWER);
     });
 
-    // The wrapper is the safety net for widths nothing can be trimmed to fit; it does not go away
-    // just because the ordinary drawer-open case now has nothing to scroll.
+    // The wrapper is the safety net for widths nothing can be trimmed to fit.
     it("keeps the horizontal scroll container while the drawer is open", async () => {
       await render();
       await openRow();

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -1593,8 +1593,7 @@ describe("AccessAuditComponent", () => {
       expect(cell().textContent!.trim()).toBe(medium);
     });
 
-    // The tooltip existed only to recover what `short` left out; a cell that shows the whole
-    // timestamp has nothing left to reveal on hover.
+    // The cell renders the whole timestamp, so a hover has nothing left to reveal.
     it("carries nothing to hover over", async () => {
       await renderRow();
 

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -281,6 +281,68 @@ const MIXED_LINK_EVENTS: AccessAuditEventResponse[] = [
 ];
 
 /**
+ * The absence check. Every cell that can carry no value carries none here, so the five that render an em
+ * dash — actor, requester, item, duration, detail — line up in one look beside the one absence that is not
+ * one: the automated row's Actor cell, which reads System because that IS the value.
+ */
+const EMPTY_FIELD_EVENTS: AccessAuditEventResponse[] = [
+  // Nothing but a time and a kind: no actor, no requester, no item, no duration, no detail.
+  event({
+    kind: AccessAuditEventKind.LeasingFreezeEnabled,
+    occurredAt: fromNow(-5 * MINUTE),
+    actorId: null,
+    actorName: null,
+    actorEmail: null,
+    requesterId: null,
+    requesterName: null,
+    requesterEmail: null,
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+  }),
+  // Automated with nothing else: the Actor cell reads System while the rest of the row dashes.
+  event({
+    kind: AccessAuditEventKind.LeaseExpired,
+    occurredAt: fromNow(-25 * MINUTE),
+    leaseId: "lease-4",
+    actorId: null,
+    actorName: null,
+    actorEmail: null,
+    requesterId: null,
+    requesterName: null,
+    requesterEmail: null,
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+    automated: true,
+  }),
+  // An actor but no requester: a rule change nobody asked for, and no comment recorded against it.
+  event({
+    kind: AccessAuditEventKind.RuleCreated,
+    occurredAt: fromNow(-2 * HOUR),
+    cipherId: null,
+    collectionId: null,
+    requestId: null,
+    ruleId: "rule-4",
+    ruleName: "Production access",
+    requesterId: null,
+    requesterName: null,
+    requesterEmail: null,
+    ...APPROVER,
+  }),
+  // A full row beside them, so a regression that dashes a value is as visible as one that blanks an absence.
+  event({
+    kind: AccessAuditEventKind.LeaseActivated,
+    occurredAt: fromNow(-3 * HOUR),
+    leaseId: "lease-5",
+    leaseNotBefore: fromNow(-3 * HOUR),
+    leaseNotAfter: fromNow(-HOUR),
+    ...APPROVER,
+    detail: "Approved for the incident window.",
+  }),
+];
+
+/**
  * A trail stamped against the REAL clock, for the stories that exercise the Time period presets. The
  * presets are measured from `Date.now()`, so a {@link fromNow} fixture — anchored to a fixed past
  * instant — would fall outside every window and leave those stories showing an empty table forever.
@@ -459,6 +521,15 @@ export const Refreshing: Story = {
     const update = canvasElement.querySelector<HTMLButtonElement>("#access-audit_button_refresh")!;
     await fireEvent.click(update);
   },
+};
+
+/**
+ * Absence, rendered the one way. Actor, Requester, Item, Duration and Detail each render the same muted em
+ * dash where the trail carries no value, so a reader can tell "we have no value for this" from a cell that
+ * failed to render — while the automated row keeps its System actor, which is a value rather than an absence.
+ */
+export const EmptyFields: Story = {
+  decorators: [audit({ events: EMPTY_FIELD_EVENTS })],
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -165,10 +165,11 @@ const EVENTS: AccessAuditEventResponse[] = [
 ];
 
 /**
- * Item and Detail both render unbounded free text, so the column widths only hold up under values
- * long enough to fight for room. These three are the shapes that broke the layout: a rule name well
- * past sixty characters, a full-sentence detail, and a single token longer than the column cap —
- * which has to break mid-word rather than push the table wider than the page.
+ * Item renders unbounded free text, so the column widths only hold up under values long enough to
+ * fight for room. These three are the shapes that broke the layout: a rule name well past sixty
+ * characters, and a single token longer than the column cap — which has to break mid-word rather
+ * than push the table wider than the page. Their details, now the drawer's, are carried along so
+ * the pane behind them has something long to lay out too.
  */
 const LONG_TEXT_EVENTS: AccessAuditEventResponse[] = [
   event({
@@ -281,8 +282,8 @@ const MIXED_LINK_EVENTS: AccessAuditEventResponse[] = [
 ];
 
 /**
- * The absence check. Every cell that can carry no value carries none here, so the five that render an em
- * dash — actor, requester, item, duration, detail — line up in one look beside the one absence that is not
+ * The absence check. Every cell that can carry no value carries none here, so the four that render an em
+ * dash — actor, requester, item, duration — line up in one look beside the one absence that is not
  * one: the automated row's Actor cell, which reads System because that IS the value.
  */
 const EMPTY_FIELD_EVENTS: AccessAuditEventResponse[] = [
@@ -432,7 +433,13 @@ function audit(
           getAllMiniUserDetails: () => Promise.resolve({ data: MEMBERS }),
         },
       },
-      { provide: DialogService, useValue: { open: () => ({ closed: of(undefined) }) } },
+      {
+        provide: DialogService,
+        useValue: {
+          open: () => ({ closed: of(undefined) }),
+          openDrawer: () => Promise.resolve(undefined),
+        },
+      },
       {
         provide: FileDownloadService,
         useValue: { download: (): void => undefined },
@@ -492,9 +499,9 @@ export const SingleEvent: Story = {
 };
 
 /**
- * The width check. Time and Event hold on one line beside Item and Detail values long enough to
- * wrap, and the over-long token breaks inside its column — so the table stays within the page
- * instead of dragging a horizontal scrollbar onto it.
+ * The width check. Timestamp and Event hold on one line beside Item values long enough to wrap, and
+ * the over-long token breaks inside its column — so the table stays within the page instead of
+ * dragging a horizontal scrollbar onto it.
  */
 export const LongValues: Story = {
   decorators: [audit({ events: [...LONG_TEXT_EVENTS, ...EVENTS] })],
@@ -524,8 +531,8 @@ export const Refreshing: Story = {
 };
 
 /**
- * Absence, rendered the one way. Actor, Requester, Item, Duration and Detail each render the same muted em
- * dash where the trail carries no value, so a reader can tell "we have no value for this" from a cell that
+ * Absence, rendered the one way. Actor, Requester, Item and Duration each render the same muted em dash
+ * where the trail carries no value, so a reader can tell "we have no value for this" from a cell that
  * failed to render — while the automated row keeps its System actor, which is a value rather than an absence.
  */
 export const EmptyFields: Story = {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -1,7 +1,7 @@
 import { importProvidersFrom } from "@angular/core";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
-import { of } from "rxjs";
+import { NEVER, of } from "rxjs";
 import { fireEvent, userEvent, within } from "storybook/test";
 
 import { OrganizationUserApiService } from "@bitwarden/admin-console/common";
@@ -398,9 +398,15 @@ function audit(
     events?: AccessAuditEventResponse[];
     fails?: boolean;
     refreshPending?: boolean;
+    drawerStaysOpen?: boolean;
   } = {},
 ) {
-  const { events = EVENTS, fails = false, refreshPending = false } = options;
+  const {
+    events = EVENTS,
+    fails = false,
+    refreshPending = false,
+    drawerStaysOpen = false,
+  } = options;
   return moduleMetadata({
     imports: [AccessAuditComponent],
     providers: [
@@ -437,7 +443,10 @@ function audit(
         provide: DialogService,
         useValue: {
           open: () => ({ closed: of(undefined) }),
-          openDrawer: () => Promise.resolve(undefined),
+          // A ref whose `closed` never emits is a drawer that stays open, which is what the page
+          // reads to decide how many columns the table can hold.
+          openDrawer: () =>
+            Promise.resolve(drawerStaysOpen ? { closed: NEVER, isDrawer: true } : undefined),
         },
       },
       {
@@ -505,6 +514,24 @@ export const SingleEvent: Story = {
  */
 export const LongValues: Story = {
   decorators: [audit({ events: [...LONG_TEXT_EVENTS, ...EVENTS] })],
+};
+
+/**
+ * The table with the details drawer open. Actor, Requester and Duration stand down — the pane shows all
+ * three for the selected row anyway — leaving Timestamp, Event and Item, which is what an auditor needs
+ * to keep their place and step to the next row.
+ *
+ * The story mounts the page on its own, so there is no layout to render the pane in and nothing beside
+ * the table; the narrow wrapper stands in for the width the drawer would leave, and the drawer itself is
+ * a ref that never closes. What this shows is the column set and the fit, not the pane.
+ */
+export const DetailsDrawerOpen: Story = {
+  decorators: [audit({ events: [...LONG_TEXT_EVENTS, ...EVENTS], drawerStaysOpen: true })],
+  render: () => ({ template: `<div class="tw-max-w-3xl"><app-pam-access-audit /></div>` }),
+  play: async ({ canvasElement }) => {
+    const row = canvasElement.querySelector<HTMLElement>("#access-audit_button_details-0")!;
+    await userEvent.click(row);
+  },
 };
 
 /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.stories.ts
@@ -533,9 +533,10 @@ export const EmptyFields: Story = {
 };
 
 /**
- * A filter that matches nothing — Today over a trail whose newest event is older than that. Export is
- * disabled alongside the no-matches callout: the file follows the filtered table, so with nothing on screen
- * there is nothing to download. Clear all sits at the end of the chip row, which is the way back.
+ * A filter that matches nothing — Today over a trail whose newest event is older than that. The standard
+ * empty state, the same shape a trail with no events at all gets, rather than a callout: an over-narrow
+ * filter is an ordinary outcome, not a warning. Export is disabled alongside it, the file following the
+ * filtered table, and Clear all sits inside the empty state as well as at the end of the chip row.
  */
 export const NoMatches: Story = {
   decorators: [audit()],

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -216,18 +216,21 @@ export class AccessAuditComponent implements OnInit {
 
   private readonly activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
 
+  /** The organization the trail belongs to, which is what every permission below is read off. */
+  private readonly organization = toSignal(
+    this.activeUserId$.pipe(
+      switchMap((userId) => this.organizationService.organizations$(userId)),
+      getById(this.organizationId()),
+    ),
+  );
+
   /**
    * Gates the empty state's "Access rules" link. This page's own guard, `canAccessEventLogs`, does
    * not imply `canManageAccessRules` (the target route's guard) — an auditor holding only the events
    * permission would follow the link into an "Access denied" bounce.
    */
-  protected readonly canManageAccessRules = toSignal(
-    this.activeUserId$.pipe(
-      switchMap((userId) => this.organizationService.organizations$(userId)),
-      getById(this.organizationId()),
-      map((organization) => organization?.canManageAccessRules ?? false),
-    ),
-    { initialValue: false },
+  protected readonly canManageAccessRules = computed(
+    () => this.organization()?.canManageAccessRules ?? false,
   );
 
   /**
@@ -236,13 +239,8 @@ export class AccessAuditComponent implements OnInit {
    * neither implied by this page's own `canAccessEventLogs`, so a custom auditor holding the events
    * permission alone would follow the link into an "Access denied" bounce.
    */
-  private readonly canViewCollections = toSignal(
-    this.activeUserId$.pipe(
-      switchMap((userId) => this.organizationService.organizations$(userId)),
-      getById(this.organizationId()),
-      map((organization) => organization?.canViewAllCollections ?? false),
-    ),
-    { initialValue: false },
+  private readonly canViewCollections = computed(
+    () => this.organization()?.canViewAllCollections ?? false,
   );
 
   protected readonly status = signal<AuditStatus>("loading");

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -67,6 +67,7 @@ import {
   toAuditRow,
 } from "./access-audit-row";
 import { AuditApiService } from "./audit-api.service";
+import { AuditEventDrawerComponent } from "./audit-event-drawer/audit-event-drawer.component";
 import { AuditExportService } from "./audit-export.service";
 import {
   CustomRangeDialogComponent,
@@ -153,7 +154,8 @@ function identityOptions(rows: AuditRow[], identity: "actor" | "requester"): Aud
  * the one that opens this trail, so an auditor holding only AccessEventLogs would follow such a link
  * into a 404. What the cells do open is the shared entity-events dialog, over the same AccessEventLogs
  * permission that authorized this page — an actor, a requester or a cipher, never an access rule, which
- * has no such dialog.
+ * has no such dialog. The row itself opens {@link AuditEventDrawerComponent} over the same trail this
+ * page already holds, which is where the fields too wide for a column live.
  *
  * The toolbar filters (event kind, actor, requester, item, time period) run client-side over the already-fetched
  * window: the endpoint takes no query parameters and returns the whole 90 days at once, so changing a
@@ -543,6 +545,7 @@ export class AccessAuditComponent implements OnInit {
    */
   protected openMemberEvents(event: Event, member: ResolvedMember): void {
     event.preventDefault();
+    event.stopPropagation();
     if (member.organizationUserId == null) {
       return;
     }
@@ -563,6 +566,7 @@ export class AccessAuditComponent implements OnInit {
    */
   protected openCipherEvents(event: Event, row: AuditRow): void {
     event.preventDefault();
+    event.stopPropagation();
     if (row.cipherId == null || row.cipherName == null) {
       return;
     }
@@ -573,6 +577,25 @@ export class AccessAuditComponent implements OnInit {
         organizationId: this.organizationId(),
         name: row.cipherName,
         showUser: true,
+      },
+    });
+  }
+
+  /**
+   * Opens one event's details in the side drawer.
+   *
+   * The identities are resolved here rather than in the drawer so the pane links exactly what the row
+   * under it links — the member lookup ran once for the whole trail, and a second answer could
+   * disagree with the first. An automated row has no actor to resolve: its cell reads "System",
+   * which is a value, not a member.
+   */
+  protected openDetails(row: AuditRow): void {
+    void AuditEventDrawerComponent.open(this.dialogService, {
+      data: {
+        row,
+        organizationId: this.organizationId(),
+        actor: row.automated ? null : this.linkedMember(row.actorId, row.actor),
+        requester: this.linkedMember(row.requesterId, row.requester),
       },
     });
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -227,6 +227,21 @@ export class AccessAuditComponent implements OnInit {
     { initialValue: false },
   );
 
+  /**
+   * Gates the drawer's collection link, which lands on the organization vault narrowed to that one
+   * collection. That route is guarded by `canAccessVaultTab`, which reads `canViewAllCollections` —
+   * neither implied by this page's own `canAccessEventLogs`, so a custom auditor holding the events
+   * permission alone would follow the link into an "Access denied" bounce.
+   */
+  private readonly canViewCollections = toSignal(
+    this.activeUserId$.pipe(
+      switchMap((userId) => this.organizationService.organizations$(userId)),
+      getById(this.organizationId()),
+      map((organization) => organization?.canViewAllCollections ?? false),
+    ),
+    { initialValue: false },
+  );
+
   protected readonly status = signal<AuditStatus>("loading");
   protected readonly rows = signal<AuditRow[]>([]);
 
@@ -588,6 +603,9 @@ export class AccessAuditComponent implements OnInit {
    * under it links — the member lookup ran once for the whole trail, and a second answer could
    * disagree with the first. An automated row has no actor to resolve: its cell reads "System",
    * which is a value, not a member.
+   *
+   * The two permissions travel with the data for the same reason: this page already reads the viewer's
+   * membership once, and a drawer re-deriving them could offer a link the page would not.
    */
   protected openDetails(row: AuditRow): void {
     void AuditEventDrawerComponent.open(this.dialogService, {
@@ -596,6 +614,8 @@ export class AccessAuditComponent implements OnInit {
         organizationId: this.organizationId(),
         actor: row.automated ? null : this.linkedMember(row.actorId, row.actor),
         requester: this.linkedMember(row.requesterId, row.requester),
+        canManageAccessRules: this.canManageAccessRules(),
+        canViewCollections: this.canViewCollections(),
       },
     });
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -643,6 +643,7 @@ export class AccessAuditComponent implements OnInit {
    */
   private async showDetails(row: AuditRow): Promise<void> {
     const drawer = await AuditEventDrawerComponent.open(this.dialogService, {
+      closeOnNavigation: true,
       data: {
         row,
         organizationId: this.organizationId(),

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   OnInit,
   computed,
   effect,
@@ -10,7 +11,7 @@ import {
   untracked,
   viewChild,
 } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, RouterLink } from "@angular/router";
 import { firstValueFrom, map, switchMap } from "rxjs";
 
@@ -30,6 +31,7 @@ import {
   ButtonModule,
   CalloutModule,
   DialogService,
+  DrawerRef,
   FILTER_CONTROL,
   FilterControl,
   FilterMenuModule,
@@ -201,6 +203,7 @@ export class AccessAuditComponent implements OnInit {
   private readonly organizationUserApiService = inject(OrganizationUserApiService);
   private readonly userNamePipe = inject(UserNamePipe);
   private readonly dialogService = inject(DialogService);
+  private readonly destroyRef = inject(DestroyRef);
 
   /**
    * The organization whose trail to show, from the route. `requireSync` holds because `params` emits
@@ -244,6 +247,25 @@ export class AccessAuditComponent implements OnInit {
 
   protected readonly status = signal<AuditStatus>("loading");
   protected readonly rows = signal<AuditRow[]>([]);
+
+  /**
+   * The open details drawer, or null when none is open. Held as the ref rather than a bare flag so a
+   * ref closing late — the drawer being replaced by activating a second row, which closes the first
+   * one on the way — cannot report the newer drawer as closed.
+   */
+  private readonly detailsDrawer = signal<DrawerRef<unknown, AuditEventDrawerComponent> | null>(
+    null,
+  );
+
+  /**
+   * Whether the drawer is over the table, which is what drops Actor, Requester and Duration from it.
+   *
+   * Driven by the drawer's own state rather than a viewport breakpoint. What narrows the table is the
+   * drawer taking its own grid column beside it, which a media query cannot see: a wide window with no
+   * drawer would lose columns it has room for, and a window narrow enough for the drawer to overlay
+   * rather than push would lose them while nothing was covering the table at all.
+   */
+  protected readonly detailsOpen = computed(() => this.detailsDrawer() != null);
 
   /**
    * The organization's members, keyed by PLATFORM user id — the id an audit row carries. The entity-events
@@ -608,7 +630,21 @@ export class AccessAuditComponent implements OnInit {
    * membership once, and a drawer re-deriving them could offer a link the page would not.
    */
   protected openDetails(row: AuditRow): void {
-    void AuditEventDrawerComponent.open(this.dialogService, {
+    void this.showDetails(row);
+  }
+
+  /**
+   * Opens the pane and tracks it for as long as it is open.
+   *
+   * A drawer has no backdrop to dismiss — it occupies its own column beside the table rather than
+   * covering the page — so every way out of one ends in `DrawerRef.close()` or `_forceClose()`, and
+   * both emit on `closed`: the X button, Escape, a route change under `closeOnNavigation`, and
+   * `openDrawer` itself tearing the stack down when a second row is activated. Subscribing to that one
+   * observable therefore covers every route, including the replacement, where the outgoing ref emits
+   * before this call has the incoming one.
+   */
+  private async showDetails(row: AuditRow): Promise<void> {
+    const drawer = await AuditEventDrawerComponent.open(this.dialogService, {
       data: {
         row,
         organizationId: this.organizationId(),
@@ -618,6 +654,13 @@ export class AccessAuditComponent implements OnInit {
         canViewCollections: this.canViewCollections(),
       },
     });
+    if (drawer == null) {
+      return;
+    }
+    drawer.closed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.detailsDrawer.update((open) => (open === drawer ? null : open));
+    });
+    this.detailsDrawer.set(drawer);
   }
 
   /**

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.html
@@ -95,7 +95,16 @@
       <div>
         <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "collection" | i18n }}</dt>
         <dd class="tw-m-0 tw-break-words" data-testid="drawer-collection">
-          @if (row.collectionName) {
+          @if (collectionRoute; as route) {
+            <a
+              bitLink
+              id="pam-audit-event-drawer_link_collection"
+              [routerLink]="route"
+              [queryParams]="{ collectionId: row.collectionId }"
+              (click)="closeDrawer()"
+              >{{ row.collectionName }}</a
+            >
+          } @else if (row.collectionName) {
             {{ row.collectionName }}
           } @else {
             <span class="tw-text-muted">—</span>
@@ -143,11 +152,21 @@
         data-testid="drawer-trace"
       >
         <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAccessRequestTitle" | i18n }}</dt>
-        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-request-id">
-          @if (row.requestId) {
-            {{ row.requestId }}
+        <dd class="tw-m-0 tw-flex tw-items-center tw-gap-1" data-testid="drawer-request-id">
+          @if (row.requestId; as requestId) {
+            <span class="tw-font-mono tw-text-sm">{{ shortId(requestId) }}</span>
+            <button
+              type="button"
+              bitIconButton="bwi-clone"
+              buttonType="subtleGhost"
+              size="small"
+              id="pam-audit-event-drawer_button_copy-request-id"
+              [appCopyClick]="requestId"
+              showToast
+              [label]="'copyValue' | i18n"
+            ></button>
           } @else {
-            <span class="tw-font-sans tw-text-muted">—</span>
+            <span class="tw-text-muted">—</span>
           }
         </dd>
       </div>
@@ -156,22 +175,40 @@
         <dt class="tw-text-sm tw-font-bold tw-text-muted">
           {{ "pamAccessRequestLeaseTitle" | i18n }}
         </dt>
-        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-lease-id">
-          @if (row.leaseId) {
-            {{ row.leaseId }}
+        <dd class="tw-m-0 tw-flex tw-items-center tw-gap-1" data-testid="drawer-lease-id">
+          @if (row.leaseId; as leaseId) {
+            <span class="tw-font-mono tw-text-sm">{{ shortId(leaseId) }}</span>
+            <button
+              type="button"
+              bitIconButton="bwi-clone"
+              buttonType="subtleGhost"
+              size="small"
+              id="pam-audit-event-drawer_button_copy-lease-id"
+              [appCopyClick]="leaseId"
+              showToast
+              [label]="'copyValue' | i18n"
+            ></button>
           } @else {
-            <span class="tw-font-sans tw-text-muted">—</span>
+            <span class="tw-text-muted">—</span>
           }
         </dd>
       </div>
 
       <div>
         <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamResolverAccessRule" | i18n }}</dt>
-        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-rule-id">
-          @if (row.ruleId) {
-            {{ row.ruleId }}
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-rule">
+          @if (ruleRoute; as route) {
+            <a
+              bitLink
+              id="pam-audit-event-drawer_link_rule"
+              [routerLink]="route"
+              (click)="closeDrawer()"
+              >{{ row.ruleName }}</a
+            >
+          } @else if (row.ruleName) {
+            {{ row.ruleName }}
           } @else {
-            <span class="tw-font-sans tw-text-muted">—</span>
+            <span class="tw-text-muted">—</span>
           }
         </dd>
       </div>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.html
@@ -1,0 +1,180 @@
+<bit-dialog dialogSize="small">
+  <ng-container bitDialogTitle>
+    <span>{{ row.kindLabelKey | i18n }}</span>
+    @if (row.inDoubt) {
+      <span
+        bitBadge
+        variant="warning"
+        class="tw-ms-2"
+        [bitTooltip]="'pamAuditIncompleteTooltip' | i18n"
+        >{{ "pamAuditIncomplete" | i18n }}</span
+      >
+    }
+  </ng-container>
+
+  <ng-container bitDialogContent>
+    <dl class="tw-m-0 tw-flex tw-flex-col tw-gap-4">
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "timestamp" | i18n }}</dt>
+        <dd class="tw-m-0" data-testid="drawer-timestamp">{{ row.occurredAt | date: "long" }}</dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAuditColumnActor" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-actor">
+          @if (row.automated) {
+            <span class="tw-text-muted">{{ "pamAuditSystem" | i18n }}</span>
+          } @else if (row.actor) {
+            @if (params.actor; as member) {
+              <a
+                bitLink
+                href="#"
+                id="pam-audit-event-drawer_link_actor"
+                (click)="openMemberEvents($event, member)"
+                >{{ row.actor }}</a
+              >
+            } @else {
+              {{ row.actor }}
+            }
+            @if (row.actorEmail && row.actorEmail !== row.actor) {
+              <div class="tw-text-sm tw-text-muted">{{ row.actorEmail }}</div>
+            }
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">
+          {{ "pamAuditColumnRequester" | i18n }}
+        </dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-requester">
+          @if (row.requester) {
+            @if (params.requester; as member) {
+              <a
+                bitLink
+                href="#"
+                id="pam-audit-event-drawer_link_requester"
+                (click)="openMemberEvents($event, member)"
+                >{{ row.requester }}</a
+              >
+            } @else {
+              {{ row.requester }}
+            }
+            @if (row.requesterEmail && row.requesterEmail !== row.requester) {
+              <div class="tw-text-sm tw-text-muted">{{ row.requesterEmail }}</div>
+            }
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAuditColumnItem" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-item">
+          @if (row.cipherName && row.cipherId) {
+            <a
+              bitLink
+              href="#"
+              id="pam-audit-event-drawer_link_item"
+              (click)="openCipherEvents($event)"
+              >{{ row.cipherName }}</a
+            >
+          } @else if (row.cipherName) {
+            {{ row.cipherName }}
+          } @else if (row.ruleName) {
+            {{ row.ruleName }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "collection" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-collection">
+          @if (row.collectionName) {
+            {{ row.collectionName }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAuditColumnDuration" | i18n }}</dt>
+        <dd class="tw-m-0" data-testid="drawer-duration">
+          @if (row.duration; as duration) {
+            {{ duration.key | i18n: duration.value }}
+          } @else if (row.extendedUntil) {
+            {{ "pamAuditDurationExtendedTo" | i18n: (row.extendedUntil | date: "medium") }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamColumnWindow" | i18n }}</dt>
+        <dd class="tw-m-0" data-testid="drawer-window">
+          @if (row.exactWindow) {
+            {{ row.exactWindow }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAuditColumnDetail" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-words" data-testid="drawer-detail">
+          @if (row.detail) {
+            {{ row.detail }}
+          } @else {
+            <span class="tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div
+        class="tw-border-0 tw-border-t tw-border-solid tw-border-border-base tw-pt-4"
+        data-testid="drawer-trace"
+      >
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamAccessRequestTitle" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-request-id">
+          @if (row.requestId) {
+            {{ row.requestId }}
+          } @else {
+            <span class="tw-font-sans tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">
+          {{ "pamAccessRequestLeaseTitle" | i18n }}
+        </dt>
+        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-lease-id">
+          @if (row.leaseId) {
+            {{ row.leaseId }}
+          } @else {
+            <span class="tw-font-sans tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+
+      <div>
+        <dt class="tw-text-sm tw-font-bold tw-text-muted">{{ "pamResolverAccessRule" | i18n }}</dt>
+        <dd class="tw-m-0 tw-break-all tw-font-mono tw-text-sm" data-testid="drawer-rule-id">
+          @if (row.ruleId) {
+            {{ row.ruleId }}
+          } @else {
+            <span class="tw-font-sans tw-text-muted">—</span>
+          }
+        </dd>
+      </div>
+    </dl>
+  </ng-container>
+</bit-dialog>

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
@@ -1,0 +1,319 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { DIALOG_DATA, DialogModule, DialogService, I18nMockService } from "@bitwarden/components";
+
+import { AuditRow } from "../access-audit-row";
+
+import { AuditEventDrawerComponent, AuditEventDrawerParams } from "./audit-event-drawer.component";
+
+const ORGANIZATION_ID = "org-1";
+
+const ADA = { name: "Ada", email: "ada@example.com", organizationUserId: "org-user-1" };
+const GRACE = { name: "Grace", email: "grace@example.com", organizationUserId: "org-user-2" };
+
+/** A fully-populated row, so a test can knock out the one field it is about. */
+function row(overrides: Partial<AuditRow> = {}): AuditRow {
+  return {
+    occurredAt: new Date("2026-08-18T09:00:00.000Z"),
+    kindLabelKey: "pamAuditKindLeaseActivated",
+    actor: "Ada",
+    actorId: "user-1",
+    actorEmail: "ada@example.com",
+    requester: "Grace",
+    requesterId: "user-2",
+    requesterEmail: "grace@example.com",
+    cipherName: "Prod database",
+    cipherId: "cipher-1",
+    collectionName: "Production",
+    ruleName: null,
+    ruleId: "rule-1",
+    detail: "Approved for the incident window.",
+    automated: false,
+    inDoubt: false,
+    requestId: "req-1",
+    leaseId: "lease-1",
+    duration: { key: "pamInboxDuration1Hour", value: null },
+    exactWindow: "18/08/2026, 09:00 – 18/08/2026, 10:00",
+    extendedUntil: null,
+    ...overrides,
+  };
+}
+
+describe("AuditEventDrawerComponent", () => {
+  let fixture: ComponentFixture<AuditEventDrawerComponent>;
+  let dialogService: MockProxy<DialogService>;
+
+  const render = async (overrides: Partial<AuditEventDrawerParams> = {}) => {
+    const params: AuditEventDrawerParams = {
+      row: row(),
+      organizationId: ORGANIZATION_ID,
+      actor: ADA,
+      requester: GRACE,
+      ...overrides,
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [AuditEventDrawerComponent],
+      providers: [
+        { provide: DIALOG_DATA, useValue: params },
+        { provide: DialogService, useValue: dialogService },
+        {
+          provide: I18nService,
+          // I18nMockService throws on an unknown key, so this is every key the pane can render.
+          useValue: new I18nMockService({
+            timestamp: "Timestamp",
+            collection: "Collection",
+            pamAuditColumnActor: "Actor",
+            pamAuditColumnRequester: "Requester",
+            pamAuditColumnItem: "Item",
+            pamAuditColumnDuration: "Duration",
+            pamAuditColumnDetail: "Detail",
+            pamColumnWindow: "Window",
+            pamAccessRequestTitle: "Access request",
+            pamAccessRequestLeaseTitle: "Access",
+            pamResolverAccessRule: "Access rule",
+            pamAuditSystem: "System",
+            pamAuditIncomplete: "Incomplete",
+            pamAuditIncompleteTooltip: "Outcome never confirmed.",
+            pamAuditDurationExtendedTo: "Extended to __$1__",
+            pamInboxDuration1Hour: "1 hour",
+            pamAuditKindLeaseActivated: "Lease activated",
+            pamAuditKindLeaseExtended: "Lease extended",
+            close: "Close",
+          }),
+        },
+      ],
+    })
+      // Stub the dialog shell so these tests exercise the pane's own fields rather than
+      // `bit-dialog`'s chrome, which wants a real DialogRef and a drawer stack to sit in.
+      .overrideComponent(AuditEventDrawerComponent, {
+        remove: { imports: [DialogModule] },
+        add: { schemas: [NO_ERRORS_SCHEMA] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AuditEventDrawerComponent);
+    fixture.detectChanges();
+  };
+
+  beforeEach(() => {
+    dialogService = mock<DialogService>();
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  const field = (name: string): HTMLElement =>
+    fixture.nativeElement.querySelector(`[data-testid="drawer-${name}"]`);
+
+  const text = (name: string) => field(name).textContent!.trim().replace(/\s+/g, " ");
+
+  /** The params the one opened dialog was configured with. */
+  const dialogData = () =>
+    (dialogService.open.mock.calls[0][1] as { data: Record<string, unknown> }).data;
+
+  describe("title", () => {
+    it("titles the pane with the event label", async () => {
+      await render();
+
+      expect(fixture.nativeElement.textContent).toContain("Lease activated");
+    });
+
+    it("carries the in-doubt badge when the outcome never landed", async () => {
+      await render({ row: row({ inDoubt: true }) });
+
+      expect(fixture.nativeElement.querySelector("[bitBadge]").textContent!.trim()).toBe(
+        "Incomplete",
+      );
+    });
+
+    it("carries no badge for an event whose outcome landed", async () => {
+      await render();
+
+      expect(fixture.nativeElement.querySelector("[bitBadge]")).toBeNull();
+    });
+  });
+
+  describe("fields", () => {
+    it("renders the whole timestamp", async () => {
+      await render();
+
+      // `long` carries the seconds and the zone, which is what an auditor correlating two systems needs.
+      expect(text("timestamp")).toContain("2026");
+      expect(text("timestamp")).toContain(":00:00");
+    });
+
+    it("renders each populated field", async () => {
+      await render();
+
+      expect(text("actor")).toContain("Ada");
+      expect(text("requester")).toContain("Grace");
+      expect(text("item")).toBe("Prod database");
+      expect(text("collection")).toBe("Production");
+      expect(text("duration")).toBe("1 hour");
+      expect(text("window")).toBe("18/08/2026, 09:00 – 18/08/2026, 10:00");
+      expect(text("detail")).toBe("Approved for the incident window.");
+      expect(text("request-id")).toBe("req-1");
+      expect(text("lease-id")).toBe("lease-1");
+      expect(text("rule-id")).toBe("rule-1");
+    });
+
+    it("puts each identity's email under their name", async () => {
+      await render();
+
+      expect(field("actor").querySelector("a")!.textContent!.trim()).toBe("Ada");
+      expect(field("actor").querySelector(":scope > div")!.textContent!.trim()).toBe(
+        "ada@example.com",
+      );
+      expect(field("requester").querySelector(":scope > div")!.textContent!.trim()).toBe(
+        "grace@example.com",
+      );
+    });
+
+    // The trail falls back to the email as the display name, and the same address twice reads as a bug.
+    it("does not repeat an email that is already the display name", async () => {
+      await render({ row: row({ actor: "ada@example.com" }), actor: null });
+
+      expect(text("actor")).toBe("ada@example.com");
+    });
+
+    it("falls back to the rule name when the event names no item", async () => {
+      await render({
+        row: row({ cipherName: null, cipherId: null, ruleName: "Production access" }),
+      });
+
+      expect(text("item")).toBe("Production access");
+    });
+
+    // "System" is a value, not an absence: an automated event has an actor, it just is not a person.
+    it("reads System rather than a dash for an automated event", async () => {
+      await render({ row: row({ automated: true }), actor: null });
+
+      expect(text("actor")).toBe("System");
+    });
+
+    it("renders an extension's new end as the duration", async () => {
+      await render({
+        row: row({
+          kindLabelKey: "pamAuditKindLeaseExtended",
+          duration: null,
+          exactWindow: null,
+          extendedUntil: "2026-08-18T12:00:00.000Z",
+        }),
+      });
+
+      expect(text("duration")).toContain("Extended to");
+    });
+  });
+
+  // A pane that dropped its empty rows would read as a different event each time, and an auditor
+  // could not tell "we hold no value for this" from "this pane failed to draw it".
+  describe("absent values", () => {
+    const EMPTY_ROW = row({
+      actor: null,
+      actorId: null,
+      actorEmail: null,
+      requester: null,
+      requesterId: null,
+      requesterEmail: null,
+      cipherName: null,
+      cipherId: null,
+      collectionName: null,
+      ruleName: null,
+      ruleId: null,
+      detail: null,
+      requestId: null,
+      leaseId: null,
+      duration: null,
+      exactWindow: null,
+      extendedUntil: null,
+    });
+
+    it.each([
+      "actor",
+      "requester",
+      "item",
+      "collection",
+      "duration",
+      "window",
+      "detail",
+      "request-id",
+      "lease-id",
+      "rule-id",
+    ])("renders the muted em dash for an absent %s", async (name) => {
+      await render({ row: EMPTY_ROW, actor: null, requester: null });
+
+      expect(text(name)).toBe("—");
+      expect(field(name).querySelector(".tw-text-muted")).not.toBeNull();
+    });
+  });
+
+  describe("entity event history links", () => {
+    it("opens the actor's event history from their name", async () => {
+      await render();
+
+      fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_actor").click();
+
+      expect(dialogService.open).toHaveBeenCalledTimes(1);
+      expect(dialogData()).toEqual({
+        entity: "user",
+        entityId: "org-user-1",
+        organizationId: ORGANIZATION_ID,
+        name: "Ada",
+        showUser: true,
+      });
+    });
+
+    it("opens the requester's event history from their name", async () => {
+      await render();
+
+      fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_requester").click();
+
+      expect(dialogData()).toEqual({
+        entity: "user",
+        entityId: "org-user-2",
+        organizationId: ORGANIZATION_ID,
+        name: "Grace",
+        showUser: true,
+      });
+    });
+
+    it("opens the item's event history from its name", async () => {
+      await render();
+
+      fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_item").click();
+
+      expect(dialogData()).toEqual({
+        entity: "cipher",
+        entityId: "cipher-1",
+        organizationId: ORGANIZATION_ID,
+        name: "Prod database",
+        showUser: true,
+      });
+    });
+
+    // A dead link on an audit surface invites a click that reports nothing.
+    it("leaves an identity the page could not resolve as plain text", async () => {
+      await render({ actor: null, requester: null });
+
+      expect(fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_actor")).toBeNull();
+      expect(
+        fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_requester"),
+      ).toBeNull();
+      expect(text("actor")).toContain("Ada");
+    });
+
+    // There is no entity-events dialog for an access rule.
+    it("leaves a rule-named item as plain text", async () => {
+      await render({
+        row: row({ cipherName: null, cipherId: null, ruleName: "Production access" }),
+      });
+
+      expect(fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_item")).toBeNull();
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
@@ -432,7 +432,6 @@ describe("AuditEventDrawerComponent", () => {
       expect(platformUtilsService.copyToClipboard).toHaveBeenCalledWith(id);
     });
 
-    // Nothing to copy, so nothing to offer copying.
     it.each(["request-id", "lease-id"])(
       "offers no copy affordance beside an absent %s",
       async (name) => {

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.spec.ts
@@ -1,15 +1,27 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Router, provideRouter } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DIALOG_DATA, DialogModule, DialogService, I18nMockService } from "@bitwarden/components";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import {
+  DIALOG_DATA,
+  DialogModule,
+  DialogRef,
+  DialogService,
+  I18nMockService,
+  ToastService,
+} from "@bitwarden/components";
 
 import { AuditRow } from "../access-audit-row";
 
 import { AuditEventDrawerComponent, AuditEventDrawerParams } from "./audit-event-drawer.component";
 
 const ORGANIZATION_ID = "org-1";
+
+const REQUEST_ID = "3a9d5f74-2c18-4c6b-9f0d-71b8e4a2c6d5";
+const LEASE_ID = "b27e4c91-5d3a-4f88-a1c6-90e7d5f2b834";
 
 const ADA = { name: "Ada", email: "ada@example.com", organizationUserId: "org-user-1" };
 const GRACE = { name: "Grace", email: "grace@example.com", organizationUserId: "org-user-2" };
@@ -28,13 +40,14 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     cipherName: "Prod database",
     cipherId: "cipher-1",
     collectionName: "Production",
-    ruleName: null,
+    collectionId: "collection-1",
+    ruleName: "Approval required",
     ruleId: "rule-1",
     detail: "Approved for the incident window.",
     automated: false,
     inDoubt: false,
-    requestId: "req-1",
-    leaseId: "lease-1",
+    requestId: REQUEST_ID,
+    leaseId: LEASE_ID,
     duration: { key: "pamInboxDuration1Hour", value: null },
     exactWindow: "18/08/2026, 09:00 – 18/08/2026, 10:00",
     extendedUntil: null,
@@ -45,6 +58,8 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
 describe("AuditEventDrawerComponent", () => {
   let fixture: ComponentFixture<AuditEventDrawerComponent>;
   let dialogService: MockProxy<DialogService>;
+  let dialogRef: MockProxy<DialogRef>;
+  let platformUtilsService: MockProxy<PlatformUtilsService>;
 
   const render = async (overrides: Partial<AuditEventDrawerParams> = {}) => {
     const params: AuditEventDrawerParams = {
@@ -52,14 +67,20 @@ describe("AuditEventDrawerComponent", () => {
       organizationId: ORGANIZATION_ID,
       actor: ADA,
       requester: GRACE,
+      canManageAccessRules: true,
+      canViewCollections: true,
       ...overrides,
     };
 
     await TestBed.configureTestingModule({
       imports: [AuditEventDrawerComponent],
       providers: [
+        provideRouter([]),
         { provide: DIALOG_DATA, useValue: params },
         { provide: DialogService, useValue: dialogService },
+        { provide: DialogRef, useValue: dialogRef },
+        { provide: PlatformUtilsService, useValue: platformUtilsService },
+        { provide: ToastService, useValue: mock<ToastService>() },
         {
           provide: I18nService,
           // I18nMockService throws on an unknown key, so this is every key the pane can render.
@@ -82,6 +103,9 @@ describe("AuditEventDrawerComponent", () => {
             pamInboxDuration1Hour: "1 hour",
             pamAuditKindLeaseActivated: "Lease activated",
             pamAuditKindLeaseExtended: "Lease extended",
+            pamAuditKindRuleDeleted: "Access rule deleted",
+            copyValue: "Copy value",
+            copySuccessful: "Copy Successful",
             close: "Close",
           }),
         },
@@ -101,6 +125,8 @@ describe("AuditEventDrawerComponent", () => {
 
   beforeEach(() => {
     dialogService = mock<DialogService>();
+    dialogRef = mock<DialogRef>();
+    platformUtilsService = mock<PlatformUtilsService>();
   });
 
   afterEach(() => {
@@ -157,9 +183,9 @@ describe("AuditEventDrawerComponent", () => {
       expect(text("duration")).toBe("1 hour");
       expect(text("window")).toBe("18/08/2026, 09:00 – 18/08/2026, 10:00");
       expect(text("detail")).toBe("Approved for the incident window.");
-      expect(text("request-id")).toBe("req-1");
-      expect(text("lease-id")).toBe("lease-1");
-      expect(text("rule-id")).toBe("rule-1");
+      expect(text("request-id")).toBe("3a9d5f74");
+      expect(text("lease-id")).toBe("b27e4c91");
+      expect(text("rule")).toBe("Approval required");
     });
 
     it("puts each identity's email under their name", async () => {
@@ -223,6 +249,7 @@ describe("AuditEventDrawerComponent", () => {
       cipherName: null,
       cipherId: null,
       collectionName: null,
+      collectionId: null,
       ruleName: null,
       ruleId: null,
       detail: null,
@@ -243,7 +270,7 @@ describe("AuditEventDrawerComponent", () => {
       "detail",
       "request-id",
       "lease-id",
-      "rule-id",
+      "rule",
     ])("renders the muted em dash for an absent %s", async (name) => {
       await render({ row: EMPTY_ROW, actor: null, requester: null });
 
@@ -315,5 +342,105 @@ describe("AuditEventDrawerComponent", () => {
 
       expect(fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_item")).toBeNull();
     });
+  });
+
+  describe("access rule", () => {
+    const link = () => fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_rule");
+
+    // A uuid tells an auditor nothing, and the store already carries the name it stood for.
+    it("names the rule rather than identifying it by uuid", async () => {
+      await render();
+
+      expect(text("rule")).toBe("Approval required");
+      expect(text("rule")).not.toContain("rule-1");
+    });
+
+    it("links the name to the rule editor when the viewer administers rules", async () => {
+      await render();
+
+      expect(link().getAttribute("href")).toBe("/organizations/org-1/pam/access-rules/rule-1");
+    });
+
+    // The rule is gone, so the editor would answer the one event most worth reading with a 404.
+    it("leaves a rule deletion's name as plain text", async () => {
+      await render({ row: row({ kindLabelKey: "pamAuditKindRuleDeleted" }) });
+
+      expect(link()).toBeNull();
+      expect(text("rule")).toBe("Approval required");
+    });
+
+    // This page's own guard does not imply the rule editor's.
+    it("leaves the name as plain text without the rules permission", async () => {
+      await render({ canManageAccessRules: false });
+
+      expect(link()).toBeNull();
+      expect(text("rule")).toBe("Approval required");
+    });
+
+    it("closes the drawer before following the link out of it", async () => {
+      await render();
+      jest.spyOn(TestBed.inject(Router), "navigateByUrl").mockResolvedValue(true);
+
+      link().click();
+
+      expect(dialogRef.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("collection", () => {
+    const link = () =>
+      fixture.nativeElement.querySelector("#pam-audit-event-drawer_link_collection");
+
+    it("links the name to the organization vault narrowed to that collection", async () => {
+      await render();
+
+      expect(link().getAttribute("href")).toBe(
+        "/organizations/org-1/vault?collectionId=collection-1",
+      );
+    });
+
+    it("leaves the name as plain text without permission to open the vault", async () => {
+      await render({ canViewCollections: false });
+
+      expect(link()).toBeNull();
+      expect(text("collection")).toBe("Production");
+    });
+  });
+
+  describe("request and lease ids", () => {
+    const copyButton = (name: string): HTMLElement =>
+      fixture.nativeElement.querySelector(`#pam-audit-event-drawer_button_copy-${name}`);
+
+    it.each([
+      ["request-id", REQUEST_ID],
+      ["lease-id", LEASE_ID],
+    ])("shortens the %s to its first eight characters", async (name, id) => {
+      await render();
+
+      expect(text(name)).toBe(id.substring(0, 8));
+      expect(text(name)).toHaveLength(8);
+    });
+
+    it.each([
+      ["request-id", REQUEST_ID],
+      ["lease-id", LEASE_ID],
+    ])("copies the whole %s, not the short form", async (name, id) => {
+      await render();
+
+      copyButton(name).click();
+
+      expect(platformUtilsService.copyToClipboard).toHaveBeenCalledWith(id);
+    });
+
+    // Nothing to copy, so nothing to offer copying.
+    it.each(["request-id", "lease-id"])(
+      "offers no copy affordance beside an absent %s",
+      async (name) => {
+        await render({ row: row({ requestId: null, leaseId: null }) });
+
+        expect(text(name)).toBe("—");
+        expect(copyButton(name)).toBeNull();
+      },
+    );
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.stories.ts
@@ -1,7 +1,10 @@
 import { importProvidersFrom } from "@angular/core";
+import { provideNoopAnimations } from "@angular/platform-browser/animations";
+import { provideRouter } from "@angular/router";
 import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 
-import { DIALOG_DATA, DialogService } from "@bitwarden/components";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { DIALOG_DATA, DialogService, ToastModule } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
 import { AuditRow } from "../access-audit-row";
@@ -23,7 +26,8 @@ const POPULATED: AuditRow = {
   cipherName: "Production database credential",
   cipherId: "cipher-1",
   collectionName: "Production infrastructure",
-  ruleName: null,
+  collectionId: "5c4b3a29-1d8e-4f60-b2a7-3e9c8d1f0a64",
+  ruleName: "Approval required",
   ruleId: "8f1c0f2e-9b4a-4d1e-8a77-6c2f9d3b4a51",
   detail:
     "Approved ahead of the scheduled window after the on-call engineer confirmed the primary replica had not recovered, on the understanding that the credential would be surrendered as soon as failover completed.",
@@ -53,6 +57,7 @@ const BARE: AuditRow = {
   cipherName: null,
   cipherId: null,
   collectionName: null,
+  collectionId: null,
   ruleName: null,
   ruleId: null,
   detail: null,
@@ -65,7 +70,25 @@ const BARE: AuditRow = {
   extendedUntil: null,
 };
 
-function params(row: AuditRow, linked: boolean): AuditEventDrawerParams {
+/**
+ * A rule deletion, whose name the store snapshotted at write time. The rule itself is gone, so the
+ * name must render without an anchor however the viewer is permissioned.
+ */
+const RULE_DELETED: AuditRow = {
+  ...POPULATED,
+  kindLabelKey: "pamAuditKindRuleDeleted",
+  cipherName: null,
+  cipherId: null,
+  collectionName: null,
+  collectionId: null,
+  requestId: null,
+  leaseId: null,
+  duration: null,
+  exactWindow: null,
+  detail: null,
+};
+
+function params(row: AuditRow, linked: boolean, permitted = linked): AuditEventDrawerParams {
   return {
     row,
     organizationId: "org-1",
@@ -75,6 +98,8 @@ function params(row: AuditRow, linked: boolean): AuditEventDrawerParams {
     requester: linked
       ? { name: "Grace Hopper", email: "grace@example.com", organizationUserId: "org-user-1" }
       : null,
+    canManageAccessRules: permitted,
+    canViewCollections: permitted,
   };
 }
 
@@ -87,7 +112,18 @@ export default {
       providers: [{ provide: DialogService, useValue: { open: (): undefined => undefined } }],
     }),
     applicationConfig({
-      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+      providers: [
+        importProvidersFrom(PreloadedEnglishI18nModule),
+        provideRouter([]),
+        provideNoopAnimations(),
+        ToastModule.forRoot().providers!,
+        {
+          provide: PlatformUtilsService,
+          useValue: {
+            copyToClipboard: (): void => undefined,
+          },
+        },
+      ],
     }),
   ],
 } as Meta<AuditEventDrawerComponent>;
@@ -115,6 +151,34 @@ export const EmptyFields: Story = {
   render: () => ({
     moduleMetadata: {
       providers: [{ provide: DIALOG_DATA, useValue: params(BARE, false) }],
+    },
+    template: `<pam-audit-event-drawer />`,
+  }),
+};
+
+/**
+ * The rule this event names no longer exists, so the Access rule field reads as a name with no anchor
+ * even though the viewer administers rules. Following one would land on a 404 from the very event an
+ * auditor reconstructing a change is most likely to open.
+ */
+export const DeletedRule: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: DIALOG_DATA, useValue: params(RULE_DELETED, true) }],
+    },
+    template: `<pam-audit-event-drawer />`,
+  }),
+};
+
+/**
+ * The same event read by an auditor holding AccessEventLogs and nothing more. Every name is still
+ * there — the pane withholds no fact — but the rule and the collection are plain text, because the
+ * pages behind them are guarded by permissions this viewer does not hold.
+ */
+export const WithoutLinkPermissions: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: DIALOG_DATA, useValue: params(POPULATED, true, false) }],
     },
     template: `<pam-audit-event-drawer />`,
   }),

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.stories.ts
@@ -1,0 +1,121 @@
+import { importProvidersFrom } from "@angular/core";
+import { Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
+
+import { DIALOG_DATA, DialogService } from "@bitwarden/components";
+import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
+
+import { AuditRow } from "../access-audit-row";
+
+import { AuditEventDrawerComponent, AuditEventDrawerParams } from "./audit-event-drawer.component";
+
+const OCCURRED_AT = new Date("2026-08-18T09:00:00.000Z");
+
+/** A lease activation with every field the trail can carry — the widest the pane ever gets. */
+const POPULATED: AuditRow = {
+  occurredAt: OCCURRED_AT,
+  kindLabelKey: "pamAuditKindLeaseActivated",
+  actor: "Ada Lovelace",
+  actorId: "user-2",
+  actorEmail: "ada@example.com",
+  requester: "Grace Hopper",
+  requesterId: "user-1",
+  requesterEmail: "grace@example.com",
+  cipherName: "Production database credential",
+  cipherId: "cipher-1",
+  collectionName: "Production infrastructure",
+  ruleName: null,
+  ruleId: "8f1c0f2e-9b4a-4d1e-8a77-6c2f9d3b4a51",
+  detail:
+    "Approved ahead of the scheduled window after the on-call engineer confirmed the primary replica had not recovered, on the understanding that the credential would be surrendered as soon as failover completed.",
+  automated: false,
+  inDoubt: false,
+  requestId: "3a9d5f74-2c18-4c6b-9f0d-71b8e4a2c6d5",
+  leaseId: "b27e4c91-5d3a-4f88-a1c6-90e7d5f2b834",
+  duration: { key: "pamInboxDurationHours", value: 4 },
+  exactWindow: "18/08/2026, 09:00 – 18/08/2026, 13:00",
+  extendedUntil: null,
+};
+
+/**
+ * The absence check: a freeze the system recorded against nothing, whose outcome was never confirmed.
+ * Every field the pane can render carries no value, so the muted em dash lines up down the whole pane
+ * — beside the one absence that is not one, the automated event's actor, which reads "System".
+ */
+const BARE: AuditRow = {
+  occurredAt: OCCURRED_AT,
+  kindLabelKey: "pamAuditKindLeasingFreezeEnabled",
+  actor: null,
+  actorId: null,
+  actorEmail: null,
+  requester: null,
+  requesterId: null,
+  requesterEmail: null,
+  cipherName: null,
+  cipherId: null,
+  collectionName: null,
+  ruleName: null,
+  ruleId: null,
+  detail: null,
+  automated: true,
+  inDoubt: true,
+  requestId: null,
+  leaseId: null,
+  duration: null,
+  exactWindow: null,
+  extendedUntil: null,
+};
+
+function params(row: AuditRow, linked: boolean): AuditEventDrawerParams {
+  return {
+    row,
+    organizationId: "org-1",
+    actor: linked
+      ? { name: "Ada Lovelace", email: "ada@example.com", organizationUserId: "org-user-2" }
+      : null,
+    requester: linked
+      ? { name: "Grace Hopper", email: "grace@example.com", organizationUserId: "org-user-1" }
+      : null,
+  };
+}
+
+export default {
+  title: "Web/PAM/Access Audit/Event Drawer",
+  component: AuditEventDrawerComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [AuditEventDrawerComponent],
+      providers: [{ provide: DialogService, useValue: { open: (): undefined => undefined } }],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(PreloadedEnglishI18nModule)],
+    }),
+  ],
+} as Meta<AuditEventDrawerComponent>;
+
+type Story = StoryObj<AuditEventDrawerComponent>;
+
+/**
+ * Everything an auditor needs about one event, in the order they read it: when, who, what, the window
+ * granted, the free text the table's Detail column gave up, and the ids support asks for.
+ */
+export const Default: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: DIALOG_DATA, useValue: params(POPULATED, true) }],
+    },
+    template: `<pam-audit-event-drawer />`,
+  }),
+};
+
+/**
+ * An event that names almost nothing. Every field still renders, absence showing as the muted em dash
+ * the table uses, so a reader can tell "we hold no value for this" from a pane that failed to draw it.
+ */
+export const EmptyFields: Story = {
+  render: () => ({
+    moduleMetadata: {
+      providers: [{ provide: DIALOG_DATA, useValue: params(BARE, false) }],
+    },
+    template: `<pam-audit-event-drawer />`,
+  }),
+};

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.ts
@@ -1,0 +1,108 @@
+import { CommonModule } from "@angular/common";
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+
+import {
+  BadgeModule,
+  DIALOG_DATA,
+  DialogConfig,
+  DialogModule,
+  DialogService,
+  LinkModule,
+  TooltipDirective,
+} from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+import { openEntityEventsDialog } from "@bitwarden/web-vault/app/dirt/event-logs/components/entity-events/entity-events.component";
+import { ResolvedMember } from "@bitwarden/web-vault/app/dirt/event-logs/components/send-access-member";
+
+import { AuditRow } from "../access-audit-row";
+
+/**
+ * One audit event, plus what the table already worked out about it.
+ *
+ * The two identities arrive already resolved rather than as ids to look up: whether a name is an
+ * anchor depends on the member lookup the page ran once for the whole trail, which this drawer has
+ * no business repeating — and must not disagree with, or a name that is plain text in the row would
+ * become a link in the pane over it.
+ */
+export type AuditEventDrawerParams = {
+  row: AuditRow;
+  organizationId: string;
+  /** The actor as someone whose event history can be opened, or null when the row shows no anchor. */
+  actor: ResolvedMember | null;
+  /** The requester, on the same terms as {@link AuditEventDrawerParams.actor}. */
+  requester: ResolvedMember | null;
+};
+
+/**
+ * One audit event read whole, in the side drawer.
+ *
+ * The table cannot hold every field an auditor needs — Detail alone is unbounded free text, and the
+ * column it used to occupy cost the other six more width than it earned. Everything the row carries
+ * is here instead, including the request, lease and rule ids, which the table never showed at all
+ * and which are what support asks for when an event has to be chased beyond this page.
+ *
+ * Read-only, and deliberately without a drill-down to another PAM page, for the reason the table has
+ * none: the request-detail page is authorized for the requester or a managing approver, a different
+ * permission from the AccessEventLogs one that opens this trail. What the names and the item do open
+ * is the shared entity-events dialog, exactly as the equivalent cells do, over that same permission.
+ *
+ * Every field renders, whether or not the event carries a value for it, absence showing as the muted
+ * em dash the table uses. A pane that dropped its empty rows would read as a different event each
+ * time, and an auditor could not tell "we hold no value for this" from "this pane forgot to draw it".
+ */
+@Component({
+  selector: "pam-audit-event-drawer",
+  templateUrl: "./audit-event-drawer.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, BadgeModule, DialogModule, LinkModule, TooltipDirective, I18nPipe],
+})
+export class AuditEventDrawerComponent {
+  private readonly dialogService = inject(DialogService);
+  protected readonly params = inject<AuditEventDrawerParams>(DIALOG_DATA);
+
+  protected get row(): AuditRow {
+    return this.params.row;
+  }
+
+  /** Opens an identity's own event history, the way the table's equivalent cell opens it. */
+  protected openMemberEvents(event: Event, member: ResolvedMember): void {
+    event.preventDefault();
+    if (member.organizationUserId == null) {
+      return;
+    }
+    openEntityEventsDialog(this.dialogService, {
+      data: {
+        entity: "user",
+        entityId: member.organizationUserId,
+        organizationId: this.params.organizationId,
+        name: member.name,
+        showUser: true,
+      },
+    });
+  }
+
+  /** Opens the subject item's own event history. Reachable only from an item this viewer's vault decrypted. */
+  protected openCipherEvents(event: Event): void {
+    event.preventDefault();
+    const { cipherId, cipherName } = this.row;
+    if (cipherId == null || cipherName == null) {
+      return;
+    }
+    openEntityEventsDialog(this.dialogService, {
+      data: {
+        entity: "cipher",
+        entityId: cipherId,
+        organizationId: this.params.organizationId,
+        name: cipherName,
+        showUser: true,
+      },
+    });
+  }
+
+  static open(dialogService: DialogService, config: DialogConfig<AuditEventDrawerParams>) {
+    return dialogService.openDrawer<unknown, AuditEventDrawerParams, AuditEventDrawerComponent>(
+      AuditEventDrawerComponent,
+      config,
+    );
+  }
+}

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-event-drawer/audit-event-drawer.component.ts
@@ -1,12 +1,16 @@
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { RouterLink } from "@angular/router";
 
 import {
   BadgeModule,
+  CopyClickDirective,
   DIALOG_DATA,
   DialogConfig,
   DialogModule,
+  DialogRef,
   DialogService,
+  IconButtonModule,
   LinkModule,
   TooltipDirective,
 } from "@bitwarden/components";
@@ -14,7 +18,7 @@ import { I18nPipe } from "@bitwarden/ui-common";
 import { openEntityEventsDialog } from "@bitwarden/web-vault/app/dirt/event-logs/components/entity-events/entity-events.component";
 import { ResolvedMember } from "@bitwarden/web-vault/app/dirt/event-logs/components/send-access-member";
 
-import { AuditRow } from "../access-audit-row";
+import { AuditRow, auditRuleDeleted } from "../access-audit-row";
 
 /**
  * One audit event, plus what the table already worked out about it.
@@ -31,6 +35,16 @@ export type AuditEventDrawerParams = {
   actor: ResolvedMember | null;
   /** The requester, on the same terms as {@link AuditEventDrawerParams.actor}. */
   requester: ResolvedMember | null;
+  /**
+   * Whether the viewer may open the rule editor this pane's access-rule name links to. This page's own
+   * `canAccessEventLogs` does not imply it, so for many auditors the name stays plain text.
+   */
+  canManageAccessRules: boolean;
+  /**
+   * Whether the viewer may open the organization vault the collection name links to, which is guarded
+   * by `canViewAllCollections` — again not implied by the permission that opened this trail.
+   */
+  canViewCollections: boolean;
 };
 
 /**
@@ -38,13 +52,20 @@ export type AuditEventDrawerParams = {
  *
  * The table cannot hold every field an auditor needs — Detail alone is unbounded free text, and the
  * column it used to occupy cost the other six more width than it earned. Everything the row carries
- * is here instead, including the request, lease and rule ids, which the table never showed at all
- * and which are what support asks for when an event has to be chased beyond this page.
+ * is here instead, including the request and lease ids, which the table never showed at all and which
+ * are what support asks for when an event has to be chased beyond this page.
  *
- * Read-only, and deliberately without a drill-down to another PAM page, for the reason the table has
- * none: the request-detail page is authorized for the requester or a managing approver, a different
- * permission from the AccessEventLogs one that opens this trail. What the names and the item do open
- * is the shared entity-events dialog, exactly as the equivalent cells do, over that same permission.
+ * Read-only, and every anchor is gated on the viewer holding the permission its target is guarded by.
+ * This page is authorized by AccessEventLogs alone, which implies very little else, so an ungated link
+ * would send an auditor into a bounce from the pane that is meant to explain the event. The actor, the
+ * requester and the item open the shared entity-events dialog over that same AccessEventLogs
+ * permission; the access rule opens the rule editor only under `canManageAccessRules`, and the
+ * collection opens the organization vault narrowed to it only under `canViewAllCollections`.
+ *
+ * The request and lease ids anchor nothing at all: the request-detail page is authorized for the
+ * request's requester or a managing approver, which is a different permission again, and no page keys
+ * on a lease id. They are rendered short and made copyable instead, so an auditor can hand support the
+ * whole id without reading thirty-six characters off the screen.
  *
  * Every field renders, whether or not the event carries a value for it, absence showing as the muted
  * em dash the table uses. A pane that dropped its empty rows would read as a different event each
@@ -54,14 +75,76 @@ export type AuditEventDrawerParams = {
   selector: "pam-audit-event-drawer",
   templateUrl: "./audit-event-drawer.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, BadgeModule, DialogModule, LinkModule, TooltipDirective, I18nPipe],
+  imports: [
+    CommonModule,
+    RouterLink,
+    BadgeModule,
+    CopyClickDirective,
+    DialogModule,
+    IconButtonModule,
+    LinkModule,
+    TooltipDirective,
+    I18nPipe,
+  ],
 })
 export class AuditEventDrawerComponent {
   private readonly dialogService = inject(DialogService);
+  /**
+   * Optional: the pane normally sits in a drawer it must close before navigating away, but it also
+   * renders standalone (a story), where there is no drawer to close.
+   */
+  private readonly dialogRef = inject(DialogRef, { optional: true });
   protected readonly params = inject<AuditEventDrawerParams>(DIALOG_DATA);
 
   protected get row(): AuditRow {
     return this.params.row;
+  }
+
+  /**
+   * The rule editor's route for this event's access rule, or null when the pane must not link it.
+   *
+   * Null on a deletion even though the name is still there to render: the store snapshotted it at write
+   * time and the rule itself is gone, so the route would 404 on the one rule event an auditor most needs
+   * to read. Null too without `canManageAccessRules`, which is the guard on that route and is not what
+   * authorized this page.
+   */
+  protected get ruleRoute(): string[] | null {
+    const { ruleName, ruleId } = this.row;
+    if (
+      ruleName == null ||
+      ruleId == null ||
+      !this.params.canManageAccessRules ||
+      auditRuleDeleted(this.row)
+    ) {
+      return null;
+    }
+    return ["/organizations", this.params.organizationId, "pam", "access-rules", ruleId];
+  }
+
+  /**
+   * The organization vault's route for this event's collection, or null when the pane must not link it.
+   *
+   * The collection id rides in a query parameter rather than the path — the same anchor the admin
+   * console's own collection rows use — so the landing is that one collection's contents, never an
+   * unfiltered list. A name that did not resolve means the collection is not in this viewer's local
+   * vault state, which is reason enough not to send them to it.
+   */
+  protected get collectionRoute(): string[] | null {
+    const { collectionName, collectionId } = this.row;
+    if (collectionName == null || collectionId == null || !this.params.canViewCollections) {
+      return null;
+    }
+    return ["/organizations", this.params.organizationId, "vault"];
+  }
+
+  /** An id in the short form the organization event log uses, which is enough to match two records by eye. */
+  protected shortId(id: string): string {
+    return id.substring(0, 8);
+  }
+
+  /** Closes the drawer when following a link out of it, so no pane is stranded over the page beneath. */
+  protected closeDrawer(): void {
+    void this.dialogRef?.close();
   }
 
   /** Opens an identity's own event history, the way the table's equivalent cell opens it. */

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -74,6 +74,7 @@ describe("AuditExportService", () => {
         automated: false,
         incomplete: false,
         requestId: "req-1",
+        leaseId: "lease-1",
       });
     });
 
@@ -102,6 +103,7 @@ describe("AuditExportService", () => {
           ruleName: null,
           detail: null,
           requestId: null,
+          leaseId: null,
           duration: null,
           exactWindow: null,
           extendedUntil: null,
@@ -126,6 +128,7 @@ describe("AuditExportService", () => {
         automated: true,
         incomplete: true,
         requestId: "",
+        leaseId: "",
       });
       expect(JSON.stringify(exported)).not.toMatch(/null|undefined/);
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -26,6 +26,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     automated: false,
     inDoubt: false,
     requestId: "req-1",
+    leaseId: "lease-1",
     duration: { key: "pamInboxDurationHours", value: 4 },
     exactWindow: "6/30/26, 12:00 – 6/30/26, 16:00",
     extendedUntil: null,

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.spec.ts
@@ -20,6 +20,7 @@ function row(overrides: Partial<AuditRow> = {}): AuditRow {
     cipherName: "prod db",
     cipherId: "cipher-1",
     collectionName: "production",
+    collectionId: "collection-1",
     ruleName: "Production access",
     ruleId: "rule-1",
     detail: "Approved for the incident window.",

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit-export.service.ts
@@ -90,6 +90,7 @@ export class AuditExportService {
       automated: row.automated,
       incomplete: row.inDoubt,
       requestId: row.requestId ?? "",
+      leaseId: row.leaseId ?? "",
     });
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/audit.export.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/audit.export.ts
@@ -37,4 +37,9 @@ export type AuditExport = {
    * correlation id is what joins this file to another export or to a support ticket.
    */
   requestId: string;
+  /**
+   * The lease this event belongs to, if any. Carried for the same reason as {@link AuditExport.requestId}:
+   * it is the id support asks for, and the table has no column for it.
+   */
+  leaseId: string;
 };

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.stories.ts
@@ -129,9 +129,9 @@ export const Edit: Story = {
 /** Edit mode on a deactivated rule: the header badge reads "Off" and the Status checkbox is clear. */
 export const EditInactive: Story = {
   decorators: [
+    atUrl("/organizations/org-1/access-rules/rule-1"),
     moduleMetadata({
       providers: [
-        { provide: ActivatedRoute, useValue: routeStub({ accessRuleId: "rule-1" }) },
         {
           provide: AccessRuleSdkService,
           useValue: {
@@ -176,9 +176,9 @@ export const SaveError: Story = {
  */
 export const SaveErrorOnField: Story = {
   decorators: [
+    atUrl("/organizations/org-1/access-rules/rule-1"),
     moduleMetadata({
       providers: [
-        { provide: ActivatedRoute, useValue: routeStub({ accessRuleId: "rule-1" }) },
         {
           provide: AccessRuleSdkService,
           useValue: {

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.html
@@ -175,13 +175,31 @@
         @if (loadingRequestForm()) {
           <p bitTypography="body2" class="tw-m-0">{{ "loading" | i18n }}</p>
         } @else if (requestMode() !== null) {
-          <p bitTypography="body2" class="tw-mb-4 tw-mt-0">
-            @if (requestMode() === "automatic") {
-              {{ "requestAccessModalAutomaticDescription" | i18n }}
-            } @else {
-              {{ "requestAccessModalHumanDescription" | i18n }}
-            }
-          </p>
+          @if (slotContention(); as contention) {
+            <!--
+              Replaces the description rather than stacking on top of it: the automatic path's
+              "you'll get immediate access" is false while the slot is taken, so showing both would
+              contradict itself. The form below stays enabled — the request is still worth making.
+            -->
+            <p bitTypography="body2" class="tw-mb-4 tw-mt-0 tw-flex tw-items-start tw-gap-2">
+              <bit-icon name="bwi-exclamation-triangle" class="tw-mt-0.5 tw-text-warning" />
+              <span>
+                @if (contention.freesAt) {
+                  {{ "pamRequestSlotTakenUntil" | i18n: (contention.freesAt | date: "short") }}
+                } @else {
+                  {{ "pamRequestSlotTaken" | i18n }}
+                }
+              </span>
+            </p>
+          } @else {
+            <p bitTypography="body2" class="tw-mb-4 tw-mt-0">
+              @if (requestMode() === "automatic") {
+                {{ "requestAccessModalAutomaticDescription" | i18n }}
+              } @else {
+                {{ "requestAccessModalHumanDescription" | i18n }}
+              }
+            </p>
+          }
 
           @if (requestMode() === "automatic") {
             <form [formGroup]="automaticForm" class="tw-flex tw-flex-col tw-gap-4">

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.spec.ts
@@ -113,6 +113,8 @@ function preCheck(overrides: Partial<AccessPreCheckView> = {}): AccessPreCheckVi
     // empty and every submit path invalid.
     defaultDurationSeconds: 3600,
     maxDurationSeconds: 86_400,
+    // The SDK reads an absent canStartLease as true, so the resting fixture is the startable case.
+    canStartLease: true,
     ...overrides,
   } as unknown as AccessPreCheckView;
 }
@@ -934,6 +936,96 @@ describe("CipherViewBannerComponent", () => {
 
       expect(component["requestError"]()).toBe("requestAccessModalGenericError");
       expect(component["requestMode"]()).toBeNull();
+    });
+
+    describe("when another member holds the single-active-lease slot", () => {
+      it("warns with the time the slot frees, in place of the immediate-access copy", async () => {
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({ canStartLease: false, slotFreesAt: "2026-08-31T10:52:00Z" }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        const text = fixture.nativeElement.textContent as string;
+        expect(text).toContain("pamRequestSlotTakenUntil");
+        // The "you'll get immediate access" line is a lie while the slot is taken, so it must be
+        // replaced rather than stacked on top of.
+        expect(text).not.toContain("requestAccessModalAutomaticDescription");
+      });
+
+      it("warns without a time when the server does not say when it frees", async () => {
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({ canStartLease: false, slotFreesAt: undefined }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        const text = fixture.nativeElement.textContent as string;
+        expect(text).toContain("pamRequestSlotTaken");
+        expect(text).not.toContain("pamRequestSlotTakenUntil");
+      });
+
+      it("leaves the form submittable, because contention is a manual retry", async () => {
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({ canStartLease: false, slotFreesAt: "2026-08-31T10:52:00Z" }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        // An approved request is still worth holding: it can be started the moment the slot frees.
+        expect(query("#pam-cipher-view-banner_select_duration")).not.toBeNull();
+        const submit = query("#pam-cipher-view-banner_button_request-submit");
+        expect(submit).not.toBeNull();
+        expect(submit?.hasAttribute("disabled")).toBe(false);
+      });
+
+      it("stays quiet on the human path, whose window is not now", async () => {
+        // canStartLease answers about NOW. A requester picking Thursday learns nothing from "taken
+        // until 10:52 today", and the spec scopes the warning to an otherwise-auto_approve request.
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({
+            approvalMode: "human",
+            canStartLease: false,
+            slotFreesAt: "2026-08-31T10:52:00Z",
+          }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        expect(component["slotContention"]()).toBeNull();
+        const text = fixture.nativeElement.textContent as string;
+        expect(text).not.toContain("pamRequestSlotTaken");
+        expect(text).toContain("requestAccessModalHumanDescription");
+      });
+
+      it("clears the warning when the form is reopened against a freed slot", async () => {
+        requestsApi.preCheck.mockResolvedValue(
+          preCheck({ canStartLease: false, slotFreesAt: "2026-08-31T10:52:00Z" }),
+        );
+        await create(gatedCipher());
+
+        await component["toggleRequestForm"]();
+        expect(component["slotContention"]()).not.toBeNull();
+
+        // Collapse, then reopen once the holder is done.
+        await component["toggleRequestForm"]();
+        requestsApi.preCheck.mockResolvedValue(preCheck({ canStartLease: true }));
+        await component["toggleRequestForm"]();
+        fixture.detectChanges();
+
+        expect(component["slotContention"]()).toBeNull();
+        expect(fixture.nativeElement.textContent).toContain(
+          "requestAccessModalAutomaticDescription",
+        );
+      });
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/cipher-view-banner/cipher-view-banner.component.ts
@@ -344,6 +344,21 @@ export class CipherViewBannerComponent implements OnInit {
    */
   protected readonly minRequestDate = signal("");
 
+  /**
+   * When another member holds this cipher's single-active-lease slot: `freesAt` is when it ends, or
+   * `null` if the server did not say. `null` overall means the slot is free — or that we have not
+   * asked yet, or that the server predates the field, both of which read as free on purpose.
+   *
+   * Only ever set for a member the singleton actually binds; someone with an ungated or
+   * non-singleton path to the cipher is unconstrained and the server reports them startable.
+   *
+   * One signal rather than two so the pair cannot drift: "taken" and "when it frees" are only ever
+   * learnt together. The retry time is a nicety — the warning still stands without it, and either
+   * way the form stays submittable, because contention is a manual retry and holding an approved
+   * request is still worth doing.
+   */
+  protected readonly slotContention = signal<{ freesAt: string | null } | null>(null);
+
   protected readonly automaticForm = this.formBuilder.nonNullable.group({
     durationSeconds: [DEFAULT_REQUEST_ACCESS_DURATION_SECONDS, Validators.required],
     reason: [""],
@@ -434,6 +449,7 @@ export class CipherViewBannerComponent implements OnInit {
     this.requestError.set(null);
     this.requestMode.set(null);
     this.requestBounds.set(null);
+    this.slotContention.set(null);
     this.automaticForm.reset({
       durationSeconds: DEFAULT_REQUEST_ACCESS_DURATION_SECONDS,
       reason: "",
@@ -466,10 +482,18 @@ export class CipherViewBannerComponent implements OnInit {
         const { date, start, end } = defaultRequestWindow(openedAt, bounds.defaultSeconds);
         this.minRequestDate.set(toDateInputValue(openedAt));
         this.humanForm.patchValue({ date: date ?? "", start: start ?? "", end: end ?? "" });
+        // No contention warning on this path, per the spec's "an otherwise-auto_approve request":
+        // `canStartLease` answers about now, and the window being picked here is in the future, so a
+        // slot taken right now says nothing about it.
       } else {
         // Pre-select the rule's own default rather than a hardcoded hour. `requestDurationOptions`
         // guarantees it is one of the offered options, so the select cannot render blank.
         this.automaticForm.patchValue({ durationSeconds: bounds.defaultSeconds });
+
+        // The SDK owns the fail-open default (absent reads as true), so this is a plain boolean.
+        if (!preCheck.canStartLease) {
+          this.slotContention.set({ freesAt: preCheck.slotFreesAt ?? null });
+        }
       }
       this.requestMode.set(preCheck.approvalMode);
     } catch (e) {

--- a/bitwarden_license/bit-web/src/app/pam/pam.allium
+++ b/bitwarden_license/bit-web/src/app/pam/pam.allium
@@ -35,8 +35,9 @@
 --   - Governance dashboard (GovernanceDashboard) — no server or SDK backing
 --   - EmailApprovalDeepLink as a distinct landing page; /pam/requests/:id currently
 --     serves the requester's own request only
---   - ForecastDecision and RuleAllowsLease as separate reads; the built request form
---     shapes itself from AccessRequestsClient::pre_check instead
+--   - ForecastDecision as a separate read; the built request form shapes itself from
+--     AccessRequestsClient::pre_check instead. RuleAllowsLease now lands through that
+--     same pre_check (PM-42446), as can_start_lease / slot_frees_at.
 
 -- ----------------------------------------------------------------------------
 -- External entities (other systems own these; PAM only references them)
@@ -1409,6 +1410,13 @@ surface RequestAccessModal {
         -- (union/OR); otherwise always startable. Lets the modal warn that an
         -- otherwise-auto_approve request could not be started yet because another lease
         -- is active on this cipher. A current-state hint, re-checked for real at start.
+        --
+        -- Surfaced with the time the slot frees (the blocking lease's not_after, latest
+        -- one wins), so the requester gets a retry time rather than polling. Deliberately
+        -- WITHOUT the holder's identity: same-collection members can already enumerate
+        -- each other, but who is using which privileged credential right now is
+        -- behavioural data only approvers see (ActiveLeasesPage). Revisit only behind an
+        -- org opt-in.
         RuleAllowsLease(requester, target_cipher)
 
     provides:


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket. PAM audit log milestone chain.

## 📔 Objective

Fixes how the trail renders what is absent, and how it renders time.

- Every empty cell is an em dash. A blank cell reads as a rendering fault rather than as a field that does not apply to that event kind.
- No matching events uses the standard `bit-no-items` empty state instead of a callout, so it matches every other filtered table in the admin console.
- Timestamps render the way the organization event log renders them, rather than in a second format on a page an auditor reads beside it.

Sits on `pam/audit-time-period-chip`.
