### PR TITLE
[PM-41001] Wire up ManagedSettingsService into dependency injection

### DIFF
--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -296,6 +296,7 @@ import {
   LegacyCompatKeyService as LegacyCompatKeyServiceAbstraction,
   WebCryptoFunctionService,
 } from "@bitwarden/legacy-crypto";
+import { DefaultManagedSettingsService, ManagedSettingsService } from "@bitwarden/managed-settings";
 import { BackgroundSyncService } from "@bitwarden/platform/background-sync";
 import {
   ActiveUserStateProvider,
@@ -546,6 +547,7 @@ export default class MainBackground {
   sdkService: SdkService;
   registerSdkService: RegisterSdkService;
   sdkLoadService: SdkLoadService;
+  managedSettingsService: ManagedSettingsService;
   cipherAuthorizationService: CipherAuthorizationService;
   endUserNotificationService: EndUserNotificationService;
   inlineMenuFieldQualificationService: InlineMenuFieldQualificationService;
@@ -957,6 +959,11 @@ export default class MainBackground {
       ? new DefaultSdkClientFactory()
       : new NoopSdkClientFactory();
     this.sdkLoadService = new BrowserSdkLoadService(this.logService);
+
+    // The background is the only place a management profile is ever pushed, so it owns the host
+    // handle. Both SDK services share this one instance.
+    this.managedSettingsService = new DefaultManagedSettingsService(SdkLoadService.Ready);
+
     this.sdkService = new DefaultSdkService(
       sdkClientFactory,
       this.environmentService,
@@ -969,6 +976,7 @@ export default class MainBackground {
       this.stateProvider,
       this.configService,
       this.v2UpgradeTokenStateService,
+      this.managedSettingsService,
     );
 
     this.registerSdkService = new DefaultRegisterSdkService(
@@ -979,6 +987,7 @@ export default class MainBackground {
       this.apiService,
       this.stateProvider,
       this.configService,
+      this.managedSettingsService,
     );
 
     this.collectionEncryptionService = new DefaultCollectionEncryptionService(

--- a/apps/browser/src/background/main.background.ts
+++ b/apps/browser/src/background/main.background.ts
@@ -960,8 +960,6 @@ export default class MainBackground {
       : new NoopSdkClientFactory();
     this.sdkLoadService = new BrowserSdkLoadService(this.logService);
 
-    // The background is the only place a management profile is ever pushed, so it owns the host
-    // handle. Both SDK services share this one instance.
     this.managedSettingsService = new DefaultManagedSettingsService(SdkLoadService.Ready);
 
     this.sdkService = new DefaultSdkService(

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -207,6 +207,7 @@ import {
 } from "@bitwarden/legacy-crypto";
 // eslint-disable-next-line no-restricted-imports
 import { NodeCryptoFunctionService } from "@bitwarden/legacy-crypto/node";
+import { DefaultManagedSettingsService } from "@bitwarden/managed-settings";
 import {
   ActiveUserStateProvider,
   DerivedStateProvider,
@@ -698,6 +699,11 @@ export class ServiceContainer {
       ? new DefaultSdkClientFactory()
       : new NoopSdkClientFactory();
     this.sdkLoadService = new CliSdkLoadService();
+
+    // The CLI has no code to read an operating system management profile yet, so nothing pushes one
+    // and every setting reads as unmanaged.
+    const managedSettingsService = new DefaultManagedSettingsService(SdkLoadService.Ready);
+
     this.sdkService = new DefaultSdkService(
       sdkClientFactory,
       this.environmentService,
@@ -710,6 +716,7 @@ export class ServiceContainer {
       this.stateProvider,
       this.configService,
       this.v2UpgradeTokenStateService,
+      managedSettingsService,
       customUserAgent,
     );
 
@@ -746,6 +753,7 @@ export class ServiceContainer {
       this.apiService,
       this.stateProvider,
       this.configService,
+      managedSettingsService,
       customUserAgent,
     );
 

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -700,8 +700,6 @@ export class ServiceContainer {
       : new NoopSdkClientFactory();
     this.sdkLoadService = new CliSdkLoadService();
 
-    // The CLI has no code to read an operating system management profile yet, so nothing pushes one
-    // and every setting reads as unmanaged.
     const managedSettingsService = new DefaultManagedSettingsService(SdkLoadService.Ready);
 
     this.sdkService = new DefaultSdkService(

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -249,6 +249,7 @@ import { MessagingService as MessagingServiceAbstraction } from "@bitwarden/comm
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { RegisterSdkService } from "@bitwarden/common/platform/abstractions/sdk/register-sdk.service";
 import { SdkClientFactory } from "@bitwarden/common/platform/abstractions/sdk/sdk-client-factory";
+import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
 import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { StateService as StateServiceAbstraction } from "@bitwarden/common/platform/abstractions/state.service";
 import { AbstractStorageService } from "@bitwarden/common/platform/abstractions/storage.service";
@@ -387,6 +388,7 @@ import {
   LegacyCompatKeyService,
   WebCryptoFunctionService,
 } from "@bitwarden/legacy-crypto";
+import { DefaultManagedSettingsService, ManagedSettingsService } from "@bitwarden/managed-settings";
 import {
   DefaultOrganizationInviteLinkApiService,
   DefaultOrganizationInviteLinkService,
@@ -1866,6 +1868,7 @@ const safeProviders: SafeProvider[] = [
       ApiServiceAbstraction,
       StateProvider,
       ConfigService,
+      ManagedSettingsService,
     ],
   }),
   safeProvider({
@@ -1883,7 +1886,17 @@ const safeProviders: SafeProvider[] = [
       StateProvider,
       ConfigService,
       V2UpgradeTokenStateService,
+      ManagedSettingsService,
     ],
+  }),
+  safeProvider({
+    // No Angular client pushes a management profile, so every setting reads as unmanaged here: web
+    // cannot read an OS profile from a web page, desktop has no acquisition code yet, and the
+    // browser popup will read the background's profile only once a foreground proxy exists. The
+    // browser background registers its own instance and is the only place a profile is pushed.
+    provide: ManagedSettingsService,
+    useFactory: () => new DefaultManagedSettingsService(SdkLoadService.Ready),
+    deps: [],
   }),
   safeProvider({
     provide: CipherAuthorizationService,

--- a/libs/angular/src/services/jslib-services.module.ts
+++ b/libs/angular/src/services/jslib-services.module.ts
@@ -1890,10 +1890,6 @@ const safeProviders: SafeProvider[] = [
     ],
   }),
   safeProvider({
-    // No Angular client pushes a management profile, so every setting reads as unmanaged here: web
-    // cannot read an OS profile from a web page, desktop has no acquisition code yet, and the
-    // browser popup will read the background's profile only once a foreground proxy exists. The
-    // browser background registers its own instance and is the only place a profile is pushed.
     provide: ManagedSettingsService,
     useFactory: () => new DefaultManagedSettingsService(SdkLoadService.Ready),
     deps: [],

--- a/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.spec.ts
@@ -6,6 +6,7 @@ import { BehaviorSubject, firstValueFrom, of } from "rxjs";
 import { KdfConfigService, KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { EncryptedString, PBKDF2KdfConfig, SymmetricCryptoKey } from "@bitwarden/legacy-crypto";
+import { ManagedSettingsService } from "@bitwarden/managed-settings";
 import { PasswordManagerClient } from "@bitwarden/sdk-internal";
 
 import {
@@ -86,6 +87,7 @@ describe("DefaultSdkService", () => {
         fakeStateProvider,
         configService,
         upgradeTokenStateService,
+        mock<ManagedSettingsService>(),
       );
     });
 

--- a/libs/common/src/platform/services/sdk/default-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/default-sdk.service.ts
@@ -24,6 +24,7 @@ import {
 import { KeyService, KdfConfigService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import { EncString } from "@bitwarden/legacy-crypto";
+import { ManagedSettingsService } from "@bitwarden/managed-settings";
 import {
   PasswordManagerClient,
   ClientSettings,
@@ -116,6 +117,10 @@ export class DefaultSdkService implements SdkService {
     private stateProvider: StateProvider,
     private configService: ConfigService,
     private v2UpgradeTokenStateService: V2UpgradeTokenStateService,
+    // Not yet read. The SDK's `PasswordManagerClient` constructor gains a `ManagedSettingsClient`
+    // parameter in sdk-internal#1405; once that publishes, `client$` is resolved here and passed to
+    // `createSdkClient`.
+    private managedSettingsService: ManagedSettingsService,
     private userAgent: string | null = null,
   ) {}
 

--- a/libs/common/src/platform/services/sdk/register-sdk.service.spec.ts
+++ b/libs/common/src/platform/services/sdk/register-sdk.service.spec.ts
@@ -1,6 +1,7 @@
 import { mock, MockProxy } from "jest-mock-extended";
 import { BehaviorSubject, firstValueFrom, of } from "rxjs";
 
+import { ManagedSettingsService } from "@bitwarden/managed-settings";
 import { BitwardenClient } from "@bitwarden/sdk-internal";
 
 import {
@@ -66,6 +67,7 @@ describe("DefaultRegisterSdkService", () => {
         apiService,
         fakeStateProvider,
         configService,
+        mock<ManagedSettingsService>(),
       );
     });
 

--- a/libs/common/src/platform/services/sdk/register-sdk.service.ts
+++ b/libs/common/src/platform/services/sdk/register-sdk.service.ts
@@ -14,6 +14,7 @@ import {
   firstValueFrom,
 } from "rxjs";
 
+import { ManagedSettingsService } from "@bitwarden/managed-settings";
 import { PasswordManagerClient, ClientSettings, TokenProvider } from "@bitwarden/sdk-internal";
 
 import { ApiService } from "../../../abstractions/api.service";
@@ -82,6 +83,10 @@ export class DefaultRegisterSdkService implements RegisterSdkService {
     private apiService: ApiService,
     private stateProvider: StateProvider,
     private configService: ConfigService,
+    // Not yet read. The SDK's `PasswordManagerClient` constructor gains a `ManagedSettingsClient`
+    // parameter in sdk-internal#1405; once that publishes, `client$` is resolved here and passed to
+    // `createSdkClient`.
+    private managedSettingsService: ManagedSettingsService,
     private userAgent: string | null = null,
   ) {}
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41001

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Only adds `ManageSettingService` and it's default implementation into the dependency injection and preps for fixing the breaking change introduced with https://github.com/bitwarden/sdk-internal/pull/1405 in a small follow-up PR