### PR TITLE
[CL-1175] Create chip group component

### DIFF
--- a/libs/components/src/chips/chip-group/chip-group.component.html
+++ b/libs/components/src/chips/chip-group/chip-group.component.html
@@ -1,0 +1,56 @@
+<div
+  bitOverflowList
+  [gap]="8"
+  #ovf="bitOverflowList"
+  [class.tw-invisible]="!ovf.ready()"
+  class="tw-flex"
+  role="group"
+  [attr.aria-label]="accessibleName() ?? null"
+>
+  <!-- The first chip is pinned so at least one is always visible. -->
+  @for (chip of chips(); track $index) {
+    <button
+      type="button"
+      bit-chip-action
+      bitOverflowItem
+      #ovfItem="bitOverflowItem"
+      [pinned]="$first"
+      [variant]="chip.variant ?? 'primary'"
+      [size]="size()"
+      [startIcon]="chip.startIcon"
+      [label]="chip.label"
+      [bitTooltip]="chip.label"
+      [class]="
+        ovfItem.shouldShrink() ? 'tw-flex-initial tw-min-w-0 tw-overflow-hidden' : 'tw-shrink-0'
+      "
+      (click)="chipSelect.emit(chip)"
+    ></button>
+  }
+  <button
+    type="button"
+    bit-chip-action
+    bitOverflowTrigger
+    variant="subtle"
+    [size]="size()"
+    [label]="'+' + overflow().length"
+    [attr.aria-label]="'showMoreCount' | i18n: overflow().length"
+    [bitPopoverTriggerFor]="overflowPopover"
+  ></button>
+</div>
+
+<bit-popover-panel #overflowPopover [accessibleName]="'showMore' | i18n">
+  <div class="tw-flex tw-flex-col tw-items-start tw-gap-4">
+    @for (chip of overflowChips(); track $index) {
+      <button
+        type="button"
+        bit-chip-action
+        [variant]="chip.variant ?? 'primary'"
+        [size]="size()"
+        [startIcon]="chip.startIcon"
+        [label]="chip.label"
+        [bitTooltip]="chip.label"
+        (click)="selectOverflowChip(chip)"
+      ></button>
+    }
+  </div>
+</bit-popover-panel>

--- a/libs/components/src/chips/chip-group/chip-group.component.spec.ts
+++ b/libs/components/src/chips/chip-group/chip-group.component.spec.ts
@@ -1,0 +1,299 @@
+import { ComponentFixture, TestBed, fakeAsync, flush, tick } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { I18nMockService } from "../../utils/i18n-mock.service";
+
+import { ChipGroupComponent, ChipGroupItem } from "./chip-group.component";
+
+// Opening the overflow popover mounts a CDK overlay, and JSDOM can neither parse the
+// stylesheets the overlay pulls in nor decide that the panel's focus target is visible.
+// Both are environment limitations rather than anything the component controls, so they're
+// filtered out to keep real failures legible.
+/* eslint-disable no-console */
+const originalError = console.error;
+const originalWarn = console.warn;
+
+console.error = (...args: unknown[]) => {
+  // JSDOM constructs the error in its own realm, so `instanceof Error` doesn't hold here.
+  if (
+    typeof args[0] === "object" &&
+    (args[0] as Error)?.message?.includes("Could not parse CSS stylesheet")
+  ) {
+    return;
+  }
+  originalError(...args);
+};
+
+console.warn = (...args: unknown[]) => {
+  if (typeof args[0] === "string" && args[0].includes("[cdkFocusInitial]' is not focusable")) {
+    return;
+  }
+  originalWarn(...args);
+};
+/* eslint-enable no-console */
+
+// JSDOM implements neither ResizeObserver nor layout. `observedWidth` primes the
+// container width from `clientWidth` before it ever observes, so a no-op stub plus
+// the geometry overrides below are enough to drive packing deterministically.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+
+/** Wide enough for the pinned chip only: 100 + trigger(40) + two gaps leaves no room for a second. */
+const CONTAINER_WIDTH = 150;
+/** Wide enough for two chips, but not for three plus the trigger. */
+const TWO_CHIP_WIDTH = 250;
+const CHIP_WIDTH = 100;
+const TRIGGER_WIDTH = 40;
+
+const chips: ChipGroupItem[] = [
+  { id: "personal", label: "Personal", variant: "subtle" },
+  { id: "work", label: "Work", variant: "subtle" },
+  { id: "favorite", label: "Favorite", variant: "subtle" },
+];
+
+describe("ChipGroupComponent", () => {
+  let fixture: ComponentFixture<ChipGroupComponent>;
+  let selected: ChipGroupItem[];
+
+  // Every geometry read in JSDOM returns zero, so packing can never be exercised
+  // against real layout. Report fixed widths per element role instead, which keeps
+  // `measure.ts` and `observed-width.ts` in the code path rather than mocking them.
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+  const originalClientWidth = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    "clientWidth",
+  ) as PropertyDescriptor;
+
+  // `observedWidth` primes from `clientWidth` at first render, so a test that needs a
+  // different budget sets this before the first `settle()`.
+  let containerWidth = CONTAINER_WIDTH;
+
+  beforeAll(() => {
+    Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
+      const width = this.hasAttribute("bitoverflowtrigger")
+        ? TRIGGER_WIDTH
+        : this.hasAttribute("bit-chip-action")
+          ? CHIP_WIDTH
+          : 0;
+      return {
+        width,
+        height: 0,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect;
+    };
+
+    Object.defineProperty(Element.prototype, "clientWidth", {
+      configurable: true,
+      get(this: Element) {
+        return this.hasAttribute("bitoverflowlist") ? containerWidth : 0;
+      },
+    });
+  });
+
+  afterAll(() => {
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    Object.defineProperty(Element.prototype, "clientWidth", originalClientWidth);
+  });
+
+  beforeEach(async () => {
+    containerWidth = CONTAINER_WIDTH;
+
+    await TestBed.configureTestingModule({
+      imports: [ChipGroupComponent],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () =>
+            new I18nMockService({ showMore: "Show more", showMoreCount: "Show more" }),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChipGroupComponent);
+    selected = [];
+    fixture.componentInstance.chipSelect.subscribe((chip) => selected.push(chip));
+  });
+
+  /** The chip buttons in the visible row, excluding the trailing overflow trigger. */
+  const rowChips = () =>
+    fixture.debugElement
+      .queryAll(By.css("[bit-chip-action]"))
+      .map((el) => el.nativeElement as HTMLButtonElement)
+      .filter((el) => !el.hasAttribute("bitoverflowtrigger"));
+
+  const triggerChip = () =>
+    fixture.debugElement.query(By.css("[bitOverflowTrigger]")).nativeElement as HTMLButtonElement;
+
+  /** The chip buttons rendered into the overflow popover's CDK overlay. */
+  const popoverChips = () =>
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".cdk-overlay-container [bit-chip-action]"),
+    );
+
+  const popoverIsOpen = () =>
+    document.querySelector(".cdk-overlay-container [role=dialog]") != null;
+
+  /** Flush the overflow list's `afterNextRender` + `fonts.ready` measurement pass. */
+  const settle = () => {
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+  };
+
+  describe("rendering", () => {
+    it("renders a chip per item, labelled by the item's label", () => {
+      fixture.componentRef.setInput("chips", chips);
+      fixture.detectChanges();
+
+      expect(rowChips().map((chip) => chip.textContent?.trim())).toEqual([
+        "Personal",
+        "Work",
+        "Favorite",
+      ]);
+    });
+
+    it("renders no chips when given an empty list", () => {
+      fixture.componentRef.setInput("chips", []);
+      fixture.detectChanges();
+
+      expect(rowChips()).toHaveLength(0);
+    });
+
+    it("names the group when accessibleName is set", () => {
+      fixture.componentRef.setInput("chips", chips);
+      fixture.componentRef.setInput("accessibleName", "Shared folders");
+      fixture.detectChanges();
+
+      const group = fixture.debugElement.query(By.css("[role=group]")).nativeElement as HTMLElement;
+      expect(group.getAttribute("aria-label")).toBe("Shared folders");
+    });
+
+    it("leaves the group unnamed when accessibleName is omitted", () => {
+      fixture.componentRef.setInput("chips", chips);
+      fixture.detectChanges();
+
+      const group = fixture.debugElement.query(By.css("[role=group]")).nativeElement as HTMLElement;
+      expect(group.hasAttribute("aria-label")).toBe(false);
+    });
+  });
+
+  describe("selection", () => {
+    it("emits the activated item from the visible row", () => {
+      fixture.componentRef.setInput("chips", chips);
+      fixture.detectChanges();
+
+      rowChips()[1].click();
+
+      expect(selected).toEqual([chips[1]]);
+    });
+
+    it("emits the whole item, so consumers get both the id and the label", () => {
+      fixture.componentRef.setInput("chips", chips);
+      fixture.detectChanges();
+
+      rowChips()[0].click();
+
+      expect(selected[0].id).toBe("personal");
+      expect(selected[0].label).toBe("Personal");
+    });
+
+    it("emits for a chip activated inside the overflow popover", fakeAsync(() => {
+      fixture.componentRef.setInput("chips", chips);
+      settle();
+
+      // Only the pinned first chip fits; "Work" and "Favorite" are behind the "+2" chip.
+      expect(rowChips().filter((chip) => !chip.hidden)).toHaveLength(1);
+
+      triggerChip().click();
+      fixture.detectChanges();
+      expect(popoverChips().map((chip) => chip.textContent?.trim())).toEqual(["Work", "Favorite"]);
+
+      popoverChips()[1].click();
+      fixture.detectChanges();
+
+      expect(selected).toEqual([chips[2]]);
+      flush();
+    }));
+
+    it("closes the overflow popover when a chip inside it is activated", fakeAsync(() => {
+      fixture.componentRef.setInput("chips", chips);
+      settle();
+
+      triggerChip().click();
+      fixture.detectChanges();
+      expect(popoverIsOpen()).toBe(true);
+
+      // Leaving the popover open over a list the consumer is about to filter would
+      // strand focus in stale content.
+      popoverChips()[0].click();
+      fixture.detectChanges();
+
+      expect(popoverIsOpen()).toBe(false);
+      flush();
+    }));
+  });
+
+  // Chips are buttons, so anything the packing pass hides is a control that may hold focus.
+  // JSDOM has no layout and so never blurs a `display: none` element the way a browser does;
+  // these assert the replacement the component picks, which is what prevents the browser
+  // from dropping focus on `document.body`.
+  describe("focus management", () => {
+    it("moves focus to the overflow trigger when the focused chip is packed away", fakeAsync(() => {
+      containerWidth = TWO_CHIP_WIDTH;
+      fixture.componentRef.setInput("chips", chips.slice(0, 2));
+      settle();
+      expect(rowChips().filter((chip) => !chip.hidden)).toHaveLength(2);
+
+      rowChips()[1].focus();
+
+      // A third chip pushes the row past the container, so "Work" is packed into the popover.
+      fixture.componentRef.setInput("chips", chips);
+      settle();
+
+      expect(rowChips()[1].hidden).toBe(true);
+      expect(document.activeElement).toBe(triggerChip());
+      flush();
+    }));
+
+    it("moves focus into the row when the focused overflow trigger is hidden", fakeAsync(() => {
+      fixture.componentRef.setInput("chips", chips);
+      settle();
+      expect(triggerChip().hidden).toBe(false);
+
+      triggerChip().focus();
+
+      // Down to one chip, nothing overflows and the trigger goes away with it.
+      fixture.componentRef.setInput("chips", [chips[0]]);
+      settle();
+
+      expect(triggerChip().hidden).toBe(true);
+      expect(document.activeElement).toBe(rowChips()[0]);
+      flush();
+    }));
+
+    it("leaves focus alone when it sits outside the group", fakeAsync(() => {
+      const outside = document.createElement("button");
+      document.body.appendChild(outside);
+      outside.focus();
+
+      fixture.componentRef.setInput("chips", chips);
+      settle();
+
+      expect(document.activeElement).toBe(outside);
+      outside.remove();
+      flush();
+    }));
+  });
+});

--- a/libs/components/src/chips/chip-group/chip-group.component.ts
+++ b/libs/components/src/chips/chip-group/chip-group.component.ts
@@ -100,8 +100,8 @@ export class ChipGroupComponent {
   private readonly injector = inject(Injector);
 
   private readonly list = viewChild.required(OverflowListDirective);
-  private readonly overflowTrigger = viewChild.required(PopoverTriggerForDirective);
-  private readonly overflowItem = viewChild.required(OverflowTriggerDirective);
+  private readonly popoverTrigger = viewChild.required(PopoverTriggerForDirective);
+  private readonly overflowTrigger = viewChild.required(OverflowTriggerDirective);
 
   protected readonly overflow = computed(() => this.list().overflow());
 
@@ -146,7 +146,7 @@ export class ChipGroupComponent {
    * the row for when the trigger itself is what's going away.
    */
   private focusFallback(hidden: ReadonlySet<HTMLElement>): HTMLElement | undefined {
-    const trigger = this.overflowItem().elementRef.nativeElement;
+    const trigger = this.overflowTrigger().elementRef.nativeElement;
     if (!hidden.has(trigger)) {
       return trigger;
     }
@@ -167,7 +167,7 @@ export class ChipGroupComponent {
    * open over a list the consumer is about to filter would strand focus in stale content.
    */
   protected selectOverflowChip(chip: ChipGroupItem) {
-    this.overflowTrigger().closePopover();
+    this.popoverTrigger().closePopover();
     this.chipSelect.emit(chip);
   }
 }

--- a/libs/components/src/chips/chip-group/chip-group.component.ts
+++ b/libs/components/src/chips/chip-group/chip-group.component.ts
@@ -1,0 +1,173 @@
+import { DOCUMENT } from "@angular/common";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Injector,
+  afterNextRender,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  viewChild,
+} from "@angular/core";
+
+import { I18nPipe } from "@bitwarden/ui-common";
+
+import { OverflowItemDirective } from "../../overflow-list/overflow-item.directive";
+import { OverflowListDirective } from "../../overflow-list/overflow-list.directive";
+import { OverflowTriggerDirective } from "../../overflow-list/overflow-trigger.directive";
+import { PopoverModule } from "../../popover";
+import { PopoverPanelComponent } from "../../popover/popover-panel.component";
+import { PopoverTriggerForDirective } from "../../popover/popover-trigger-for.directive";
+import { TooltipDirective } from "../../tooltip/tooltip.directive";
+import { ChipActionComponent } from "../chip-action";
+import { BaseChipDirective } from "../shared/base-chip.directive";
+
+/** A single action chip rendered by {@link ChipGroupComponent}. */
+export type ChipGroupItem = {
+  /**
+   * Stable identifier for the thing the chip stands for — a collection id, a folder id, a filter
+   * key. Carried through {@link ChipGroupComponent.chipSelect} so the consumer can act on the
+   * activated chip without matching on its display text.
+   */
+  id: string;
+  /** Text shown inside the chip. */
+  label: string;
+  /** Visual variant of the chip. Defaults to the chip's own default (`primary`). */
+  variant?: ReturnType<BaseChipDirective["variant"]>;
+  /** Leading icon shown inside the chip. */
+  startIcon?: ReturnType<ChipActionComponent["startIcon"]>;
+};
+
+/**
+ * Displays a collection of action chips in a horizontal row that doesn't wrap. Chips
+ * that don't fit the container width are hidden via `bitOverflowList`, and a
+ * "+N" action chip is rendered at the end. Clicking the chip opens a popover
+ * that lists the hidden chips, which stay activatable there.
+ *
+ * Chips are passed as data through the `chips` input; the group renders both
+ * the row and the popover from that data, so variant, icon, and label are
+ * described per-item rather than authored as markup. The first chip is pinned,
+ * so at least one chip is always visible regardless of available width.
+ *
+ * Activating any chip — in the row or in the overflow popover — emits it through
+ * {@link chipSelect}. The group holds no selection state of its own; it reports the
+ * activation and leaves the consequence (filtering, navigating) to the consumer.
+ *
+ * Sizing is fully measurement-driven; the group does not take a `maxItems`
+ * input. Resize the container and more or fewer chips become visible.
+ */
+@Component({
+  selector: "bit-chip-group",
+  templateUrl: "chip-group.component.html",
+  imports: [
+    ChipActionComponent,
+    PopoverModule,
+    PopoverPanelComponent,
+    OverflowItemDirective,
+    OverflowListDirective,
+    OverflowTriggerDirective,
+    TooltipDirective,
+    I18nPipe,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChipGroupComponent {
+  readonly chips = input<ChipGroupItem[]>([]);
+
+  /**
+   * Size applied to every chip in the group, including the overflow "+N" chip. Group-level
+   * rather than per-item, since a row of mismatched chip heights isn't a supported design.
+   */
+  readonly size = input<ReturnType<BaseChipDirective["size"]>>("large");
+
+  /**
+   * Accessible name for the group as a whole, e.g. "Shared folders". Individual chips are
+   * named by their own label, which on its own doesn't say what the collection of them is.
+   * Omit when a nearby heading or column header already supplies that context.
+   */
+  readonly accessibleName = input<string>();
+
+  /**
+   * Emits the activated chip, from either the visible row or the overflow popover. The whole
+   * item is emitted rather than just its `id`, so consumers that filter by id and consumers
+   * that need the label (a "Filtered by X" pill, say) are both served without a second lookup.
+   */
+  readonly chipSelect = output<ChipGroupItem>();
+
+  private readonly document = inject(DOCUMENT);
+  private readonly injector = inject(Injector);
+
+  private readonly list = viewChild.required(OverflowListDirective);
+  private readonly overflowTrigger = viewChild.required(PopoverTriggerForDirective);
+  private readonly overflowItem = viewChild.required(OverflowTriggerDirective);
+
+  protected readonly overflow = computed(() => this.list().overflow());
+
+  /** The hidden chips, in original order, rendered inside the popover. */
+  protected readonly overflowChips = computed(() => {
+    const chips = this.chips();
+    return this.overflow()
+      .map((i) => chips[i])
+      .filter((chip) => chip != null);
+  });
+
+  constructor() {
+    // Labels/variants change in place under `track $index`, so the item instances stay
+    // the same and the list won't remeasure on its own.
+    effect(() => {
+      this.chips();
+      this.size();
+      this.list().remeasure({ reset: true });
+    });
+
+    // Every chip is a button, so the packing pass can pull the focused node out of the tab
+    // order: a chip packed into the popover, or the "+N" trigger once nothing overflows
+    // anymore. The browser drops focus on `document.body` when that happens, which loses
+    // the user's place in the page. Hand focus to a control that survives the pass instead.
+    effect(() => {
+      const hidden = this.list().hiddenElements();
+      const active = this.document.activeElement;
+      if (!(active instanceof HTMLElement) || !hidden.has(active)) {
+        return;
+      }
+
+      const target = this.focusFallback(hidden);
+      // The fallback may still be hidden as this runs — revealing the trigger and hiding a
+      // chip happen in the same pass — so focus it once the DOM reflects the new state.
+      afterNextRender(() => target?.focus(), { injector: this.injector });
+    });
+  }
+
+  /**
+   * Where focus goes when the control holding it is about to be hidden: the "+N" trigger,
+   * since it opens the popover that now holds the hidden chips, else the last chip left in
+   * the row for when the trigger itself is what's going away.
+   */
+  private focusFallback(hidden: ReadonlySet<HTMLElement>): HTMLElement | undefined {
+    const trigger = this.overflowItem().elementRef.nativeElement;
+    if (!hidden.has(trigger)) {
+      return trigger;
+    }
+
+    const items = this.list().items();
+    const displayed = this.list().displayed();
+    for (let i = displayed.length - 1; i >= 0; i--) {
+      const el = items[displayed[i]]?.elementRef.nativeElement;
+      if (el != null && !hidden.has(el)) {
+        return el;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Activating an overflow chip closes the popover first: the popover is modal, and leaving it
+   * open over a list the consumer is about to filter would strand focus in stale content.
+   */
+  protected selectOverflowChip(chip: ChipGroupItem) {
+    this.overflowTrigger().closePopover();
+    this.chipSelect.emit(chip);
+  }
+}

--- a/libs/components/src/chips/chip-group/chip-group.mdx
+++ b/libs/components/src/chips/chip-group/chip-group.mdx
@@ -1,0 +1,106 @@
+import { Meta, Primary, Controls, Canvas, Title, Description } from "@storybook/addon-docs/blocks";
+
+import * as stories from "./chip-group.stories";
+
+<Meta of={stories} />
+
+```ts
+import { ChipGroupComponent, ChipGroupItem } from "@bitwarden/components";
+```
+
+<Title />
+
+## Overview
+
+<Description />
+
+<Canvas of={stories.Default} />
+
+For general information about chips, their types, and usage guidelines, see the
+[Chip overview](?path=/docs/component-library-chips--docs).
+
+## Basic Usage
+
+Chips are supplied as data through the `chips` input rather than authored as markup, so the group
+can render the same item twice — once in the row, once in the overflow popover — from a single
+description.
+
+```html
+<bit-chip-group
+  [chips]="sharedFolders"
+  accessibleName="Shared folders"
+  (chipSelect)="filterBy($event.id)"
+></bit-chip-group>
+```
+
+```ts
+readonly sharedFolders: ChipGroupItem[] = [
+  { id: "1a2b", label: "Engineering", variant: "subtle", startIcon: "bwi-collection-shared" },
+  { id: "3c4d", label: "Design", variant: "subtle", startIcon: "bwi-collection-shared" },
+];
+```
+
+Every `ChipGroupItem` requires an `id` and a `label`; `variant` and `startIcon` are optional and
+default to the action chip's own defaults.
+
+## Selection
+
+Activating a chip — in the row or in the overflow popover — emits that item through `chipSelect`.
+The whole item is emitted rather than just its `id`, so consumers that filter by id and consumers
+that need the label are both served without a second lookup.
+
+The group holds no selection state of its own. It reports the activation and leaves the consequence
+— filtering a table, navigating, opening a dialog — to the consumer. If the result of a selection
+should change which chips are shown, feed a new `chips` array back in.
+
+Selecting a chip from inside the overflow popover closes the popover first, so focus isn't stranded
+in a list the consumer is about to change.
+
+## Overflow
+
+The group lays chips out in a single row that never wraps. Chips that don't fit the container are
+hidden and collected behind a trailing `+N` action chip, which opens a popover listing them.
+
+Sizing is measurement-driven — there is no `maxItems` input. Resize the container and more or fewer
+chips become visible.
+
+<Canvas of={stories.Narrow} />
+
+The first chip is pinned, so at least one chip is always visible regardless of available width. At
+very small widths that chip truncates rather than disappearing.
+
+<Canvas of={stories.Truncation} />
+
+With no chips, the group renders an empty container — no `+N` chip is shown. Consumers that need an
+empty state (an em dash, "None") should render it themselves in place of the group.
+
+<Canvas of={stories.Empty} />
+
+## Sizes
+
+`size` is set on the group, not per chip, and applies to the `+N` chip as well. A row of mismatched
+chip heights is not a supported design.
+
+<Canvas of={stories.Small} />
+
+## Icons
+
+Each chip can carry its own `startIcon`. Use the same icon across chips that mean the same kind of
+thing — a set of shared folders, say — so the icon reads as a category marker rather than as a
+per-chip distinction.
+
+<Canvas of={stories.WithIcons} />
+
+## Accessibility
+
+- Each chip is a `<button>` named by its visible label, and the row is a `role="group"`.
+- Pass `accessibleName` to name that group (e.g. "Shared folders") when nothing nearby already
+  supplies the context. Chip labels alone say what each chip is, not what the collection of them is.
+  Omit it when a column header or heading already does that job.
+- The `+N` chip is labelled "Show N more" for screen readers; its visible text is only the count.
+- Chip labels truncate rather than wrapping, and every chip carries a tooltip with its full label so
+  a truncated chip stays readable.
+- Every chip is focusable, so resizing the container can hide the chip the user is on. When that
+  happens focus moves to the `+N` chip, which opens the popover the chip was packed into; when the
+  `+N` chip is the one going away, focus moves to the last chip left in the row. Focus is never
+  dropped on the document body.

--- a/libs/components/src/chips/chip-group/chip-group.stories.ts
+++ b/libs/components/src/chips/chip-group/chip-group.stories.ts
@@ -161,7 +161,7 @@ export const Truncation: Story = {
         <bit-chip-group [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
       </div>
 
-      <div class="tw-mt-4 tw-w-20 tw-border tw-border-solid tw-border-secondary-300">
+      <div class="tw-mt-4 tw-w-16 tw-border tw-border-solid tw-border-secondary-300">
         <bit-chip-group [chips]="singleChip" (chipSelect)="chipSelect($event)"></bit-chip-group>
       </div>
     `,

--- a/libs/components/src/chips/chip-group/chip-group.stories.ts
+++ b/libs/components/src/chips/chip-group/chip-group.stories.ts
@@ -1,0 +1,194 @@
+import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+import { findByRole, fn, userEvent } from "storybook/test";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { I18nMockService } from "../../utils/i18n-mock.service";
+
+import { ChipGroupComponent, ChipGroupItem } from "./chip-group.component";
+
+const chips: ChipGroupItem[] = [
+  { id: "personal", label: "Personal", variant: "subtle" },
+  { id: "work", label: "Work", variant: "subtle" },
+  { id: "shared", label: "Shared", variant: "subtle" },
+  { id: "archived", label: "Archived", variant: "subtle" },
+  { id: "favorite", label: "Favorite", variant: "subtle" },
+];
+
+const singleChip: ChipGroupItem[] = [{ id: "personal", label: "Personal", variant: "subtle" }];
+
+const variants = ["primary", "subtle", "accent-primary", "accent-secondary"] as const;
+const manyChips: ChipGroupItem[] = Array.from({ length: 30 }, (_, i) => ({
+  id: `label-${i + 1}`,
+  label: `Label ${i + 1}`,
+  variant: variants[i % variants.length],
+}));
+
+export default {
+  title: "Component Library/Chips/Chip Group",
+  component: ChipGroupComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [ChipGroupComponent],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () =>
+            new I18nMockService({ showMore: "Show more", showMoreCount: "Show 5 more" }),
+        },
+      ],
+    }),
+  ],
+  args: {
+    chipSelect: fn(),
+  },
+} as Meta;
+
+type Story = StoryObj<ChipGroupComponent>;
+
+export const Default: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <div style="width: 600px;">
+        <bit-chip-group [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+    `,
+  }),
+  args: { chips },
+};
+
+export const Narrow: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <div style="width: 200px;">
+        <bit-chip-group [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+    `,
+  }),
+  args: { chips },
+};
+
+export const WithIcons: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <div style="width: 300px;">
+        <bit-chip-group [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+    `,
+  }),
+  args: {
+    chips: [
+      {
+        id: "engineering",
+        label: "Engineering",
+        variant: "subtle",
+        startIcon: "bwi-collection-shared",
+      },
+      { id: "design", label: "Design", variant: "subtle", startIcon: "bwi-collection-shared" },
+      { id: "support", label: "Support", variant: "subtle", startIcon: "bwi-collection-shared" },
+      { id: "sales", label: "Sales", variant: "subtle", startIcon: "bwi-collection-shared" },
+    ],
+  },
+};
+
+/** Chips are available in both chip sizes; the size applies to the "+N" chip too. */
+export const Small: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <div style="width: 300px;">
+        <bit-chip-group size="small" [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+    `,
+  }),
+  args: { chips },
+};
+
+/**
+ * With no chips, the group renders an empty container — no overflow "+N" chip
+ * is shown.
+ */
+export const Empty: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <div style="width: 300px;">
+        <bit-chip-group [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+    `,
+  }),
+  args: { chips: [] },
+};
+
+/**
+ * With many chips in a narrow container, nearly all collapse into the overflow
+ * "+N" chip. Opening the popover lists the hidden chips in a single column that
+ * scrolls once it exceeds its 400px max height. Chips stay activatable there.
+ */
+export const ScrollingOverflow: Story = {
+  // The popover's positioning is animated/flaky in snapshots (see CL-822).
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <div style="width: 200px;">
+        <bit-chip-group [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+    `,
+  }),
+  args: { chips: manyChips },
+  play: async (context) => {
+    const canvasEl = context.canvasElement;
+    const chip = await findByRole(canvasEl, "button", { name: "Show 5 more" });
+    await userEvent.click(chip);
+  },
+};
+
+export const Truncation: Story = {
+  render: (args) => ({
+    props: {
+      singleChip,
+      ...args,
+    },
+    template: /*html*/ `
+      <div>The visible pinned chip should truncate at very small container sizes</div>
+      <div class="tw-w-28 tw-border tw-border-solid tw-border-secondary-300">
+        <bit-chip-group [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+
+      <div class="tw-mt-4 tw-w-20 tw-border tw-border-solid tw-border-secondary-300">
+        <bit-chip-group [chips]="singleChip" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+    `,
+  }),
+  args: { chips },
+};
+
+/**
+ * Drag the bottom-right corner to resize the container and watch chips move in
+ * and out of the overflow "+N" chip as the available width changes. Click the
+ * chip to see the hidden chips listed in a popover.
+ */
+export const Resizable: Story = {
+  // Resizing is interactive; a static snapshot adds no coverage over the other stories.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+      <div
+        class="tw-resize-x tw-overflow-hidden tw-rounded tw-border tw-border-solid tw-border-secondary-300 tw-p-2"
+        style="width: 400px; max-width: 100%;"
+      >
+        <bit-chip-group [chips]="chips" (chipSelect)="chipSelect($event)"></bit-chip-group>
+      </div>
+    `,
+  }),
+  args: { chips },
+};

--- a/libs/components/src/chips/chip-group/index.ts
+++ b/libs/components/src/chips/chip-group/index.ts
@@ -1,0 +1,1 @@
+export { ChipGroupComponent, ChipGroupItem } from "./chip-group.component";

--- a/libs/components/src/chips/chips.mdx
+++ b/libs/components/src/chips/chips.mdx
@@ -3,6 +3,7 @@ import { Meta, Primary, Controls, Canvas, Title, Description } from "@storybook/
 import * as chipStories from "./chip/chip.stories";
 import * as filterChipStories from "./chip-filter/chip-filter.stories";
 import * as actionChipStories from "./chip-action/chip-action.stories";
+import * as chipGroupStories from "./chip-group/chip-group.stories";
 
 <Meta title="Component Library/Chips" />
 
@@ -73,6 +74,23 @@ structures.
 - Supporting hierarchical filter selections
 
 See [Chip Filter](?path=/docs/component-library-chips-chip-filter--docs) for detailed usage and
+examples.
+
+## Chip Group
+
+The `bit-chip-group` component displays a collection of action chips in a single row that doesn't
+wrap. Chips that don't fit collapse behind a `+N` chip that opens a popover listing the rest.
+Activating any chip emits it, so the consumer can filter or navigate.
+
+<Canvas of={chipGroupStories.Default} />
+
+**Use the chip group when:**
+
+- Showing a row of related memberships or tags whose count varies per row
+- The available width is unpredictable — a table cell, a resizable panel
+- Each chip should be individually actionable
+
+See [Chip Group](?path=/docs/component-library-chips-chip-group--docs) for detailed usage and
 examples.
 
 ## Content Guidelines

--- a/libs/components/src/chips/index.ts
+++ b/libs/components/src/chips/index.ts
@@ -1,3 +1,4 @@
 export * from "./chip";
 export * from "./chip-action";
 export * from "./chip-filter";
+export * from "./chip-group";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1175](https://bitwarden.atlassian.net/browse/CL-1175)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Create a net-new chip-group component, similar to the badge-group, that controls overflow into a popover-panel based on the container width. Includes focus management -- if focus is on a chip that gets put into overflow, focus is moved to the overflow trigger instead of being lost.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/eb0234f1-5177-4a7a-af2c-80b9f56a7485



[CL-1175]: https://bitwarden.atlassian.net/browse/CL-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ