### PR TITLE
[BRE-2219] Replace 'checksum' usage with 'Get-FileHash' cmdlet for Desktop/CLI builds

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -350,7 +350,6 @@ jobs:
 
       - name: Setup Windows builder
         run: |
-          choco install checksum --no-progress
           choco install reshack --no-progress
           choco install nasm --no-progress
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -534,9 +534,6 @@ jobs:
       - name: Install AST
         run: dotnet tool install --global AzureSignTool --version 4.0.1
 
-      - name: Set up environment
-        run: choco install checksum --no-progress
-
       - name: Print environment
         run: |
           node --version
@@ -649,7 +646,7 @@ jobs:
           Copy-Item -Path ./dist/nsis-web/Bitwarden-Installer-$env:_PACKAGE_VERSION.exe `
           -Destination ./dist/chocolatey
 
-          $checksum = checksum -t sha256 ./dist/chocolatey/Bitwarden-Installer-$env:_PACKAGE_VERSION.exe
+          $checksum = (Get-FileHash -Algorithm SHA256 ./dist/chocolatey/Bitwarden-Installer-$env:_PACKAGE_VERSION.exe).Hash.ToLower()
           $chocoInstall = "./dist/chocolatey/tools/chocolateyinstall.ps1"
           (Get-Content $chocoInstall).replace('__version__', "$env:_PACKAGE_VERSION").replace('__checksum__', $checksum) | Set-Content $chocoInstall
           choco pack ./dist/chocolatey/bitwarden.nuspec --version "$env:_PACKAGE_VERSION" --out ./dist/chocolatey


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2219](https://bitwarden.atlassian.net/browse/BRE-2219)

## 📔 Objective

This PR updates the `build-cli.yml` and `build-desktop.yml` workflows to use the `Get-FileHash` cmdlet in Powershell instead of using the 'checksum' binary. Builds are currently failing because the `checksum` binary is no longer available.

[BRE-2219]: https://bitwarden.atlassian.net/browse/BRE-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ