### PR TITLE
[PM-42582] Add Staged Member Management Actions

### DIFF
--- a/apps/web/src/app/admin-console/organizations/core/views/organization-user.view.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/core/views/organization-user.view.spec.ts
@@ -101,19 +101,4 @@ describe("OrganizationUserView", () => {
       expect(createMember(OrganizationUserStatusType.Confirmed, true).canRemove).toBe(false);
     });
   });
-
-  describe("canManageMember", () => {
-    it("is false for staged members so only Revoke and Remove remain", () => {
-      expect(createMember(OrganizationUserStatusType.Staged).canManageMember).toBe(false);
-    });
-
-    it.each([
-      ["invited", OrganizationUserStatusType.Invited],
-      ["accepted", OrganizationUserStatusType.Accepted],
-      ["confirmed", OrganizationUserStatusType.Confirmed],
-      ["revoked", OrganizationUserStatusType.Revoked],
-    ])("is true for %s members", (_, status) => {
-      expect(createMember(status).canManageMember).toBe(true);
-    });
-  });
 });

--- a/apps/web/src/app/admin-console/organizations/core/views/organization-user.view.ts
+++ b/apps/web/src/app/admin-console/organizations/core/views/organization-user.view.ts
@@ -41,7 +41,6 @@ export class OrganizationUserView {
   readonly canRestore: boolean;
   readonly canRevoke: boolean;
   readonly canRemove: boolean;
-  readonly canManageMember: boolean;
 
   constructor(c: {
     id: Guid;
@@ -72,7 +71,6 @@ export class OrganizationUserView {
     this.canRestore = this.status === OrganizationUserStatusType.Revoked;
     this.canRevoke = this.status !== OrganizationUserStatusType.Revoked;
     this.canRemove = !this.claimedByOrganization;
-    this.canManageMember = this.status !== OrganizationUserStatusType.Staged;
   }
 
   static fromResponse(response: OrganizationUserUserDetailsResponse): OrganizationUserView {

--- a/apps/web/src/app/admin-console/organizations/members/members.component.html
+++ b/apps/web/src/app/admin-console/organizations/members/members.component.html
@@ -461,33 +461,31 @@
                     @if (u.canConfirm || u.canReinvite || u.canSendInvite) {
                       <bit-menu-divider></bit-menu-divider>
                     }
-                    @if (u.canManageMember) {
+                    <button
+                      type="button"
+                      bitMenuItem
+                      (click)="isProcessing ? null : edit(u, organization, memberTab.Role)"
+                    >
+                      <i aria-hidden="true" class="bwi bwi-user"></i> {{ "memberRole" | i18n }}
+                    </button>
+                    @if (organization.useGroups) {
                       <button
                         type="button"
                         bitMenuItem
-                        (click)="isProcessing ? null : edit(u, organization, memberTab.Role)"
+                        (click)="isProcessing ? null : edit(u, organization, memberTab.Groups)"
                       >
-                        <i aria-hidden="true" class="bwi bwi-user"></i> {{ "memberRole" | i18n }}
+                        <i aria-hidden="true" class="bwi bwi-users"></i> {{ "groups" | i18n }}
                       </button>
-                      @if (organization.useGroups) {
-                        <button
-                          type="button"
-                          bitMenuItem
-                          (click)="isProcessing ? null : edit(u, organization, memberTab.Groups)"
-                        >
-                          <i aria-hidden="true" class="bwi bwi-users"></i> {{ "groups" | i18n }}
-                        </button>
-                      }
-                      <button
-                        type="button"
-                        bitMenuItem
-                        (click)="isProcessing ? null : edit(u, organization, memberTab.Collections)"
-                      >
-                        <bit-icon [name]="'bwi-collection-shared' | vfo1Icon" slot="start" />
-                        {{ "collections" | vfo1I18n: "sharedFolders" }}
-                      </button>
-                      <bit-menu-divider></bit-menu-divider>
                     }
+                    <button
+                      type="button"
+                      bitMenuItem
+                      (click)="isProcessing ? null : edit(u, organization, memberTab.Collections)"
+                    >
+                      <bit-icon [name]="'bwi-collection-shared' | vfo1Icon" slot="start" />
+                      {{ "collections" | vfo1I18n: "sharedFolders" }}
+                    </button>
+                    <bit-menu-divider></bit-menu-divider>
                     @if (organization.useEvents && u.status === userStatusType.Confirmed) {
                       <button
                         type="button"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42582](https://bitwarden.atlassian.net/browse/PM-42582)

## 📔 Objective

Stacked on #22822 - review that one first.

Staged was the only status excluded from the **Member role**, **Groups**, and **Collections** entries in the members row action menu. Those same three actions were already reachable for a staged member by clicking the name, groups, or role cell in the row - all four paths open the same member dialog, just on a different initial tab - so the action menu was the only place they were hidden.

[PM-42582]: https://bitwarden.atlassian.net/browse/PM-42582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ