### PR TITLE
[PM-42880] Add CSS class directly to form control component  

### DIFF
--- a/libs/components/src/form-control/form-control-card.component.html
+++ b/libs/components/src/form-control/form-control-card.component.html
@@ -2,7 +2,7 @@
 <div class="tw-flex tw-h-full tw-flex-col tw-gap-2">
   <!-- tw-outline-none supports forced colors mode; ring utility does not -->
   <div
-    class="tw-flex tw-flex-1 tw-items-center tw-relative tw-isolate tw-p-4 tw-border tw-border-border-base tw-rounded-xl tw-justify-between tw-gap-4 has-[input:focus-visible]:tw-ring-2 has-[input:focus-visible]:tw-outline-none has-[input:focus-visible]:tw-ring-border-focus has-[input:focus-visible]:tw-border-transparent tw-transition-colors"
+    class="tw-flex tw-flex-1 tw-items-center tw-relative tw-isolate tw-p-4 tw-border tw-border-solid tw-border-border-base tw-rounded-xl tw-justify-between tw-gap-4 has-[input:focus-visible]:tw-ring-2 has-[input:focus-visible]:tw-outline-none has-[input:focus-visible]:tw-ring-border-focus has-[input:focus-visible]:tw-border-transparent tw-transition-colors"
     [class]="
       control.disabled
         ? ''


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42880

## 📔 Objective

This PR adds the `tw-border-solid` class to the `bit-form-control-card` component, allowing this component to render expected card borders on the desktop client. 

[Reference Figma thread](https://www.figma.com/design/XSVfwUs74g0353SKulKmWN/Import?node-id=3298-45835#1905309316)

## 📸 Screenshots

Before: 

<img width="3790" height="2482" alt="Screenshot 2026-08-30 at 08 22 40" src="https://github.com/user-attachments/assets/8a696996-a3fe-43cd-810d-cb39b4152f88" />


After: 

<img width="1383" height="1107" alt="Screenshot 2026-08-31 at 16 45 02" src="https://github.com/user-attachments/assets/7b415e4e-fc39-4404-b4f7-407ed8c705a5" />
