### PR TITLE
[PM-42851] Fail the vault health scan when the exposed-password check errors

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.spec.ts
@@ -95,13 +95,19 @@ describe("DefaultVaultHealthReportService", () => {
 
   const risk = (
     id: string,
-    opts: { strength?: number; exposed?: number; reuse?: number } = {},
+    opts: { strength?: number; exposed?: number; reuse?: number; exposedError?: string } = {},
   ): CipherRiskResult => {
     const exposed = opts.exposed ?? 0;
+    const exposedResult =
+      opts.exposedError != null
+        ? { type: "Error", value: opts.exposedError }
+        : exposed > 0
+          ? { type: "Found", value: exposed }
+          : { type: "NotChecked" };
     return {
       id,
       password_strength: opts.strength ?? 4,
-      exposed_result: exposed > 0 ? { type: "Found", value: exposed } : { type: "NotChecked" },
+      exposed_result: exposedResult,
       reuse_count: opts.reuse ?? 1,
     } as unknown as CipherRiskResult;
   };
@@ -331,6 +337,99 @@ describe("DefaultVaultHealthReportService", () => {
     expect(cipherIds(result.categoryItems.exposed)).toEqual(["a"]);
     expect(cipherIds(result.categoryItems.weak)).toEqual(["b"]);
     expect(cipherIds(result.categoryItems.reused)).toEqual(["c"]);
+  });
+
+  describe("a failed exposed-password check", () => {
+    it("publishes an error state when every login's exposed check failed", async () => {
+      const ciphers = withRisks([
+        { cipher: login("a"), risk: risk("a", { exposedError: "network error" }) },
+        { cipher: login("b"), risk: risk("b", { exposedError: "network error" }) },
+      ]);
+
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      const state = await firstValueFrom(service.getVaultHealthReport$(userId));
+      expect(state.status).toBe(VaultHealthReportStatus.Error);
+    });
+
+    it("publishes an error state when only one login's exposed check failed", async () => {
+      const ciphers = withRisks([
+        { cipher: login("a"), risk: risk("a", { exposed: 5 }) },
+        { cipher: login("b"), risk: risk("b", { exposedError: "429 Too Many Requests" }) },
+        { cipher: login("c"), risk: risk("c") },
+      ]);
+
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      const state = await firstValueFrom(service.getVaultHealthReport$(userId));
+      expect(state.status).toBe(VaultHealthReportStatus.Error);
+    });
+
+    it("does not publish a report that under-counts the exposed category", async () => {
+      const ciphers = withRisks([
+        { cipher: login("a"), risk: risk("a", { exposedError: "network error" }) },
+      ]);
+
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      expect(await currentReport()).toBeNull();
+    });
+
+    it("logs how many logins could not be checked", async () => {
+      const ciphers = withRisks([
+        { cipher: login("a"), risk: risk("a", { exposedError: "network error" }) },
+        { cipher: login("b"), risk: risk("b", { exposedError: "network error" }) },
+      ]);
+
+      await service.buildVaultHealthReport(ciphers, userId);
+
+      expect(logService.error).toHaveBeenCalledWith(
+        "Vault health report generation failed",
+        expect.objectContaining({ message: expect.stringContaining("2 of 2") }),
+      );
+    });
+
+    it("still scores an unchecked login as healthy, so a scan without breach data does not fail", async () => {
+      const built = await report(withRisks([{ cipher: login("a"), risk: risk("a") }]));
+
+      expect(built.atRiskCount).toBe(0);
+      expect(built.categoryItems.exposed).toEqual([]);
+    });
+
+    it("keeps the previous report readable when a rescan's exposed check fails", async () => {
+      const healthy = withRisks([{ cipher: login("a"), risk: risk("a", { exposed: 5 }) }]);
+      await service.buildVaultHealthReport(healthy, userId);
+      const before = await currentReport();
+
+      const failing = withRisks([
+        { cipher: editedLogin("a"), risk: risk("a", { exposedError: "network error" }) },
+      ]);
+      await service.buildVaultHealthReport(failing, userId);
+
+      expect(await currentReport()).toBe(before);
+    });
+
+    it("leaves the report on screen when a background refresh's exposed check fails", async () => {
+      const healthy = withRisks([{ cipher: login("a"), risk: risk("a", { exposed: 5 }) }]);
+      await service.buildVaultHealthReport(healthy, userId);
+      const before = await currentReport();
+
+      const failing = withRisks([
+        { cipher: editedLogin("a"), risk: risk("a", { exposedError: "network error" }) },
+      ]);
+      await service.refreshVaultHealthReport(failing, userId);
+
+      const state = await firstValueFrom(service.getVaultHealthReport$(userId));
+      expect(state.status).toBe(VaultHealthReportStatus.Success);
+      expect(state.report).toBe(before);
+    });
+
+    it("does not fail an empty vault, which is never checked against the breach API", async () => {
+      const built = await report([]);
+
+      expect(built.totalCount).toBe(0);
+      expect(cipherRiskService.computeRiskForCiphers).not.toHaveBeenCalled();
+    });
   });
 
   // --- the published state and report --------------------------------------

--- a/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/vault-health/services/implementations/default-vault-health-report.service.ts
@@ -191,11 +191,27 @@ export class DefaultVaultHealthReportService implements VaultHealthReportService
       checkExposed: true,
     });
 
+    // A failed breach lookup arrives per login rather than a rejection, and reads as not exposed.
+    this.throwIfExposedCheckFailed(risks);
+
     // Each CipherRiskResult carries its own `id`, so map results to per-login
     // views directly by id (no reliance on array position).
     return VaultHealthReportView.fromCipherHealth(
       risks.map((risk) => this.toCipherHealthView(risk)),
       totalCount,
+    );
+  }
+
+  private throwIfExposedCheckFailed(risks: CipherRiskResult[]): void {
+    const messages = risks.flatMap((risk) =>
+      risk.exposed_result.type === "Error" ? [risk.exposed_result.value] : [],
+    );
+    if (messages.length === 0) {
+      return;
+    }
+
+    throw new Error(
+      `Exposed-password check failed for ${messages.length} of ${risks.length} logins: ${messages[0]}`,
     );
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42851](https://bitwarden.atlassian.net/browse/PM-42851)

## 📔 Objective

With the network offline, the browser Health tab showed the Health Overview with the Exposed passwords category reading as all clear, instead of the scan-failure state.

The cause is one line in the report builder. The SDK reports a failed Have I Been Pwned lookup **per login** rather than rejecting (its own doc: "This method only returns `Err` for internal logic failures. HIBP API errors are captured per-cipher in the `exposed_result` field"). `ExposedPasswordResult` has three arms, and `toCipherHealthView` kept only `Found`, folding `Error` into the same zero as `NotChecked`. Nothing threw, so the scan published `success` with an under-counted Exposed category, which is a confident wrong answer about the user's security.

This throws when any login's exposed check errored. The existing `catch` in `buildVaultHealthReport` then publishes the `error` status and the Health tab renders its existing scan-failure view with Try again, so there is no UI, i18n, or model change. Both callers route through the same private builder, so a background refresh is covered too, and keeps its current behavior of leaving results on screen rather than replacing them with a failure view.

This also restores what the service abstraction's JSDoc already promised: "Failures (e.g. a breach lookup being down) come back as an `error` status".

Behind the `pm-35928-premium-user-health-reports` flag, which stays defaulted off.

### Verification

- 8 new unit tests, 6 of which fail without the guard. All 41 existing report service tests kept and passing, plus 217 Health tab tests. `npm run test:types` clean.
- Ran end to end in a real Chrome against a vault with four genuinely breached passwords. Offline scan now shows the scan-failure view, retry while still offline stays on it, and Try again once back online returns the same counts as the online baseline.
- Same run against a build with the guard reverted reproduces the bug: "No exposed passwords" with a green check, despite all 11 breach lookups failing. It also silently reclassified the four breached logins as weak (1 weak became 5), since the report only counts each login in its highest category.


[PM-42851]: https://bitwarden.atlassian.net/browse/PM-42851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
