### PR TITLE
[PM-41981] Keep v1 users on TS key rotation when SDK key rotation is enabled

### DIFF
--- a/apps/web/src/app/auth/settings/security/security-keys.component.html
+++ b/apps/web/src/app/auth/settings/security/security-keys.component.html
@@ -3,7 +3,7 @@
     <app-change-kdf></app-change-kdf>
   }
 
-  @if (showKeyRotation && sdkKeyRotationFlag$ | async) {
+  @if (showKeyRotation$ | async) {
     <app-user-key-rotation></app-user-key-rotation>
   }
 

--- a/apps/web/src/app/auth/settings/security/security-keys.component.html
+++ b/apps/web/src/app/auth/settings/security/security-keys.component.html
@@ -1,5 +1,5 @@
 <div class="tw-grid tw-gap-16 tw-mt-6">
-  @if (showChangeKdf) {
+  @if (showChangeKdf$ | async) {
     <app-change-kdf></app-change-kdf>
   }
 

--- a/apps/web/src/app/auth/settings/security/security-keys.component.spec.ts
+++ b/apps/web/src/app/auth/settings/security/security-keys.component.spec.ts
@@ -1,15 +1,11 @@
 import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
-import { mock, MockProxy } from "jest-mock-extended";
-import { of } from "rxjs";
+import { mock } from "jest-mock-extended";
+import { BehaviorSubject } from "rxjs";
 
-import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
-import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
-import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
@@ -18,7 +14,7 @@ import { newGuid } from "@bitwarden/guid";
 
 import { ChangeKdfModule } from "../../../key-management/change-kdf/change-kdf.module";
 import { KeyRotationComponent } from "../../../key-management/key-rotation/key-rotation.component";
-import { UserKeyRotationService } from "../../../key-management/key-rotation/user-key-rotation.service";
+import { SecurityKeysComponentService } from "../../../key-management/services/security-keys-component.service";
 
 import { SecurityKeysComponent } from "./security-keys.component";
 
@@ -39,45 +35,40 @@ class MockChangeKdfComponent {}
 describe("SecurityKeysComponent", () => {
   let fixture: ComponentFixture<SecurityKeysComponent>;
 
-  let userDecryptionOptionsService: MockProxy<UserDecryptionOptionsServiceAbstraction>;
-  let keyConnectorService: MockProxy<KeyConnectorService>;
-  let deviceTrustService: MockProxy<DeviceTrustServiceAbstraction>;
-  let userKeyRotationService: MockProxy<UserKeyRotationService>;
+  let showChangeKdf: BehaviorSubject<boolean>;
+  let showKeyRotation: BehaviorSubject<boolean>;
 
   const mockUserId = newGuid() as UserId;
 
   beforeEach(async () => {
-    userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
-    keyConnectorService = mock<KeyConnectorService>();
-    deviceTrustService = mock<DeviceTrustServiceAbstraction>();
-    userKeyRotationService = mock<UserKeyRotationService>();
+    showChangeKdf = new BehaviorSubject<boolean>(false);
+    showKeyRotation = new BehaviorSubject<boolean>(false);
 
-    // Baseline: no decryption options. Each arrangement below adds the ones that it needs.
-    userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(false));
-    keyConnectorService.getUsesKeyConnector.mockResolvedValue(false);
-    keyConnectorService.getManagingOrganization.mockResolvedValue(null as unknown as Organization);
-    deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(false));
-    userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(true));
+    const securityKeysComponentService = {
+      showChangeKdf$: showChangeKdf.asObservable(),
+      showKeyRotation$: showKeyRotation.asObservable(),
+    } as unknown as SecurityKeysComponentService;
 
     await TestBed.configureTestingModule({
       imports: [SecurityKeysComponent],
       providers: [
         { provide: AccountService, useValue: mockAccountServiceWith(mockUserId) },
-        {
-          provide: UserDecryptionOptionsServiceAbstraction,
-          useValue: userDecryptionOptionsService,
-        },
-        { provide: KeyConnectorService, useValue: keyConnectorService },
-        { provide: DeviceTrustServiceAbstraction, useValue: deviceTrustService },
-        { provide: UserKeyRotationService, useValue: userKeyRotationService },
         { provide: ApiService, useValue: mock<ApiService>() },
         { provide: DialogService, useValue: mock<DialogService>() },
         { provide: I18nService, useValue: { t: (key: string) => key } },
       ],
     })
       .overrideComponent(SecurityKeysComponent, {
-        remove: { imports: [ChangeKdfModule, KeyRotationComponent] },
-        add: { imports: [MockChangeKdfComponent, MockKeyRotationComponent] },
+        remove: {
+          imports: [ChangeKdfModule, KeyRotationComponent],
+          providers: [SecurityKeysComponentService],
+        },
+        add: {
+          imports: [MockChangeKdfComponent, MockKeyRotationComponent],
+          providers: [
+            { provide: SecurityKeysComponentService, useValue: securityKeysComponentService },
+          ],
+        },
       })
       .compileComponents();
   });
@@ -89,87 +80,47 @@ describe("SecurityKeysComponent", () => {
     fixture.detectChanges();
   }
 
+  function changeKdfElement() {
+    return fixture.debugElement.query(By.directive(MockChangeKdfComponent));
+  }
+
   function keyRotationElement() {
     return fixture.debugElement.query(By.directive(MockKeyRotationComponent));
   }
 
-  describe("showKeyRotation$", () => {
-    describe("when the user uses SDK key rotation", () => {
-      beforeEach(() => {
-        userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(true));
-      });
+  describe("KDF settings", () => {
+    it("shows the KDF settings when the component service shows them", async () => {
+      showChangeKdf.next(true);
 
-      it("shows key rotation for a master password user", async () => {
-        userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(true));
+      await renderComponent();
 
-        await renderComponent();
-
-        expect(keyRotationElement()).not.toBeNull();
-      });
-
-      it("shows key rotation for a Key Connector user with a managing organization", async () => {
-        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
-        keyConnectorService.getManagingOrganization.mockResolvedValue({} as Organization);
-
-        await renderComponent();
-
-        expect(keyRotationElement()).not.toBeNull();
-      });
-
-      it("shows key rotation for a TDE user", async () => {
-        deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(true));
-
-        await renderComponent();
-
-        expect(keyRotationElement()).not.toBeNull();
-      });
-
-      it("hides key rotation for a Key Connector user without a managing organization", async () => {
-        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
-
-        await renderComponent();
-
-        expect(keyRotationElement()).toBeNull();
-      });
+      expect(changeKdfElement()).not.toBeNull();
     });
 
-    describe("when the user does not use SDK key rotation", () => {
-      beforeEach(() => {
-        userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(false));
-      });
+    it("hides the KDF settings when the component service hides them", async () => {
+      showChangeKdf.next(false);
 
-      it("hides key rotation for a master password user", async () => {
-        userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(true));
+      await renderComponent();
 
-        await renderComponent();
+      expect(changeKdfElement()).toBeNull();
+    });
+  });
 
-        expect(keyRotationElement()).toBeNull();
-      });
+  describe("key rotation", () => {
+    it("shows key rotation when the component service shows it", async () => {
+      showKeyRotation.next(true);
 
-      it("hides key rotation for a Key Connector user with a managing organization", async () => {
-        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
-        keyConnectorService.getManagingOrganization.mockResolvedValue({} as Organization);
+      await renderComponent();
 
-        await renderComponent();
+      expect(keyRotationElement()).not.toBeNull();
+    });
 
-        expect(keyRotationElement()).toBeNull();
-      });
+    it("hides key rotation when the component service hides it", async () => {
+      showKeyRotation.next(false);
 
-      it("hides key rotation for a TDE user", async () => {
-        deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(true));
+      await renderComponent();
 
-        await renderComponent();
-
-        expect(keyRotationElement()).toBeNull();
-      });
-
-      it("hides key rotation for a Key Connector user without a managing organization", async () => {
-        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
-
-        await renderComponent();
-
-        expect(keyRotationElement()).toBeNull();
-      });
+      expect(keyRotationElement()).toBeNull();
     });
   });
 });

--- a/apps/web/src/app/auth/settings/security/security-keys.component.spec.ts
+++ b/apps/web/src/app/auth/settings/security/security-keys.component.spec.ts
@@ -1,0 +1,175 @@
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { mock, MockProxy } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
+import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
+import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { mockAccountServiceWith } from "@bitwarden/common/spec";
+import { UserId } from "@bitwarden/common/types/guid";
+import { DialogService } from "@bitwarden/components";
+import { newGuid } from "@bitwarden/guid";
+
+import { ChangeKdfModule } from "../../../key-management/change-kdf/change-kdf.module";
+import { KeyRotationComponent } from "../../../key-management/key-rotation/key-rotation.component";
+import { UserKeyRotationService } from "../../../key-management/key-rotation/user-key-rotation.service";
+
+import { SecurityKeysComponent } from "./security-keys.component";
+
+@Component({
+  selector: "app-user-key-rotation",
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockKeyRotationComponent {}
+
+@Component({
+  selector: "app-change-kdf",
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MockChangeKdfComponent {}
+
+describe("SecurityKeysComponent", () => {
+  let fixture: ComponentFixture<SecurityKeysComponent>;
+
+  let userDecryptionOptionsService: MockProxy<UserDecryptionOptionsServiceAbstraction>;
+  let keyConnectorService: MockProxy<KeyConnectorService>;
+  let deviceTrustService: MockProxy<DeviceTrustServiceAbstraction>;
+  let userKeyRotationService: MockProxy<UserKeyRotationService>;
+
+  const mockUserId = newGuid() as UserId;
+
+  beforeEach(async () => {
+    userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
+    keyConnectorService = mock<KeyConnectorService>();
+    deviceTrustService = mock<DeviceTrustServiceAbstraction>();
+    userKeyRotationService = mock<UserKeyRotationService>();
+
+    // Baseline: no decryption options. Each arrangement below adds the ones that it needs.
+    userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(false));
+    keyConnectorService.getUsesKeyConnector.mockResolvedValue(false);
+    keyConnectorService.getManagingOrganization.mockResolvedValue(null as unknown as Organization);
+    deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(false));
+    userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(true));
+
+    await TestBed.configureTestingModule({
+      imports: [SecurityKeysComponent],
+      providers: [
+        { provide: AccountService, useValue: mockAccountServiceWith(mockUserId) },
+        {
+          provide: UserDecryptionOptionsServiceAbstraction,
+          useValue: userDecryptionOptionsService,
+        },
+        { provide: KeyConnectorService, useValue: keyConnectorService },
+        { provide: DeviceTrustServiceAbstraction, useValue: deviceTrustService },
+        { provide: UserKeyRotationService, useValue: userKeyRotationService },
+        { provide: ApiService, useValue: mock<ApiService>() },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+      ],
+    })
+      .overrideComponent(SecurityKeysComponent, {
+        remove: { imports: [ChangeKdfModule, KeyRotationComponent] },
+        add: { imports: [MockChangeKdfComponent, MockKeyRotationComponent] },
+      })
+      .compileComponents();
+  });
+
+  async function renderComponent() {
+    fixture = TestBed.createComponent(SecurityKeysComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function keyRotationElement() {
+    return fixture.debugElement.query(By.directive(MockKeyRotationComponent));
+  }
+
+  describe("showKeyRotation$", () => {
+    describe("when the user uses SDK key rotation", () => {
+      beforeEach(() => {
+        userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(true));
+      });
+
+      it("shows key rotation for a master password user", async () => {
+        userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(true));
+
+        await renderComponent();
+
+        expect(keyRotationElement()).not.toBeNull();
+      });
+
+      it("shows key rotation for a Key Connector user with a managing organization", async () => {
+        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
+        keyConnectorService.getManagingOrganization.mockResolvedValue({} as Organization);
+
+        await renderComponent();
+
+        expect(keyRotationElement()).not.toBeNull();
+      });
+
+      it("shows key rotation for a TDE user", async () => {
+        deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(true));
+
+        await renderComponent();
+
+        expect(keyRotationElement()).not.toBeNull();
+      });
+
+      it("hides key rotation for a Key Connector user without a managing organization", async () => {
+        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
+
+        await renderComponent();
+
+        expect(keyRotationElement()).toBeNull();
+      });
+    });
+
+    describe("when the user does not use SDK key rotation", () => {
+      beforeEach(() => {
+        userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(false));
+      });
+
+      it("hides key rotation for a master password user", async () => {
+        userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(true));
+
+        await renderComponent();
+
+        expect(keyRotationElement()).toBeNull();
+      });
+
+      it("hides key rotation for a Key Connector user with a managing organization", async () => {
+        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
+        keyConnectorService.getManagingOrganization.mockResolvedValue({} as Organization);
+
+        await renderComponent();
+
+        expect(keyRotationElement()).toBeNull();
+      });
+
+      it("hides key rotation for a TDE user", async () => {
+        deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(true));
+
+        await renderComponent();
+
+        expect(keyRotationElement()).toBeNull();
+      });
+
+      it("hides key rotation for a Key Connector user without a managing organization", async () => {
+        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
+
+        await renderComponent();
+
+        expect(keyRotationElement()).toBeNull();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/auth/settings/security/security-keys.component.ts
+++ b/apps/web/src/app/auth/settings/security/security-keys.component.ts
@@ -1,18 +1,17 @@
 import { Component, OnInit } from "@angular/core";
-import { firstValueFrom, map } from "rxjs";
+import { combineLatest, firstValueFrom, map, switchMap } from "rxjs";
 
 import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
 import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
-import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { DialogService } from "@bitwarden/components";
 
 import { ChangeKdfModule } from "../../../key-management/change-kdf/change-kdf.module";
 import { KeyRotationComponent } from "../../../key-management/key-rotation/key-rotation.component";
+import { UserKeyRotationService } from "../../../key-management/key-rotation/user-key-rotation.service";
 import { SharedModule } from "../../../shared";
 
 import { ApiKeyComponent } from "./api-key.component";
@@ -25,34 +24,50 @@ import { ApiKeyComponent } from "./api-key.component";
 })
 export class SecurityKeysComponent implements OnInit {
   showChangeKdf = true;
-  showKeyRotation = true;
-  readonly sdkKeyRotationFlag$ = this.configService.getFeatureFlag$(FeatureFlag.SdkKeyRotation);
+
+  protected readonly showKeyRotation$ = this.accountService.activeAccount$.pipe(
+    getUserId,
+    switchMap((userId) =>
+      combineLatest([
+        this.userDecryptionOptionsService.hasMasterPasswordById$(userId),
+        this.keyConnectorService.getUsesKeyConnector(userId),
+        this.keyConnectorService.getManagingOrganization(userId),
+        this.deviceTrustService.supportsDeviceTrustByUserId$(userId),
+        this.userKeyRotationService.shouldUseSdkKeyRotation$(userId),
+      ]),
+    ),
+    map(
+      ([
+        hasMasterPassword,
+        usesKeyConnector,
+        managingOrganization,
+        hasTdeKeys,
+        useSdkKeyRotation,
+      ]) => {
+        const hasManagingKeyConnectorOrganization =
+          usesKeyConnector && managingOrganization != null;
+        const canRotate = hasMasterPassword || hasManagingKeyConnectorOrganization || hasTdeKeys;
+        return canRotate && useSdkKeyRotation;
+      },
+    ),
+  );
 
   constructor(
     private userDecryptionOptionsService: UserDecryptionOptionsServiceAbstraction,
     private accountService: AccountService,
     private apiService: ApiService,
     private dialogService: DialogService,
-    private configService: ConfigService,
     private keyConnectorService: KeyConnectorService,
     private deviceTrustService: DeviceTrustServiceAbstraction,
+    private userKeyRotationService: UserKeyRotationService,
   ) {}
 
   async ngOnInit() {
     const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-    const hasMasterPassword = await firstValueFrom(
+
+    this.showChangeKdf = await firstValueFrom(
       this.userDecryptionOptionsService.hasMasterPasswordById$(userId),
     );
-    const usesKeyConnector = await this.keyConnectorService.getUsesKeyConnector(userId);
-    const hasManagingOrganization = usesKeyConnector
-      ? (await this.keyConnectorService.getManagingOrganization(userId)) != null
-      : false;
-    const hasTdeKeys = await firstValueFrom(
-      this.deviceTrustService.supportsDeviceTrustByUserId$(userId),
-    );
-
-    this.showChangeKdf = hasMasterPassword;
-    this.showKeyRotation = hasMasterPassword || hasManagingOrganization || hasTdeKeys;
   }
 
   async viewUserApiKey() {

--- a/apps/web/src/app/auth/settings/security/security-keys.component.ts
+++ b/apps/web/src/app/auth/settings/security/security-keys.component.ts
@@ -1,17 +1,13 @@
-import { Component, OnInit } from "@angular/core";
-import { combineLatest, firstValueFrom, map, switchMap } from "rxjs";
+import { Component, inject } from "@angular/core";
+import { firstValueFrom, map } from "rxjs";
 
-import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
-import { getUserId } from "@bitwarden/common/auth/services/account.service";
-import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
-import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
 import { DialogService } from "@bitwarden/components";
 
 import { ChangeKdfModule } from "../../../key-management/change-kdf/change-kdf.module";
 import { KeyRotationComponent } from "../../../key-management/key-rotation/key-rotation.component";
-import { UserKeyRotationService } from "../../../key-management/key-rotation/user-key-rotation.service";
+import { SecurityKeysComponentService } from "../../../key-management/services/security-keys-component.service";
 import { SharedModule } from "../../../shared";
 
 import { ApiKeyComponent } from "./api-key.component";
@@ -21,54 +17,16 @@ import { ApiKeyComponent } from "./api-key.component";
 @Component({
   templateUrl: "security-keys.component.html",
   imports: [SharedModule, ChangeKdfModule, KeyRotationComponent],
+  providers: [SecurityKeysComponentService],
 })
-export class SecurityKeysComponent implements OnInit {
-  showChangeKdf = true;
+export class SecurityKeysComponent {
+  private readonly accountService = inject(AccountService);
+  private readonly apiService = inject(ApiService);
+  private readonly dialogService = inject(DialogService);
+  private readonly securityKeysComponentService = inject(SecurityKeysComponentService);
 
-  protected readonly showKeyRotation$ = this.accountService.activeAccount$.pipe(
-    getUserId,
-    switchMap((userId) =>
-      combineLatest([
-        this.userDecryptionOptionsService.hasMasterPasswordById$(userId),
-        this.keyConnectorService.getUsesKeyConnector(userId),
-        this.keyConnectorService.getManagingOrganization(userId),
-        this.deviceTrustService.supportsDeviceTrustByUserId$(userId),
-        this.userKeyRotationService.shouldUseSdkKeyRotation$(userId),
-      ]),
-    ),
-    map(
-      ([
-        hasMasterPassword,
-        usesKeyConnector,
-        managingOrganization,
-        hasTdeKeys,
-        useSdkKeyRotation,
-      ]) => {
-        const hasManagingKeyConnectorOrganization =
-          usesKeyConnector && managingOrganization != null;
-        const canRotate = hasMasterPassword || hasManagingKeyConnectorOrganization || hasTdeKeys;
-        return canRotate && useSdkKeyRotation;
-      },
-    ),
-  );
-
-  constructor(
-    private userDecryptionOptionsService: UserDecryptionOptionsServiceAbstraction,
-    private accountService: AccountService,
-    private apiService: ApiService,
-    private dialogService: DialogService,
-    private keyConnectorService: KeyConnectorService,
-    private deviceTrustService: DeviceTrustServiceAbstraction,
-    private userKeyRotationService: UserKeyRotationService,
-  ) {}
-
-  async ngOnInit() {
-    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
-
-    this.showChangeKdf = await firstValueFrom(
-      this.userDecryptionOptionsService.hasMasterPasswordById$(userId),
-    );
-  }
+  protected readonly showChangeKdf$ = this.securityKeysComponentService.showChangeKdf$;
+  protected readonly showKeyRotation$ = this.securityKeysComponentService.showKeyRotation$;
 
   async viewUserApiKey() {
     const entityId = await firstValueFrom(

--- a/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.spec.ts
+++ b/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.spec.ts
@@ -1,5 +1,5 @@
-import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject, of } from "rxjs";
+import { any, mock, MockProxy } from "jest-mock-extended";
+import { BehaviorSubject, firstValueFrom, of } from "rxjs";
 
 import { OrganizationUserResetPasswordWithIdRequest } from "@bitwarden/admin-console/common";
 import { LogoutService } from "@bitwarden/auth/common";
@@ -28,6 +28,7 @@ import { CipherType } from "@bitwarden/common/vault/enums";
 import { CipherWithIdRequest } from "@bitwarden/common/vault/models/request/cipher-with-id.request";
 import { FolderWithIdRequest } from "@bitwarden/common/vault/models/request/folder-with-id.request";
 import { DialogService, ToastService } from "@bitwarden/components";
+import { newGuid } from "@bitwarden/guid";
 import { KeyService, KdfConfigService } from "@bitwarden/key-management";
 import {
   AccountRecoveryTrustComponent,
@@ -288,7 +289,7 @@ describe("KeyRotationService", () => {
   let mockSdkUserKeyRotationService: MockProxy<UserKeyRotationServiceAbstraction>;
 
   const mockUser = {
-    id: "mockUserId" as UserId,
+    id: newGuid() as UserId,
     ...mockAccountInfoWith({
       email: "mockEmail",
       name: "mockName",
@@ -403,10 +404,75 @@ describe("KeyRotationService", () => {
       configurable: true,
     });
     mockMasterPasswordService.saltForUser$.mockReturnValue(of(mockUserSalt as MasterPasswordSalt));
+    // Register the default through `calledWith` so that a test can override a single flag.
+    // A plain `mockReturnValue` here would stop jest-mock-extended from matching on arguments.
+    mockConfigService.getFeatureFlag$.calledWith(any()).mockReturnValue(of(false));
+  });
+
+  describe("shouldUseSdkKeyRotation$", () => {
+    function arrangeFlags(sdkKeyRotation: boolean, forceUpgradeV2Encryption: boolean) {
+      mockConfigService.getFeatureFlag$
+        .calledWith(FeatureFlag.SdkKeyRotation)
+        .mockReturnValue(of(sdkKeyRotation));
+      mockConfigService.getFeatureFlag$
+        .calledWith(FeatureFlag.ForceUpgradeV2Encryption)
+        .mockReturnValue(of(forceUpgradeV2Encryption));
+    }
+
+    it.each([
+      [false, false],
+      [true, false],
+      [false, true],
+    ])(
+      "returns false for a v1 user when SdkKeyRotation is %s and ForceUpgradeV2Encryption is %s",
+      async (sdkKeyRotation, forceUpgradeV2Encryption) => {
+        mockKeyService.userKey$.mockReturnValue(new BehaviorSubject(TEST_VECTOR_USER_KEY_V1));
+        arrangeFlags(sdkKeyRotation, forceUpgradeV2Encryption);
+
+        await expect(
+          firstValueFrom(keyRotationService.shouldUseSdkKeyRotation$(mockUser.id)),
+        ).resolves.toBe(false);
+      },
+    );
+
+    it("returns true for a v1 user when both feature flags are enabled", async () => {
+      mockKeyService.userKey$.mockReturnValue(new BehaviorSubject(TEST_VECTOR_USER_KEY_V1));
+      arrangeFlags(true, true);
+
+      await expect(
+        firstValueFrom(keyRotationService.shouldUseSdkKeyRotation$(mockUser.id)),
+      ).resolves.toBe(true);
+    });
+
+    it.each([
+      [false, false],
+      [true, false],
+      [false, true],
+      [true, true],
+    ])(
+      "returns true for a v2 user when SdkKeyRotation is %s and ForceUpgradeV2Encryption is %s",
+      async (sdkKeyRotation, forceUpgradeV2Encryption) => {
+        mockKeyService.userKey$.mockReturnValue(new BehaviorSubject(TEST_VECTOR_USER_KEY_V2));
+        arrangeFlags(sdkKeyRotation, forceUpgradeV2Encryption);
+
+        await expect(
+          firstValueFrom(keyRotationService.shouldUseSdkKeyRotation$(mockUser.id)),
+        ).resolves.toBe(true);
+      },
+    );
+
+    it("returns false when the user key is null", async () => {
+      mockKeyService.userKey$.mockReturnValue(new BehaviorSubject(null));
+      arrangeFlags(true, true);
+
+      await expect(
+        firstValueFrom(keyRotationService.shouldUseSdkKeyRotation$(mockUser.id)),
+      ).resolves.toBe(false);
+    });
   });
 
   describe("rotateUserKeyMasterPasswordAndEncryptedData", () => {
-    let keyPair: BehaviorSubject<{ privateKey: UserPrivateKey; publicKey: UserPublicKey }>;
+    let keyPair: BehaviorSubject<{ privateKey: UserPrivateKey; publicKey: UserPublicKey } | null>;
 
     beforeEach(() => {
       mockSyncService.getLastSync.mockResolvedValue(new Date());
@@ -427,7 +493,7 @@ describe("KeyRotationService", () => {
       } as any);
 
       // Mock user key
-      mockKeyService.userKey$.mockReturnValue(new BehaviorSubject("mockOriginalUserKey" as any));
+      mockKeyService.userKey$.mockReturnValue(new BehaviorSubject(TEST_VECTOR_USER_KEY_V1));
 
       mockLegacyCompatKeyService.getFingerprint.mockResolvedValue(["a", "b"]);
 
@@ -559,6 +625,60 @@ describe("KeyRotationService", () => {
         expect.objectContaining({ version: 1 }),
         true,
       );
+    });
+
+    describe("SDK and TypeScript path selection", () => {
+      beforeEach(() => {
+        mockKdfConfigService.getKdfConfig$.mockReturnValue(
+          new BehaviorSubject(new PBKDF2KdfConfig(100000)),
+        );
+        mockKeyService.userEncryptedPrivateKey$.mockReturnValue(
+          new BehaviorSubject(TEST_VECTOR_PRIVATE_KEY_V1 as string as EncryptedString),
+        );
+        mockKeyService.userSigningKey$.mockReturnValue(new BehaviorSubject(null));
+        mockSecurityStateService.accountSecurityState$.mockReturnValue(new BehaviorSubject(null));
+        mockSdkUserKeyRotationService.changePasswordAndRotateUserKey.mockResolvedValue(true);
+        jest.spyOn(keyRotationService, "getRotatedAccountKeysFlagged").mockResolvedValue({
+          userKey: TEST_VECTOR_USER_KEY_V1,
+          accountKeysRequest: {
+            userKeyEncryptedAccountPrivateKey: TEST_VECTOR_PRIVATE_KEY_V1_ROTATED,
+            accountPublicKey: TEST_VECTOR_PUBLIC_KEY_V1,
+          } as AccountKeysRequest,
+        });
+      });
+
+      it("uses the SDK when the user uses SDK key rotation", async () => {
+        jest.spyOn(keyRotationService, "shouldUseSdkKeyRotation$").mockReturnValue(of(true));
+
+        await keyRotationService.rotateUserKeyMasterPasswordAndEncryptedData(
+          "mockMasterPassword",
+          "mockMasterPassword1",
+          mockUser,
+          "masterPasswordHint",
+        );
+
+        expect(mockSdkUserKeyRotationService.changePasswordAndRotateUserKey).toHaveBeenCalledWith(
+          "mockMasterPassword",
+          "mockMasterPassword1",
+          "masterPasswordHint",
+          mockUser.id,
+        );
+        expect(mockApiService.postUserKeyUpdate).not.toHaveBeenCalled();
+      });
+
+      it("uses TypeScript when the user does not use SDK key rotation", async () => {
+        jest.spyOn(keyRotationService, "shouldUseSdkKeyRotation$").mockReturnValue(of(false));
+
+        await keyRotationService.rotateUserKeyMasterPasswordAndEncryptedData(
+          "mockMasterPassword",
+          "mockMasterPassword1",
+          mockUser,
+          "masterPasswordHint",
+        );
+
+        expect(mockSdkUserKeyRotationService.changePasswordAndRotateUserKey).not.toHaveBeenCalled();
+        expect(mockApiService.postUserKeyUpdate).toHaveBeenCalled();
+      });
     });
 
     it("throws if kdf config is null", async () => {
@@ -1019,7 +1139,7 @@ describe("KeyRotationService", () => {
       const newKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
       const userAccount = mockUser;
 
-      mockCipherService.getRotatedData.mockResolvedValue(null);
+      mockCipherService.getRotatedData.mockResolvedValue(null as unknown as CipherWithIdRequest[]);
       mockFolderService.getRotatedData.mockResolvedValue(mockFolders);
       mockSendService.getRotatedData.mockResolvedValue(mockSends);
 
@@ -1034,7 +1154,7 @@ describe("KeyRotationService", () => {
       const userAccount = mockUser;
 
       mockCipherService.getRotatedData.mockResolvedValue(mockCiphers);
-      mockFolderService.getRotatedData.mockResolvedValue(null);
+      mockFolderService.getRotatedData.mockResolvedValue(null as unknown as FolderWithIdRequest[]);
       mockSendService.getRotatedData.mockResolvedValue(mockSends);
 
       await expect(
@@ -1049,7 +1169,7 @@ describe("KeyRotationService", () => {
 
       mockCipherService.getRotatedData.mockResolvedValue(mockCiphers);
       mockFolderService.getRotatedData.mockResolvedValue(mockFolders);
-      mockSendService.getRotatedData.mockResolvedValue(null);
+      mockSendService.getRotatedData.mockResolvedValue(null as unknown as SendWithIdRequest[]);
 
       await expect(
         keyRotationService.getAccountDataRequest(initialKey, newKey, userAccount),

--- a/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.ts
+++ b/apps/web/src/app/key-management/key-rotation/user-key-rotation.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { firstValueFrom, Observable } from "rxjs";
+import { combineLatest, firstValueFrom, map, Observable } from "rxjs";
 
 import { LogoutService } from "@bitwarden/auth/common";
 import { Account } from "@bitwarden/common/auth/abstractions/account.service";
@@ -110,6 +110,31 @@ export class UserKeyRotationService {
   ) {}
 
   /**
+   * Whether a manual user key rotation goes through the SDK.
+   *
+   * SDK key rotation always rotates to v2 encryption, so a v2 user always uses it.
+   *
+   * A v1 user uses it only when `force-upgrade-v2-encryption` is on. That flag starts the
+   * automated forced v2 upgrade, which rotates the user to v2 anyway. While the flag is off, a
+   * manual key rotation must keep the user on v1. Otherwise an older device that does not fully
+   * support v2 can no longer read the vault data.
+   */
+  shouldUseSdkKeyRotation$(userId: UserId): Observable<boolean> {
+    return combineLatest([
+      this.keyService.userKey$(userId),
+      this.configService.getFeatureFlag$(FeatureFlag.SdkKeyRotation),
+      this.configService.getFeatureFlag$(FeatureFlag.ForceUpgradeV2Encryption),
+    ]).pipe(
+      map(([userKey, sdkKeyRotation, forceUpgradeV2]) => {
+        if (userKey == null) {
+          return false;
+        }
+        return !this.isV1User(userKey) || (sdkKeyRotation && forceUpgradeV2);
+      }),
+    );
+  }
+
+  /**
    * Creates a new user key and re-encrypts all required data with the it.
    * @param currentMasterPassword: The current master password
    * @param newMasterPassword: The new master password
@@ -122,7 +147,7 @@ export class UserKeyRotationService {
     user: Account,
     newMasterPasswordHint?: string,
   ): Promise<void> {
-    const useSdkKeyRotation = await this.configService.getFeatureFlag(FeatureFlag.SdkKeyRotation);
+    const useSdkKeyRotation = await firstValueFrom(this.shouldUseSdkKeyRotation$(user.id));
     if (useSdkKeyRotation) {
       this.logService.info(
         "[UserKey Rotation] Using SDK-based key rotation service from user-crypto-management",

--- a/apps/web/src/app/key-management/services/security-keys-component.service.spec.ts
+++ b/apps/web/src/app/key-management/services/security-keys-component.service.spec.ts
@@ -1,0 +1,158 @@
+import { TestBed } from "@angular/core/testing";
+import { mock, MockProxy } from "jest-mock-extended";
+import { firstValueFrom, of } from "rxjs";
+
+import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
+import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
+import { mockAccountServiceWith } from "@bitwarden/common/spec";
+import { UserId } from "@bitwarden/common/types/guid";
+import { newGuid } from "@bitwarden/guid";
+
+import { UserKeyRotationService } from "../key-rotation/user-key-rotation.service";
+
+import { SecurityKeysComponentService } from "./security-keys-component.service";
+
+describe("SecurityKeysComponentService", () => {
+  let service: SecurityKeysComponentService;
+
+  let userDecryptionOptionsService: MockProxy<UserDecryptionOptionsServiceAbstraction>;
+  let keyConnectorService: MockProxy<KeyConnectorService>;
+  let deviceTrustService: MockProxy<DeviceTrustServiceAbstraction>;
+  let userKeyRotationService: MockProxy<UserKeyRotationService>;
+
+  const mockUserId = newGuid() as UserId;
+
+  beforeEach(() => {
+    userDecryptionOptionsService = mock<UserDecryptionOptionsServiceAbstraction>();
+    keyConnectorService = mock<KeyConnectorService>();
+    deviceTrustService = mock<DeviceTrustServiceAbstraction>();
+    userKeyRotationService = mock<UserKeyRotationService>();
+
+    // Baseline: no decryption options. Each arrangement below adds the ones that it needs.
+    userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(false));
+    keyConnectorService.getUsesKeyConnector.mockResolvedValue(false);
+    keyConnectorService.getManagingOrganization.mockResolvedValue(null as unknown as Organization);
+    deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(false));
+    userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(true));
+
+    TestBed.configureTestingModule({
+      providers: [
+        SecurityKeysComponentService,
+        { provide: AccountService, useValue: mockAccountServiceWith(mockUserId) },
+        {
+          provide: UserDecryptionOptionsServiceAbstraction,
+          useValue: userDecryptionOptionsService,
+        },
+        { provide: KeyConnectorService, useValue: keyConnectorService },
+        { provide: DeviceTrustServiceAbstraction, useValue: deviceTrustService },
+        { provide: UserKeyRotationService, useValue: userKeyRotationService },
+      ],
+    });
+  });
+
+  function createService() {
+    service = TestBed.inject(SecurityKeysComponentService);
+    return service;
+  }
+
+  describe("showChangeKdf$", () => {
+    it("shows the KDF settings for a master password user", async () => {
+      userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(true));
+
+      const showChangeKdf = await firstValueFrom(createService().showChangeKdf$);
+
+      expect(showChangeKdf).toBe(true);
+    });
+
+    it("hides the KDF settings for a user without a master password", async () => {
+      userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(false));
+
+      const showChangeKdf = await firstValueFrom(createService().showChangeKdf$);
+
+      expect(showChangeKdf).toBe(false);
+    });
+  });
+
+  describe("showKeyRotation$", () => {
+    describe("when the user uses SDK key rotation", () => {
+      beforeEach(() => {
+        userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(true));
+      });
+
+      it("shows key rotation for a master password user", async () => {
+        userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(true));
+
+        const showKeyRotation = await firstValueFrom(createService().showKeyRotation$);
+
+        expect(showKeyRotation).toBe(true);
+      });
+
+      it("shows key rotation for a Key Connector user with a managing organization", async () => {
+        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
+        keyConnectorService.getManagingOrganization.mockResolvedValue({} as Organization);
+
+        const showKeyRotation = await firstValueFrom(createService().showKeyRotation$);
+
+        expect(showKeyRotation).toBe(true);
+      });
+
+      it("shows key rotation for a TDE user", async () => {
+        deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(true));
+
+        const showKeyRotation = await firstValueFrom(createService().showKeyRotation$);
+
+        expect(showKeyRotation).toBe(true);
+      });
+
+      it("hides key rotation for a Key Connector user without a managing organization", async () => {
+        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
+
+        const showKeyRotation = await firstValueFrom(createService().showKeyRotation$);
+
+        expect(showKeyRotation).toBe(false);
+      });
+    });
+
+    describe("when the user does not use SDK key rotation", () => {
+      beforeEach(() => {
+        userKeyRotationService.shouldUseSdkKeyRotation$.mockReturnValue(of(false));
+      });
+
+      it("hides key rotation for a master password user", async () => {
+        userDecryptionOptionsService.hasMasterPasswordById$.mockReturnValue(of(true));
+
+        const showKeyRotation = await firstValueFrom(createService().showKeyRotation$);
+
+        expect(showKeyRotation).toBe(false);
+      });
+
+      it("hides key rotation for a Key Connector user with a managing organization", async () => {
+        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
+        keyConnectorService.getManagingOrganization.mockResolvedValue({} as Organization);
+
+        const showKeyRotation = await firstValueFrom(createService().showKeyRotation$);
+
+        expect(showKeyRotation).toBe(false);
+      });
+
+      it("hides key rotation for a TDE user", async () => {
+        deviceTrustService.supportsDeviceTrustByUserId$.mockReturnValue(of(true));
+
+        const showKeyRotation = await firstValueFrom(createService().showKeyRotation$);
+
+        expect(showKeyRotation).toBe(false);
+      });
+
+      it("hides key rotation for a Key Connector user without a managing organization", async () => {
+        keyConnectorService.getUsesKeyConnector.mockResolvedValue(true);
+
+        const showKeyRotation = await firstValueFrom(createService().showKeyRotation$);
+
+        expect(showKeyRotation).toBe(false);
+      });
+    });
+  });
+});

--- a/apps/web/src/app/key-management/services/security-keys-component.service.ts
+++ b/apps/web/src/app/key-management/services/security-keys-component.service.ts
@@ -1,0 +1,66 @@
+import { inject, Injectable } from "@angular/core";
+import { combineLatest, map, Observable, switchMap } from "rxjs";
+
+import { UserDecryptionOptionsServiceAbstraction } from "@bitwarden/auth/common";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
+import { DeviceTrustServiceAbstraction } from "@bitwarden/common/key-management/device-trust/abstractions/device-trust.service.abstraction";
+import { KeyConnectorService } from "@bitwarden/common/key-management/key-connector/abstractions/key-connector.service";
+
+import { UserKeyRotationService } from "../key-rotation/user-key-rotation.service";
+
+/**
+ * Key management logic for the account security keys page.
+ */
+@Injectable()
+export class SecurityKeysComponentService {
+  private readonly accountService = inject(AccountService);
+  private readonly userDecryptionOptionsService = inject(UserDecryptionOptionsServiceAbstraction);
+  private readonly keyConnectorService = inject(KeyConnectorService);
+  private readonly deviceTrustService = inject(DeviceTrustServiceAbstraction);
+  private readonly userKeyRotationService = inject(UserKeyRotationService);
+
+  private readonly activeUserId$ = this.accountService.activeAccount$.pipe(getUserId);
+
+  /**
+   * The KDF settings derive the master key, so only a master password user can change them.
+   */
+  readonly showChangeKdf$: Observable<boolean> = this.activeUserId$.pipe(
+    switchMap((userId) => this.userDecryptionOptionsService.hasMasterPasswordById$(userId)),
+  );
+
+  /**
+   * Whether to show the manual key rotation section.
+   *
+   * The user must unlock with a method that the key rotation dialog supports: a master password,
+   * Key Connector with a managing organization, or trusted device encryption.
+   *
+   * The key rotation must also go through the SDK. See
+   * {@link UserKeyRotationService.shouldUseSdkKeyRotation$}.
+   */
+  readonly showKeyRotation$: Observable<boolean> = this.activeUserId$.pipe(
+    switchMap((userId) =>
+      combineLatest([
+        this.userDecryptionOptionsService.hasMasterPasswordById$(userId),
+        this.keyConnectorService.getUsesKeyConnector(userId),
+        this.keyConnectorService.getManagingOrganization(userId),
+        this.deviceTrustService.supportsDeviceTrustByUserId$(userId),
+        this.userKeyRotationService.shouldUseSdkKeyRotation$(userId),
+      ]),
+    ),
+    map(
+      ([
+        hasMasterPassword,
+        usesKeyConnector,
+        managingOrganization,
+        hasTdeKeys,
+        useSdkKeyRotation,
+      ]) => {
+        const hasManagingKeyConnectorOrganization =
+          usesKeyConnector && managingOrganization != null;
+        const canRotate = hasMasterPassword || hasManagingKeyConnectorOrganization || hasTdeKeys;
+        return canRotate && useSdkKeyRotation;
+      },
+    ),
+  );
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41981

## 📔 Objective

When SDK key rotation flag is enabled, it always rotates to v2 encryption. Since LaunchDarkly cannot target v1 or v2 users specifically, the `pm-30144-sdk-key-rotation` flag also moves v1 users to v2 on manual key rotation.
Existing accounts might still use older device, that does not fully support v2, which might cause decryption errors.

To prevent this, manual key rotation in the web client, now uses the SDK key rotation and force upgrade v2 encryption feature flags together, to determine whether to upgrade v1 user to v2.
V2 users always use SDK key rotation, regardless of the feature flags.

The Security -> Keys component, should only display user key rotation when the key rotation always leads to v2 user, hence also behind both feature flags.

KM business logic separated from the security keys component into standalone component service.

## 📸 Screenshots

N/A - no component changes.
