### PR TITLE
Declare target-system kind labels and session termination per kind

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18910,6 +18910,9 @@
   "pamTargetSystemKindMssql": {
     "message": "MSSQL"
   },
+  "pamTargetSystemKindActiveDirectory": {
+    "message": "Active Directory (on-premises)"
+  },
   "pamTargetSystemKindCustomScript": {
     "message": "Custom script"
   },
@@ -18972,6 +18975,15 @@
   },
   "pamTargetSystemSessionTerminationNativeHint": {
     "message": "Native integrations always terminate active sessions after a credential is rotated."
+  },
+  "pamTargetSystemSessionTerminationNotSupported": {
+    "message": "Not supported"
+  },
+  "pamTargetSystemSessionTerminationUnsupportedHint": {
+    "message": "This integration cannot end sessions that are already open. Rotating the credential blocks new sign-ins, but existing sessions continue until they expire."
+  },
+  "pamTargetSystemSessionTerminationRetainedHint": {
+    "message": "This target is recorded as supporting session termination, and rotation configs can still use it. Saving here leaves that record as it is."
   },
   "pamTargetSystemTerminationWithdrawalWarning": {
     "message": "Warning: the server will reject removing session termination support while any rotation config on this target still relies on it. Update those configs first."

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
@@ -66,6 +66,32 @@ export const TargetSystemKind = Object.freeze({
 } as const satisfies Record<string, SdkTargetSystemKind>);
 export type TargetSystemKind = SdkTargetSystemKind;
 
+/**
+ * The i18n id naming each {@link TargetSystemKind}, for every surface that shows one.
+ *
+ * An exhaustive `Record` rather than a switch with a default, because a default is what lets a kind
+ * nobody has named yet borrow another kind's label. Here a kind the SDK gains fails to compile
+ * until someone says what to call it.
+ *
+ * `Unknown` reuses the generic `unknown` message: the kind arrived from a newer server, so there is
+ * no honest name for it, and "Unknown" says that where an empty cell would read as a target with no
+ * integration at all.
+ */
+export const TargetSystemKindLabel = Object.freeze({
+  entra: "pamTargetSystemKindEntra",
+  mssql: "pamTargetSystemKindMssql",
+  custom_script: "pamTargetSystemKindCustomScript",
+  active_directory: "pamTargetSystemKindActiveDirectory",
+  unknown: "unknown",
+} as const satisfies Record<TargetSystemKind, string>);
+
+/** The kinds offered when creating an automatic target system, in presentation order. */
+export const SELECTABLE_TARGET_SYSTEM_KINDS = [
+  TargetSystemKind.Entra,
+  TargetSystemKind.Mssql,
+  TargetSystemKind.CustomScript,
+] as const;
+
 /** Lifecycle state of a target system. `Disabled` stops new jobs; in-flight jobs finish. */
 export const TargetSystemStatus = Object.freeze({
   Active: "active",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
@@ -79,9 +79,8 @@
         <bit-label>{{ "pamTargetSystemPolicySymbols" | i18n }}</bit-label>
       </bit-form-control>
 
-      <!-- Session termination (Automatic only): intrinsic for native integrations, opt-in for custom scripts -->
       @if (isAutomatic()) {
-        @if (isNativeIntegration()) {
+        @if (sessionTerminationAlways()) {
           <div>
             <p bitTypography="body2" class="tw-mb-1 tw-font-semibold">
               {{ "pamTargetSystemSupportsSessionTermination" | i18n }}
@@ -96,6 +95,31 @@
             <p bitTypography="helper" class="tw-mb-0 tw-mt-1 tw-text-muted">
               {{ "pamTargetSystemSessionTerminationNativeHint" | i18n }}
             </p>
+          </div>
+        } @else if (sessionTerminationNever()) {
+          <div id="target-system-edit_session-termination-unsupported">
+            <p bitTypography="body2" class="tw-mb-1 tw-font-semibold">
+              {{ "pamTargetSystemSupportsSessionTermination" | i18n }}
+            </p>
+            <span
+              bitTypography="body2"
+              class="tw-inline-flex tw-items-center tw-gap-1 tw-text-muted"
+            >
+              <bit-icon name="bwi-minus-circle"></bit-icon>
+              {{ "pamTargetSystemSessionTerminationNotSupported" | i18n }}
+            </span>
+            <p bitTypography="helper" class="tw-mb-0 tw-mt-1 tw-text-muted">
+              {{ "pamTargetSystemSessionTerminationUnsupportedHint" | i18n }}
+            </p>
+            @if (showRetainedTermination()) {
+              <p
+                bitTypography="helper"
+                class="tw-mb-0 tw-mt-1 tw-text-muted"
+                id="target-system-edit_session-termination-retained"
+              >
+                {{ "pamTargetSystemSessionTerminationRetainedHint" | i18n }}
+              </p>
+            }
           </div>
         } @else {
           <bit-form-control disableMargin>
@@ -208,9 +232,7 @@
       </div>
     </form>
   } @else {
-
     <div class="tw-max-w-4xl">
-      <!-- Setup guidance: how to connect this target system to a daemon + add a credential -->
       <bit-callout type="info" [title]="'pamTargetSystemSetupGuidanceTitle' | i18n">
         @if (existing()?.method === TargetSystemMethod.Automatic) {
           <ol class="tw-mb-0 tw-ps-4">
@@ -222,7 +244,6 @@
         }
       </bit-callout>
 
-      <!-- Name card -->
       <bit-section [formGroup]="nameForm">
         <bit-section-header>
           <h2 bitTypography="h5">{{ "pamTargetSystemGeneralInfoHeading" | i18n }}</h2>
@@ -231,15 +252,9 @@
           @if (existing()?.method === TargetSystemMethod.Automatic) {
             <p bitTypography="body2" class="tw-text-muted">
               {{ "pamTargetSystemMethodAutomatic" | i18n }}
-              @if (existing()?.kind != null) {
+              @if (existingKindLabel(); as kindLabel) {
                 ·
-                {{
-                  existing()!.kind === TargetSystemKind.Entra
-                    ? ("pamTargetSystemKindEntra" | i18n)
-                    : existing()!.kind === TargetSystemKind.Mssql
-                      ? ("pamTargetSystemKindMssql" | i18n)
-                      : ("pamTargetSystemKindCustomScript" | i18n)
-                }}
+                {{ kindLabel | i18n }}
               }
             </p>
           } @else {
@@ -255,7 +270,6 @@
         </bit-card>
       </bit-section>
 
-      <!-- Policy card (Automatic + Manual) -->
       @if (showPolicyCard()) {
         <ng-container *ngTemplateOutlet="policyCard"></ng-container>
       }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -156,7 +156,6 @@ describe("TargetSystemEditComponent — create mode", () => {
     rotationSdk.createTargetSystem.mockResolvedValue(makeSystem());
     const nav = jest.spyOn(router, "navigate").mockResolvedValue(true);
 
-    // Patch form to valid state via the formGroup
     const createForm = (
       fixture.componentInstance as unknown as { createForm: { patchValue: (v: unknown) => void } }
     ).createForm;
@@ -208,7 +207,6 @@ describe("TargetSystemEditComponent — create mode", () => {
     const call = rotationSdk.createTargetSystem.mock.calls[0];
     expect(call).toBeDefined();
     expect(call![1].method).toBe(TargetSystemMethod.Manual);
-    // Manual systems now carry an editable password policy.
     expect(call![1].passwordPolicy).toBeDefined();
   });
 
@@ -216,7 +214,6 @@ describe("TargetSystemEditComponent — create mode", () => {
     rotationSdk.createTargetSystem.mockResolvedValue(makeSystem());
     jest.spyOn(router, "navigate").mockResolvedValue(true);
 
-    // Leave name empty (invalid)
     const comp = fixture.componentInstance as unknown as { submitCreate: () => Promise<void> };
     await comp.submitCreate();
 
@@ -227,7 +224,6 @@ describe("TargetSystemEditComponent — create mode", () => {
     TestBed.resetTestingModule();
     const comp = await setupCreateWithTemplate("manual");
     expect(comp.createForm.getRawValue().method).toBe(TargetSystemMethod.Manual);
-    // No integration card for Manual (not Automatic), but the password-policy card is now shown.
     expect((comp as unknown as { isAutomatic: () => boolean }).isAutomatic()).toBe(false);
     expect((comp as unknown as { showPolicyCard: () => boolean }).showPolicyCard()).toBe(true);
   });
@@ -410,6 +406,13 @@ describe("TargetSystemEditComponent — create mode (rendered)", () => {
     patchKind(TargetSystemKind.CustomScript);
     expect(el.querySelector("#target-system-edit_checkbox_session-termination")).toBeTruthy();
   });
+
+  it("keeps the not-supported notice off a kind that does terminate sessions", () => {
+    const el = fixture.nativeElement as HTMLElement;
+    patchKind(TargetSystemKind.Entra);
+
+    expect(el.querySelector("#target-system-edit_session-termination-unsupported")).toBeNull();
+  });
 });
 
 describe("TargetSystemEditComponent — edit mode", () => {
@@ -462,7 +465,6 @@ describe("TargetSystemEditComponent — edit mode", () => {
     comp.nameForm.patchValue({ name: "Renamed" });
     await comp.submitEdit();
 
-    // One call, not two: the server takes the name, the policy and the capability together.
     expect(rotationSdk.updateTargetSystem).toHaveBeenCalledTimes(1);
     expect(rotationSdk.updateTargetSystem).toHaveBeenCalledWith(
       ORG_ID,
@@ -526,7 +528,6 @@ describe("TargetSystemEditComponent — edit mode", () => {
   });
 
   it("offers the reverse action for a retired system and returns it to service", async () => {
-    // Rebuild against a system that is already out of service.
     TestBed.resetTestingModule();
     const retiredSdk = mock<RotationSdkService>();
     const retiredToast = mock<ToastService>();
@@ -557,7 +558,6 @@ describe("TargetSystemEditComponent — edit mode", () => {
   });
 
   it("shows termination withdrawal warning when supportsSessionTermination unchecked", async () => {
-    // existing has supportsSessionTermination: true; uncheck it
     const comp = fixture.componentInstance as unknown as {
       policyForm: { patchValue: (v: unknown) => void };
       showTerminationWarning: () => boolean;
@@ -621,8 +621,70 @@ describe("TargetSystemEditComponent — edit mode", () => {
     );
   });
 
+  // A kind this SDK version cannot model reaches the form with whatever capability the server
+  // already holds for it, and the card offers no control to change it. Saving a rename must
+  // therefore leave that capability exactly as it stands, in either direction.
+  async function buildEditFixture(
+    system: TargetSystem,
+  ): Promise<
+    [ComponentFixture<TargetSystemEditComponent>, ReturnType<typeof mock<RotationSdkService>>]
+  > {
+    TestBed.resetTestingModule();
+    const sdk = mock<RotationSdkService>();
+    sdk.listTargetSystems.mockResolvedValue([system]);
+    sdk.updateTargetSystem.mockResolvedValue(undefined);
+    await setupEdit(sdk);
+    const fx = TestBed.createComponent(TargetSystemEditComponent);
+    fx.detectChanges();
+    await fx.whenStable();
+    fx.detectChanges();
+    return [fx, sdk];
+  }
+
+  it("keeps a stored session-termination capability the form cannot express", async () => {
+    const [fx, sdk] = await buildEditFixture(
+      makeSystem({ kind: TargetSystemKind.Unknown, supportsSessionTermination: true }),
+    );
+    const comp = fx.componentInstance as unknown as {
+      nameForm: { patchValue: (v: unknown) => void };
+      showRetainedTermination: () => boolean;
+      submitEdit: () => Promise<void>;
+    };
+
+    comp.nameForm.patchValue({ name: "Renamed" });
+    await comp.submitEdit();
+
+    expect(sdk.updateTargetSystem).toHaveBeenCalledWith(
+      ORG_ID,
+      sysId("sys-1"),
+      expect.objectContaining({ name: "Renamed", supportsSessionTermination: true }),
+    );
+    expect(comp.showRetainedTermination()).toBe(true);
+  });
+
+  it("claims no session-termination capability the server has not granted", async () => {
+    const [fx, sdk] = await buildEditFixture(
+      makeSystem({ kind: TargetSystemKind.Unknown, supportsSessionTermination: false }),
+    );
+    const comp = fx.componentInstance as unknown as {
+      policyForm: { patchValue: (v: unknown) => void };
+      showRetainedTermination: () => boolean;
+      submitEdit: () => Promise<void>;
+    };
+
+    // A stale true, as if the control had been checked while a custom script was loaded.
+    comp.policyForm.patchValue({ supportsSessionTermination: true });
+    await comp.submitEdit();
+
+    expect(sdk.updateTargetSystem).toHaveBeenCalledWith(
+      ORG_ID,
+      sysId("sys-1"),
+      expect.objectContaining({ supportsSessionTermination: false }),
+    );
+    expect(comp.showRetainedTermination()).toBe(false);
+  });
+
   it("navigates back when not found", async () => {
-    // Rebuild for a missing id scenario
     TestBed.resetTestingModule();
     const rotationApi2 = mock<RotationSdkService>();
     const toastService2 = mock<ToastService>();

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
@@ -40,8 +40,10 @@ import { I18nPipe } from "@bitwarden/ui-common";
 
 import {
   PasswordPolicy,
+  SELECTABLE_TARGET_SYSTEM_KINDS,
   TargetSystemId,
   TargetSystemKind,
+  TargetSystemKindLabel,
   TargetSystemMethod,
   TargetSystemStatus,
   TargetSystem,
@@ -51,6 +53,36 @@ import { RotationSdkService } from "../rotation-sdk.service";
 const NAME_MAX_LENGTH = 200;
 const DEFAULT_MIN_LENGTH = 14;
 const DEFAULT_MAX_LENGTH = 64;
+
+/**
+ * Whether an integration can end sessions that are already open, and who decides.
+ *
+ * - `always` — the integration ends them itself; the form states the fact rather than asking.
+ * - `never` — it cannot, whatever the operator would like; the form says so and claims nothing.
+ *   It declines the capability rather than withdrawing one — see {@link sessionTerminationForUpdate}.
+ * - `operatorDeclared` — only the operator's own implementation knows, so the form asks.
+ */
+type SessionTerminationCapability = "always" | "never" | "operatorDeclared";
+
+/**
+ * What each integration can do about sessions that are already open.
+ *
+ * This is a per-kind fact, not "native versus custom script": rotating an Active Directory account
+ * password blocks new sign-ins, but a Kerberos ticket already issued stays valid until it expires,
+ * so an LDAP write cannot revoke live sessions the way the Entra and MSSQL APIs do. Declaring it
+ * per kind over a `Record<TargetSystemKind, …>` also means a kind the SDK gains cannot reach this
+ * form until someone states what it can do.
+ *
+ * `Unknown` is `never` deliberately: a kind this SDK version cannot model must not claim a
+ * capability the operator would then rely on.
+ */
+const SESSION_TERMINATION_CAPABILITY = Object.freeze({
+  entra: "always",
+  mssql: "always",
+  custom_script: "operatorDeclared",
+  active_directory: "never",
+  unknown: "never",
+} as const satisfies Record<TargetSystemKind, SessionTerminationCapability>);
 
 type PolicyControls = {
   minLength: FormControl<number>;
@@ -148,16 +180,17 @@ export class TargetSystemEditComponent {
     this.i18nService.t(this.editing ? "pamTargetSystemEditTitle" : "pamTargetSystemCreateTitle"),
   );
 
-  /** Expose const objects for template comparisons. */
+  /**
+   * An Angular template can only resolve names against the component instance, so a module-level
+   * const has to be held as a field before the template can reference it.
+   */
   protected readonly TargetSystemMethod = TargetSystemMethod;
-  protected readonly TargetSystemKind = TargetSystemKind;
 
   /** Kind options for the bit-select in Automatic mode. */
-  protected readonly kindOptions = [
-    { value: TargetSystemKind.Entra, label: "pamTargetSystemKindEntra" },
-    { value: TargetSystemKind.Mssql, label: "pamTargetSystemKindMssql" },
-    { value: TargetSystemKind.CustomScript, label: "pamTargetSystemKindCustomScript" },
-  ] as const;
+  protected readonly kindOptions = SELECTABLE_TARGET_SYSTEM_KINDS.map((value) => ({
+    value,
+    label: TargetSystemKindLabel[value],
+  }));
 
   protected readonly createForm = this.formBuilder.nonNullable.group({
     name: ["", [Validators.required, Validators.maxLength(NAME_MAX_LENGTH)]],
@@ -210,15 +243,44 @@ export class TargetSystemEditComponent {
       : null,
   );
 
-  /**
-   * Native integrations (Entra, Mssql — anything other than a custom script) always terminate
-   * active sessions after rotation; the capability is intrinsic, so the form shows a static
-   * "Supported" indicator rather than an editable checkbox.
-   */
-  protected readonly isNativeIntegration = computed(() => {
-    const kind = this.selectedKind();
-    return kind != null && kind !== TargetSystemKind.CustomScript;
+  /** The i18n id naming the loaded system's integration, or `null` when it has none. */
+  protected readonly existingKindLabel = computed(() => {
+    const kind = this.existing()?.kind;
+    return kind == null ? null : TargetSystemKindLabel[kind];
   });
+
+  /**
+   * What the integration in play can do about sessions that are already open. `null` while the
+   * method is Manual, which has no integration and no daemon session to end.
+   */
+  private readonly sessionTermination = computed<SessionTerminationCapability | null>(() => {
+    const kind = this.selectedKind();
+    return kind == null ? null : SESSION_TERMINATION_CAPABILITY[kind];
+  });
+
+  protected readonly sessionTerminationAlways = computed(
+    () => this.sessionTermination() === "always",
+  );
+
+  protected readonly sessionTerminationNever = computed(
+    () => this.sessionTermination() === "never",
+  );
+
+  /**
+   * A loaded system whose kind declares no session termination, which the server nonetheless
+   * records as supporting it — a capability written before this kind was named, or by a newer
+   * server this SDK version cannot model.
+   *
+   * The card's "Not supported" line then disagrees with the stored fact, and the fact is the one
+   * rotation configs still gate their terminateSessions control on, so the page says which of the
+   * two a save keeps.
+   */
+  protected readonly showRetainedTermination = computed(
+    () =>
+      this.editing &&
+      this.sessionTerminationNever() &&
+      this.existing()?.supportsSessionTermination === true,
+  );
 
   /** Shows the session-termination withdrawal warning: edit mode only, when an existing supportsSessionTermination system is unchecked. */
   protected readonly showTerminationWarning = computed(() => {
@@ -329,11 +391,38 @@ export class TargetSystemEditComponent {
   }
 
   /**
-   * Effective session-termination support for an Automatic system: native integrations always
-   * support it; custom scripts follow the checkbox. Callers gate this on the method being Automatic.
+   * Effective session-termination support for an Automatic system. Only `operatorDeclared` reads
+   * the checkbox, so a kind that cannot end sessions submits `false` even when the control still
+   * holds a `true` left over from a kind that could.
    */
   private resolvedSessionTermination(): boolean {
-    return this.isNativeIntegration() || this.policyForm.controls.supportsSessionTermination.value;
+    const capability = this.sessionTermination();
+    if (capability === "operatorDeclared") {
+      return this.policyForm.controls.supportsSessionTermination.value;
+    }
+    return capability === "always";
+  }
+
+  /**
+   * What a save writes for `supportsSessionTermination` on a system that already exists.
+   *
+   * Declining to claim a capability and withdrawing one already granted are different writes, and
+   * only the first is this form's to make. A `never` kind states that it cannot end sessions; it
+   * says nothing about what the server was told before it, and the update request has no "leave
+   * this alone" — the field is required — so the only way to leave the stored fact standing is to
+   * send it back. Without that, renaming a system of an unmodelled kind strips a capability that
+   * rotation configs gate on, through a card that shows no control to put it back with.
+   *
+   * Withdrawal stays available where the form does ask: unchecking the `operatorDeclared` box.
+   */
+  private sessionTerminationForUpdate(): boolean {
+    if (!this.isAutomatic()) {
+      return false;
+    }
+    if (this.sessionTermination() === "never") {
+      return this.existing()?.supportsSessionTermination ?? false;
+    }
+    return this.resolvedSessionTermination();
   }
 
   /** Create mode: single submit creates the target system. */
@@ -342,7 +431,6 @@ export class TargetSystemEditComponent {
     this.policyForm.markAllAsTouched();
     const method = this.createForm.controls.method.value;
 
-    // The password policy applies to both methods now, so it is always validated.
     if (this.createForm.invalid || this.policyForm.invalid) {
       return;
     }
@@ -387,19 +475,16 @@ export class TargetSystemEditComponent {
     this.nameForm.markAllAsTouched();
     this.policyForm.markAllAsTouched();
 
-    // Both methods carry a password policy now, so it is always validated + saved.
     if (this.nameForm.invalid || this.policyForm.invalid) {
       return;
     }
 
     const { name } = this.nameForm.getRawValue();
     try {
-      // One write, not two: the server takes the name, the policy and the capability together.
       await this.rotationSdk.updateTargetSystem(this.organizationId, this.targetSystemId!, {
         name,
         passwordPolicy: this.buildPasswordPolicy(),
-        // Automatic follows native/custom-script rules; Manual has no daemon session to terminate.
-        supportsSessionTermination: this.isAutomatic() && this.resolvedSessionTermination(),
+        supportsSessionTermination: this.sessionTerminationForUpdate(),
       });
 
       // The write answers with no content, so re-read rather than assume the request body is now

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
@@ -13,7 +13,7 @@ import type { TargetSystem } from "../rotation";
 import { TargetSystemKind, TargetSystemMethod, TargetSystemStatus } from "../rotation";
 import { ORGANIZATION_ID, sysId } from "../testing/rotation-builders";
 
-import { TargetSystemsTabComponent } from "./target-systems-tab.component";
+import { TargetSystemRow, TargetSystemsTabComponent } from "./target-systems-tab.component";
 import { TargetSystemsService } from "./target-systems.service";
 
 /** Echoes the key as its translation so form-field components don't crash. */
@@ -201,6 +201,44 @@ describe("TargetSystemsTabComponent", () => {
       expect(toastService.showToast).toHaveBeenCalledWith(
         expect.objectContaining({ variant: "success" }),
       );
+    });
+  });
+
+  // A blank kind cell is indistinguishable from a manual target, which has no integration at all,
+  // so every kind the SDK models has to name itself.
+  describe("kind column", () => {
+    function rowsFor(systems: TargetSystem[]): TargetSystemRow[] {
+      targetSystemsService.systems$.next(systems);
+      fixture.detectChanges();
+      return (component as unknown as { dataSource: { data: TargetSystemRow[] } }).dataSource.data;
+    }
+
+    it("gives every modelled kind its own label", () => {
+      const rows = rowsFor([
+        makeSystem({ id: sysId("1"), kind: TargetSystemKind.Entra }),
+        makeSystem({ id: sysId("2"), kind: TargetSystemKind.Mssql }),
+        makeSystem({ id: sysId("3"), kind: TargetSystemKind.CustomScript }),
+      ]);
+
+      expect(rows.map((row) => row.kindLabel)).toEqual([
+        "pamTargetSystemKindEntra",
+        "pamTargetSystemKindMssql",
+        "pamTargetSystemKindCustomScript",
+      ]);
+    });
+
+    it("names a kind only a newer server knows rather than leaving the cell blank", () => {
+      const [row] = rowsFor([makeSystem({ id: sysId("sys-new"), kind: TargetSystemKind.Unknown })]);
+
+      expect(row!.kindLabel).toBe("unknown");
+    });
+
+    it("leaves the kind unset for a manual target, which has no integration", () => {
+      const [row] = rowsFor([
+        makeSystem({ id: sysId("sys-manual"), method: TargetSystemMethod.Manual, kind: null }),
+      ]);
+
+      expect(row!.kindLabel).toBeNull();
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
@@ -26,6 +26,7 @@ import { DaemonsService } from "../daemons/daemons.service";
 import {
   TargetSystemId,
   TargetSystemKind,
+  TargetSystemKindLabel,
   TargetSystemMethod,
   TargetSystemStatus,
   TargetSystem,
@@ -97,7 +98,10 @@ export class TargetSystemsTabComponent {
 
   private readonly searchText = toSignal(this.searchControl.valueChanges, { initialValue: "" });
 
-  /** Expose const objects for template comparisons. */
+  /**
+   * An Angular template can only resolve names against the component instance, so a module-level
+   * const has to be held as a field before the template can reference it.
+   */
   protected readonly TargetSystemStatus = TargetSystemStatus;
   protected readonly TargetSystemMethod = TargetSystemMethod;
 
@@ -227,16 +231,7 @@ export class TargetSystemsTabComponent {
   }
 
   private kindLabel(kind: TargetSystemKind): string {
-    switch (kind) {
-      case TargetSystemKind.Entra:
-        return this.i18nService.t("pamTargetSystemKindEntra");
-      case TargetSystemKind.Mssql:
-        return this.i18nService.t("pamTargetSystemKindMssql");
-      case TargetSystemKind.CustomScript:
-        return this.i18nService.t("pamTargetSystemKindCustomScript");
-      default:
-        return "";
-    }
+    return this.i18nService.t(TargetSystemKindLabel[kind]);
   }
 
   private showError(e: unknown): void {


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Makes the rotation admin console handle correctly every target-system kind the server can send, including ones it does not model.

- Replaces `isNativeIntegration` (`kind !== CustomScript`) with an exhaustive `Record<TargetSystemKind, SessionTerminationCapability>`. A kind now declares `always`, `never`, or `operatorDeclared` rather than being inferred.
- Collapses two duplicated kind-to-label mappings onto one exhaustive record beside the enum, so a kind cannot be added without declaring both its label and its capability.
- Fixes two existing bugs: an unmodelled kind rendered blank in the Kind column, and as `Custom script` in the edit header, because a nested ternary fell through to that label.

Adds no kind to the create form or the empty state. Sits on the saved-message PR.

## 📸 Screenshots
