### PR TITLE
Offer on-premises Active Directory as a rotation target-system kind

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18856,6 +18856,9 @@
   "pamTargetSystemTemplateEntraSummary": {
     "message": "Bitwarden automatically rotates a Microsoft Entra ID application secret."
   },
+  "pamTargetSystemTemplateActiveDirectorySummary": {
+    "message": "Bitwarden automatically rotates a domain account password on an Active Directory server you run."
+  },
   "pamTargetSystemTemplateCustomScriptSummary": {
     "message": "Bitwarden automatically rotates the credential by running your script on a registered daemon."
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
@@ -62,6 +62,7 @@ export const TargetSystemKind = Object.freeze({
   Entra: "entra",
   Mssql: "mssql",
   CustomScript: "custom_script",
+  ActiveDirectory: "active_directory",
   Unknown: "unknown",
 } as const satisfies Record<string, SdkTargetSystemKind>);
 export type TargetSystemKind = SdkTargetSystemKind;
@@ -89,6 +90,7 @@ export const TargetSystemKindLabel = Object.freeze({
 export const SELECTABLE_TARGET_SYSTEM_KINDS = [
   TargetSystemKind.Entra,
   TargetSystemKind.Mssql,
+  TargetSystemKind.ActiveDirectory,
   TargetSystemKind.CustomScript,
 ] as const;
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -269,6 +269,47 @@ describe("TargetSystemEditComponent — create mode", () => {
     expect(request).toMatchObject({ supportsSessionTermination: true });
   });
 
+  it("submits supportsSessionTermination=false for Active Directory even when the control is checked", async () => {
+    rotationSdk.createTargetSystem.mockResolvedValue(makeSystem());
+    jest.spyOn(router, "navigate").mockResolvedValue(true);
+
+    const comp = fixture.componentInstance as unknown as {
+      createForm: { patchValue: (v: unknown) => void };
+      policyForm: { patchValue: (v: unknown) => void };
+      submitCreate: () => Promise<void>;
+    };
+    comp.createForm.patchValue({
+      name: "Corp DC",
+      method: TargetSystemMethod.Automatic,
+      kind: TargetSystemKind.ActiveDirectory,
+    });
+    // A stale true, as if the operator had checked it while a custom script was selected.
+    comp.policyForm.patchValue({
+      minLength: 14,
+      maxLength: 64,
+      includeUppercase: true,
+      includeLowercase: true,
+      includeDigits: true,
+      includeSymbols: true,
+      supportsSessionTermination: true,
+    });
+    fixture.detectChanges();
+    await comp.submitCreate();
+
+    const request = rotationSdk.createTargetSystem.mock.calls[0]![1];
+    expect(request.method).toBe("automatic");
+    expect(request).toMatchObject({ supportsSessionTermination: false });
+  });
+
+  it("seeds Automatic + Active Directory from the ?template=active-directory query param", async () => {
+    TestBed.resetTestingModule();
+    const comp = await setupCreateWithTemplate("active-directory");
+    const value = comp.createForm.getRawValue();
+
+    expect(value.method).toBe(TargetSystemMethod.Automatic);
+    expect(value.kind).toBe(TargetSystemKind.ActiveDirectory);
+  });
+
   it("honors the checkbox for a custom script", async () => {
     rotationSdk.createTargetSystem.mockResolvedValue(makeSystem());
     jest.spyOn(router, "navigate").mockResolvedValue(true);
@@ -405,6 +446,17 @@ describe("TargetSystemEditComponent — create mode (rendered)", () => {
     const el = fixture.nativeElement as HTMLElement;
     patchKind(TargetSystemKind.CustomScript);
     expect(el.querySelector("#target-system-edit_checkbox_session-termination")).toBeTruthy();
+  });
+
+  // An LDAP password write cannot revoke a Kerberos ticket that has already been issued, so
+  // Active Directory offers neither the checkbox nor the "Supported" claim a native integration
+  // makes — it says so instead.
+  it("offers no session termination at all for Active Directory", () => {
+    const el = fixture.nativeElement as HTMLElement;
+    patchKind(TargetSystemKind.ActiveDirectory);
+
+    expect(el.querySelector("#target-system-edit_checkbox_session-termination")).toBeNull();
+    expect(el.querySelector("#target-system-edit_session-termination-unsupported")).toBeTruthy();
   });
 
   it("keeps the not-supported notice off a kind that does terminate sessions", () => {
@@ -717,5 +769,60 @@ describe("TargetSystemEditComponent — edit mode", () => {
     expect(toastService2.showToast).toHaveBeenCalledWith(
       expect.objectContaining({ variant: "error" }),
     );
+  });
+});
+
+// A stored supportsSessionTermination=true can reach the form on a kind that offers no control
+// for it — the server holds whatever was written before this kind was named. Active Directory
+// declines the capability at creation; it does not take back one an existing system was granted.
+describe("TargetSystemEditComponent — Active Directory edit mode", () => {
+  let fixture: ComponentFixture<TargetSystemEditComponent>;
+  let rotationSdk: ReturnType<typeof mock<RotationSdkService>>;
+
+  const activeDirectorySystem = makeSystem({
+    name: "Corp DC",
+    kind: TargetSystemKind.ActiveDirectory,
+    supportsSessionTermination: true,
+  });
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    rotationSdk = mock<RotationSdkService>();
+    rotationSdk.listTargetSystems.mockResolvedValue([activeDirectorySystem]);
+    rotationSdk.updateTargetSystem.mockResolvedValue(undefined);
+    await setupEdit(rotationSdk);
+    fixture = TestBed.createComponent(TargetSystemEditComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it("leaves the stored supportsSessionTermination=true standing on save", async () => {
+    const comp = fixture.componentInstance as unknown as {
+      nameForm: { patchValue: (v: unknown) => void };
+      showRetainedTermination: () => boolean;
+      submitEdit: () => Promise<void>;
+    };
+
+    comp.nameForm.patchValue({ name: "Corp DC (Frankfurt)" });
+    await comp.submitEdit();
+
+    expect(rotationSdk.updateTargetSystem).toHaveBeenCalledWith(
+      ORG_ID,
+      activeDirectorySystem.id,
+      expect.objectContaining({
+        name: "Corp DC (Frankfurt)",
+        supportsSessionTermination: true,
+      }),
+    );
+    expect(comp.showRetainedTermination()).toBe(true);
+  });
+
+  it("names the integration on the loaded system rather than falling back to a custom script", () => {
+    const comp = fixture.componentInstance as unknown as {
+      existingKindLabel: () => string | null;
+    };
+
+    expect(comp.existingKindLabel()).toBe("pamTargetSystemKindActiveDirectory");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
@@ -316,7 +316,7 @@ export class TargetSystemEditComponent {
 
   /**
    * Seed the create form from a starter template chosen on the empty state
-   * (Manual / Entra / Custom script). Unknown/absent values keep the defaults.
+   * (Manual / Entra / Active Directory / Custom script). Unknown/absent values keep the defaults.
    */
   private applyTemplate(template: string | undefined): void {
     switch (template) {
@@ -327,6 +327,12 @@ export class TargetSystemEditComponent {
         this.createForm.patchValue({
           method: TargetSystemMethod.Automatic,
           kind: TargetSystemKind.Entra,
+        });
+        break;
+      case "active-directory":
+        this.createForm.patchValue({
+          method: TargetSystemMethod.Automatic,
+          kind: TargetSystemKind.ActiveDirectory,
         });
         break;
       case "custom-script":

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-empty-state.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-empty-state.component.spec.ts
@@ -24,9 +24,22 @@ describe("TargetSystemsEmptyStateComponent", () => {
   it("renders the hero create button and one button per template", () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector("#target-systems-empty-state_button_create")).toBeTruthy();
-    (["manual", "entra", "custom-script"] as TargetSystemTemplateKey[]).forEach((key) => {
-      expect(el.querySelector(`#target-systems-empty-state_button_template-${key}`)).toBeTruthy();
-    });
+    (["manual", "entra", "active-directory", "custom-script"] as TargetSystemTemplateKey[]).forEach(
+      (key) => {
+        expect(el.querySelector(`#target-systems-empty-state_button_template-${key}`)).toBeTruthy();
+      },
+    );
+  });
+
+  it("emits useTemplate with the active-directory key, so the deep link is reachable from the UI", () => {
+    const spy = jest.fn();
+    fixture.componentInstance.useTemplate.subscribe(spy);
+    (
+      fixture.nativeElement.querySelector(
+        "#target-systems-empty-state_button_template-active-directory",
+      ) as HTMLButtonElement
+    ).click();
+    expect(spy).toHaveBeenCalledWith("active-directory");
   });
 
   it("emits create when the hero button is clicked", () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-empty-state.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-empty-state.component.ts
@@ -14,7 +14,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 /** Starter templates offered on the empty state; the parent maps each key to a create-form prefill. */
-export type TargetSystemTemplateKey = "manual" | "entra" | "custom-script";
+export type TargetSystemTemplateKey = "manual" | "entra" | "active-directory" | "custom-script";
 
 type TargetSystemTemplate = {
   key: TargetSystemTemplateKey;
@@ -35,6 +35,12 @@ const TEMPLATES: TargetSystemTemplate[] = [
     icon: "bwi-globe",
     titleKey: "pamTargetSystemKindEntra",
     summaryKey: "pamTargetSystemTemplateEntraSummary",
+  },
+  {
+    key: "active-directory",
+    icon: "bwi-business",
+    titleKey: "pamTargetSystemKindActiveDirectory",
+    summaryKey: "pamTargetSystemTemplateActiveDirectorySummary",
   },
   {
     key: "custom-script",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
@@ -213,16 +213,26 @@ describe("TargetSystemsTabComponent", () => {
       return (component as unknown as { dataSource: { data: TargetSystemRow[] } }).dataSource.data;
     }
 
+    it("labels an Active Directory target as Active Directory, not as a custom script", () => {
+      const [row] = rowsFor([
+        makeSystem({ id: sysId("sys-ad"), kind: TargetSystemKind.ActiveDirectory }),
+      ]);
+
+      expect(row!.kindLabel).toBe("pamTargetSystemKindActiveDirectory");
+    });
+
     it("gives every modelled kind its own label", () => {
       const rows = rowsFor([
         makeSystem({ id: sysId("1"), kind: TargetSystemKind.Entra }),
         makeSystem({ id: sysId("2"), kind: TargetSystemKind.Mssql }),
-        makeSystem({ id: sysId("3"), kind: TargetSystemKind.CustomScript }),
+        makeSystem({ id: sysId("3"), kind: TargetSystemKind.ActiveDirectory }),
+        makeSystem({ id: sysId("4"), kind: TargetSystemKind.CustomScript }),
       ]);
 
       expect(rows.map((row) => row.kindLabel)).toEqual([
         "pamTargetSystemKindEntra",
         "pamTargetSystemKindMssql",
+        "pamTargetSystemKindActiveDirectory",
         "pamTargetSystemKindCustomScript",
       ]);
     });


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Offers on-premises Active Directory as a rotation target-system kind in the admin console.

- Adds the kind to the create form and an empty-state template card, with its locale keys.
- Active Directory declares session termination as `never`: an LDAP password reset cannot revoke live Kerberos tickets, so the form neither offers nor implies it, and submits `false` even if a control holds a stale `true`.
- The capability and label records this fills in arrive in the PR below, which already handles the kind correctly if a server sends one.

Requires `TargetSystemKind::ActiveDirectory` in `@bitwarden/commercial-sdk-internal`, which is not in the published package yet. Top of a three PR stack.

## 📸 Screenshots

Not yet captured. The rotation UI was ported onto the Rust SDK after this work was first written, so earlier before and after images no longer describe this branch, and re-capturing needs a locally built commercial SDK. Flagging rather than attaching stale images.
