### PR TITLE
chore(km): Add browser and CLI process reload to codecov component

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -40,6 +40,8 @@ component_management:
     - component_id: key-management-process-reload
       name: Key Management - Process Reload
       paths:
+        - apps/browser/src/key-management/browser-process-reload.service.ts
+        - apps/cli/src/key-management/cli-process-reload.service.ts
         - apps/web/src/app/key-management/services/web-process-reload.service.ts
         - libs/common/src/key-management/process-reload/**
     - component_id: key-management-keys


### PR DESCRIPTION
## 🎟️ Tracking

n/a

## 📔 Objective

The `key-management-process-reload` codecov component only listed the web and `libs/common` paths. Add the browser and CLI process reload services so their coverage is attributed to the component.

## 📸 Screenshots

n/a
