### PR TITLE
[POC] Expose SDK object-graph introspection via automation driver

### DIFF
--- a/apps/desktop/src/app/services/init.service.ts
+++ b/apps/desktop/src/app/services/init.service.ts
@@ -16,6 +16,7 @@ import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platfor
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
@@ -85,6 +86,7 @@ export class InitService {
     private logService: LogService,
     private configService: ConfigService,
     private toastService: ToastService,
+    private sdkService: SdkService,
   ) {}
 
   init() {
@@ -156,6 +158,7 @@ export class InitService {
         },
         this.messagingService,
         this.toastService,
+        this.sdkService,
       );
       await this.biometricMessageHandlerService.init();
       await this.autofillService.init();

--- a/apps/web/src/app/core/init.service.ts
+++ b/apps/web/src/app/core/init.service.ts
@@ -15,6 +15,7 @@ import { SharedUnlockPeerService } from "@bitwarden/common/key-management/shared
 import { DefaultVaultTimeoutService } from "@bitwarden/common/key-management/vault-timeout";
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
@@ -66,6 +67,7 @@ export class InitService {
     private logService: LogService,
     private configService: ConfigService,
     private toastService: ToastService,
+    private sdkService: SdkService,
   ) {}
 
   init() {
@@ -133,6 +135,7 @@ export class InitService {
         undefined,
         undefined,
         this.toastService,
+        this.sdkService,
       );
     };
   }

--- a/libs/automation-driver/src/automation-driver.service.ts
+++ b/libs/automation-driver/src/automation-driver.service.ts
@@ -2,6 +2,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { StateProvider } from "@bitwarden/common/platform/state";
 import { FlightRecorder } from "@bitwarden/logging";
 import { StorageServiceProvider } from "@bitwarden/storage-core";
@@ -16,6 +17,7 @@ import {
   LoggingCapability,
   ProcessReloadCapability,
   ReloadProcess,
+  SdkIntrospectCapability,
   StateCapability,
   ToastCapability,
 } from "./capabilities";
@@ -32,6 +34,7 @@ export class AutomationDriver {
   private readonly desktopNavigationCapability?: DesktopNavigationCapability;
   private readonly lockCapability: LockCapability;
   private readonly toastCapability?: ToastCapability;
+  private readonly sdkIntrospectCapability?: SdkIntrospectCapability;
 
   /**
    * Every parameter is required. The `undefined`-able ones are capabilities not every client
@@ -42,6 +45,8 @@ export class AutomationDriver {
    * @param biometricsController - Desktop only.
    * @param messagingService - Desktop only; backs menubar navigation.
    * @param toastService - `undefined` on clients without a UI.
+   * @param sdkService - `undefined` on clients without the WASM SDK; enables the introspection
+   *   capability. Trailing and optional so existing call sites need not change.
    */
   constructor(
     configService: ConfigService,
@@ -56,6 +61,7 @@ export class AutomationDriver {
     private biometricsController: AutomationBiometricsController | undefined,
     messagingService: MessagingService | undefined,
     toastService: AutomationToastController | undefined,
+    sdkService?: SdkService,
   ) {
     this.featureFlagsCapability = new FeatureFlagsCapability(configService, stateProvider);
     this.stateCapability = new StateCapability(storageServiceProvider);
@@ -74,6 +80,10 @@ export class AutomationDriver {
 
     if (toastService != null) {
       this.toastCapability = new ToastCapability(toastService);
+    }
+
+    if (sdkService != null) {
+      this.sdkIntrospectCapability = new SdkIntrospectCapability(sdkService);
     }
 
     this.lockCapability = new LockCapability(
@@ -99,6 +109,7 @@ export class AutomationDriver {
     biometrics: AutomationBiometricsController | undefined,
     messagingService: MessagingService | undefined,
     toastService: AutomationToastController | undefined,
+    sdkService?: SdkService,
   ): void {
     new AutomationDriver(
       configService,
@@ -113,6 +124,7 @@ export class AutomationDriver {
       biometrics,
       messagingService,
       toastService,
+      sdkService,
     ).attachToGlobal(global);
   }
 
@@ -154,5 +166,9 @@ export class AutomationDriver {
 
   get toast(): ToastCapability | undefined {
     return this.toastCapability;
+  }
+
+  get sdkIntrospect(): SdkIntrospectCapability | undefined {
+    return this.sdkIntrospectCapability;
   }
 }

--- a/libs/automation-driver/src/capabilities/index.ts
+++ b/libs/automation-driver/src/capabilities/index.ts
@@ -4,5 +4,6 @@ export * from "./feature-flags";
 export * from "./lock";
 export * from "./logging";
 export * from "./process-reload";
+export * from "./sdk-introspect";
 export * from "./state";
 export * from "./toast";

--- a/libs/automation-driver/src/capabilities/sdk-introspect.ts
+++ b/libs/automation-driver/src/capabilities/sdk-introspect.ts
@@ -1,0 +1,62 @@
+import { firstValueFrom, switchMap } from "rxjs";
+
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { PasswordManagerClient } from "@bitwarden/sdk-internal";
+
+/**
+ * Crawls the live SDK object graph and reaches hand-rolled debug capabilities
+ * (for example the login method) that the SDK's public API does not expose.
+ *
+ * Everything is path-addressed, mirroring the SDK's `IntrospectClient`: the JS
+ * surface is a fixed set of generic verbs, not one method per thing, so it does
+ * not grow as the SDK adds capabilities. Available only on clients backed by the
+ * WASM SDK, and only when that SDK was built with the dev-only `introspect`
+ * feature (otherwise `introspect()` is absent and calls throw).
+ *
+ * Each verb takes the `userId` whose client to crawl. User state such as the
+ * login method lives on the per-user client; the userless client carries none of
+ * it, so a user id is required rather than defaulting to the active user.
+ */
+export class SdkIntrospectCapability {
+  constructor(private sdkService: SdkService) {}
+
+  /** Structural crawl: the node at `path` (type, preview, writeability, children), or null. */
+  async describe(userId: string, path: string[]): Promise<unknown> {
+    const json = await this.withClient(userId, (client) => client.introspect().describe(path));
+    return json == null ? null : JSON.parse(json);
+  }
+
+  /** Read the value at `path`, resolving async capabilities such as the login method. */
+  async read(userId: string, path: string[]): Promise<unknown> {
+    const json = await this.withClient(userId, (client) => client.introspect().read(path));
+    return json == null ? null : JSON.parse(json);
+  }
+
+  /** Write `value` to the node at `path`. Debug-only; bypasses public-API guards. */
+  async write(userId: string, path: string[], value: unknown): Promise<void> {
+    await this.withClient(userId, (client) =>
+      client.introspect().write(path, JSON.stringify(value)),
+    );
+  }
+
+  /**
+   * Resolve the per-user client and run `fn` against it while a reference is
+   * held, so the client is not freed mid-call. All work happens inside the
+   * observable (the client is destroyed once the subscription ends); only the
+   * serialized result of `fn` escapes.
+   */
+  private withClient<T>(
+    userId: string,
+    fn: (client: PasswordManagerClient) => T | Promise<T>,
+  ): Promise<T> {
+    return firstValueFrom(
+      this.sdkService.userClient$(userId as UserId).pipe(
+        switchMap(async (rc) => {
+          using ref = rc.take();
+          return await fn(ref.value);
+        }),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## ⚠️ Proof of concept — not for merge

Wires the SDK's runtime object-graph introspection (companion POC: bitwarden/sdk-internal#1446) into the automation driver, so automated tooling can crawl live SDK state and reach hand-rolled debug capabilities from JS.

> Targets `driver-skills` (built on that driver framework), not `main`.

### What's here
- `SdkIntrospectCapability`: forwards path-addressed `describe`/`read`/`write` to the WASM SDK's `IntrospectClient`. Each verb takes the `userId` whose client to crawl and resolves it through `SdkService.userClient$` (holding an `Rc` reference for the call) — user state such as the login method lives on the per-user client, not the userless one.
- Threads an optional trailing `sdkService` through `AutomationDriver` (constructor, `attachToGlobal`, `sdkIntrospect` getter); passed from the web and desktop `InitService`.
- Exposed at `window.bitwardenAutomationDriver.sdkIntrospect` on clients backed by the WASM SDK built with the dev-only `introspect` feature.

## Usage examples

Driven from the renderer (desktop DevTools console shown; the userId is the active account id). All verbs are `(userId, path[, value])` and return parsed JSON (or `null`).

### Discover the graph — `describe`

```js
const d = window.bitwardenAutomationDriver.sdkIntrospect;
const uid = "55a443cd-…"; // active account id

await d.describe(uid, []);
```
```jsonc
{
  "typeName": "PasswordManagerClient",
  "preview": "PasswordManagerClient { .. }",
  "writeability": "readOnly",
  "children": [
    { "key": "vault",      "typeName": "VaultClient",           "preview": "VaultClient { .. }",           "writeability": "readOnly" },
    { "key": "key_store",  "typeName": "KeyStore",              "preview": "<key store>",                  "writeability": "readOnly" },
    { "key": "auth",       "typeName": "IntrospectCapabilities", "preview": "{ hand-rolled capabilities }", "writeability": "readOnly" }
  ]
}
```

The `auth` node is a hand-rolled capability surfaced on the crawl (not a derived type):

```js
await d.describe(uid, ["auth"]);
```
```jsonc
{
  "typeName": "IntrospectCapabilities",
  "preview": "{ hand-rolled capabilities }",
  "writeability": "readOnly",
  "children": [
    { "key": "login_method", "typeName": "UserLoginMethod", "preview": "UserLoginMethod (hand-rolled capability)", "writeability": "capability" }
  ]
}
```

### Read a value — `read`

```js
await d.read(uid, ["auth", "login_method"]);
```
```jsonc
{
  "Username": {
    "client_id": "",
    "email": "user@example.com",
    "kdf": { "pBKDF2": { "iterations": 600000 } }
  }
}
```

### Crawl the key store (navigable, redacted)

```js
await d.describe(uid, ["key_store"]);
```
```jsonc
{
  "typeName": "KeyStore",
  "preview": "<key store>",
  "writeability": "readOnly",
  "children": [
    { "key": "cipher_suite",           "typeName": "CipherSuite",  "preview": "Standard",  "writeability": "readOnly" },
    { "key": "security_state_version", "typeName": "u64",          "preview": "1",         "writeability": "readOnly" },
    { "key": "symmetric_keys",         "typeName": "StoreBackend", "preview": "2 slots",   "writeability": "readOnly" },
    { "key": "private_keys",           "typeName": "StoreBackend", "preview": "1 slots",   "writeability": "readOnly" },
    { "key": "signing_keys",           "typeName": "StoreBackend", "preview": "0 slots",   "writeability": "readOnly" }
  ]
}
```

```js
await d.describe(uid, ["key_store", "symmetric_keys"]);
```
```jsonc
{
  "typeName": "StoreBackend",
  "preview": "",
  "writeability": "readOnly",
  "children": [
    { "key": "User",          "typeName": "Key", "preview": "<redacted: enable dangerous-crypto-debug>", "writeability": "readOnly" },
    { "key": "LocalUserData", "typeName": "Key", "preview": "<redacted: enable dangerous-crypto-debug>", "writeability": "readOnly" }
  ]
}
```

Key material stays redacted unless the SDK is built with `bitwarden-crypto`'s `dangerous-crypto-debug` feature.

### Write a value — `write`

```js
// e.g. round-trip the login method (write takes the value as the 3rd arg)
const current = await d.read(uid, ["auth", "login_method"]);
await d.write(uid, ["auth", "login_method"], current);
```

Returns `void`; errors if the path is not a writable capability.

## Verified on desktop (Electron)
- `describe` discovers `vault`, `key_store`, and `auth`.
- `read(uid, ["auth","login_method"])` returns the real per-user login method.
- `write` round-trips (verified non-destructively).

### Note for local runs
Depends on an `@bitwarden/sdk-internal` built with `-i`. A one-line local shim in `send.ts` (SDK `Send.data` version skew) is **not** included here; it's build scaffolding, not part of the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
