### PR TITLE
[POC] SDK debug capabilities via typed debug tree

### DIFF
--- a/.claude/skills/interact-client/SKILL.md
+++ b/.claude/skills/interact-client/SKILL.md
@@ -170,6 +170,8 @@ Driver capabilities are documented in the references:
 - **Biometrics** → [references/biometrics.md](references/biometrics.md)
 - **Flight recorder** → [references/flight-recorder.md](references/flight-recorder.md)
 - **Log buffer** → [references/log-buffer.md](references/log-buffer.md)
+- **SDK debug capabilities** → [references/sdk-debug.md](references/sdk-debug.md) — read/write internal
+  SDK state (login method, key-store slots, state-registry get/set/list) via the typed `debug()` tree
 
 ### Messaging / menubar
 

--- a/.claude/skills/interact-client/references/sdk-debug.md
+++ b/.claude/skills/interact-client/references/sdk-debug.md
@@ -1,0 +1,138 @@
+# SDK debug capabilities
+
+Read and drive **internal SDK state** that the public API does not expose — the
+login method and the key store — from the running app. Backed by the SDK's
+hand-rolled debug tree (`client.debug()`), surfaced on the automation driver as
+`window.bitwardenAutomationDriver.debug`.
+
+Dev-only. Available only when the app is backed by an `@bitwarden/sdk-internal`
+built with the `debug-capabilities` feature (`crates/bitwarden-wasm-internal/build.sh -d`);
+otherwise `client.debug()` is absent and calls throw. Wired on web, desktop, and
+the CLI.
+
+## Shape
+
+`debug` exposes a single verb, `forUser(userId, fn)`. It resolves the per-user
+SDK client, then runs your callback against that client's typed debug tree while
+the client is held alive; only the callback's result escapes.
+
+```js
+async () => {
+  const d = window.bitwardenAutomationDriver.debug;
+  if (!d) return "debug capabilities unavailable — SDK not built with -d";
+  // the vault must be unlocked; state is read from the per-user client.
+};
+```
+
+Get the active user id (the verbs are user-scoped):
+
+```js
+async () => window.bitwardenAutomationDriver.state.readGlobal({
+  stateName: "account",
+  key: "activeAccountId",
+});
+```
+
+The callback argument `d` is the typed debug tree, so `d.` autocompletes the
+available nodes/capabilities in the console. **Do not stash `d`** (or anything
+reached through it) for use after the callback returns — the client is freed once
+`forUser` resolves.
+
+## Login method
+
+```js
+async () => {
+  const uid = await window.bitwardenAutomationDriver.state.readGlobal({
+    stateName: "account", key: "activeAccountId",
+  });
+  return window.bitwardenAutomationDriver.debug.forUser(uid, (d) => d.auth().login_method());
+};
+// → { Username: { client_id, email, kdf: { pBKDF2: { iterations } } } }  (or undefined)
+```
+
+Overwrite it (debug-only; bypasses the login flow):
+
+```js
+async () => {
+  const uid = await window.bitwardenAutomationDriver.state.readGlobal({
+    stateName: "account", key: "activeAccountId",
+  });
+  await window.bitwardenAutomationDriver.debug.forUser(uid, (d) =>
+    d.auth().set_login_method({
+      Username: { client_id: "", email: "user@example.com", kdf: { pBKDF2: { iterations: 600000 } } },
+    }),
+  );
+};
+```
+
+## Key store (redacted)
+
+```js
+async () => {
+  const uid = await window.bitwardenAutomationDriver.state.readGlobal({
+    stateName: "account", key: "activeAccountId",
+  });
+  return window.bitwardenAutomationDriver.debug.forUser(uid, (d) => d.key_store().list());
+};
+// → {
+//   cipher_suite: "Standard",
+//   security_state_version: 1,
+//   backends: [
+//     { name: "symmetric_keys", slots: [ { id: "User", material: "<redacted: ...>" }, ... ] },
+//     { name: "private_keys",   slots: [ { id: "UserPrivateKey", material: "<redacted: ...>" } ] },
+//     { name: "signing_keys",   slots: [] },
+//   ],
+// }
+```
+
+Key material is redacted unless the SDK is also built with the crypto
+`dangerous-crypto-debug` feature.
+
+## State registry (get/set/list)
+
+`d.state()` is a generic browse over the SDK's state registry — both
+client-managed and SDK-managed repositories — addressed by the repository's
+string name and a string key.
+
+```js
+async () => {
+  const uid = await window.bitwardenAutomationDriver.state.readGlobal({
+    stateName: "account", key: "activeAccountId",
+  });
+  return window.bitwardenAutomationDriver.debug.forUser(uid, async (d) => {
+    const s = d.state();
+    return {
+      types: s.types(),                                   // ["Cipher","LocalUserDataKey","Send", ...]
+      items: JSON.parse(await s.list("LocalUserDataKey")),// values (JSON string → parse)
+      one: JSON.parse(await s.get("LocalUserDataKey", uid)),// by key ("null" if absent)
+    };
+  });
+};
+```
+
+- `types()` → `string[]` (registered repository names).
+- `list(type)` / `get(type, key)` return **JSON strings** — `JSON.parse` them. `list`
+  is values only (the repository API lists values without keys).
+- `set(type, key, value)` takes the value as a **JSON string** (`JSON.stringify` it).
+  Debug-only; it writes raw JSON straight into the repository.
+- Keys are parsed from the string via the key type's `FromStr` (e.g. a `UserId`
+  is the uuid string). Unknown type or unparseable key → `null` / no-op.
+
+Caveats: repositories only registered lazily (e.g. `Setting`) or bridged from the
+TS client (e.g. `Cipher` on desktop) may not appear in `types()` or may be empty;
+`list`/`get` return **raw, unredacted** JSON, so treat secret-bearing repos with care.
+
+## Notes
+
+- **Unlock first.** `login_method`/`key_store` read per-user state, so they are
+  `undefined`/empty on a locked or userless client. See [lock.md](lock.md).
+- Adding a new SDK debug capability requires **no clients change** — once it
+  exists on the SDK's `debug()` tree, call it straight through the callback
+  (`d.<new_thing>()`).
+
+## CLI
+
+The CLI attaches the same driver to the Node `global` (`global.bitwardenAutomationDriver.debug`).
+There is no console, so launch the CLI with `node --inspect` (or `--inspect-brk`)
+to expose a CDP endpoint, attach, and `evaluate` the same snippets against
+`global.bitwardenAutomationDriver.debug` — the calls are identical to desktop/web.

--- a/apps/cli/src/service-container/service-container.ts
+++ b/apps/cli/src/service-container/service-container.ts
@@ -1230,6 +1230,7 @@ export class ServiceContainer {
       undefined,
       undefined,
       undefined,
+      this.sdkService,
     );
 
     await this.i18nService.init();

--- a/apps/desktop/src/app/services/init.service.ts
+++ b/apps/desktop/src/app/services/init.service.ts
@@ -16,6 +16,7 @@ import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platfor
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
@@ -85,6 +86,7 @@ export class InitService {
     private logService: LogService,
     private configService: ConfigService,
     private toastService: ToastService,
+    private sdkService: SdkService,
   ) {}
 
   init() {
@@ -156,6 +158,7 @@ export class InitService {
         },
         this.messagingService,
         this.toastService,
+        this.sdkService,
       );
       await this.biometricMessageHandlerService.init();
       await this.autofillService.init();

--- a/apps/web/src/app/core/init.service.ts
+++ b/apps/web/src/app/core/init.service.ts
@@ -15,6 +15,7 @@ import { SharedUnlockPeerService } from "@bitwarden/common/key-management/shared
 import { DefaultVaultTimeoutService } from "@bitwarden/common/key-management/vault-timeout";
 import { I18nService as I18nServiceAbstraction } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { SdkLoadService } from "@bitwarden/common/platform/abstractions/sdk/sdk-load.service";
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { IpcService } from "@bitwarden/common/platform/ipc";
 import { ServerNotificationsService } from "@bitwarden/common/platform/server-notifications";
 import { ContainerService } from "@bitwarden/common/platform/services/container.service";
@@ -66,6 +67,7 @@ export class InitService {
     private logService: LogService,
     private configService: ConfigService,
     private toastService: ToastService,
+    private sdkService: SdkService,
   ) {}
 
   init() {
@@ -133,6 +135,7 @@ export class InitService {
         undefined,
         undefined,
         this.toastService,
+        this.sdkService,
       );
     };
   }

--- a/libs/automation-driver/src/automation-driver.service.ts
+++ b/libs/automation-driver/src/automation-driver.service.ts
@@ -2,6 +2,7 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { MessagingService } from "@bitwarden/common/platform/abstractions/messaging.service";
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { StateProvider } from "@bitwarden/common/platform/state";
 import { FlightRecorder } from "@bitwarden/logging";
 import { StorageServiceProvider } from "@bitwarden/storage-core";
@@ -16,6 +17,7 @@ import {
   LoggingCapability,
   ProcessReloadCapability,
   ReloadProcess,
+  SdkDebugCapability,
   StateCapability,
   ToastCapability,
 } from "./capabilities";
@@ -32,6 +34,7 @@ export class AutomationDriver {
   private readonly desktopNavigationCapability?: DesktopNavigationCapability;
   private readonly lockCapability: LockCapability;
   private readonly toastCapability?: ToastCapability;
+  private readonly sdkDebugCapability?: SdkDebugCapability;
 
   /**
    * Every parameter is required. The `undefined`-able ones are capabilities not every client
@@ -42,6 +45,8 @@ export class AutomationDriver {
    * @param biometricsController - Desktop only.
    * @param messagingService - Desktop only; backs menubar navigation.
    * @param toastService - `undefined` on clients without a UI.
+   * @param sdkService - `undefined` on clients without the WASM SDK; enables the debug
+   *   capabilities. Trailing and optional so existing call sites need not change.
    */
   constructor(
     configService: ConfigService,
@@ -56,6 +61,7 @@ export class AutomationDriver {
     private biometricsController: AutomationBiometricsController | undefined,
     messagingService: MessagingService | undefined,
     toastService: AutomationToastController | undefined,
+    sdkService?: SdkService,
   ) {
     this.featureFlagsCapability = new FeatureFlagsCapability(configService, stateProvider);
     this.stateCapability = new StateCapability(storageServiceProvider);
@@ -74,6 +80,10 @@ export class AutomationDriver {
 
     if (toastService != null) {
       this.toastCapability = new ToastCapability(toastService);
+    }
+
+    if (sdkService != null) {
+      this.sdkDebugCapability = new SdkDebugCapability(sdkService);
     }
 
     this.lockCapability = new LockCapability(
@@ -99,6 +109,7 @@ export class AutomationDriver {
     biometrics: AutomationBiometricsController | undefined,
     messagingService: MessagingService | undefined,
     toastService: AutomationToastController | undefined,
+    sdkService?: SdkService,
   ): void {
     new AutomationDriver(
       configService,
@@ -113,6 +124,7 @@ export class AutomationDriver {
       biometrics,
       messagingService,
       toastService,
+      sdkService,
     ).attachToGlobal(global);
   }
 
@@ -154,5 +166,9 @@ export class AutomationDriver {
 
   get toast(): ToastCapability | undefined {
     return this.toastCapability;
+  }
+
+  get debug(): SdkDebugCapability | undefined {
+    return this.sdkDebugCapability;
   }
 }

--- a/libs/automation-driver/src/capabilities/index.ts
+++ b/libs/automation-driver/src/capabilities/index.ts
@@ -4,5 +4,6 @@ export * from "./feature-flags";
 export * from "./lock";
 export * from "./logging";
 export * from "./process-reload";
+export * from "./sdk-debug";
 export * from "./state";
 export * from "./toast";

--- a/libs/automation-driver/src/capabilities/sdk-debug.ts
+++ b/libs/automation-driver/src/capabilities/sdk-debug.ts
@@ -1,0 +1,40 @@
+import { firstValueFrom, switchMap } from "rxjs";
+
+import { SdkService } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { DebugClient } from "@bitwarden/sdk-internal";
+
+/**
+ * Dev-only access to the SDK's hand-rolled debug tree (`client.debug()`), which
+ * reaches past the public API into internal client state. Available only on
+ * clients backed by the WASM SDK built with the dev-only `debug-capabilities`
+ * feature (otherwise `debug()` is absent and calls throw).
+ *
+ * This capability adds no per-function surface of its own: it resolves the
+ * per-user client and hands its debug tree to a callback, so new SDK debug
+ * capabilities are callable here with no clients change. The callback runs while
+ * an `Rc` reference is held and the client is guaranteed alive; do not stash the
+ * `DebugClient` (or any handle reached through it) for use after it returns —
+ * the client is freed once the callback completes.
+ */
+export class SdkDebugCapability {
+  constructor(private sdkService: SdkService) {}
+
+  /**
+   * Run `fn` against `userId`'s SDK debug tree and resolve with its result.
+   *
+   * @example
+   * await driver.debug.forUser(uid, (d) => d.key_store().list());
+   * await driver.debug.forUser(uid, (d) => d.auth().login_method());
+   */
+  forUser<T>(userId: string, fn: (debug: DebugClient) => T | Promise<T>): Promise<T> {
+    return firstValueFrom(
+      this.sdkService.userClient$(userId as UserId).pipe(
+        switchMap(async (rc) => {
+          using ref = rc.take();
+          return await fn(ref.value.debug());
+        }),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## ⚠️ Proof of concept — not for merge

Client half of the hand-rolled SDK **debug capabilities** POC (companion:
bitwarden/sdk-internal#1447). An alternative to the introspection-driver POC
(#22871): instead of forwarding a fixed set of verbs, expose the SDK's typed
debug tree directly through the automation driver.

### What's here
- Threads an optional trailing `sdkService` through `AutomationDriver` (constructor, `attachToGlobal`, `debug` getter); passed from web + desktop `InitService`.
- `SdkDebugCapability` with **no per-capability surface** — a single
  `forUser(userId, fn)` that resolves the per-user client through
  `SdkService.userClient$` and hands its typed debug tree (`client.debug()`) to
  the callback while an `Rc` reference is held.
- Surfaced at `window.bitwardenAutomationDriver.debug`.
- New SDK debug capabilities are callable with **zero clients changes** — just
  call `d.<whatever>()` in the callback.
- Requires an `@bitwarden/sdk-internal` built with the dev-only
  `debug-capabilities` feature.

## Usage examples

Driven from the desktop DevTools console. Verbs run against a specific user, so
grab the active user id first, then run capabilities inside the callback.

```js
// active user id (capabilities are user-scoped)
const uid = await window.bitwardenAutomationDriver.state.readGlobal(
  { stateName: "account", key: "activeAccountId" },
);
const debug = window.bitwardenAutomationDriver.debug;
```

### List key-store slots (material redacted)

```js
await debug.forUser(uid, (d) => d.key_store().list());
```
```jsonc
{
  "cipher_suite": "Standard",
  "security_state_version": 1,
  "backends": [
    { "name": "symmetric_keys", "slots": [
      { "id": "LocalUserData", "material": "<redacted: enable dangerous-crypto-debug>" },
      { "id": "User",          "material": "<redacted: enable dangerous-crypto-debug>" }
    ] },
    { "name": "private_keys",  "slots": [
      { "id": "UserPrivateKey", "material": "<redacted: enable dangerous-crypto-debug>" }
    ] },
    { "name": "signing_keys",  "slots": [] }
  ]
}
```

### Read / write the login method

```js
await debug.forUser(uid, (d) => d.auth().login_method());
```
```jsonc
{
  "Username": {
    "client_id": "",
    "email": "user@example.com",
    "kdf": { "pBKDF2": { "iterations": 600000 } }
  }
}
```

```js
await debug.forUser(uid, (d) =>
  d.auth().set_login_method({
    Username: { client_id: "", email: "user@example.com", kdf: { pBKDF2: { iterations: 600000 } } },
  }),
);
```

Everything on `d` is typed, so the console autocompletes the available
capabilities. Don't stash `d` (or handles reached through it) past the callback —
the per-user client is freed once `forUser` resolves.

## Verified on desktop (Electron)
`debug.forUser(uid, d => d.key_store().list())` returned the real key store
(above), and `d => d.auth().login_method()` the real login method.

### Note for local runs
A one-line local shim in `send.ts` (SDK `Send.data` version skew) is **not**
included here; it's build scaffolding, not part of the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
