### PR TITLE
[BRE-2230] fix(ci): derive web build git hash from checked-out HEAD

### DIFF
--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Get GitHub sha as version
         id: version
-        run: echo "value=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+        run: echo "value=$(git rev-parse HEAD | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Get Node Version
         id: retrieve-node-version
@@ -239,7 +239,7 @@ jobs:
         if: matrix.git_metadata
         run: |
           VERSION=$( jq -r ".version" package.json)
-          jq --arg version "$VERSION+${GITHUB_SHA:0:7}" '.version = $version' package.json > package.json.tmp
+          jq --arg version "$VERSION+$_VERSION" '.version = $version' package.json > package.json.tmp
           mv package.json.tmp package.json
 
       ########## Set up Docker ##########

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -77,9 +77,12 @@ jobs:
           persist-credentials: false
           allow-unsafe-pr-checkout: true
 
-      - name: Get GitHub sha as version
+      - name: Get checked-out commit as version
         id: version
-        run: echo "value=$(git rev-parse HEAD | cut -c1-7)" >> "$GITHUB_OUTPUT"
+        run: |
+          sha="$(git rev-parse HEAD)"
+          echo "value=${sha:0:7}" >> "$GITHUB_OUTPUT"
+          echo "### Build git hash: \`${sha:0:7}\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Get Node Version
         id: retrieve-node-version


### PR DESCRIPTION
## 🎟️ Tracking

BRE-2230

## 📔 Objective

QA validates web vault deploys by comparing the git hash shown next to the version in lower environments against the commit they expect to be testing. On feature-branch deploys that hash has never matched.

The version stamp was derived from `$GITHUB_SHA`, which on `pull_request` events is GitHub's ephemeral test merge commit rather than the branch commit. The checkout at L76 correctly pins `ref: head.sha`, so the *code* built was always right — only the label was wrong. Verified across build history: 0 of 40 recent PR builds stamped the correct hash, vs 30 of 30 recent `main` builds.

This happened because the checkout ref and the version stamp were derived independently. The stamp has read `$GITHUB_SHA` since #746 (Dec 2020) and its semantics were never revisited. #11897 (Nov 2024) later added `ref: head.sha` to the checkout while migrating artifact builds onto the `check-run` approval flow — a deliberate security change, since `pull_request_target` requires explicitly checking out the PR head. The stamp six lines below it was left alone, and the two have disagreed on every PR build since.

For the record, `git rev-parse` has never previously been used for this stamp, so this is not a revert of an earlier approach.

Three changes:

- `setup` now derives the hash from the checked-out `HEAD` rather than `$GITHUB_SHA`, so it cannot disagree with what was built. This mirrors how the server derives its `/api/config` hash — SourceLink reading the checked-out `.git` — which is why that endpoint was never affected.
- The `package.json` stamp reuses `$_VERSION` instead of recomputing the short SHA, so the artifact filename and the UI string share one source of truth.
- The resolved hash is echoed to the build run summary, so it is readable without digging through artifact names.

`git rev-parse` is assigned directly rather than piped. Steps run under `bash -e` without pipefail, so piping into `cut` would have masked a non-zero exit and stamped a version of `HEAD`; assigning directly lets `-e` fail the step. Slicing with `${sha:0:7}` keeps the value at exactly 7 characters, matching the previous behavior QA already correlates against.

### Behavior by trigger

Verified against real runs of each event:

| Event | Checkout resolves to | Old stamp | New stamp |
|---|---|---|---|
| `push` (main / rc / hotfix-rc-web) | `$GITHUB_SHA` | correct | **unchanged** |
| `release` | tag → `$GITHUB_SHA` | correct | **unchanged** |
| `workflow_dispatch` | ref tip → `$GITHUB_SHA` | correct | **unchanged** |
| `pull_request` | PR head | test merge commit ❌ | PR head ✅ |
| `pull_request_target` (forks, via `build-web-target.yml`) | PR head | default branch tip ❌ | PR head ✅ |

On non-PR events `github.event.pull_request.head.sha` is empty, so checkout falls back to `$GITHUB_SHA` and the stamp is identical to before. Confirmed in logs — e.g. a `push` run checks out `-B main refs/remotes/origin/main` at exactly `$GITHUB_SHA`, and a `release` run checks out `refs/tags/web-v2026.8.1`.

The `pull_request_target` row is reasoned rather than run-verified: that path is fork-only and no recent fork PR has triggered a web build. `$GITHUB_SHA` there is documented as "Last commit on default branch," so fork builds were previously labelled with an unrelated `main` commit.

Artifact filenames change value but not format (`web-<7hex>-<variant>.zip`); both consumers in `bitwarden/deploy` glob, so nothing downstream needs updating.

I was able to successfully deploy a web build from this workflow

