### PR TITLE
[PM-42932] fix: normalize null hostname from getUriHostname to prevent search crash

### DIFF
--- a/libs/common/src/vault/services/lunr-search.service.spec.ts
+++ b/libs/common/src/vault/services/lunr-search.service.spec.ts
@@ -1,6 +1,11 @@
+import { CipherListView } from "@bitwarden/sdk-internal";
+
 import { LogService } from "../../platform/abstractions/log.service";
 import { OrganizationId, UserId } from "../../types/guid";
+import { CipherType } from "../enums";
 import { CipherView } from "../models/view/cipher.view";
+import { LoginUriView } from "../models/view/login-uri.view";
+import { LoginView } from "../models/view/login.view";
 
 import { LunrSearchService } from "./lunr-search.service";
 
@@ -12,6 +17,26 @@ function createCipherView(id: string, name: string, revisionDate?: Date): Cipher
     cipher.revisionDate = revisionDate;
   }
   return cipher;
+}
+
+function createLoginCipherView(id: string, name: string, uris: string[]): CipherView {
+  const cipher = createCipherView(id, name);
+  cipher.type = CipherType.Login;
+  cipher.login = new LoginView();
+  cipher.login.uris = uris.map((uri) => {
+    const uriView = new LoginUriView();
+    uriView.uri = uri;
+    return uriView;
+  });
+  return cipher;
+}
+
+function createLoginCipherListView(id: string, name: string, uris: string[]): CipherListView {
+  return {
+    id,
+    name,
+    type: { login: { uris: uris.map((uri) => ({ uri })) } },
+  } as unknown as CipherListView;
 }
 
 describe("LunrSearchService", () => {
@@ -119,5 +144,46 @@ describe("LunrSearchService", () => {
     expect(
       mockLogService.info.mock.calls.filter((call) => call[0] === "Starting Lunr index build"),
     ).toHaveLength(2);
+  });
+
+  describe("login URI indexing", () => {
+    it("indexes the URI hostname for a CipherView login", async () => {
+      const ciphers = [
+        createLoginCipherView("11111111-1111-1111-1111-111111111111", "Work Login", [
+          "https://example.com/path",
+        ]),
+      ];
+
+      const result = await service.searchCiphers(userId, null, ">example.com", ciphers);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("indexes the URI hostname for a CipherListView login", async () => {
+      const ciphers = [
+        createLoginCipherListView("11111111-1111-1111-1111-111111111111", "Work Login", [
+          "https://example.com/path",
+        ]),
+      ];
+
+      const result = await service.searchCiphers(userId, null, ">example.com", ciphers);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it("does not index the literal word 'null' when a URI has no parseable hostname", async () => {
+      const ciphers = [
+        createLoginCipherView("11111111-1111-1111-1111-111111111111", "Work Login", [
+          "data:text/plain,hello",
+        ]),
+        createLoginCipherListView("22222222-2222-2222-2222-222222222222", "Other Login", [
+          "data:text/plain,hello",
+        ]),
+      ];
+
+      const result = await service.searchCiphers(userId, null, ">null", ciphers);
+
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/libs/common/src/vault/services/lunr-search.service.ts
+++ b/libs/common/src/vault/services/lunr-search.service.ts
@@ -319,7 +319,7 @@ function uriExtractor(c: CipherViewLike): string[] {
     const port = portMatch?.[1];
 
     const hostname = CipherViewLikeUtils.getUriHostname(u);
-    if (hostname !== undefined) {
+    if (hostname) {
       uris.push(hostname);
       if (port) {
         uris.push(`${hostname}:${port}`);

--- a/libs/common/src/vault/services/search.service.spec.ts
+++ b/libs/common/src/vault/services/search.service.spec.ts
@@ -1,5 +1,7 @@
 import { BehaviorSubject } from "rxjs";
 
+import { CipherListView } from "@bitwarden/sdk-internal";
+
 import { I18nService } from "../../platform/abstractions/i18n.service";
 import { LogService } from "../../platform/abstractions/log.service";
 import { UserId } from "../../types/guid";
@@ -27,6 +29,14 @@ function createLoginCipherView(id: string, name: string, uris: string[]): Cipher
     return uriView;
   });
   return cipher;
+}
+
+function createLoginCipherListView(id: string, name: string, uris: string[]): CipherListView {
+  return {
+    id,
+    name,
+    type: { login: { uris: uris.map((uri) => ({ uri })) } },
+  } as unknown as CipherListView;
 }
 
 describe("SearchService", () => {
@@ -191,6 +201,24 @@ describe("SearchService", () => {
 
         expect(service.searchCiphersBasic(ciphers, "secret-path")).toHaveLength(0);
         expect(service.searchCiphersBasic(ciphers, "secretvalue")).toHaveLength(0);
+      });
+
+      it("matches against the URI hostname of a CipherListView", () => {
+        const ciphers = [
+          createLoginCipherListView("cipher-1", "My Login", ["https://example.com/path"]),
+        ];
+
+        expect(service.searchCiphersBasic(ciphers, "example.com")).toHaveLength(1);
+      });
+
+      it("does not throw and does not match when a URI has no parseable hostname", () => {
+        const ciphers = [
+          createLoginCipherView("cipher-1", "My Login", ["data:text/plain,hello"]),
+          createLoginCipherListView("cipher-2", "Other Login", ["data:text/plain,hello"]),
+        ];
+
+        expect(() => service.searchCiphersBasic(ciphers, "hello")).not.toThrow();
+        expect(service.searchCiphersBasic(ciphers, "hello")).toHaveLength(0);
       });
     });
   });

--- a/libs/common/src/vault/services/search.service.ts
+++ b/libs/common/src/vault/services/search.service.ts
@@ -148,7 +148,7 @@ export class SearchService implements SearchServiceAbstraction {
               return false;
             }
             const hostname = CipherViewLikeUtils.getUriHostname(loginUri);
-            if (hostname === undefined) {
+            if (!hostname) {
               return false;
             }
             return normalizeSearchQuery(hostname.toLowerCase()).indexOf(term) > -1;

--- a/libs/common/src/vault/utils/cipher-view-like-utils.spec.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.spec.ts
@@ -1,7 +1,8 @@
 import { mock } from "jest-mock-extended";
 
-import { CipherListView } from "@bitwarden/sdk-internal";
+import { CipherListView, LoginUriView as LoginListUriView } from "@bitwarden/sdk-internal";
 
+import { UriMatchStrategy } from "../../models/domain/domain-service";
 import { I18nService } from "../../platform/abstractions/i18n.service";
 import { BankAccountType, CipherType } from "../enums";
 import { Attachment } from "../models/domain/attachment";
@@ -1118,6 +1119,67 @@ describe("CipherViewLikeUtils", () => {
         } as CipherListView;
 
         expect(CipherViewLikeUtils.getAttachmentNames(cipherListView)).toBeUndefined();
+      });
+    });
+  });
+
+  describe("getUriHostname", () => {
+    describe("CipherView (LoginUriView)", () => {
+      it("returns the hostname for a valid URI", () => {
+        const uri = new LoginUriView();
+        uri.uri = "https://example.com/path";
+
+        expect(CipherViewLikeUtils.getUriHostname(uri)).toBe("example.com");
+      });
+
+      it("returns undefined, not null, when the URI has no parseable hostname", () => {
+        const uri = new LoginUriView();
+        uri.uri = "data:text/plain,hello";
+
+        expect(CipherViewLikeUtils.getUriHostname(uri)).toBeUndefined();
+      });
+
+      it("returns undefined for RegularExpression match strategy", () => {
+        const uri = new LoginUriView();
+        uri.uri = "https://example.com";
+        uri.match = UriMatchStrategy.RegularExpression;
+
+        expect(CipherViewLikeUtils.getUriHostname(uri)).toBeUndefined();
+      });
+
+      it("returns undefined when there is no URI", () => {
+        const uri = new LoginUriView();
+
+        expect(CipherViewLikeUtils.getUriHostname(uri)).toBeUndefined();
+      });
+    });
+
+    describe("CipherListView (LoginListUriView)", () => {
+      it("returns the hostname for a valid URI", () => {
+        const uri = { uri: "https://example.com/path" } as LoginListUriView;
+
+        expect(CipherViewLikeUtils.getUriHostname(uri)).toBe("example.com");
+      });
+
+      it("returns undefined, not null, when the URI has no parseable hostname", () => {
+        const uri = { uri: "data:text/plain,hello" } as LoginListUriView;
+
+        expect(CipherViewLikeUtils.getUriHostname(uri)).toBeUndefined();
+      });
+
+      it("returns undefined for RegularExpression match strategy", () => {
+        const uri = {
+          uri: "https://example.com",
+          match: UriMatchStrategy.RegularExpression,
+        } as LoginListUriView;
+
+        expect(CipherViewLikeUtils.getUriHostname(uri)).toBeUndefined();
+      });
+
+      it("returns undefined when the URI is empty", () => {
+        const uri = { uri: "" } as LoginListUriView;
+
+        expect(CipherViewLikeUtils.getUriHostname(uri)).toBeUndefined();
       });
     });
   });

--- a/libs/common/src/vault/utils/cipher-view-like-utils.ts
+++ b/libs/common/src/vault/utils/cipher-view-like-utils.ts
@@ -464,7 +464,7 @@ export class CipherViewLikeUtils {
 
     if (uri.match !== UriMatchStrategy.RegularExpression && uri.uri) {
       const hostname = Utils.getHostname(uri.uri);
-      return hostname === "" ? undefined : hostname;
+      return !hostname ? undefined : hostname;
     }
 
     return undefined;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42932](https://bitwarden.atlassian.net/browse/PM-42932)

## 📔 Objective

- `CipherViewLikeUtils.getUriHostname` is typed `string | undefined`, but for SDK`CipherListView`s any URI that didn't pass the checks for `Utils.getHostname()` returned `null`. 
  - (Ex: `data:`/`about:`/`file:`/unparseable URIs)
- Downstream strict equality checks for undefined` let that `null` past, and `search.service.ts` then called `.toLowerCase()` on it.

Fixes `getUriHostname` to normalize any falsy hostname to `undefined`, 

NOTE: I did not fix the typing on `getHostname` to be `string | null`, this had a handful of impacts across files and teams to shore up strongly typing that method that would widen the scope of this fix quite far. 

## 📸 Screenshots

|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/3b51396b-d9b0-422e-a976-75f5f7f91fe2" /> | <video src="https://github.com/user-attachments/assets/09f508d1-778a-41dc-bfe7-4d3bac5fded2" />|

[PM-42932]: https://bitwarden.atlassian.net/browse/PM-42932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ