### PR TITLE
fix(snap): add hardware-observe plug for FIDO HID enumeration

### DIFF
--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -301,7 +301,8 @@
           ]
         }
       },
-      "u2f-devices"
+      "u2f-devices",
+      "hardware-observe"
     ],
     "stagePackages": ["default"],
     "allowNativeWayland": true


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42050
https://github.com/bitwarden/clients/issues/22457

## 📔 Objective

https://github.com/bitwarden/clients/issues/22457 reports this error when using yubikey 2FA during login on a snap desktop installation:

```
apparmor="DENIED" operation="open"  name="/run/udev/data/+hid:0003:1050:0407.0008"
```

This PR (hopefully, untested) resolves this by declaring `hardware-observe` permissions in the snap's AppArmor profile.

## Notes

From what I understand, this is because of the logic in Chromium that detects hardware keys[[1]](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/device/fido/hid/fido_hid_discovery.cc), and what AppArmor permissions are required to run those operations. We have `u2f-devices` declared[[6]](https://github.com/bitwarden/clients/blob/main/apps/desktop/electron-builder.json), which is enough to talk to security keys[[7]](https://snapcraft.io/docs/u2f-devices-interface), but the logic in Chromium that detects what device to talk to requires `hardware-observe`[[2]](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/device/udev_linux/udev_watcher.cc)[[3]](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/services/device/hid/hid_service_linux.cc). We need `hardware-observe` to let Chromium identify the device, and then `u2f-devices` to communicate with it, basically. `u2f-devices` grants access to `/dev/hidraw* rwk`[[7]](https://snapcraft.io/docs/u2f-devices-interface), the actual device node. `hardware-observe` grants `/run/udev/data/** r`[[4]](https://github.com/snapcore/snapd/blob/master/interfaces/builtin/hardware_observe.go)[[5]](https://snapcraft.io/docs/reference/interfaces/hardware-observe-interface/), the udev metadata database. udev maintains a record of every plugged-in device.

This is just an implementation quirk of running our security key detection and comms through Chromium. You could loop through each plugged in device, check if it's a security key, and start communicating with just `u2f-devices`. Chromium's method of identifying the correct device through a lookup in the udev metadata database[[2]](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/device/udev_linux/udev_watcher.cc)[[3]](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/services/device/hid/hid_service_linux.cc) is, as I understand it, just the way they have decided to implement this.

This diagram, generated with Claude, describes what I think is happening across Bitwarden, Chromium, Snap, and Linux:


```mermaid
sequenceDiagram
    participant BW as Bitwarden
    participant CR as Chromium
    participant SN as Snap
    participant LX as Linux

    BW->>CR: WebAuthn 2FA triggered
    CR->>SN: open(/run/udev/data/+hid:*)<br/>libudev HID enumeration

    alt hardware-observe missing (current state)
        SN-->>CR: DENIED — AppArmor profile lacks /run/udev/data/+hid:* r,
        CR-->>BW: no authenticators found — "Awaiting security key…" hangs
    else hardware-observe added (fix)
        SN-->>CR: permitted — /run/udev/data/** r, granted
        CR->>LX: read udev metadata → identify /dev/hidraw0 as YubiKey
        CR->>SN: open(/dev/hidraw0)
        SN-->>CR: permitted — /dev/hidraw* rwk granted (u2f-devices)
        CR->>LX: CTAP exchange via /dev/hidraw0
        LX-->>CR: CTAP response — authenticator contacted
        CR-->>BW: key lights up — login completes
    end
```

## References

1. [`fido_hid_discovery.cc:88`, Chromium source](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/device/fido/hid/fido_hid_discovery.cc#88), `DeviceAdded()`: where a discovered HID device is handed off to the FIDO layer as a candidate authenticator
2. [`udev_watcher.cc:96`, Chromium source](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/device/udev_linux/udev_watcher.cc#96), `EnumerateExistingDevices()`: calls `udev_enumerate_scan_devices()`
3. [`hid_service_linux.cc:269`, Chromium source](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/services/device/hid/hid_service_linux.cc#269), `OnDeviceAdded():269`: `udev_device_get_property_value(parent, kHIDID)`, the udev metadata read that AppArmor blocks under the snap
4. [`hardware_observe.go:70`, snapd source](https://github.com/canonical/snapd/blob/master/interfaces/builtin/hardware_observe.go#L70), AppArmor rule `/run/udev/data/** r,` granted by `hardware-observe`
5. [`hardware-observe` interface reference, Snapcraft docs](https://snapcraft.io/docs/reference/interfaces/hardware-observe-interface/), Official interface documentation listing all paths granted, including `/run/udev/data/**`
6. [`electron-builder.json:283`, bitwarden/clients](https://github.com/bitwarden/clients/blob/main/apps/desktop/electron-builder.json#L304), `snap.plugs` declaration: shows `u2f-devices` present, `hardware-observe` absent
7. [`u2f_devices.go:242`, snapd source](https://github.com/canonical/snapd/blob/master/interfaces/builtin/u2f_devices.go#L242): AppArmor rule `/dev/hidraw* rwk,` granted by `u2f-devices`