### PR TITLE
[PM-42858] Implement changes for policy for vault banner info callout

### DIFF
--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/organization-user-notification-policy.component.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/organization-user-notification-policy.component.spec.ts
@@ -42,6 +42,7 @@ describe("OrganizationUserNotificationPolicy", () => {
     expect(policy.type).toBe(PolicyType.OrganizationUserNotification);
     expect(policy.component).toBe(OrganizationUserNotificationPolicyComponent);
     expect(policy.prerequisiteKey).toBe("singleOrgPrerequisite");
+    expect(policy.prerequisiteKeyVfo1).toBe("singleOrgPrerequisiteVfo1");
   });
 });
 

--- a/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/organization-user-notification-policy.component.ts
+++ b/apps/web/src/app/admin-console/organizations/policies/policy-edit-definitions/organization-user-notification-policy.component.ts
@@ -52,6 +52,7 @@ export class OrganizationUserNotificationPolicy extends BasePolicyEditDefinition
   category = PolicyCategory.VaultManagement;
   priority = 70;
   prerequisiteKey = "singleOrgPrerequisite";
+  prerequisiteKeyVfo1 = "singleOrgPrerequisiteVfo1";
 }
 
 interface OrganizationUserNotificationPolicyOptions {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17033,8 +17033,7 @@
     "message": "The single organization policy must be turned on before activating this policy."
   },
   "singleOrgPrerequisiteVfo1": {
-    "message": "The single organization membership policy must be turned on before activating this policy.",
-    "description": "VFO1 terminology variant of 'singleOrgPrerequisite'"
+    "message": "The single organization membership policy must be turned on before activating this policy."
   },
   "enableBanner": {
     "message": "Enable banner"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17032,6 +17032,10 @@
   "singleOrgPrerequisite": {
     "message": "The single organization policy must be turned on before activating this policy."
   },
+  "singleOrgPrerequisiteVfo1": {
+    "message": "The single organization membership policy must be turned on before activating this policy.",
+    "description": "VFO1 terminology variant of 'singleOrgPrerequisite'"
+  },
   "enableBanner": {
     "message": "Enable banner"
   },


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42858

## 📔 Objective

Updates the callout to new verbiage for VFO 1 terminology changes

## 📸 Screenshots

<img width="506" height="895" alt="image" src="https://github.com/user-attachments/assets/dcfefcff-2293-48e5-b56c-1d2baebba15e" />

