### PR TITLE
desktop-autofill: Windows native passkey fixes

### DIFF
--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/assert.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/assert.rs
@@ -4,9 +4,8 @@ use std::{
 };
 
 use autofill_provider::{
-    CallbackError, PasskeyAssertionRequest, PasskeyAssertionResponse,
-    PasskeyAssertionWithoutUserInterfaceRequest, Position, TimedCallback, UserVerification,
-    WindowDetails,
+    CallbackError, PasskeyAssertionRequest, PasskeyAssertionResponse, Position, TimedCallback,
+    UserVerification, WindowDetails,
 };
 use desktop_core::autofill::create_context_string;
 use win_webauthn::{plugin::PluginGetAssertionRequest, CborWriter};
@@ -99,26 +98,7 @@ fn send_assertion_request(
     );
 
     let callback = Arc::new(TimedCallback::new());
-    if request.allowed_credentials.len() == 1 {
-        // Copy details into without user interface. On Windows, we don't
-        // require any extra fields, but we use a separate method/type to signal
-        // to the desktop app to try resolving this without the UI.
-        let request = PasskeyAssertionWithoutUserInterfaceRequest {
-            rp_id: request.rp_id,
-            credential_id: request.allowed_credentials[0].clone(),
-            client_data_hash: request.client_data_hash,
-            user_verification: request.user_verification,
-            client_window: request.client_window,
-            context: request.context,
-            // These are currently only used on macOS
-            record_identifier: None,
-            user_name: None,
-            user_handle: None,
-        };
-        ipc_client.prepare_passkey_assertion_without_user_interface(request, callback.clone());
-    } else {
-        ipc_client.prepare_passkey_assertion(request, callback.clone());
-    }
+    ipc_client.prepare_passkey_assertion(request, callback.clone());
     let wait_time = Duration::from_secs(600);
     callback
         .wait_for_response(wait_time, Some(cancellation_token))

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
@@ -310,8 +310,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use autofill_provider::{
-        ConnectionStatus, LockStatusResponse, PasskeyAssertionRequest,
-        PasskeyAssertionWithoutUserInterfaceRequest, PasskeyRegistrationRequest,
+        ConnectionStatus, LockStatusResponse, PasskeyAssertionRequest, PasskeyRegistrationRequest,
         PreparePasskeyAssertionCallback, PreparePasskeyRegistrationCallback,
         WindowHandleQueryResponse,
     };
@@ -407,14 +406,6 @@ mod tests {
         fn prepare_passkey_assertion(
             &self,
             _req: PasskeyAssertionRequest,
-            _cb: Arc<dyn PreparePasskeyAssertionCallback>,
-        ) {
-            unimplemented!("not needed in these tests")
-        }
-
-        fn prepare_passkey_assertion_without_user_interface(
-            &self,
-            _req: PasskeyAssertionWithoutUserInterfaceRequest,
             _cb: Arc<dyn PreparePasskeyAssertionCallback>,
         ) {
             unimplemented!("not needed in these tests")

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/authenticator.rs
@@ -127,7 +127,16 @@ impl<C: IpcConnector> PluginAuthenticator for BitwardenPluginAuthenticator<C> {
 
         self.wait_for_connected_client(&client)?;
 
-        present_window(client.as_ref())?;
+        // Present the window if necessary.
+        // The desktop app still may need to show UI based on information in the vault;
+        // this preempts the presentation in order to work around focusing issues.
+        let is_unlocked = client
+            .get_lock_status(Duration::from_secs(3))
+            .is_ok_and(|response| response.is_unlocked);
+        let needs_ui = needs_ui_for_registration(is_unlocked);
+        if needs_ui {
+            present_window(client.as_ref())?;
+        }
 
         let (cancel_tx, cancel_rx) = mpsc::channel();
         let transaction_id = request.transaction_id;
@@ -157,6 +166,8 @@ impl<C: IpcConnector> PluginAuthenticator for BitwardenPluginAuthenticator<C> {
         self.wait_for_connected_client(&client)?;
 
         // Present the window if necessary
+        // The desktop app still may need to show UI based on information in the vault;
+        // this preempts the presentation in order to work around focusing issues.
         let is_unlocked = client
             .get_lock_status(Duration::from_secs(3))
             .is_ok_and(|response| response.is_unlocked);
@@ -229,6 +240,13 @@ impl<C: IpcConnector> PluginAuthenticator for BitwardenPluginAuthenticator<C> {
                 Ok(PluginLockStatus::PluginLocked)
             })
     }
+}
+
+/// Returns true when UI will be required for this registration request.
+///
+/// Split out for testing purposes.
+fn needs_ui_for_registration(is_unlocked: bool) -> bool {
+    !is_unlocked
 }
 
 /// Returns true when the authenticator needs to show UI for a get-assertion
@@ -680,7 +698,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // needs_ui_for_assertion tests
+    // needs_ui tests
     // -----------------------------------------------------------------------
 
     #[test]
@@ -693,6 +711,7 @@ mod tests {
         assert!(needs_ui_for_assertion(false, 1));
         assert!(needs_ui_for_assertion(false, 0));
         assert!(needs_ui_for_assertion(false, 2));
+        assert!(needs_ui_for_registration(false));
     }
 
     #[test]

--- a/apps/desktop/desktop_native/windows_plugin_authenticator/src/ipc.rs
+++ b/apps/desktop/desktop_native/windows_plugin_authenticator/src/ipc.rs
@@ -2,9 +2,8 @@ use std::{sync::Arc, time::Duration};
 
 use autofill_provider::{
     AutofillProviderClient, ConnectionStatus, LockStatusResponse, PasskeyAssertionRequest,
-    PasskeyAssertionWithoutUserInterfaceRequest, PasskeyRegistrationRequest,
-    PreparePasskeyAssertionCallback, PreparePasskeyRegistrationCallback, TimedCallback,
-    WindowHandleQueryResponse,
+    PasskeyRegistrationRequest, PreparePasskeyAssertionCallback,
+    PreparePasskeyRegistrationCallback, TimedCallback, WindowHandleQueryResponse,
 };
 
 /// Abstraction over an active IPC connection to the desktop app.
@@ -39,12 +38,6 @@ pub(crate) trait IpcClient: Send + Sync {
     fn prepare_passkey_assertion(
         &self,
         request: PasskeyAssertionRequest,
-        callback: Arc<dyn PreparePasskeyAssertionCallback>,
-    );
-
-    fn prepare_passkey_assertion_without_user_interface(
-        &self,
-        request: PasskeyAssertionWithoutUserInterfaceRequest,
         callback: Arc<dyn PreparePasskeyAssertionCallback>,
     );
 }
@@ -101,15 +94,6 @@ impl IpcClient for RealIpcClient {
         callback: Arc<dyn PreparePasskeyAssertionCallback>,
     ) {
         self.0.prepare_passkey_assertion(request, callback)
-    }
-
-    fn prepare_passkey_assertion_without_user_interface(
-        &self,
-        request: PasskeyAssertionWithoutUserInterfaceRequest,
-        callback: Arc<dyn PreparePasskeyAssertionCallback>,
-    ) {
-        self.0
-            .prepare_passkey_assertion_without_user_interface(request, callback)
     }
 }
 

--- a/libs/common/src/platform/services/fido2/fido2-autofill-utils.spec.ts
+++ b/libs/common/src/platform/services/fido2/fido2-autofill-utils.spec.ts
@@ -1,0 +1,66 @@
+import { CipherType } from "../../../vault/enums";
+import { CipherView } from "../../../vault/models/view/cipher.view";
+import { Fido2CredentialView } from "../../../vault/models/view/fido2-credential.view";
+import { LoginUriView } from "../../../vault/models/view/login-uri.view";
+import { LoginView } from "../../../vault/models/view/login.view";
+
+import { getCredentialsForAutofill } from "./fido2-autofill-utils";
+
+function createCipher(fido2Overrides: Partial<Fido2CredentialView> = {}): CipherView {
+  const cipher = new CipherView();
+  cipher.id = "cipher-id";
+  cipher.type = CipherType.Login;
+  cipher.name = "acme.com";
+
+  cipher.login = new LoginView();
+  cipher.login.username = "user@example.com";
+  cipher.login.uris = [Object.assign(new LoginUriView(), { uri: "https://acme.com" })];
+
+  const fido2Credential = Object.assign(new Fido2CredentialView(), {
+    credentialId: "e75fc430-01f5-482d-a4ec-c72d710705de",
+    keyType: "public-key",
+    keyAlgorithm: "ECDSA",
+    keyCurve: "P-256",
+    rpId: "acme.com",
+    userHandle: "NWZuGJdmCKnVupDQ5dsXOB1MSm_RKkoPV2jmcXOtNRo",
+    userName: undefined,
+    counter: 0,
+    rpName: "Acme Corp",
+    userDisplayName: "Bob Parr",
+    discoverable: true,
+    ...fido2Overrides,
+  } satisfies Partial<Fido2CredentialView>);
+
+  cipher.login.fido2Credentials = [fido2Credential];
+
+  return cipher;
+}
+
+describe("getCredentialsForAutofill", () => {
+  describe("when the fido2Credential userName is null", () => {
+    it("falls back to the userDisplayName", async () => {
+      const cipher = createCipher({ userName: undefined, userDisplayName: "Bob Parr" });
+
+      const [result] = await getCredentialsForAutofill([cipher]);
+
+      expect(result.userName).toBe("Bob Parr");
+    });
+
+    it("falls back to the cipher login username when userDisplayName is also empty", async () => {
+      const cipher = createCipher({ userName: undefined, userDisplayName: undefined });
+
+      const [result] = await getCredentialsForAutofill([cipher]);
+
+      expect(result.userName).toBe("user@example.com");
+    });
+
+    it("falls back to the cipher name when userDisplayName and login username are empty", async () => {
+      const cipher = createCipher({ userName: undefined, userDisplayName: undefined });
+      cipher.login.username = undefined;
+
+      const [result] = await getCredentialsForAutofill([cipher]);
+
+      expect(result.userName).toBe("acme.com");
+    });
+  });
+});

--- a/libs/common/src/platform/services/fido2/fido2-autofill-utils.ts
+++ b/libs/common/src/platform/services/fido2/fido2-autofill-utils.ts
@@ -28,7 +28,11 @@ export async function getCredentialsForAutofill(
         credentialId: credId,
         rpId: credential.rpId,
         userHandle: credential.userHandle!,
-        userName: credential.userName!,
+        userName:
+          credential.userName ||
+          credential.userDisplayName ||
+          cipher.login.username ||
+          cipher.name!,
       } satisfies Fido2CredentialAutofillView;
     });
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-43067](https://bitwarden.atlassian.net/browse/PM-43067)
[PM-43068](https://bitwarden.atlassian.net/browse/PM-43068)

## 📔 Objective
Fixes 2 bugs from internal QA, and another clarification:

- When a passkey ceremony starts while Bitwarden is in the background, the Bitwarden window shows up in front of the browser and Windows Hello prompt, so you have to minimize it to see.
- When the native passkey plugin is enabled and a older or imported FIDO2 credential exists without a `userName` field, it fails to synchronize to the autofill store. This makes it impossible to log into the website with native passkeys when the vault is unlocked.
- Windows uses passkey_assertion_without_user_interface, but it's the same as using the normal path, since Windows does things differently. This cleans up the usage so it doesn't confuse future devs.

[PM-43067]: https://bitwarden.atlassian.net/browse/PM-43067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-43068]: https://bitwarden.atlassian.net/browse/PM-43068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ