### PR TITLE
[CL-XXXX] Add bottomSheet option to DialogService.open

### DIFF
--- a/bitwarden_license/bit-web/src/app/key-management/policies/session-timeout.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/key-management/policies/session-timeout.component.spec.ts
@@ -36,6 +36,7 @@ class MockDialogRef extends DialogRef {
   componentInstance: unknown | null;
   disableClose: boolean | undefined;
   isDrawer: boolean = false;
+  isBottomSheet: boolean = false;
 }
 
 describe("SessionTimeoutPolicyComponent", () => {

--- a/libs/components/src/dialog/dialog-ref.ts
+++ b/libs/components/src/dialog/dialog-ref.ts
@@ -20,6 +20,9 @@ export abstract class DialogRef<R = unknown, C = unknown> implements Pick<
 > {
   abstract readonly isDrawer?: boolean;
 
+  /** Whether this dialog is presented as a bottom sheet at every breakpoint. */
+  abstract readonly isBottomSheet?: boolean;
+
   // --- From CdkDialogRefBase ---
   abstract close(result?: R, options?: DialogCloseOptions): Promise<DialogCloseRef>;
   abstract readonly closed: Observable<R | undefined>;
@@ -50,6 +53,12 @@ export type DialogConfig<D = unknown, R = unknown> = Pick<
   | "closeOnNavigation"
 > & {
   closePredicate?: (result?: R) => Promise<boolean>;
+
+  /**
+   * Present the dialog as a full-width bottom sheet at every breakpoint, rather than only on
+   * small screens.
+   */
+  bottomSheet?: boolean;
 };
 
 /**
@@ -67,6 +76,7 @@ export type DialogConfig<D = unknown, R = unknown> = Pick<
  */
 export class DrawerRef<R = unknown, C = unknown> implements DialogRef<R, C> {
   readonly isDrawer = true;
+  readonly isBottomSheet = false;
 
   private _closedSubject = new Subject<R | undefined>();
   private _isClosed = false;
@@ -176,6 +186,7 @@ export class CdkDialogRef<R = unknown, C = unknown> implements DialogRef<R, C> {
   constructor(
     private readonly logService?: LogService | null,
     closePredicate?: (result?: R) => Promise<boolean>,
+    readonly isBottomSheet = false,
   ) {
     this.closePredicate = closePredicate;
   }

--- a/libs/components/src/dialog/dialog.service.stories.ts
+++ b/libs/components/src/dialog/dialog.service.stories.ts
@@ -33,6 +33,9 @@ interface DrawerLevel {
       <button class="tw-mr-2" bitButton type="button" (click)="openDialogNonDismissable()">
         Open Non-Dismissable Dialog
       </button>
+      <button class="tw-mr-2" bitButton type="button" (click)="openBottomSheet()">
+        Open Bottom Sheet
+      </button>
       <button class="tw-mr-2" bitButton type="button" (click)="openDrawer()">Open Drawer</button>
       <button class="tw-mr-2" bitButton size="small" type="button" (click)="openSmallDrawer()">
         Open Small Drawer
@@ -63,6 +66,15 @@ class StoryDialogComponent {
         animal: "panda",
       },
       disableClose: true,
+    });
+  }
+
+  openBottomSheet() {
+    this.dialogService.open(StoryDialogContentComponent, {
+      data: {
+        animal: "panda",
+      },
+      bottomSheet: true,
     });
   }
 
@@ -338,8 +350,11 @@ export const NonDismissable: Story = {
   },
 };
 
-/** Drawers must be a descendant of `bit-layout`. */
-export const Drawer: Story = {
+/**
+ * `bottomSheet: true` pins the dialog to the bottom of the viewport at every breakpoint, rather
+ * than only on small screens.
+ */
+export const BottomSheet: Story = {
   play: async (context) => {
     const canvas = context.canvasElement;
 
@@ -348,7 +363,8 @@ export const Drawer: Story = {
   },
 };
 
-export const DrawerSmall: Story = {
+/** Drawers must be a descendant of `bit-layout`. */
+export const Drawer: Story = {
   play: async (context) => {
     const canvas = context.canvasElement;
 
@@ -357,11 +373,20 @@ export const DrawerSmall: Story = {
   },
 };
 
-export const DrawerLarge: Story = {
+export const DrawerSmall: Story = {
   play: async (context) => {
     const canvas = context.canvasElement;
 
     const button = getAllByRole(canvas, "button")[4];
+    await userEvent.click(button);
+  },
+};
+
+export const DrawerLarge: Story = {
+  play: async (context) => {
+    const canvas = context.canvasElement;
+
+    const button = getAllByRole(canvas, "button")[5];
     await userEvent.click(button);
   },
 };
@@ -371,7 +396,7 @@ export const DrawerStacked: Story = {
   play: async (context) => {
     const canvas = context.canvasElement;
 
-    await userEvent.click(getAllByRole(canvas, "button")[5]);
+    await userEvent.click(getAllByRole(canvas, "button")[6]);
 
     const level2Button = await findByRole(canvas, "button", { name: "Open Level 2" });
     await userEvent.click(level2Button);

--- a/libs/components/src/dialog/dialog.service.ts
+++ b/libs/components/src/dialog/dialog.service.ts
@@ -88,6 +88,17 @@ class ResponsivePositionStrategy extends GlobalPositionStrategy {
 }
 
 /**
+ * Position strategy that pins the dialog to the bottom of the screen regardless of screen size.
+ * Used by dialogs opened with `bottomSheet: true`.
+ */
+export class BottomSheetPositionStrategy extends GlobalPositionStrategy {
+  constructor() {
+    super();
+    this.bottom().centerHorizontally();
+  }
+}
+
+/**
  * Position strategy that centers dialogs regardless of screen size.
  * Use this for simple dialogs and custom dialogs that should not use
  * the responsive bottom-sheet behavior on mobile.
@@ -138,8 +149,9 @@ export class DialogService {
     componentOrTemplateRef: ComponentType<C> | TemplateRef<C>,
     config?: DialogConfig<D, R>,
   ): DialogRef<R, C> {
-    // We need to split out our async closePredicate here because the CDK's closePredicate is sync
-    const { closePredicate, ...otherConfig } = config ?? {};
+    // We need to split out our async closePredicate here because the CDK's closePredicate is sync.
+    // `bottomSheet` is ours as well and is not part of the CDK config.
+    const { closePredicate, bottomSheet, ...otherConfig } = config ?? {};
 
     /**
      * This is a bit circular in nature:
@@ -149,7 +161,7 @@ export class DialogService {
      * To break the circle, we define CDKDialogRef as a wrapper for the CDKDialogRefBase.
      * This allows us to create the class instance and provide the base instance later, almost like "deferred inheritance".
      **/
-    const ref = new CdkDialogRef<R, C>(this.logService, closePredicate);
+    const ref = new CdkDialogRef<R, C>(this.logService, closePredicate, bottomSheet);
     const injector = this.createInjector({
       data: config?.data,
       dialogRef: ref,
@@ -159,7 +171,9 @@ export class DialogService {
     const _config = {
       backdropClass: this.backDropClasses,
       scrollStrategy: this.defaultScrollStrategy,
-      positionStrategy: config?.positionStrategy ?? new ResponsivePositionStrategy(),
+      positionStrategy:
+        config?.positionStrategy ??
+        (bottomSheet ? new BottomSheetPositionStrategy() : new ResponsivePositionStrategy()),
       closeOnNavigation: config?.closeOnNavigation,
       injector,
       ...otherConfig,

--- a/libs/components/src/dialog/dialog/dialog.component.html
+++ b/libs/components/src/dialog/dialog/dialog.component.html
@@ -1,12 +1,7 @@
 @let isDrawer = dialogRef?.isDrawer;
-<!-- Storybook/Angular bugs out without this nullcheck. See the Access Selector Dialog story when removed. -->
-@let widthClass = width() ?? "";
 <section
   class="tw-flex tw-w-full tw-flex-col tw-self-center tw-overflow-hidden tw-border tw-border-solid tw-border-secondary-100 tw-bg-background tw-text-main"
-  [ngClass]="[
-    widthClass,
-    isDrawer ? 'tw-h-full tw-border-t-0' : 'tw-rounded-t-xl md:tw-rounded-xl tw-shadow-lg',
-  ]"
+  [ngClass]="containerClasses()"
   cdkTrapFocus
 >
   @let showHeaderBorder = bodyHasScrolledFrom().top;

--- a/libs/components/src/dialog/dialog/dialog.component.ts
+++ b/libs/components/src/dialog/dialog/dialog.component.ts
@@ -147,11 +147,30 @@ export class DialogComponent implements AfterViewInit {
     if (this.dialogRef?.isDrawer) {
       return this.drawerService.isPushMode() ? drawerSizeToWidth[size] : "";
     }
+    // Bottom sheets span the full viewport width at every breakpoint.
+    if (this.dialogRef?.isBottomSheet) {
+      return "";
+    }
     return dialogSizeToWidth[size];
+  });
+
+  /** Classes for the dialog's inner container. */
+  protected readonly containerClasses = computed(() => {
+    const shapeClasses = this.dialogRef?.isDrawer
+      ? ["tw-h-full", "tw-border-t-0"]
+      : [
+          "tw-rounded-t-xl",
+          ...(this.dialogRef?.isBottomSheet ? [] : ["md:tw-rounded-xl"]),
+          "tw-shadow-lg",
+        ];
+
+    /** Storybook/Angular bugs out without this nullcheck. See the Access Selector Dialog story when removed. */
+    return [this.width() ?? "", ...shapeClasses];
   });
 
   protected readonly classes = computed(() => {
     const isDrawer = this.dialogRef?.isDrawer;
+    const isBottomSheet = this.dialogRef?.isBottomSheet;
     // Drawers use tw-w-full (100% of column) so the element fills its grid track
     // without overflowing — the column itself is capped by the grid template.
     // Regular dialogs use tw-w-screen for full-width mobile presentation.
@@ -160,17 +179,20 @@ export class DialogComponent implements AfterViewInit {
     const sizeClasses = isDrawer
       ? ["tw-h-full"]
       : [
-          "md:tw-p-4",
+          // Bottom sheets sit flush against the viewport edges, so they get no surrounding gutter.
+          ...(isBottomSheet ? [] : ["md:tw-p-4"]),
           "tw-max-h-[90vh]", // needed to prevent dialogs from overlapping the desktop header
         ];
 
     const size = this.dialogSize();
     const animationClasses =
-      this.disableAnimations() || this.animationCompleted() || this.dialogRef?.isDrawer
+      this.disableAnimations() || this.animationCompleted() || isDrawer
         ? []
-        : size === "small"
-          ? ["tw-animate-slide-down"]
-          : ["tw-animate-slide-up", "md:tw-animate-slide-down"];
+        : isBottomSheet
+          ? ["tw-animate-slide-up"]
+          : size === "small"
+            ? ["tw-animate-slide-down"]
+            : ["tw-animate-slide-up", "md:tw-animate-slide-down"];
 
     return [...baseClasses, this.width(), ...sizeClasses, ...animationClasses];
   });


### PR DESCRIPTION
## 🎟️ Tracking

CL-XXXX

## 📔 Objective

Dialogs only present as a bottom sheet below the `md` breakpoint. This adds `bottomSheet: true` to `DialogService.open`'s config so a dialog can opt into that presentation at every breakpoint.

```ts
this.dialogService.open(MyComponent, { bottomSheet: true });
```

When set, the dialog is pinned to the bottom of the viewport (`BottomSheetPositionStrategy`), spans the full viewport width, loses its desktop gutter, and keeps the slide-up animation and top-only corner rounding at all widths. Behavior is unchanged for every existing caller.

Covered by a new `BottomSheet` story under Component Library/Dialogs/Service.

## 📸 Screenshots

- [ ] Bottom Sheet story at a desktop viewport
- [ ] Default dialog story at a desktop viewport (no regression)