### PR TITLE
[PM-42972] [PM-42441] Restore notification bar pointer events

### DIFF
--- a/apps/browser/src/autofill/overlay/notifications/content/__snapshots__/overlay-notifications-content.service.spec.ts.snap
+++ b/apps/browser/src/autofill/overlay/notifications/content/__snapshots__/overlay-notifications-content.service.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`OverlayNotificationsContentService opening the notification bar creates the notification bar elements and appends them to the body within a shadow root 1`] = `
 <div
   id="bit-notification-bar"
-  style="height: 400px !important; width: 430px !important; max-width: calc(100% - 20px) !important; min-height: initial !important; top: 10px !important; right: 0px !important; padding: 0px !important; position: fixed !important; z-index: 2147483647 !important; visibility: visible !important; border-radius: 4px !important; background-color: transparent !important; overflow: hidden !important; transition: box-shadow 0.15s ease !important; transition-delay: 0.15s;"
+  style="height: 400px !important; width: 430px !important; max-width: calc(100% - 20px) !important; min-height: initial !important; top: 10px !important; right: 0px !important; padding: 0px !important; position: fixed !important; z-index: 2147483647 !important; visibility: visible !important; border-radius: 4px !important; background-color: transparent !important; overflow: hidden !important; pointer-events: auto !important; transition: box-shadow 0.15s ease !important; transition-delay: 0.15s;"
 >
   <iframe
     credentialless=""

--- a/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.spec.ts
+++ b/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.spec.ts
@@ -84,6 +84,9 @@ describe("OverlayNotificationsContentService", () => {
       const rootElement = overlayNotificationsContentService["notificationBarRootElement"];
       expect(bodyAppendChildSpy).toHaveBeenCalledWith(rootElement);
       expect(rootElement?.tagName).toBe("BIT-NOTIFICATION-BAR-ROOT");
+      expect(
+        overlayNotificationsContentService["notificationBarElement"]?.style.pointerEvents,
+      ).toBe("auto");
 
       expect(document.getElementById("bit-notification-bar")).toBeNull();
       expect(document.querySelector("#bit-notification-bar-iframe")).toBeNull();

--- a/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.ts
+++ b/apps/browser/src/autofill/overlay/notifications/content/overlay-notifications-content.service.ts
@@ -36,6 +36,7 @@ export class OverlayNotificationsContentService implements OverlayNotificationsC
     border: "none",
     backgroundColor: "transparent",
     overflow: "hidden",
+    pointerEvents: "auto",
     transition: "box-shadow 0.15s ease",
     transitionDelay: "0.15s",
   };


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #22643. Internal tracking: PM-42441.

## 📔 Objective

Keep the browser notification bar clickable when a host-page dialog sets inherited `pointer-events: none` on the page body.

Set `pointer-events: auto` on the notification bar container, matching the protection already used by the autofill inline menu. The focused test and snapshot cover the computed container style.

## 📸 Screenshots

Not applicable: this changes pointer interaction rather than visual rendering.
