### PR TITLE
feat(desktop): Connect debug browser and desktop over native messaging

### DIFF
--- a/apps/desktop/scripts/debug-start.js
+++ b/apps/desktop/scripts/debug-start.js
@@ -5,6 +5,7 @@
 // so it does not interfere with the host system's bitwarden desktop installation.
 //
 //   .debug/desktop-profile/           app data (vault, settings, logs)
+//   .debug/chrome-profile/            native messaging manifest for the debug browser
 //   .debug/.bitwarden-ssh-agent.sock  SSH agent socket
 //   .debug/s.<name>                   IPC sockets
 ////
@@ -22,6 +23,7 @@ const args = process.argv.splice(2);
 const DEBUG_DIR = path.resolve(__dirname, "../../..", ".debug");
 
 process.env.BITWARDEN_APPDATA_DIR = path.join(DEBUG_DIR, "desktop-profile");
+process.env.BITWARDEN_CHROME_PROFILE_DIR = path.join(DEBUG_DIR, "chrome-profile");
 process.env.BITWARDEN_SSH_AUTH_SOCK = path.join(DEBUG_DIR, ".bitwarden-ssh-agent.sock");
 process.env.BITWARDEN_IPC_SOCKET_DIR = DEBUG_DIR;
 

--- a/apps/desktop/src/main/native-messaging.main.ts
+++ b/apps/desktop/src/main/native-messaging.main.ts
@@ -166,6 +166,13 @@ export class NativeMessagingMain {
       throw new Error(`Unable to find proxy binary: ${binaryPath}`);
     }
 
+    // When debugging against a dedicated chrome profile, only that profile gets a
+    // manifest, so the real browser installs are left untouched.
+    if (process.env.BITWARDEN_CHROME_PROFILE_DIR) {
+      await this.generateDebugChromeManifest(binaryPath);
+      return;
+    }
+
     switch (process.platform) {
       case "win32": {
         const destination = path.join(this.userPath, "browsers");
@@ -281,6 +288,23 @@ export class NativeMessagingMain {
       default:
         break;
     }
+  }
+
+  // Allow pointing chrome at a custom local profile for debugging
+  private async generateDebugChromeManifest(binaryPath: string) {
+    const profileDir = process.env.BITWARDEN_CHROME_PROFILE_DIR;
+
+    if (!profileDir) {
+      return;
+    }
+
+    const nmhsPath = path.join(profileDir, "NativeMessagingHosts");
+    await fs.mkdir(nmhsPath, { recursive: true });
+
+    await this.writeManifest(
+      path.join(nmhsPath, "com.8bit.bitwarden.json"),
+      await this.generateChromeJson(binaryPath),
+    );
   }
 
   async generateDdgManifests() {
@@ -487,6 +511,10 @@ export class NativeMessagingMain {
         ];
         break;
       }
+    }
+
+    if (process.env.BITWARDEN_CHROME_PROFILE_DIR) {
+      chromePaths.push(process.env.BITWARDEN_CHROME_PROFILE_DIR);
     }
 
     for (const chromePath of chromePaths) {

--- a/apps/desktop/src/main/native-messaging.main.ts
+++ b/apps/desktop/src/main/native-messaging.main.ts
@@ -168,7 +168,7 @@ export class NativeMessagingMain {
 
     // When debugging against a dedicated chrome profile, only that profile gets a
     // manifest, so the real browser installs are left untouched.
-    if (process.env.BITWARDEN_CHROME_PROFILE_DIR) {
+    if (this.debugChromeProfileDir() != null) {
       await this.generateDebugChromeManifest(binaryPath);
       return;
     }
@@ -290,9 +290,29 @@ export class NativeMessagingMain {
     }
   }
 
+  // Chrome only reads per-profile NativeMessagingHosts directories on macOS and Linux;
+  // on Windows it discovers hosts through the registry, which is shared with the
+  // installed client, so the debug profile is not supported there.
+  private debugChromeProfileDir(): string | null {
+    const profileDir = process.env.BITWARDEN_CHROME_PROFILE_DIR;
+
+    if (!profileDir) {
+      return null;
+    }
+
+    if (process.platform === "win32") {
+      this.logService.warning(
+        "[Native messaging] BITWARDEN_CHROME_PROFILE_DIR is not supported on Windows, ignoring it",
+      );
+      return null;
+    }
+
+    return profileDir;
+  }
+
   // Allow pointing chrome at a custom local profile for debugging
   private async generateDebugChromeManifest(binaryPath: string) {
-    const profileDir = process.env.BITWARDEN_CHROME_PROFILE_DIR;
+    const profileDir = this.debugChromeProfileDir();
 
     if (!profileDir) {
       return;
@@ -513,8 +533,9 @@ export class NativeMessagingMain {
       }
     }
 
-    if (process.env.BITWARDEN_CHROME_PROFILE_DIR) {
-      chromePaths.push(process.env.BITWARDEN_CHROME_PROFILE_DIR);
+    const debugProfileDir = this.debugChromeProfileDir();
+    if (debugProfileDir != null) {
+      chromePaths.push(debugProfileDir);
     }
 
     for (const chromePath of chromePaths) {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42981

## 📔 Objective

When `BITWARDEN_CHROME_PROFILE_DIR` is set the desktop client writes its Chrome manifest into that profile, so that we can support local chrome instances.

## 📸 Screenshots

N/A

