### PR TITLE
[PM-42984] Improve autofill content script injection performance

### DIFF
--- a/apps/browser/src/autofill/services/abstractions/autofill.service.ts
+++ b/apps/browser/src/autofill/services/abstractions/autofill.service.ts
@@ -116,6 +116,8 @@ export abstract class AutofillService {
     triggeringOnPageLoad?: boolean,
   ) => Promise<void>;
   /** Non-null asserted. */
+  handleAutofillScriptInjection!: (tab: chrome.tabs.Tab, frameId?: number) => Promise<void>;
+  /** Non-null asserted. */
   getFormsWithPasswordFields!: (pageDetails: AutofillPageDetails) => FormData[];
   /** Non-null asserted. */
   doAutoFill!: (options: AutoFillOptions) => Promise<AutoFillResult>;

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -120,7 +120,7 @@ describe("AutofillService", () => {
   let fillAssistFeatureFlagMock$: BehaviorSubject<boolean>;
   const autofillLifecycleService = mock<AutofillLifecycleService>();
 
-  beforeEach(() => {
+  beforeEach(async () => {
     configService = mock<ConfigService>();
     fillAssistFeatureFlagMock$ = new BehaviorSubject(false);
     configService.getFeatureFlag$.mockReturnValue(fillAssistFeatureFlagMock$);
@@ -147,6 +147,7 @@ describe("AutofillService", () => {
       authService,
     );
     domainSettingsService.equivalentDomains$ = of(mockEquivalentDomains);
+    await domainSettingsService.setBlockedInteractionsUris({});
 
     scriptInjectorService = new BrowserScriptInjectorService(
       domainSettingsService,
@@ -395,6 +396,97 @@ describe("AutofillService", () => {
       jest.spyOn(autofillService, "getAutofillOnPageLoad").mockResolvedValue(true);
     });
 
+    afterEach(() => jest.restoreAllMocks());
+
+    it("registers the selected bootstrap and context menu scripts for manifest v2", async () => {
+      jest.spyOn(BrowserApi, "isManifestVersion").mockImplementation((version) => version === 2);
+      const registeredContentScript = mock<browser.contentScripts.RegisteredContentScript>();
+      const registerContentScripts = jest
+        .spyOn(BrowserApi, "registerContentScriptsMv2")
+        .mockResolvedValue(registeredContentScript);
+
+      await autofillService.loadAutofillScriptsOnInstall();
+
+      expect(registerContentScripts).toHaveBeenCalledWith({
+        matches: ["*://*/*", "file:///*"],
+        excludeMatches: ["*://*/*.xml*", "file:///*.xml*"],
+        allFrames: true,
+        runAt: "document_start",
+        js: [
+          { file: "content/bootstrap-autofill-overlay.js" },
+          { file: "content/contextMenuHandler.js" },
+        ],
+      });
+    });
+
+    it("registers the selected bootstrap and context menu scripts for manifest v3", async () => {
+      jest.spyOn(BrowserApi, "isManifestVersion").mockImplementation((version) => version === 3);
+      jest.spyOn(BrowserApi, "getRegisteredContentScriptsMv3").mockResolvedValue([]);
+      jest.spyOn(BrowserApi, "unregisterContentScriptsMv3").mockResolvedValue();
+      const registerContentScripts = jest
+        .spyOn(BrowserApi, "registerContentScriptsMv3")
+        .mockResolvedValue();
+
+      await autofillService.loadAutofillScriptsOnInstall();
+
+      expect(registerContentScripts).toHaveBeenCalledWith([
+        {
+          id: "autofill-bootstrap",
+          matches: ["*://*/*", "file:///*"],
+          excludeMatches: ["*://*/*.xml*", "file:///*.xml*"],
+          allFrames: true,
+          runAt: "document_start",
+          js: ["content/bootstrap-autofill-overlay.js", "content/contextMenuHandler.js"],
+        },
+      ]);
+    });
+
+    it("excludes blocked hostnames and their subdomains from registered scripts", async () => {
+      await domainSettingsService.setBlockedInteractionsUris({ "example.com": null });
+      jest.spyOn(BrowserApi, "isManifestVersion").mockImplementation((version) => version === 2);
+      const registerContentScripts = jest
+        .spyOn(BrowserApi, "registerContentScriptsMv2")
+        .mockResolvedValue(mock<browser.contentScripts.RegisteredContentScript>());
+
+      await autofillService.loadAutofillScriptsOnInstall();
+
+      expect(registerContentScripts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeMatches: [
+            "*://*/*.xml*",
+            "file:///*.xml*",
+            "*://example.com/*",
+            "*://*.example.com/*",
+          ],
+        }),
+      );
+    });
+
+    it("reloads registration when notification settings change", async () => {
+      await autofillService.loadAutofillScriptsOnInstall();
+      const reloadAutofillScripts = jest
+        .spyOn(autofillService, "reloadAutofillScripts")
+        .mockResolvedValue();
+
+      enableChangedPasswordPromptMock$.next(false);
+      enableAddedLoginPromptMock$.next(false);
+      await flushPromises();
+
+      expect(reloadAutofillScripts).toHaveBeenCalledTimes(1);
+    });
+
+    it("reloads registration when blocked hostnames change", async () => {
+      await autofillService.loadAutofillScriptsOnInstall();
+      const reloadAutofillScripts = jest
+        .spyOn(autofillService, "reloadAutofillScripts")
+        .mockResolvedValue();
+
+      await domainSettingsService.setBlockedInteractionsUris({ "example.com": null });
+      await flushPromises();
+
+      expect(reloadAutofillScripts).toHaveBeenCalledTimes(1);
+    });
+
     it("queries all browser tabs and injects the autofill scripts into them", async () => {
       jest.spyOn(autofillService, "injectAutofillScripts");
 
@@ -459,10 +551,10 @@ describe("AutofillService", () => {
   });
 
   describe("reloadAutofillScripts", () => {
-    it("retires all frames through the lifecycle service and re-injects the autofill scripts", () => {
+    it("retires all frames through the lifecycle service and re-injects the autofill scripts", async () => {
       jest.spyOn(autofillService as any, "injectAutofillScriptsInAllTabs");
 
-      void autofillService.reloadAutofillScripts();
+      await autofillService.reloadAutofillScripts();
 
       expect(autofillLifecycleService.retireAllFrames).toHaveBeenCalled();
       expect(autofillService["injectAutofillScriptsInAllTabs"]).toHaveBeenCalled();
@@ -593,6 +685,61 @@ describe("AutofillService", () => {
         sender.tab,
         sender.frameId,
       );
+    });
+  });
+
+  describe("handleAutofillScriptInjection", () => {
+    const tabMock = createChromeTabMock({ id: 1, url: "https://example.com" });
+
+    beforeEach(() => {
+      jest.spyOn(BrowserApi, "getTab").mockResolvedValue(tabMock);
+      jest.spyOn(BrowserApi, "executeScriptInTab").mockImplementation();
+      jest.spyOn(autofillService, "getAutofillOnPageLoad").mockResolvedValue(false);
+    });
+
+    it("uses dynamic injection when content script registration is unavailable", async () => {
+      const injectAutofillScripts = jest
+        .spyOn(autofillService, "injectAutofillScripts")
+        .mockResolvedValue();
+
+      await autofillService.handleAutofillScriptInjection(tabMock, 2);
+
+      expect(injectAutofillScripts).toHaveBeenCalledWith(tabMock, 2);
+    });
+
+    it("starts lifecycle monitoring without re-injecting registered bootstrap scripts", async () => {
+      autofillService["autofillContentScriptRegistrationReady"] = true;
+      const injectAutofillScripts = jest.spyOn(autofillService, "injectAutofillScripts");
+
+      await autofillService.handleAutofillScriptInjection(tabMock, 2);
+
+      expect(injectAutofillScripts).not.toHaveBeenCalled();
+      expect(BrowserApi.executeScriptInTab).not.toHaveBeenCalled();
+      expect(autofillLifecycleService.startMonitoringFrame).toHaveBeenCalledWith(tabMock, 2);
+    });
+
+    it("only dynamically injects page-load autofill when registered scripts are available", async () => {
+      autofillService["autofillContentScriptRegistrationReady"] = true;
+      jest.spyOn(autofillService, "getAutofillOnPageLoad").mockResolvedValue(true);
+
+      await autofillService.handleAutofillScriptInjection(tabMock, 2);
+
+      expect(BrowserApi.executeScriptInTab).toHaveBeenCalledTimes(1);
+      expect(BrowserApi.executeScriptInTab).toHaveBeenCalledWith(tabMock.id, {
+        file: "content/autofiller.js",
+        frameId: 2,
+        runAt: "document_start",
+      });
+    });
+
+    it("does not start monitoring or inject scripts on blocked tabs", async () => {
+      autofillService["autofillContentScriptRegistrationReady"] = true;
+      await domainSettingsService.setBlockedInteractionsUris({ "example.com": null });
+
+      await autofillService.handleAutofillScriptInjection(tabMock, 2);
+
+      expect(BrowserApi.executeScriptInTab).not.toHaveBeenCalled();
+      expect(autofillLifecycleService.startMonitoringFrame).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -1,4 +1,5 @@
 import {
+  combineLatest,
   filter,
   firstValueFrom,
   merge,
@@ -25,10 +26,11 @@ import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/s
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { UserNotificationSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/user-notification-settings.service";
 import { InlineMenuVisibilitySetting } from "@bitwarden/common/autofill/types";
-import { normalizeExpiryYearFormat } from "@bitwarden/common/autofill/utils";
+import { isUrlInList, normalizeExpiryYearFormat } from "@bitwarden/common/autofill/utils";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions/account/billing-account-profile-state.service";
 import { EventCollectionService, EventType } from "@bitwarden/common/dirt/event-logs";
 import {
+  NeverDomains,
   UriMatchStrategySetting,
   UriMatchStrategy,
 } from "@bitwarden/common/models/domain/domain-service";
@@ -90,10 +92,18 @@ const loginIdentifierQualifierPriority: string[] = [
   AutofillTargetingRuleTypes.phone,
 ];
 
+const autofillContentScriptId = "autofill-bootstrap";
+const autofillContentScriptMatches = ["*://*/*", "file:///*"];
+const autofillContentScriptBaseExcludes = ["*://*/*.xml*", "file:///*.xml*"];
+
 export default class AutofillService implements AutofillServiceInterface {
   private openVaultItemPasswordRepromptPopout = openVaultItemPasswordRepromptPopout;
   private openPasswordRepromptPopoutDebounce?: ReturnType<typeof setTimeout>;
   private currentlyOpeningPasswordRepromptPopout = false;
+  private registeredAutofillContentScript:
+    browser.contentScripts.RegisteredContentScript | undefined;
+  private autofillContentScriptRegistrationReady = false;
+  private autofillContentScriptRegistrationUpdate = Promise.resolve();
   static searchFieldNamesSet = new Set(AutoFillConstants.SearchFieldNames);
   enableInlineMenuAnimation$: Observable<boolean>;
   enableNotificationAnimation$: Observable<boolean>;
@@ -206,6 +216,7 @@ export default class AutofillService implements AutofillServiceInterface {
    * if the extension context has been disconnected.
    */
   async loadAutofillScriptsOnInstall() {
+    await this.updateAutofillContentScriptRegistration();
     void this.injectAutofillScriptsInAllTabs();
 
     this.autofillSettingsService.inlineMenuVisibility$
@@ -225,6 +236,26 @@ export default class AutofillService implements AutofillServiceInterface {
       .subscribe(([previousSetting, currentSetting]) =>
         this.handleInlineMenuVisibilitySettingsChange(previousSetting, currentSetting),
       );
+
+    combineLatest([
+      this.userNotificationSettingsService.enableChangedPasswordPrompt$,
+      this.userNotificationSettingsService.enableAddedLoginPrompt$,
+    ])
+      .pipe(
+        map(([enableChangedPasswordPrompt, enableAddedLoginPrompt]) =>
+          Boolean(enableChangedPasswordPrompt || enableAddedLoginPrompt),
+        ),
+        pairwise(),
+      )
+      .subscribe(([previousSetting, currentSetting]) =>
+        this.handleAutofillContentScriptSettingChange(previousSetting, currentSetting),
+      );
+
+    this.domainSettingsService.blockedInteractionsUris$
+      .pipe(pairwise())
+      .subscribe(([previousSetting, currentSetting]) =>
+        this.handleBlockedInteractionsUrisChange(previousSetting, currentSetting),
+      );
   }
 
   /**
@@ -235,7 +266,50 @@ export default class AutofillService implements AutofillServiceInterface {
    */
   async reloadAutofillScripts() {
     this.autofillLifecycleService.retireAllFrames();
+    await this.updateAutofillContentScriptRegistration();
     void this.injectAutofillScriptsInAllTabs();
+  }
+
+  /**
+   * Handles the lightweight document-start trigger. Registered bootstrap scripts are already
+   * present in newly-created frames, so only page-load autofill and lifecycle startup remain.
+   * Falls back to the existing dynamic path when registration is unavailable.
+   */
+  async handleAutofillScriptInjection(tab: chrome.tabs.Tab, frameId = 0): Promise<void> {
+    if (tab.id == null) {
+      return;
+    }
+
+    if (!this.autofillContentScriptRegistrationReady) {
+      await this.injectAutofillScripts(tab, frameId);
+      return;
+    }
+
+    const blockedInteractionsUris = await firstValueFrom(
+      this.domainSettingsService.blockedInteractionsUris$,
+    );
+    if (tab.url && isUrlInList(tab.url, blockedInteractionsUris)) {
+      return;
+    }
+
+    const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
+    const authStatus = await firstValueFrom(this.authService.activeAccountStatus$);
+    if (
+      activeAccount &&
+      authStatus === AuthenticationStatus.Unlocked &&
+      (await this.getAutofillOnPageLoad())
+    ) {
+      await this.scriptInjectorService.inject({
+        tabId: tab.id,
+        injectDetails: {
+          file: "content/autofiller.js",
+          runAt: "document_start",
+          frame: frameId,
+        },
+      });
+    }
+
+    await this.autofillLifecycleService.startMonitoringFrame(tab, frameId);
   }
 
   /**
@@ -335,6 +409,74 @@ export default class AutofillService implements AutofillServiceInterface {
     }
 
     return "bootstrap-autofill-overlay.js";
+  }
+
+  /**
+   * Registers the selected bootstrap once so the browser can deliver it directly to each frame,
+   * avoiding a background round-trip and one executeScript call per file and frame.
+   */
+  private async updateAutofillContentScriptRegistration(): Promise<void> {
+    this.autofillContentScriptRegistrationUpdate =
+      this.autofillContentScriptRegistrationUpdate.then(() =>
+        this.replaceAutofillContentScriptRegistration(),
+      );
+    await this.autofillContentScriptRegistrationUpdate;
+  }
+
+  private async replaceAutofillContentScriptRegistration(): Promise<void> {
+    this.autofillContentScriptRegistrationReady = false;
+
+    try {
+      const activeAccount = await firstValueFrom(this.accountService.activeAccount$);
+      const bootstrapScript = await this.getBootstrapAutofillContentScript(activeAccount);
+      const blockedInteractionsUris = await firstValueFrom(
+        this.domainSettingsService.blockedInteractionsUris$,
+      );
+      const excludeMatches = [
+        ...autofillContentScriptBaseExcludes,
+        ...Object.keys(blockedInteractionsUris).flatMap((hostname) => [
+          `*://${hostname}/*`,
+          `*://*.${hostname}/*`,
+        ]),
+      ];
+      const js = [`content/${bootstrapScript}`, "content/contextMenuHandler.js"];
+
+      if (BrowserApi.isManifestVersion(2)) {
+        await this.registeredAutofillContentScript?.unregister();
+        this.registeredAutofillContentScript = undefined;
+        this.registeredAutofillContentScript = await BrowserApi.registerContentScriptsMv2({
+          matches: autofillContentScriptMatches,
+          excludeMatches,
+          allFrames: true,
+          runAt: "document_start",
+          js: js.map((file) => ({ file })),
+        });
+      } else {
+        const existingRegistrations = await BrowserApi.getRegisteredContentScriptsMv3({
+          ids: [autofillContentScriptId],
+        });
+        if (existingRegistrations.length > 0) {
+          await BrowserApi.unregisterContentScriptsMv3({ ids: [autofillContentScriptId] });
+        }
+        await BrowserApi.registerContentScriptsMv3([
+          {
+            id: autofillContentScriptId,
+            matches: autofillContentScriptMatches,
+            excludeMatches,
+            allFrames: true,
+            runAt: "document_start",
+            js,
+          },
+        ]);
+      }
+
+      this.autofillContentScriptRegistrationReady = true;
+    } catch (error) {
+      this.logService.error(
+        "Unable to register autofill content scripts; using dynamic injection.",
+        error,
+      );
+    }
   }
 
   /**
@@ -3382,6 +3524,33 @@ export default class AutofillService implements AutofillServiceInterface {
       !isInlineMenuVisibilitySubSetting &&
       !inlineMenuPreviouslyDisabled &&
       !inlineMenuCurrentlyDisabled
+    ) {
+      return;
+    }
+
+    await this.reloadAutofillScripts();
+  }
+
+  private async handleAutofillContentScriptSettingChange(
+    oldSettingValue: boolean,
+    newSettingValue: boolean,
+  ) {
+    if (oldSettingValue === newSettingValue) {
+      return;
+    }
+
+    await this.reloadAutofillScripts();
+  }
+
+  private async handleBlockedInteractionsUrisChange(
+    oldSettingValue: NeverDomains,
+    newSettingValue: NeverDomains,
+  ) {
+    const oldHostnames = Object.keys(oldSettingValue).sort();
+    const newHostnames = Object.keys(newSettingValue).sort();
+    if (
+      oldHostnames.length === newHostnames.length &&
+      oldHostnames.every((hostname, index) => hostname === newHostnames[index])
     ) {
       return;
     }

--- a/apps/browser/src/background/runtime.background.spec.ts
+++ b/apps/browser/src/background/runtime.background.spec.ts
@@ -19,6 +19,8 @@ import RuntimeBackground from "./runtime.background";
 describe("RuntimeBackground collectPageDetailsResponse routing", () => {
   let runtimeBackground: RuntimeBackground;
   let autofillOrchestrator: MockProxy<AutofillOrchestrator>;
+  let autofillService: MockProxy<AutofillService>;
+  let mainBackground: MockProxy<MainBackground>;
 
   const tab = createChromeTabMock({ id: 1 });
   const details = { foo: "bar" } as any;
@@ -36,10 +38,12 @@ describe("RuntimeBackground collectPageDetailsResponse routing", () => {
     (chrome.runtime as any).onInstalled = { addListener: jest.fn() };
 
     autofillOrchestrator = mock<AutofillOrchestrator>();
+    autofillService = mock<AutofillService>();
+    mainBackground = mock<MainBackground>();
 
     runtimeBackground = new RuntimeBackground(
-      mock<MainBackground>(),
-      mock<AutofillService>(),
+      mainBackground,
+      autofillService,
       mock<BrowserPlatformUtilsService>(),
       undefined as any,
       undefined as any,
@@ -55,6 +59,23 @@ describe("RuntimeBackground collectPageDetailsResponse routing", () => {
       undefined as any,
       autofillOrchestrator,
     );
+  });
+
+  it("routes the document-start trigger through the registered-script handler", async () => {
+    await runtimeBackground.processMessageWithSender(
+      { command: "triggerAutofillScriptInjection" },
+      sender,
+    );
+
+    expect(autofillService.handleAutofillScriptInjection).toHaveBeenCalledWith(tab, 0);
+    expect(autofillService.injectAutofillScripts).not.toHaveBeenCalled();
+  });
+
+  it("reloads registered scripts after logout changes the active account", async () => {
+    await runtimeBackground.processMessage({ command: "logout", expired: false });
+
+    expect(mainBackground.logout).toHaveBeenCalledWith(false, undefined);
+    expect(autofillService.reloadAutofillScripts).toHaveBeenCalled();
   });
 
   it("forwards a keyboard-shortcut collection to AutofillOrchestrator", async () => {

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -143,7 +143,7 @@ export default class RuntimeBackground {
   async processMessageWithSender(msg: any, sender: chrome.runtime.MessageSender) {
     switch (msg.command) {
       case "triggerAutofillScriptInjection":
-        await this.autofillService.injectAutofillScripts(sender.tab, sender.frameId);
+        await this.autofillService.handleAutofillScriptInjection(sender.tab, sender.frameId);
         break;
       case "bgCollectPageDetails":
         await this.main.collectPageDetailsForContentScript(sender.tab, msg.sender, sender.frameId);
@@ -344,6 +344,7 @@ export default class RuntimeBackground {
         break;
       case "logout":
         await this.main.logout(msg.expired, msg.userId);
+        await this.autofillService.reloadAutofillScripts();
         break;
       case "syncCompleted":
         if (msg.successfully) {

--- a/apps/browser/src/platform/browser/browser-api.spec.ts
+++ b/apps/browser/src/platform/browser/browser-api.spec.ts
@@ -1178,6 +1178,22 @@ describe("BrowserApi", () => {
     });
   });
 
+  describe("getRegisteredContentScriptsMv3", () => {
+    it("returns registrations from the scripting API", async () => {
+      const filter = { ids: ["autofill-bootstrap"] };
+      const registrations = [
+        mock<chrome.scripting.RegisteredContentScript>({ id: "autofill-bootstrap" }),
+      ];
+      const getRegisteredContentScripts = jest.fn().mockResolvedValue(registrations);
+      chrome.scripting.getRegisteredContentScripts = getRegisteredContentScripts;
+
+      await expect(BrowserApi.getRegisteredContentScriptsMv3(filter)).resolves.toEqual(
+        registrations,
+      );
+      expect(getRegisteredContentScripts).toHaveBeenCalledWith(filter);
+    });
+  });
+
   /*
    * Safari sometimes returns >1 tabs unexpectedly even when
    * specificing a `windowId` or `currentWindow: true` query option.

--- a/apps/browser/src/platform/browser/browser-api.ts
+++ b/apps/browser/src/platform/browser/browser-api.ts
@@ -1055,6 +1055,17 @@ export class BrowserApi {
   }
 
   /**
+   * Retrieves registered static content scripts within manifest v3.
+   *
+   * @param filter - Optional filter used to limit returned registrations.
+   */
+  static async getRegisteredContentScriptsMv3(
+    filter?: chrome.scripting.ContentScriptFilter,
+  ): Promise<chrome.scripting.RegisteredContentScript[]> {
+    return await chrome.scripting.getRegisteredContentScripts(filter);
+  }
+
+  /**
    * Handles unregistering of static content scripts within manifest v3.
    *
    * @param filter - Optional filter to unregister content scripts. Passing an empty object will unregister all content scripts.


### PR DESCRIPTION
## 🎟️ Tracking

Addresses the script-delivery portion of #20107 and the bootstrap stalls reported in #20678.

Proposal and measurements: https://github.com/bitwarden/clients/issues/20107#issuecomment-5526331714

## 📔 Objective

Reduce autofill startup overhead in frame-heavy pages by registering the selected autofill bootstrap and context-menu script once instead of dynamically evaluating both files after every `triggerAutofillScriptInjection` message.

This draft:

- reuses the existing MV2/MV3 registered-content-script abstraction used by FIDO2;
- keeps the document-start trigger for lifecycle startup and as a dynamic-injection fallback;
- preserves the conditional `autofiller.js` page-load path;
- updates registrations when overlay/notification settings or blocked domains change;
- excludes blocked hostnames and subdomains from registered injection;
- refreshes the selected registration after login/logout;
- checks persisted MV3 registrations before replacing them after a service-worker restart;
- serializes registration changes to avoid overlapping unregister/register operations.

The bootstrap scripts already guard against duplicate initialization. Existing tabs continue through the established dynamic path after a registration change; newly-created frames receive the bootstrap directly from the browser and the trigger only starts lifecycle monitoring (plus conditional page-load autofill).

### Performance evidence

An isolated frame-delivery fixture using equivalent `document_start` / `all_frames` work measured:

- dynamic `executeScript`: 285 frames/s median;
- declarative content script: 1,734 frames/s median;
- `scripting.registerContentScripts`: 1,987 frames/s median.

The registered path was 6.96x faster in that delivery-focused fixture. The new unit coverage also verifies that registered frames do not dynamically inject the bootstrap or context-menu script.

This does not attempt to optimize DOM observers or the conditional page-load autofiller itself; those are separate costs.

### Validation

- `npm test --workspace apps/browser -- --runInBand`
- `npx jest apps/browser/src/autofill/services/autofill.service.spec.ts apps/browser/src/background/runtime.background.spec.ts apps/browser/src/platform/browser/browser-api.spec.ts --runInBand`
- `npx tsc --project apps/browser/tsconfig.build.json --noEmit`
- ESLint and Prettier on changed files
- `npm run build:chrome --workspace apps/browser` (MV3)
- `npm run build:safari --workspace apps/browser` (MV2)

## Draft follow-ups

- exercise automatic/manual autofill, overlays, lock/logout, blocked domains, iframes, and passkeys in the browser integration matrix;
- rerun the frame benchmark on the packaged builds and attach raw results;
- incorporate maintainer guidance on whether registration should live in a dedicated background service.
