### PR TITLE
[PM-42912] Filter Icons

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -18,7 +18,12 @@
       appAutofocus
     ></bit-search>
 
-    <bit-filter-menu key="cipherType" [placeholderText]="'type' | i18n" [unsetLabel]="'all' | i18n">
+    <bit-filter-menu
+      key="cipherType"
+      [placeholderText]="'type' | i18n"
+      [unsetLabel]="'all' | i18n"
+      icon="bwi-list"
+    >
       @for (option of cipherTypeOptions(); track option.value) {
         <bit-filter-option [value]="option.value" [count]="optionCount('cipherType', option.value)">
           {{ option.label }}
@@ -27,7 +32,12 @@
     </bit-filter-menu>
 
     @if (organizationOptions().length) {
-      <bit-filter-menu key="organization" [placeholderText]="'vault' | vfo1I18n: 'vaults'" multiple>
+      <bit-filter-menu
+        key="organization"
+        [placeholderText]="'vault' | vfo1I18n: 'vaults'"
+        multiple
+        icon="bwi-vault"
+      >
         @for (option of organizationOptions(); track option.value.id) {
           <bit-filter-option
             [value]="option.value.id"
@@ -44,6 +54,7 @@
         [placeholderText]="'collection' | vfo1I18n: 'sharedFolders'"
         [unsetLabel]="'all' | i18n"
         multiple
+        icon="bwi-shared-folder"
       >
         @if (groupCollectionsByOrg()) {
           @for (org of collectionsByOrg(); track org.id) {
@@ -71,7 +82,12 @@
     }
 
     @if (folderOptions().length) {
-      <bit-filter-menu key="folder" [placeholderText]="'folder' | vfo1I18n: 'myFolders'" multiple>
+      <bit-filter-menu
+        key="folder"
+        [placeholderText]="'folder' | vfo1I18n: 'myFolders'"
+        multiple
+        icon="bwi-folder"
+      >
         @for (option of folderOptions(); track option.value.id) {
           <bit-filter-option
             [value]="option.value.id ?? NO_FOLDER"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42912](https://bitwarden.atlassian.net/browse/PM-42912)

## 📔 Objective

Adds icons to the filter menus on the extension

## 📸 Screenshots

|Extension|
|-|
|<img width="487" height="603" alt="Screenshot 2026-09-03 at 9 01 52 AM" src="https://github.com/user-attachments/assets/348960db-2985-4e17-96a1-7a6be1349c82" />|


[PM-42912]: https://bitwarden.atlassian.net/browse/PM-42912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ