### PR TITLE
[PM-42913] Reuse the health scan when returning to the overview

### DIFF
--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health-risk-category-detail.component.ts
@@ -148,7 +148,7 @@ export class HealthRiskCategoryDetailComponent {
     toObservable(computed(() => (this.invalidCategory() ? undefined : this.userId())))
       .pipe(
         filterOutNullish(),
-        switchMap((userId) => this.healthScanService.ensureScan$(userId)),
+        switchMap((userId) => this.healthScanService.keepReportCurrent$(userId)),
         takeUntilDestroyed(),
       )
       .subscribe();

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health.component.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health.component.spec.ts
@@ -477,38 +477,47 @@ describe("HealthComponent", () => {
       expect(overview()).toBeNull();
     });
 
-    it("rescans on every load, even when the service already has a report for this user", async () => {
-      // PM-39223: the scan runs on every Health Tab load with no caching. The
-      // popup rebuilds this component on each navigation to Health (including
-      // returning from a category detail, a sibling /health/:category route), so
-      // a fresh build runs even when a prior report is already published.
+    it("reuses a report the service already holds for this user, with no second scan", async () => {
+      // The popup rebuilds this component on each navigation to Health, including
+      // returning from a category detail (a sibling /health/:category route) that
+      // ran its own scan. Scanning again repeats every breach lookup and replaces
+      // results the user was reading a moment ago with the progress view.
       hasRunScan$.next(true);
       published.next({
         userId,
         status: VaultHealthReportStatus.Success,
         report: new VaultHealthReportView({ totalCount: 10, atRiskCount: 2 }),
       });
-      publishesOnBuild(new VaultHealthReportView({ totalCount: 10, atRiskCount: 3 }));
 
       await initComponent();
-      await settle();
+      await settleRefresh();
 
-      expect(reportService.buildVaultHealthReport).toHaveBeenCalledTimes(1);
-      expect(overview()?.report().atRiskCount).toBe(3);
+      expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
+      expect(overview()?.report().atRiskCount).toBe(2);
+      expect(scanning()).toBeNull();
+      // Reusing the scan is not a reason to stop following the vault.
+      expect(reportService.refreshVaultHealthReport).toHaveBeenCalled();
     });
 
-    it("starts a fresh scan on load even if one was already in flight", async () => {
-      // There is no in-flight reuse guard anymore: every load runs its own scan.
-      // A prior build left mid-flight (the component was destroyed on nav-away)
-      // does not stop the new load from starting its own.
+    it("follows a scan already in flight rather than starting a second", async () => {
+      // Leaving a category detail while its scan is still running lands here
+      // mid-flight. That scan publishes on its own, so a second one would only
+      // duplicate the breach lookups and discard the progress already made.
       hasRunScan$.next(true);
       published.next({ userId, status: VaultHealthReportStatus.Loading, report: null });
-      publishesOnBuild(new VaultHealthReportView({ totalCount: 8, atRiskCount: 1 }));
 
       await initComponent();
+      await settleRefresh();
+      expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
+      expect(scanning()).not.toBeNull();
+
+      published.next({
+        userId,
+        status: VaultHealthReportStatus.Success,
+        report: new VaultHealthReportView({ totalCount: 8, atRiskCount: 1 }),
+      });
       await settle();
 
-      expect(reportService.buildVaultHealthReport).toHaveBeenCalledTimes(1);
       expect(overview()?.report().atRiskCount).toBe(1);
     });
 
@@ -653,26 +662,6 @@ describe("HealthComponent", () => {
 
       expect(scanError()).toBeNull();
       expect(overview()).not.toBeNull();
-    });
-
-    it("shows the progress view on load while the rescan runs, not the report the service still holds", async () => {
-      // PM-39223 rescans on every load. The component asks the service to show
-      // progress immediately (markScanning), so while the rescan runs the tab
-      // shows the progress view rather than the report the service still holds
-      // from the last scan.
-      hasRunScan$.next(true);
-      published.next({
-        userId,
-        status: VaultHealthReportStatus.Success,
-        report: new VaultHealthReportView({ totalCount: 10, atRiskCount: 4 }),
-      });
-      buildNeverSettles();
-
-      await initComponent();
-      await settle();
-
-      expect(scanning()).not.toBeNull();
-      expect(overview()).toBeNull();
     });
   });
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/health.component.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/health.component.ts
@@ -123,8 +123,7 @@ export class HealthComponent {
   });
 
   constructor() {
-    // Runs the scan and then keeps the report current for as long as this tab is
-    // open. Reading happens through scanState above.
+    // Subscribed for the side effect; the report is read through scanState above.
     toObservable(this.userId)
       .pipe(
         filterOutNullish(),
@@ -134,7 +133,7 @@ export class HealthComponent {
             // already true. take(1) keeps it to one automatic trigger per load.
             filter(Boolean),
             take(1),
-            switchMap(() => this.healthScanService.runScan$(userId)),
+            switchMap(() => this.healthScanService.keepReportCurrent$(userId)),
           ),
         ),
         takeUntilDestroyed(),

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/services/health-scan.service.spec.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/services/health-scan.service.spec.ts
@@ -52,7 +52,7 @@ describe("HealthScanService", () => {
   };
 
   /** Subscribes like a Health view would and returns the handle so it can be destroyed. */
-  const watch = (source$: ReturnType<HealthScanService["runScan$"]>): Subscription => {
+  const watch = (source$: ReturnType<HealthScanService["keepReportCurrent$"]>): Subscription => {
     const subscription = source$.subscribe();
     subscriptions.push(subscription);
     return subscription;
@@ -109,30 +109,55 @@ describe("HealthScanService", () => {
     jest.clearAllMocks();
   });
 
-  describe("runScan$", () => {
+  describe("keepReportCurrent$", () => {
     it("does nothing until something subscribes", async () => {
-      service.runScan$(userId);
+      service.keepReportCurrent$(userId);
       await settle();
 
       expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
     });
 
-    it("runs one full scan with the ciphers from the stream", async () => {
-      watch(service.runScan$(userId));
+    it("scans when there is no report yet, using the ciphers from the stream", async () => {
+      watch(service.keepReportCurrent$(userId));
       await settle();
 
       expect(reportService.buildVaultHealthReport).toHaveBeenCalledTimes(1);
       expect(reportService.buildVaultHealthReport).toHaveBeenCalledWith([cipher("a")], userId);
     });
 
-    it("scans even when the service already has a report", async () => {
-      // The Health Overview rescans on every load by product decision.
+    it("does not scan when a report is already published", async () => {
+      // Both Health views call this, so navigating between them must not repeat
+      // the breach lookups the first one already spent.
       reportState$.next({ status: VaultHealthReportStatus.Success, report: {} as never });
 
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
 
-      expect(reportService.buildVaultHealthReport).toHaveBeenCalledTimes(1);
+      expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
+    });
+
+    it("does not scan while a scan is already running", async () => {
+      reportState$.next({ status: VaultHealthReportStatus.Loading, report: null });
+
+      watch(service.keepReportCurrent$(userId));
+      await settle();
+
+      expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
+    });
+
+    it("still watches the vault when it skipped the scan", async () => {
+      reportState$.next({ status: VaultHealthReportStatus.Success, report: {} as never });
+      watch(service.keepReportCurrent$(userId));
+      await settle();
+
+      ciphers$.next([cipher("a"), cipher("b")]);
+      await settle();
+
+      expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
+      expect(reportService.refreshVaultHealthReport).toHaveBeenCalledWith(
+        [cipher("a"), cipher("b")],
+        userId,
+      );
     });
 
     it("does not scan the replayed null from cipherViews$", async () => {
@@ -140,7 +165,7 @@ describe("HealthScanService", () => {
       // would report a permanently healthy vault.
       ciphers$.next(null);
 
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
 
       expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
@@ -156,52 +181,9 @@ describe("HealthScanService", () => {
     });
   });
 
-  describe("ensureScan$", () => {
-    it("scans when there is no report yet", async () => {
-      watch(service.ensureScan$(userId));
-      await settle();
-
-      expect(reportService.buildVaultHealthReport).toHaveBeenCalledTimes(1);
-    });
-
-    it("does not scan when a report is already published", async () => {
-      // Navigating in from the Health Overview must not repeat the breach lookups.
-      reportState$.next({ status: VaultHealthReportStatus.Success, report: {} as never });
-
-      watch(service.ensureScan$(userId));
-      await settle();
-
-      expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
-    });
-
-    it("does not scan while a scan is already running", async () => {
-      reportState$.next({ status: VaultHealthReportStatus.Loading, report: null });
-
-      watch(service.ensureScan$(userId));
-      await settle();
-
-      expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
-    });
-
-    it("still watches the vault when it skipped the scan", async () => {
-      reportState$.next({ status: VaultHealthReportStatus.Success, report: {} as never });
-      watch(service.ensureScan$(userId));
-      await settle();
-
-      ciphers$.next([cipher("a"), cipher("b")]);
-      await settle();
-
-      expect(reportService.buildVaultHealthReport).not.toHaveBeenCalled();
-      expect(reportService.refreshVaultHealthReport).toHaveBeenCalledWith(
-        [cipher("a"), cipher("b")],
-        userId,
-      );
-    });
-  });
-
   describe("watching the vault", () => {
     it("refreshes when the vault changes, without a second full scan", async () => {
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
       reportService.buildVaultHealthReport.mockClear();
 
@@ -223,7 +205,7 @@ describe("HealthScanService", () => {
         new Promise<void>((resolve) => (releaseScan = resolve)),
       );
 
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
       ciphers$.next([cipher("a"), cipher("b")]);
       await settle();
@@ -245,7 +227,7 @@ describe("HealthScanService", () => {
       // subscribes. Harmless because the vault has not changed, so
       // refreshVaultHealthReport compares fingerprints and returns without
       // publishing or spending a breach lookup.
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
 
       expect(reportService.refreshVaultHealthReport).toHaveBeenCalledTimes(1);
@@ -253,7 +235,7 @@ describe("HealthScanService", () => {
     });
 
     it("collapses a burst of vault changes into one refresh", async () => {
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
       // Drop the startup refresh so this counts only what the burst caused.
       reportService.refreshVaultHealthReport.mockClear();
@@ -273,7 +255,7 @@ describe("HealthScanService", () => {
 
     it("does not overlap refreshes", async () => {
       // A superseded promise still resolves and could publish a stale report late.
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
       reportService.refreshVaultHealthReport.mockClear();
 
@@ -296,7 +278,7 @@ describe("HealthScanService", () => {
     });
 
     it("stops watching once the last subscriber goes away", async () => {
-      const subscription = watch(service.runScan$(userId));
+      const subscription = watch(service.keepReportCurrent$(userId));
       await settle();
       reportService.refreshVaultHealthReport.mockClear();
 
@@ -310,7 +292,7 @@ describe("HealthScanService", () => {
 
   describe("retryScan", () => {
     it("runs another full scan", async () => {
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
       reportService.buildVaultHealthReport.mockClear();
 
@@ -320,10 +302,11 @@ describe("HealthScanService", () => {
       expect(reportService.buildVaultHealthReport).toHaveBeenCalledTimes(1);
     });
 
-    it("scans even when ensureScan$ skipped the initial one", async () => {
-      // The failure view is reachable on the detail page, so its retry has to work.
+    it("scans even when the initial one was skipped", async () => {
+      // The failure view is reachable on the detail page, so its retry has to work
+      // on a view that reused an existing report rather than scanning.
       reportState$.next({ status: VaultHealthReportStatus.Success, report: {} as never });
-      watch(service.ensureScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
 
       service.retryScan(userId);
@@ -333,7 +316,7 @@ describe("HealthScanService", () => {
     });
 
     it("does not scan for an account that is not subscribed", async () => {
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
       reportService.buildVaultHealthReport.mockClear();
 
@@ -357,7 +340,7 @@ describe("HealthScanService", () => {
 
     it("records and logs a failure to fetch the ciphers to scan", async () => {
       const failing$ = failingCiphers();
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       const failure = new Error("decryption unavailable");
 
       failing$.error(failure);
@@ -369,7 +352,7 @@ describe("HealthScanService", () => {
 
     it("clears at the start of the next scan", async () => {
       const failing$ = failingCiphers();
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       failing$.error(new Error("decryption unavailable"));
       await settle();
 
@@ -382,7 +365,7 @@ describe("HealthScanService", () => {
 
     it("does not leak a failure to another account", async () => {
       const failing$ = failingCiphers();
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       failing$.error(new Error("decryption unavailable"));
       await settle();
 
@@ -394,7 +377,7 @@ describe("HealthScanService", () => {
       // already reading.
       const failing$ = new BehaviorSubject<CipherView[] | null>([cipher("a")]);
       cipherService.cipherViews$.mockReturnValue(failing$ as never);
-      watch(service.runScan$(userId));
+      watch(service.keepReportCurrent$(userId));
       await settle();
       const failure = new Error("decryption cleared");
 

--- a/bitwarden_license/bit-browser/src/popup/dirt/health/services/health-scan.service.ts
+++ b/bitwarden_license/bit-browser/src/popup/dirt/health/services/health-scan.service.ts
@@ -25,9 +25,8 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { filterOutNullish } from "@bitwarden/common/vault/utils/observable-utilities";
 
 /**
- * How long a burst of vault changes is allowed to settle before the report is
- * brought up to date. A sync rewrites many ciphers across several ticks, and each
- * rebuild can cost a breach lookup per login, so they are collapsed into one.
+ * A sync rewrites many ciphers across several ticks, and each rebuild can cost a
+ * breach lookup per login, so a burst is collapsed into one refresh.
  */
 const VAULT_CHANGE_DEBOUNCE_MS = 300;
 
@@ -35,10 +34,10 @@ const VAULT_CHANGE_DEBOUNCE_MS = 300;
  * Decides *when* the browser Health views recompute their report;
  * {@link VaultHealthReportService} owns *what* the report is.
  *
- * Everything is cold and scoped to the subscriber: a Health view subscribes on
- * mount and the vault watch stops when the last one goes away, so no work happens
- * while the user is elsewhere in the popup. Nothing here throws — a scan failure
- * arrives as a published report status or on {@link pipelineFailed$}.
+ * The scan pipeline is cold and scoped to the subscriber: a Health view subscribes
+ * on mount and the vault watch stops when the last one goes away, so no work
+ * happens while the user is elsewhere in the popup. Nothing here throws — a scan
+ * failure arrives as a published report status or on {@link pipelineFailed$}.
  */
 @Injectable({ providedIn: "root" })
 export class HealthScanService {
@@ -54,21 +53,24 @@ export class HealthScanService {
   private readonly pipelineFailures = new Map<UserId, BehaviorSubject<boolean>>();
 
   /**
-   * Runs a full scan, breach lookups included, then keeps the report current until
-   * the caller unsubscribes. For a view that is expected to rescan on every load.
-   */
-  runScan$(userId: UserId): Observable<void> {
-    return this.keepCurrent$(userId, of(true));
-  }
-
-  /**
    * Keeps the report current until the caller unsubscribes, running a full scan
-   * first only when there is no report yet. For a view that can be opened directly,
-   * such as a route the popup restored, and that must not repeat the breach lookups
-   * when the user simply navigated in from the Health Overview.
+   * first only when there is no report yet. Both Health views share one scan this
+   * way: navigating between them, or landing on either directly, does not repeat
+   * the breach lookups.
    */
-  ensureScan$(userId: UserId): Observable<void> {
-    return this.keepCurrent$(userId, this.needsScan$(userId));
+  keepReportCurrent$(userId: UserId): Observable<void> {
+    return this.needsScan$(userId).pipe(
+      switchMap((scanFirst) =>
+        // A retry starts the pipeline over, scan and vault watch both.
+        merge(of(scanFirst), this.retriesFor(userId).pipe(map(() => true))).pipe(
+          switchMap((runFullScan) =>
+            // The scan has to publish before the watch starts: the vault reports a
+            // change only once, so one landing mid-scan would be lost.
+            concat(runFullScan ? this.fullScan$(userId) : EMPTY, this.refreshes$(userId)),
+          ),
+        ),
+      ),
+    );
   }
 
   /** Requests another full scan. Only `userId`'s subscribed scan reacts. */
@@ -85,24 +87,10 @@ export class HealthScanService {
     return this.pipelineFailedFor(userId).asObservable();
   }
 
-  private keepCurrent$(userId: UserId, scanFirst$: Observable<boolean>): Observable<void> {
-    return scanFirst$.pipe(
-      switchMap((scanFirst) =>
-        // switchMap, not exhaustMap: a retry has to restart both halves, and
-        // exhaustMap over a concat whose tail never completes would drop it forever.
-        merge(of(scanFirst), this.retriesFor(userId).pipe(map(() => true))).pipe(
-          switchMap((runFullScan) =>
-            // The watch must not start until the scan has published, or a change
-            // landing mid-scan finds no baseline to compare against, is treated as
-            // handled, and is then lost because cipherViews$ will not re-emit.
-            concat(runFullScan ? this.fullScan$(userId) : EMPTY, this.refreshes$(userId)),
-          ),
-        ),
-      ),
-    );
-  }
-
-  /** Whether there is no report to keep current yet. */
+  /**
+   * Whether a full scan is still owed. A scan already running is not: it publishes
+   * on its own, and a second would just repeat the same breach lookups.
+   */
   private needsScan$(userId: UserId): Observable<boolean> {
     return this.reportService.getVaultHealthReport$(userId).pipe(
       take(1),
@@ -134,14 +122,14 @@ export class HealthScanService {
     return this.cipherService.cipherViews$(userId).pipe(
       filterOutNullish(),
       debounceTime(VAULT_CHANGE_DEBOUNCE_MS),
-      // concatMap, not switchMap: a superseded refresh still resolves and could
-      // publish a stale report late. Not exhaustMap: that drops the newest change.
+      // Refreshes are queued, never replaced: an abandoned one still finishes and
+      // could publish stale results after a newer one has landed.
       concatMap((ciphers) =>
         defer(() => this.reportService.refreshVaultHealthReport(ciphers, userId)),
       ),
       catchError((error: unknown) => {
-        // Deliberately does not set pipelineFailed: a background failure must not
-        // put a failure view over results the user is already reading.
+        // Stays quiet: a background failure must not put a failure view over
+        // results the user is already reading.
         this.logService.error("Vault health refresh pipeline failed", error);
         return EMPTY;
       }),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42913](https://bitwarden.atlassian.net/browse/PM-42913)

## 📔 Objective

This pull request changes Health Overview tab and Category Tab to use the same scan for the report and reacts to live changes to the vault

**Note:** This removes the need for the scan when navigating back to the tab since the scan is run and then reacts to changes



[PM-42913]: https://bitwarden.atlassian.net/browse/PM-42913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ