### PR TITLE
[PM-42997] Clear policiesNew state when the sync response contains no policies

### DIFF
--- a/libs/common/src/platform/sync/default-sync.service.spec.ts
+++ b/libs/common/src/platform/sync/default-sync.service.spec.ts
@@ -627,12 +627,12 @@ describe("DefaultSyncService", () => {
         );
       });
 
-      it("does not call newPolicyService.replace when both policiesNew and policies are absent", async () => {
+      it("clears policiesNew state when the response contains no policies", async () => {
         apiService.getSync.mockResolvedValue(emptySyncResponse);
 
         await sut.fullSync(true);
 
-        expect(newPolicyService.replace).not.toHaveBeenCalled();
+        expect(newPolicyService.replace).toHaveBeenCalledWith({}, user1);
       });
 
       it("calls newPolicyService.replace when policiesNew is present in the response", async () => {

--- a/libs/common/src/platform/sync/default-sync.service.ts
+++ b/libs/common/src/platform/sync/default-sync.service.ts
@@ -427,10 +427,10 @@ export class DefaultSyncService extends CoreSyncService {
     fallback: PolicyResponse[] | undefined,
     userId: UserId,
   ) {
-    // Fall back to `policies` when `policiesNew` is absent or empty (e.g. the server
-    // feature flag is off) so the new service is always seeded with data.
+    // Fall back to `policies` when `policiesNew` is absent or empty, so the new service
+    // is always seeded with data on servers that do not send `policiesNew`.
     const source = response != null && response.length > 0 ? response : fallback;
-    if (source == null || source.length === 0) {
+    if (source == null) {
       return;
     }
     const policies: { [id: string]: PolicyData } = {};


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #22928 (PM-42995)

## 📔 Objective

`syncNewPolicies` skips its `replace()` call whenever the resolved policy list is empty. That call is the only code path that writes the `POLICIES_NEW` state, and the state is declared `clearOn: ["logout"]`, so a user's policies are never cleared once the list legitimately becomes empty — for example after they are removed from their last organization.

The effect is user visible. `DefaultPolicyService.policiesByType$` evaluates against `POLICIES_NEW`, and the SDK's `ResolvedPolicyView::into_enforced` treats a policy whose organization context is missing as enforced:

```rust
let context = organization_user_policy_contexts.get(&self.organization_id);
let enforced = self.enabled && context.is_none_or(|ctx| { ... });
```

`syncProfileOrganizations` clears the organization state correctly, so after the sync there is no context for the removed organization and every stale policy evaluates to enforced. Syncing does not help — the manual "Sync now" button runs the same `fullSync(true)` — only a logout clears it.

This drops `|| source.length === 0` from the guard. The fallback selection on the preceding line is untouched, so preferring `policiesNew` and falling back to `policies` when it is absent still works, including for servers that do not send `policiesNew` at all (`source` is then `undefined` and the function still returns early).

This also aligns the client with the contract `bitwarden/server` documents on `SyncResponseModel.PoliciesNew`:

> New clients should prefer this property and fall back to `Policies` if absent.

"if absent" — not "if empty".

### Note on the changed test

This flips one existing expectation:

> `"does not call newPolicyService.replace when both policiesNew and policies are absent"`

That test does not exercise the absent case it names. `SyncResponse.policies` is declared with a field initializer (`policies?: PolicyResponse[] = []`) and is only overwritten when the property is present, so `emptySyncResponse` — which omits `Policies` — reaches `syncNewPolicies` as `[]`, not `undefined`. The test therefore pins the empty case, which is the bug. Asserting `replace({}, userId)` is both the correct behaviour and a regression test for it.

The genuinely absent case (`policiesNew` and `policies` both `undefined`) still returns early via `source == null`; it is simply not reachable through `SyncResponse`.

## 📸 Screenshots

n/a — no UI changes.

## Verification

- `npx jest libs/common/src/platform/sync/default-sync.service.spec.ts` → 40/40 passing
- The new expectation fails against unpatched `main` with `Number of calls: 0`
- `eslint` and `prettier --check` clean on both changed files

---

Opened from `tom27052006/vw_web_builds` because GitHub allows only one fork per network per account and I already have one there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
