### PR TITLE
[PM-42994] Shared folders grid and Items table needs standard spacing

### DIFF
--- a/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.html
+++ b/libs/vault/src/components/shared-folder-card-grid/shared-folder-card-grid.component.html
@@ -2,6 +2,7 @@
 
 @if (count() > 0) {
   <bit-accordion
+    class="tw-mb-8"
     [title]="'sharedFoldersInParent' | i18n: parentName()"
     variant="subtle"
     [open]="open()"


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-42994)

## 📔 Objective

Add 32 px spacing between shared folder card grid and the cipher item table. Currently adds to the shared component, but can swap to the desktop/web vault components if that is more appropriate.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
web:
<img width="1613" height="1012" alt="Screenshot 2026-09-03 at 11 28 22 AM" src="https://github.com/user-attachments/assets/bf8166a4-a298-40f0-ad9e-c4ed7e4e2cdc" />

desktop:
<img width="1149" height="880" alt="Screenshot 2026-09-03 at 11 28 45 AM" src="https://github.com/user-attachments/assets/cdde3ed6-1bb3-47ff-9401-4baa8056e670" />
