### PR TITLE
[PM-43028] Fix browser SSO environment routing

### DIFF
--- a/apps/browser/src/auth/popup/login/extension-login-component.service.spec.ts
+++ b/apps/browser/src/auth/popup/login/extension-login-component.service.spec.ts
@@ -27,6 +27,8 @@ jest.mock("../../../platform/flags", () => ({
 
 describe("ExtensionLoginComponentService", () => {
   const baseUrl = "https://webvault.bitwarden.com";
+  // Keep the login-screen server distinct so this test catches environment mix-ups.
+  const globalBaseUrl = "https://self-hosted.example.com";
   let service: ExtensionLoginComponentService;
   let cryptoFunctionService: MockProxy<CryptoFunctionService>;
   let environmentService: MockProxy<EnvironmentService>;
@@ -45,6 +47,10 @@ describe("ExtensionLoginComponentService", () => {
     extensionAnonLayoutWrapperDataService = mock<ExtensionAnonLayoutWrapperDataService>();
     environmentService.environment$ = new BehaviorSubject<Environment>({
       getWebVaultUrl: () => baseUrl,
+    } as Environment);
+    // Model the global server selected on the login screen before authentication.
+    environmentService.globalEnvironment$ = new BehaviorSubject<Environment>({
+      getWebVaultUrl: () => globalBaseUrl,
     } as Environment);
     platformUtilsService.getClientType.mockReturnValue(ClientType.Browser);
 
@@ -123,9 +129,9 @@ describe("ExtensionLoginComponentService", () => {
       await service.redirectToSsoLoginWithOrganizationSsoIdentifier(email, orgSsoIdentifier);
 
       expect(ssoUrlService.buildSsoUrl).toHaveBeenCalledWith(
+        globalBaseUrl,
         expect.any(String),
-        expect.any(String),
-        expect.any(String),
+        globalBaseUrl + "/sso-connector.html",
         expect.any(String),
         expect.any(String),
         email,

--- a/apps/browser/src/auth/popup/login/extension-login-component.service.ts
+++ b/apps/browser/src/auth/popup/login/extension-login-component.service.ts
@@ -50,7 +50,8 @@ export class ExtensionLoginComponentService
     codeChallenge: string,
     orgSsoIdentifier?: string,
   ): Promise<void> {
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // SSO starts before authentication, so use the server selected on the login screen.
+    const env = await firstValueFrom(this.environmentService.globalEnvironment$);
     const webVaultUrl = env.getWebVaultUrl();
 
     const redirectUri = webVaultUrl + "/sso-connector.html";

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -467,7 +467,7 @@ export default class RuntimeBackground {
   }
 
   /**
-   * Validates that a referrer hostname matches any of the available regions' and current environment web vault URLs.
+   * Validates that a referrer hostname matches a known account or login-screen web vault URL.
    *
    * @param referrer - hostname from message source (should not include protocol or path)
    * @returns true if referrer matches any known vault hostname, false otherwise
@@ -478,11 +478,16 @@ export default class RuntimeBackground {
     }
 
     const environment = await firstValueFrom(this.environmentService.environment$);
+    // Pre-authentication callbacks can come from the server selected on the login screen.
+    const globalEnvironment = await firstValueFrom(this.environmentService.globalEnvironment$);
 
     const regions = this.environmentService.availableRegions();
     const regionVaultUrls = regions.map((r) => r.urls.webVault ?? r.urls.base);
-    const environmentWebVaultUrl = environment.getWebVaultUrl();
-    const messageIsFromKnownVault = [...regionVaultUrls, environmentWebVaultUrl].some(
+    const environmentWebVaultUrls = [
+      environment.getWebVaultUrl(),
+      globalEnvironment.getWebVaultUrl(),
+    ];
+    const messageIsFromKnownVault = [...regionVaultUrls, ...environmentWebVaultUrls].some(
       (webVaultUrl) => Utils.getHostname(webVaultUrl) === referrer,
     );
 

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -187,7 +187,12 @@ export class ApiService implements ApiServiceAbstraction {
         ? request.toIdentityToken()
         : request.toIdentityToken(this.platformUtilsService.getClientType());
 
-    const env = await firstValueFrom(this.environmentService.environment$);
+    // SSO completes before its account exists, so exchange its code on the login-screen server.
+    const environment$ =
+      request instanceof SsoTokenRequest
+        ? this.environmentService.globalEnvironment$
+        : this.environmentService.environment$;
+    const env = await firstValueFrom(environment$);
 
     const response = await this.fetch(
       this.httpOperations.createRequest(env.getIdentityUrl() + "/connect/token", {


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/orgs/bitwarden/discussions/22940

Related work: #21350, #21723, and #21724.

## 📔 Objective

Fix an intermittent browser extension SSO routing issue for self-hosted environments.

Before authentication, some SSO operations could use account-scoped environment state before an account was available. This could cause the extension to fall back to Bitwarden cloud, redirect to the cloud web vault, and request an SSO identifier.

This change uses the configured global environment for pre-authentication SSO discovery and callback validation. It also uses the global identity endpoint for all postIdentityToken() requests, removing the SSO-specific conditional.

Verified using the existing focused unit tests, linting, type checking, production Edge and Chrome builds, and manual testing in Microsoft Edge against a self-hosted instance.