### PR TITLE
[PM-42991] After selecting a pagination size option the dropdown selection and pagination is no longer clickable

### DIFF
--- a/libs/components/src/bulk-actions-bar/bulk-actions-bar.component.html
+++ b/libs/components/src/bulk-actions-bar/bulk-actions-bar.component.html
@@ -1,4 +1,10 @@
-<div #wrapper class="tw-fixed tw-bottom-0 tw-inset-x-0 tw-z-50 tw-flex tw-justify-center">
+<!-- `pointer-events-none`: the wrapper is an invisible full-width band across the bottom of the
+     viewport. Left hit-testable, it swallows clicks meant for whatever sits under it — a table's
+     own paginator, for one. The bar opts back in while visible, via `barStateClasses`. -->
+<div
+  #wrapper
+  class="tw-pointer-events-none tw-fixed tw-bottom-0 tw-inset-x-0 tw-z-50 tw-flex tw-justify-center"
+>
   <div role="status" aria-live="polite" class="tw-sr-only">
     {{ announcement() }}
   </div>

--- a/libs/components/src/bulk-actions-bar/bulk-actions-bar.component.spec.ts
+++ b/libs/components/src/bulk-actions-bar/bulk-actions-bar.component.spec.ts
@@ -155,9 +155,6 @@ describe("BulkActionsBarComponent", () => {
     );
   });
 
-  // The wrapper is an invisible full-width band across the bottom of the viewport, so it has to
-  // stay out of hit-testing or it swallows clicks on whatever sits under it — a table's paginator,
-  // for one. Only the bar itself takes clicks, and only while it's showing.
   it("keeps hit-testing off the wrapper and on the bar only while visible", () => {
     expect(wrapper().classList).toContain("tw-pointer-events-none");
     expect(innerBar().classList).not.toContain("tw-pointer-events-auto");

--- a/libs/components/src/bulk-actions-bar/bulk-actions-bar.component.spec.ts
+++ b/libs/components/src/bulk-actions-bar/bulk-actions-bar.component.spec.ts
@@ -75,6 +75,7 @@ describe("BulkActionsBarComponent", () => {
 
   const innerBar = () =>
     fixture.debugElement.query(By.css('[role="toolbar"]')).nativeElement as HTMLElement;
+  const wrapper = () => innerBar().parentElement as HTMLElement;
   const outside = () => fixture.nativeElement.querySelector("#outside") as HTMLButtonElement;
   const primaryButtons = (): HTMLButtonElement[] =>
     Array.from(
@@ -152,6 +153,20 @@ describe("BulkActionsBarComponent", () => {
     expect(liveRegion().textContent?.trim()).toBe(
       "3 items selected. The bulk actions bar is now available at the bottom of the screen. Press Ctrl+B to toggle focus to the bulk action bar.",
     );
+  });
+
+  // The wrapper is an invisible full-width band across the bottom of the viewport, so it has to
+  // stay out of hit-testing or it swallows clicks on whatever sits under it — a table's paginator,
+  // for one. Only the bar itself takes clicks, and only while it's showing.
+  it("keeps hit-testing off the wrapper and on the bar only while visible", () => {
+    expect(wrapper().classList).toContain("tw-pointer-events-none");
+    expect(innerBar().classList).not.toContain("tw-pointer-events-auto");
+
+    host.count.set(1);
+    fixture.detectChanges();
+
+    expect(wrapper().classList).toContain("tw-pointer-events-none");
+    expect(innerBar().classList).toContain("tw-pointer-events-auto");
   });
 
   it("renders one toolbar button per projected <bit-bulk-action>", () => {


### PR DESCRIPTION
## 🎟️ Tracking

[Jira](https://bitwarden.atlassian.net/browse/PM-42991)

## 📔 Objective

Fixes the shared folder pagination being unclickable after changing it. Bulk action bar was blocking it in certain scenarios. 
I know `table-v2` isn't final so this might be fixed there instead of here, just let me know if that is the case and I will close this PR.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
Before:

https://github.com/user-attachments/assets/4ed1c7b9-d3d7-4c95-81b6-41e2cd3ce7e4

After:

https://github.com/user-attachments/assets/9d42fa12-d636-4d7d-b310-d271fb36a96a

