### PR TITLE
Web: Add the member adoption report tile component

### DIFF
--- a/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.html
+++ b/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.html
@@ -1,4 +1,4 @@
-<bit-card class="!tw-flex tw-min-h-[152px] tw-flex-col tw-shadow-sm">
+<bit-card class="tw-flex tw-min-h-40 tw-flex-col tw-shadow-sm">
   <div class="tw-flex tw-items-center tw-gap-2">
     <span bitTypography="h6" noMargin data-testid="tile-label">{{ label() }}</span>
     @if (hasInfo()) {
@@ -24,11 +24,11 @@
         {{ value() }}
       </span>
     } @else {
-      <span bitTypography="h3" noMargin class="!tw-text-muted" data-testid="tile-value-empty">
+      <span bitTypography="h3" noMargin class="tw-text-muted" data-testid="tile-value-empty">
         {{ emptyValuePlaceholder }}
       </span>
     }
-    @if (unit() && showUnit()) {
+    @if (showUnit()) {
       <span bitTypography="body2" class="tw-text-muted" data-testid="tile-unit">{{ unit() }}</span>
     }
   </div>

--- a/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.html
+++ b/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.html
@@ -1,0 +1,44 @@
+<bit-card class="!tw-flex tw-min-h-[152px] tw-flex-col tw-shadow-sm">
+  <div class="tw-flex tw-items-center tw-gap-2">
+    <span bitTypography="h6" noMargin data-testid="tile-label">{{ label() }}</span>
+    @if (hasInfo()) {
+      <button
+        type="button"
+        bitLink
+        startIcon="bwi-info-circle"
+        [appA11yTitle]="infoTitleText()"
+        [bitPopoverTriggerFor]="infoPopover"
+        data-testid="tile-info"
+      ></button>
+      <bit-popover #infoPopover [title]="infoTitleText()">
+        <p class="tw-mb-0" data-testid="tile-info-body">{{ infoBodyText() }}</p>
+      </bit-popover>
+    }
+  </div>
+
+  <div class="tw-mt-3 tw-flex tw-items-baseline tw-gap-2">
+    @if (loading()) {
+      <bit-skeleton class="tw-h-7 tw-w-24" data-testid="tile-skeleton"></bit-skeleton>
+    } @else if (hasValue()) {
+      <span bitTypography="h3" noMargin class="tw-tabular-nums" data-testid="tile-value">
+        {{ value() }}
+      </span>
+    } @else {
+      <span bitTypography="h3" noMargin class="!tw-text-muted" data-testid="tile-value-empty">
+        {{ emptyValuePlaceholder }}
+      </span>
+    }
+    @if (unit() && showUnit()) {
+      <span bitTypography="body2" class="tw-text-muted" data-testid="tile-unit">{{ unit() }}</span>
+    }
+  </div>
+
+  @if (sublabel()) {
+    <span
+      bitTypography="body2"
+      class="tw-mt-auto tw-pt-3 tw-text-muted"
+      data-testid="tile-sublabel"
+      >{{ sublabel() }}</span
+    >
+  }
+</bit-card>

--- a/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.spec.ts
@@ -1,0 +1,242 @@
+import { OverlayContainer } from "@angular/cdk/overlay";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { MemberAdoptionTileComponent } from "./member-adoption-tile.component";
+
+describe("MemberAdoptionTileComponent", () => {
+  let fixture: ComponentFixture<MemberAdoptionTileComponent>;
+  let i18nService: MockProxy<I18nService>;
+  let overlayContainer: OverlayContainer;
+  // eslint-disable-next-line no-console
+  const originalError = console.error;
+
+  beforeAll(() => {
+    // eslint-disable-next-line no-console
+    console.error = (...args) => {
+      if (
+        typeof args[0] === "object" &&
+        (args[0] as Error).message?.includes("Could not parse CSS stylesheet")
+      ) {
+        // Opening the overlay container in tests causes stylesheets to be parsed,
+        // which can lead to JSDOM unable to parse CSS errors. These can be ignored safely.
+        return;
+      }
+      originalError(...args);
+    };
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line no-console
+    console.error = originalError;
+  });
+
+  const testId = (id: string) => fixture.debugElement.query(By.css(`[data-testid="${id}"]`));
+  const text = (id: string) => testId(id)?.nativeElement.textContent.trim();
+
+  const overlay = (selector: string) =>
+    overlayContainer.getContainerElement().querySelector(selector);
+
+  const infoButton = () => testId("tile-info").nativeElement as HTMLButtonElement;
+
+  const openPopover = () => {
+    infoButton().click();
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    i18nService = mock<I18nService>();
+    i18nService.t.mockImplementation((key: string) => key);
+
+    await TestBed.configureTestingModule({
+      imports: [MemberAdoptionTileComponent],
+      providers: [{ provide: I18nService, useValue: i18nService }],
+    }).compileComponents();
+
+    overlayContainer = TestBed.inject(OverlayContainer);
+
+    fixture = TestBed.createComponent(MemberAdoptionTileComponent);
+    fixture.componentRef.setInput("label", "Member adoption");
+    fixture.componentRef.setInput("value", "65%");
+  });
+
+  afterEach(() => {
+    overlayContainer.ngOnDestroy();
+  });
+
+  it("renders the label, value, unit and sublabel", () => {
+    fixture.componentRef.setInput("unit", "of members");
+    fixture.componentRef.setInput("sublabel", "Logged in over last 30 days");
+    fixture.detectChanges();
+
+    expect(text("tile-label")).toBe("Member adoption");
+    expect(text("tile-value")).toBe("65%");
+    expect(text("tile-unit")).toBe("of members");
+    expect(text("tile-sublabel")).toBe("Logged in over last 30 days");
+  });
+
+  it("omits the unit and sublabel when they are not supplied", () => {
+    fixture.detectChanges();
+
+    expect(testId("tile-unit")).toBeNull();
+    expect(testId("tile-sublabel")).toBeNull();
+  });
+
+  describe("empty value", () => {
+    it.each(["", "   "])("renders a placeholder instead of the value for %p", (value) => {
+      fixture.componentRef.setInput("value", value);
+      fixture.detectChanges();
+
+      expect(testId("tile-value")).toBeNull();
+      expect(text("tile-value-empty")).toBe("-");
+    });
+
+    it("suppresses the unit so it does not dangle on its own", () => {
+      fixture.componentRef.setInput("value", "");
+      fixture.componentRef.setInput("unit", "of members");
+      fixture.detectChanges();
+
+      expect(testId("tile-unit")).toBeNull();
+    });
+
+    it("keeps the unit beside the skeleton while loading", () => {
+      fixture.componentRef.setInput("value", "");
+      fixture.componentRef.setInput("unit", "of members");
+      fixture.componentRef.setInput("loading", true);
+      fixture.detectChanges();
+
+      expect(text("tile-unit")).toBe("of members");
+    });
+
+    it("renders the value once a non-empty one arrives", () => {
+      fixture.componentRef.setInput("value", "");
+      fixture.detectChanges();
+      fixture.componentRef.setInput("value", "65%");
+      fixture.detectChanges();
+
+      expect(testId("tile-value-empty")).toBeNull();
+      expect(text("tile-value")).toBe("65%");
+    });
+  });
+
+  describe("info popover", () => {
+    const title = "Measuring plan usage";
+    const body = "Plan usage is the share of members who have redeemed this plan.";
+
+    const withInfo = () => {
+      fixture.componentRef.setInput("infoTitle", title);
+      fixture.componentRef.setInput("infoBody", body);
+      fixture.detectChanges();
+    };
+
+    it("is not rendered when neither the title nor the body is supplied", () => {
+      fixture.detectChanges();
+
+      expect(testId("tile-info")).toBeNull();
+    });
+
+    it.each([
+      ["title", { infoTitle: title, infoBody: undefined }],
+      ["body", { infoTitle: undefined, infoBody: body }],
+    ])("is not rendered with only the %s", (_name, inputs) => {
+      fixture.componentRef.setInput("infoTitle", inputs.infoTitle);
+      fixture.componentRef.setInput("infoBody", inputs.infoBody);
+      fixture.detectChanges();
+
+      expect(testId("tile-info")).toBeNull();
+    });
+
+    it("is not rendered when the title or the body is whitespace", () => {
+      fixture.componentRef.setInput("infoTitle", "   ");
+      fixture.componentRef.setInput("infoBody", body);
+      fixture.detectChanges();
+
+      expect(testId("tile-info")).toBeNull();
+    });
+
+    it("is a focusable button named by the title", () => {
+      withInfo();
+
+      const button = infoButton();
+
+      expect(button.tagName).toBe("BUTTON");
+      expect(button.type).toBe("button");
+      expect(button.getAttribute("aria-label")).toBe(title);
+
+      button.focus();
+      expect(document.activeElement).toBe(button);
+
+      button.blur();
+    });
+
+    it("stays closed until the trigger is activated", () => {
+      withInfo();
+
+      expect(infoButton().getAttribute("aria-expanded")).toBe("false");
+      expect(overlay('[data-testid="tile-info-body"]')).toBeNull();
+    });
+
+    it("opens a labelled dialog with the title and the trimmed body", () => {
+      fixture.componentRef.setInput("infoTitle", `  ${title}  `);
+      fixture.componentRef.setInput("infoBody", `  ${body}  `);
+      fixture.detectChanges();
+
+      openPopover();
+
+      expect(infoButton().getAttribute("aria-expanded")).toBe("true");
+
+      const dialog = overlay('[role="dialog"]');
+      expect(dialog?.getAttribute("aria-label")).toBe(title);
+      expect(dialog?.textContent).toContain(title);
+      expect(overlay('[data-testid="tile-info-body"]')?.textContent?.trim()).toBe(body);
+    });
+
+    it("offers a labelled close button that dismisses the popover", () => {
+      withInfo();
+      openPopover();
+
+      const close = overlay("button[bitIconButton]") as HTMLButtonElement;
+      expect(close.getAttribute("aria-label")).toBe("close");
+
+      close.click();
+      fixture.detectChanges();
+
+      expect(overlay('[data-testid="tile-info-body"]')).toBeNull();
+      expect(infoButton().getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("closes again when the trigger is activated a second time", () => {
+      withInfo();
+      openPopover();
+      openPopover();
+
+      expect(overlay('[data-testid="tile-info-body"]')).toBeNull();
+      expect(infoButton().getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
+  describe("loading", () => {
+    it("replaces the value with a skeleton", () => {
+      fixture.componentRef.setInput("loading", true);
+      fixture.componentRef.setInput("unit", "of members");
+      fixture.detectChanges();
+
+      expect(testId("tile-skeleton")).not.toBeNull();
+      expect(testId("tile-value")).toBeNull();
+      expect(text("tile-unit")).toBe("of members");
+    });
+
+    it("shows the value once loading finishes", () => {
+      fixture.componentRef.setInput("loading", true);
+      fixture.detectChanges();
+      fixture.componentRef.setInput("loading", false);
+      fixture.detectChanges();
+
+      expect(testId("tile-skeleton")).toBeNull();
+      expect(text("tile-value")).toBe("65%");
+    });
+  });
+});

--- a/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.spec.ts
@@ -132,26 +132,15 @@ describe("MemberAdoptionTileComponent", () => {
       fixture.detectChanges();
     };
 
-    it("is not rendered when neither the title nor the body is supplied", () => {
-      fixture.detectChanges();
-
-      expect(testId("tile-info")).toBeNull();
-    });
-
-    it.each([
-      ["title", { infoTitle: title, infoBody: undefined }],
-      ["body", { infoTitle: undefined, infoBody: body }],
-    ])("is not rendered with only the %s", (_name, inputs) => {
-      fixture.componentRef.setInput("infoTitle", inputs.infoTitle);
-      fixture.componentRef.setInput("infoBody", inputs.infoBody);
-      fixture.detectChanges();
-
-      expect(testId("tile-info")).toBeNull();
-    });
-
-    it("is not rendered when the title or the body is whitespace", () => {
-      fixture.componentRef.setInput("infoTitle", "   ");
-      fixture.componentRef.setInput("infoBody", body);
+    it.each<[string, string | undefined, string | undefined]>([
+      ["neither is supplied", undefined, undefined],
+      ["only the title is supplied", title, undefined],
+      ["only the body is supplied", undefined, body],
+      ["the title is whitespace", "   ", body],
+      ["the body is whitespace", title, "   "],
+    ])("is not rendered when %s", (_name, infoTitle, infoBody) => {
+      fixture.componentRef.setInput("infoTitle", infoTitle);
+      fixture.componentRef.setInput("infoBody", infoBody);
       fixture.detectChanges();
 
       expect(testId("tile-info")).toBeNull();

--- a/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.ts
+++ b/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.ts
@@ -9,9 +9,6 @@ import {
   TypographyModule,
 } from "@bitwarden/components";
 
-/** Locale-neutral: this component does no i18n. */
-const EMPTY_VALUE_PLACEHOLDER = "-";
-
 /**
  * A metric tile: a label, one large pre-formatted metric with an optional unit, and a sublabel.
  *
@@ -54,7 +51,8 @@ export class MemberAdoptionTileComponent {
 
   readonly loading = input(false);
 
-  protected readonly emptyValuePlaceholder = EMPTY_VALUE_PLACEHOLDER;
+  /** Locale-neutral: this component does no i18n. */
+  protected readonly emptyValuePlaceholder = "-";
 
   protected readonly infoTitleText = computed(() => (this.infoTitle() ?? "").trim());
 
@@ -66,5 +64,7 @@ export class MemberAdoptionTileComponent {
 
   protected readonly hasValue = computed(() => this.value().trim().length > 0);
 
-  protected readonly showUnit = computed(() => this.loading() || this.hasValue());
+  protected readonly showUnit = computed(
+    () => !!this.unit() && (this.loading() || this.hasValue()),
+  );
 }

--- a/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.ts
+++ b/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.component.ts
@@ -1,0 +1,70 @@
+import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
+
+import {
+  A11yTitleDirective,
+  CardComponent,
+  LinkModule,
+  PopoverModule,
+  SkeletonComponent,
+  TypographyModule,
+} from "@bitwarden/components";
+
+/** Locale-neutral: this component does no i18n. */
+const EMPTY_VALUE_PLACEHOLDER = "-";
+
+/**
+ * A metric tile: a label, one large pre-formatted metric with an optional unit, and a sublabel.
+ *
+ * Every input is an already-translated display string; the tile does no i18n and no formatting.
+ */
+@Component({
+  selector: "dirt-member-adoption-tile",
+  templateUrl: "./member-adoption-tile.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    A11yTitleDirective,
+    CardComponent,
+    LinkModule,
+    PopoverModule,
+    SkeletonComponent,
+    TypographyModule,
+  ],
+  host: {
+    class: "tw-block",
+  },
+})
+export class MemberAdoptionTileComponent {
+  readonly label = input.required<string>();
+
+  /** Blank or whitespace renders a muted placeholder and suppresses the unit. */
+  readonly value = input.required<string>();
+
+  readonly unit = input<string>();
+
+  readonly sublabel = input<string>();
+
+  /**
+   * Heading of the info popover, and the trigger's accessible name, so it must stand on its own.
+   * The affordance renders only when both `infoTitle` and `infoBody` are supplied.
+   */
+  readonly infoTitle = input<string>();
+
+  /** Body of the info popover. */
+  readonly infoBody = input<string>();
+
+  readonly loading = input(false);
+
+  protected readonly emptyValuePlaceholder = EMPTY_VALUE_PLACEHOLDER;
+
+  protected readonly infoTitleText = computed(() => (this.infoTitle() ?? "").trim());
+
+  protected readonly infoBodyText = computed(() => (this.infoBody() ?? "").trim());
+
+  protected readonly hasInfo = computed(
+    () => this.infoTitleText().length > 0 && this.infoBodyText().length > 0,
+  );
+
+  protected readonly hasValue = computed(() => this.value().trim().length > 0);
+
+  protected readonly showUnit = computed(() => this.loading() || this.hasValue());
+}

--- a/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.stories.ts
+++ b/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.stories.ts
@@ -1,0 +1,105 @@
+import { Meta, StoryObj, applicationConfig, componentWrapperDecorator } from "@storybook/angular";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { I18nMockService } from "@bitwarden/components";
+
+import { MemberAdoptionTileComponent } from "./member-adoption-tile.component";
+
+export default {
+  title: "Web/Reports/Member Adoption Tile",
+  component: MemberAdoptionTileComponent,
+  decorators: [
+    applicationConfig({
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () => new I18nMockService({ close: "Close" }),
+        },
+      ],
+    }),
+    componentWrapperDecorator(
+      (story) => `<div class="tw-max-w-xs tw-p-6 tw-text-main">${story}</div>`,
+    ),
+  ],
+  args: {
+    label: "Active members",
+    value: "47",
+    unit: "members",
+    sublabel: "Logged in over last 30 days",
+    infoTitle: "Measuring active members",
+    infoBody:
+      "This metric is based on the number of confirmed members who have logged into their vault in the last 30 days.",
+    loading: false,
+  },
+} as Meta;
+
+type Story = StoryObj<MemberAdoptionTileComponent>;
+
+/** Every input supplied. Select the info button to open the popover. */
+export const Default: Story = {};
+
+/** A percentage rather than a count, so the unit reads as a share. */
+export const Percentage: Story = {
+  args: {
+    label: "Sponsored Families Plan usage",
+    value: "48%",
+    unit: "of members",
+    sublabel: "Redeemed plan",
+    infoTitle: "Measuring plan usage",
+    infoBody:
+      "Sponsored Families Plan usage is based on the number of confirmed users who have redeemed this plan out of your organization's total confirmed licensed seats.",
+  },
+};
+
+/** A bare metric, for a tile that needs no unit, sublabel or explanation. */
+export const LabelAndValueOnly: Story = {
+  args: {
+    unit: undefined,
+    sublabel: undefined,
+    infoTitle: undefined,
+    infoBody: undefined,
+  },
+};
+
+/** A count reads on its own, so no unit sits beside it. */
+export const WithoutUnit: Story = {
+  args: {
+    unit: undefined,
+  },
+};
+
+/** Without a sublabel the value stays anchored to the top of the card. */
+export const WithoutSublabel: Story = {
+  args: {
+    sublabel: undefined,
+  },
+};
+
+/** No info button renders, so the label sits alone on its row. */
+export const WithoutPopover: Story = {
+  args: {
+    infoTitle: undefined,
+    infoBody: undefined,
+  },
+};
+
+/** A title with no body cannot fill a popover, so no affordance renders. */
+export const WithoutPopoverBody: Story = {
+  args: {
+    infoBody: undefined,
+  },
+};
+
+/** The skeleton stands in for the value; the unit stays put so the tile does not reflow. */
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};
+
+/** A muted placeholder rather than a blank tile with a dangling unit. */
+export const EmptyValue: Story = {
+  args: {
+    value: "",
+  },
+};

--- a/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.stories.ts
+++ b/apps/web/src/app/dirt/reports/components/member-adoption-tile/member-adoption-tile.stories.ts
@@ -83,13 +83,6 @@ export const WithoutPopover: Story = {
   },
 };
 
-/** A title with no body cannot fill a popover, so no affordance renders. */
-export const WithoutPopoverBody: Story = {
-  args: {
-    infoBody: undefined,
-  },
-};
-
 /** The skeleton stands in for the value; the unit stays put so the tile does not reflow. */
 export const Loading: Story = {
   args: {


### PR DESCRIPTION
## 🎟️ Tracking

PM-35924

## 📔 Objective

Adds `dirt-member-adoption-tile`, the presentational stat tile used by the member adoption report.

- Standalone, `OnPush`, signal inputs. Takes only pre-translated display strings, so the consumer keeps control of locale, rounding and pluralisation.
- The info affordance is a `bit-popover` with a title, body and close button, not a hover tooltip. Built on `bitLink` rather than `bitIconButton` because the latter force feeds its `label` into its own `TooltipDirective`, which would show a hover tooltip and a click popover carrying the same text.
- Renders a muted placeholder and suppresses the unit when `value` is blank, so a missing metric does not leave a dangling unit.
- Includes a Storybook story covering the visual permutations across both themes.

Bottom of a 4 PR stack. `api-client` sits on this.

## 📸 Screenshots

Captured at 1440x1000 on this branch, against a seeded local organization.

### Tile popover

| Popover open |
|---|
| <img src="https://gist.githubusercontent.com/maxkpower/df960c8b22970f362385eca486224b53/raw/popover-active-members.png" alt="tile popover" width="460"> |
