### PR TITLE
Web: Add the member adoption report page

### DIFF
--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report-breadcrumbs.component.html
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report-breadcrumbs.component.html
@@ -1,0 +1,13 @@
+<bit-breadcrumbs>
+  @if (reportsRoute(); as route) {
+    <bit-breadcrumb icon="bwi-sliders" [route]="route">{{ "reports" | i18n }}</bit-breadcrumb>
+  }
+
+  <!--
+    `[route]="[]"` plus `merge` resolves to the current URL, query params and all, which is what
+    keeps this crumb active once the table writes its filter state there.
+  -->
+  <bit-breadcrumb [route]="[]" queryParamsHandling="merge">
+    {{ "memberAdoptionReport" | i18n }}
+  </bit-breadcrumb>
+</bit-breadcrumbs>

--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report-breadcrumbs.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report-breadcrumbs.component.spec.ts
@@ -1,0 +1,106 @@
+import { DebugElement } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { provideRouter } from "@angular/router";
+import { RouterTestingHarness } from "@angular/router/testing";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+
+import { MemberAdoptionReportBreadcrumbsComponent } from "./member-adoption-report-breadcrumbs.component";
+
+const ORGANIZATION_ID = "5a1c0000-0000-4000-8000-00000000000f" as OrganizationId;
+
+const REPORT_URL = `/organizations/${ORGANIZATION_ID}/reporting/reports/member-adoption-report`;
+
+/**
+ * A crumb is projected into `bit-breadcrumbs` as a template rather than an element, so the
+ * `bit-breadcrumb` hosts never reach the DOM — these assert on what each crumb renders as instead:
+ * a link for a crumb pointing elsewhere, and the `aria-current="page"` element for the active one.
+ */
+describe("MemberAdoptionReportBreadcrumbsComponent", () => {
+  let harness: RouterTestingHarness;
+
+  /** @param query Query params on the report URL, as the table writes when a filter is applied. */
+  async function setup(query = ""): Promise<void> {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          {
+            path: "organizations/:organizationId/reporting/reports/member-adoption-report",
+            component: MemberAdoptionReportBreadcrumbsComponent,
+          },
+        ]),
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+      ],
+    });
+
+    harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl(`${REPORT_URL}${query}`);
+  }
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function links(): DebugElement[] {
+    return harness.fixture.debugElement.queryAll(By.css("a[href]"));
+  }
+
+  function activeCrumb(): DebugElement {
+    return harness.fixture.debugElement.query(By.css('[aria-current="page"]'));
+  }
+
+  function separators(): DebugElement[] {
+    return harness.fixture.debugElement.queryAll(By.css(".bwi-angle-right"));
+  }
+
+  it("links the reports crumb to the organization's reports home, not the individual vault's", async () => {
+    await setup();
+
+    const [reports] = links();
+    expect(reports.nativeElement.getAttribute("href")).toBe(
+      `/organizations/${ORGANIZATION_ID}/reporting/reports`,
+    );
+    expect(reports.nativeElement.textContent).toContain("reports");
+  });
+
+  it("gives the reports crumb the side nav's glyph for the reporting section", async () => {
+    await setup();
+
+    const [reports] = links();
+    expect(reports.query(By.css(".bwi-sliders"))).not.toBeNull();
+  });
+
+  it("marks the member adoption crumb as the current page, and does not link it", async () => {
+    await setup();
+
+    const active = activeCrumb();
+    expect(active.nativeElement.textContent).toContain("memberAdoptionReport");
+    expect(active.nativeElement.tagName).not.toBe("A");
+    expect(links()).toHaveLength(1);
+  });
+
+  it("keeps the member adoption crumb current once the table writes its filters to the URL", async () => {
+    await setup("?memberAdoption.search=tanaka");
+
+    expect(activeCrumb().nativeElement.textContent).toContain("memberAdoptionReport");
+  });
+
+  it("exposes the trail as a named navigation landmark", async () => {
+    await setup();
+
+    const nav = harness.fixture.debugElement.query(By.css('[role="navigation"]'));
+    expect(nav).not.toBeNull();
+    expect(nav.nativeElement.getAttribute("aria-label")).toBe("breadcrumbs");
+  });
+
+  it("hides every separator from assistive technology", async () => {
+    await setup();
+
+    expect(separators().length).toBeGreaterThan(0);
+    separators().forEach((separator) => {
+      expect(separator.nativeElement.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+});

--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report-breadcrumbs.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report-breadcrumbs.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { ActivatedRoute } from "@angular/router";
+import { map } from "rxjs";
+
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import { BreadcrumbsModule } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+/** The trail above the member adoption report's header: the organization's reports home, then this page. */
+@Component({
+  selector: "dirt-member-adoption-report-breadcrumbs",
+  templateUrl: "./member-adoption-report-breadcrumbs.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [BreadcrumbsModule, I18nPipe],
+  host: {
+    // `bit-breadcrumbs` sizes itself to its container, so this wrapper has to be one.
+    class: "tw-flex tw-w-full tw-min-w-0",
+  },
+})
+export class MemberAdoptionReportBreadcrumbsComponent {
+  private readonly route = inject(ActivatedRoute);
+
+  private readonly organizationId = toSignal(
+    this.route.params.pipe(map((params) => params.organizationId as OrganizationId | undefined)),
+  );
+
+  /**
+   * Absolute commands for the organization's reports home. Relative commands resolve against the
+   * router state root rather than this page, so the organization id is spelled out.
+   */
+  protected readonly reportsRoute = computed<string[] | undefined>(() => {
+    const organizationId = this.organizationId();
+
+    if (organizationId == null) {
+      return undefined;
+    }
+
+    return ["/organizations", organizationId, "reporting", "reports"];
+  });
+}

--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.html
@@ -62,9 +62,9 @@
   </bit-table-toolbar>
 
   <bit-status-lockup slot="empty">
-    <bit-svg slot="graphic" [content]="emptyIcon()"></bit-svg>
-    <span slot="title">{{ emptyTitleKey() | i18n }}</span>
-    <span slot="description">{{ emptyDescriptionKey() | i18n }}</span>
+    <bit-svg slot="graphic" [content]="emptyState().icon"></bit-svg>
+    <span slot="title">{{ emptyState().titleKey | i18n }}</span>
+    <span slot="description">{{ emptyState().descriptionKey | i18n }}</span>
     <!-- Projection matches static top-level nodes only, so this hides rather than branches. -->
     <button
       id="member-adoption-report_button_retry"

--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.html
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.html
@@ -1,0 +1,135 @@
+<app-header>
+  <dirt-member-adoption-report-breadcrumbs slot="breadcrumbs" />
+</app-header>
+
+<div class="tw-max-w-4xl">
+  <p bitTypography="body1">{{ "memberAdoptionReportDesc" | i18n }}</p>
+</div>
+
+<!-- Failure holds the loading state: a formatted 0% would read as a real measurement. -->
+<div class="tw-mb-6 tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2">
+  <dirt-member-adoption-tile
+    [label]="'activeMembers' | i18n"
+    [value]="activeMemberCount()"
+    [unit]="activeMemberUnitKey() | i18n"
+    [sublabel]="'loggedInOverLast30Days' | i18n"
+    [infoTitle]="'activeMembersPopoverTitle' | i18n"
+    [infoBody]="'activeMembersPopoverBody' | i18n"
+    [loading]="loading() || loadFailed()"
+  />
+  <dirt-member-adoption-tile
+    [label]="'sponsoredFamiliesPlanUsage' | i18n"
+    [value]="sponsoredFamiliesPercent()"
+    [unit]="'ofMembers' | i18n"
+    [sublabel]="'redeemedPlan' | i18n"
+    [infoTitle]="'sponsoredFamiliesPlanUsagePopoverTitle' | i18n"
+    [infoBody]="'sponsoredFamiliesPlanUsagePopoverBody' | i18n"
+    [loading]="loading() || loadFailed()"
+  />
+</div>
+
+<bit-table-v2
+  [tableDef]="table"
+  [filter]="filter"
+  [loading]="loading()"
+  [trackBy]="trackByOrganizationUser"
+  queryParam="memberAdoption"
+>
+  <bit-table-toolbar>
+    <bit-search class="tw-flex-1" [placeholder]="'search' | i18n"></bit-search>
+
+    <button
+      id="member-adoption-report_button_export"
+      slot="end"
+      type="button"
+      bitButton
+      buttonType="secondary"
+      startIcon="bwi-download"
+      [bitAction]="exportReport"
+    >
+      {{ "exportNoun" | i18n }}
+    </button>
+
+    <bit-filter-menu key="recentLogin" [placeholderText]="'recentLogin' | i18n">
+      <bit-filter-option value="yes">{{ "yes" | i18n }}</bit-filter-option>
+      <bit-filter-option value="no">{{ "no" | i18n }}</bit-filter-option>
+    </bit-filter-menu>
+
+    <bit-filter-menu key="extensionInstalled" [placeholderText]="'extensionUsed' | i18n">
+      <bit-filter-option value="yes">{{ "yes" | i18n }}</bit-filter-option>
+      <bit-filter-option value="no">{{ "no" | i18n }}</bit-filter-option>
+    </bit-filter-menu>
+  </bit-table-toolbar>
+
+  <bit-status-lockup slot="empty">
+    <bit-svg slot="graphic" [content]="emptyIcon()"></bit-svg>
+    <span slot="title">{{ emptyTitleKey() | i18n }}</span>
+    <span slot="description">{{ emptyDescriptionKey() | i18n }}</span>
+    <!-- Projection matches static top-level nodes only, so this hides rather than branches. -->
+    <button
+      id="member-adoption-report_button_retry"
+      slot="button"
+      type="button"
+      bitButton
+      buttonType="secondary"
+      class="tw-mb-6"
+      [class.tw-hidden]="!loadFailed()"
+      [bitAction]="retryLoad"
+    >
+      {{ "tryAgain" | i18n }}
+    </button>
+  </bit-status-lockup>
+
+  <bit-column sortable defaultSort="asc" [sortFn]="sortByName" width="minmax(240px, 1fr)">
+    <bit-header-cell>{{ "name" | i18n }}</bit-header-cell>
+
+    <bit-cell *bitCellDef="table.columns.name; let row">
+      {{ displayName(row) }}
+      <!-- Projection matches static top-level nodes only, so this hides rather than branches. -->
+      <span slot="secondary" [class.tw-hidden]="!secondaryEmail(row)">
+        {{ secondaryEmail(row) }}
+      </span>
+    </bit-cell>
+  </bit-column>
+
+  <bit-column sortable [sortFn]="sortByRecentLogin" width="minmax(160px, 200px)">
+    <bit-header-cell>{{ "recentLogin" | i18n }}</bit-header-cell>
+
+    <bit-cell *bitCellDef="table.columns.recentLogin; let row">
+      <span bitBadge [variant]="row.hasRecentLogin ? 'success' : 'warning'">
+        {{ (row.hasRecentLogin ? "yes" : "no") | i18n }}
+      </span>
+    </bit-cell>
+  </bit-column>
+
+  <bit-column sortable [sortFn]="sortByExtensionInstalled" width="minmax(180px, 220px)">
+    <bit-header-cell>{{ "extensionUsed" | i18n }}</bit-header-cell>
+
+    <bit-cell *bitCellDef="table.columns.extensionInstalled; let row">
+      <span bitBadge [variant]="row.hasExtensionInstalled ? 'success' : 'warning'">
+        {{ (row.hasExtensionInstalled ? "yes" : "no") | i18n }}
+      </span>
+    </bit-cell>
+  </bit-column>
+
+  <bit-column sortable [sortFn]="sortByVaultItems" width="minmax(120px, 160px)">
+    <bit-header-cell>{{ "vaultItems" | i18n }}</bit-header-cell>
+
+    <bit-cell *bitCellDef="table.columns.vaultItems; let row">
+      <span class="tw-tabular-nums">{{ formatCount(row.vaultItemCount) }}</span>
+    </bit-cell>
+  </bit-column>
+
+  <bit-column sortable [sortFn]="sortBySharedItems" width="minmax(180px, 220px)">
+    <bit-header-cell>{{ "sharedItems" | i18n }}</bit-header-cell>
+
+    <bit-cell *bitCellDef="table.columns.itemsSharedWithThem; let row">
+      <span class="tw-tabular-nums">{{ formatCount(row.sharedItemCount) }}</span>
+    </bit-cell>
+  </bit-column>
+
+  <bit-table-paginator
+    [pageSize]="pageSize"
+    [pageSizeOptions]="pageSizeOptions"
+  ></bit-table-paginator>
+</bit-table-v2>

--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.spec.ts
@@ -1,0 +1,677 @@
+import { DebugElement, LOCALE_ID } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { provideNoopAnimations } from "@angular/platform-browser/animations";
+import { ActivatedRoute } from "@angular/router";
+import { mock, MockProxy } from "jest-mock-extended";
+import { of } from "rxjs";
+
+import { AccountWarning, NoResults, RegistrationUserAddIcon } from "@bitwarden/assets/svg";
+import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import {
+  BadgeComponent,
+  BitTablePaginatorComponent,
+  BitTableV2Component,
+  DialogService,
+  FilterMenuComponent,
+  SortDirection,
+  SvgComponent,
+  ToastService,
+} from "@bitwarden/components";
+
+import { WebHeaderComponent } from "../../../../../layouts/header/web-header.component";
+
+import {
+  MemberAdoptionReportComponent,
+  MemberAdoptionTableColumn,
+} from "./member-adoption-report.component";
+import { MemberAdoptionReportResponse } from "./response/member-adoption-report.response";
+import { MemberAdoptionReportApiService } from "./services/member-adoption-report-api.service";
+import { memberAdoptionReportPayloadMock } from "./services/member-adoption-report.mock";
+import { MemberAdoptionMemberView } from "./view/member-adoption-report.view";
+
+const ORGANIZATION_ID = "5a1c0000-0000-4000-8000-00000000000f" as OrganizationId;
+
+const emptyPayload = {
+  totalMemberCount: 0,
+  activeMemberCount: 0,
+  inactiveMemberCount: 0,
+  sponsoredFamiliesRedeemedCount: 0,
+  members: [] as unknown[],
+};
+
+const payloadWithTotals = (totals: {
+  totalMemberCount: number;
+  activeMemberCount: number;
+  sponsoredFamiliesRedeemedCount?: number;
+}) => ({
+  ...memberAdoptionReportPayloadMock,
+  sponsoredFamiliesRedeemedCount: 0,
+  ...totals,
+});
+
+describe("MemberAdoptionReportComponent", () => {
+  let fixture: ComponentFixture<MemberAdoptionReportComponent>;
+  let apiService: MockProxy<MemberAdoptionReportApiService>;
+  let logService: MockProxy<LogService>;
+  let fileDownloadService: MockProxy<FileDownloadService>;
+
+  async function render(payload: unknown): Promise<void> {
+    apiService.getMemberAdoptionData.mockResolvedValue(new MemberAdoptionReportResponse(payload));
+
+    fixture = TestBed.createComponent(MemberAdoptionReportComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function renderFailure(): Promise<void> {
+    apiService.getMemberAdoptionData.mockRejectedValue(new Error("boom"));
+
+    fixture = TestBed.createComponent(MemberAdoptionReportComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function click(id: string): Promise<void> {
+    const button = fixture.debugElement.query(By.css(`#${id}`));
+    if (button == null) {
+      throw new Error(`No rendered button #${id}`);
+    }
+    (button.nativeElement as HTMLButtonElement).click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  const tileValues = (): string[] =>
+    fixture.debugElement
+      .queryAll(By.css("[data-testid='tile-value']"))
+      .map((tile) => (tile.nativeElement.textContent as string).trim());
+
+  const tileUnits = (): string[] =>
+    fixture.debugElement
+      .queryAll(By.css("[data-testid='tile-unit']"))
+      .map((tile) => (tile.nativeElement.textContent as string).trim());
+
+  const tileSkeletons = (): DebugElement[] =>
+    fixture.debugElement.queryAll(By.css("[data-testid='tile-skeleton']"));
+
+  const rows = (): DebugElement[] => fixture.debugElement.queryAll(By.css("bit-row"));
+
+  const headerCells = (): DebugElement[] =>
+    fixture.debugElement.queryAll(By.css("[role=columnheader]"));
+
+  const headerLabels = (): string[] =>
+    headerCells().map((cell) =>
+      (cell.nativeElement.textContent as string).replace(/\s+/g, " ").trim(),
+    );
+
+  /** The sort affordance the header cell wraps its content in. */
+  const sharedItemsSortButton = (): HTMLButtonElement =>
+    headerCells()[4].query(By.css("button")).nativeElement as HTMLButtonElement;
+
+  const rowFor = (email: string): DebugElement => {
+    const row = rows().find((candidate) =>
+      (candidate.nativeElement.textContent as string).includes(email),
+    );
+    if (row == null) {
+      throw new Error(`No rendered row for ${email}`);
+    }
+    return row;
+  };
+
+  const renderedNames = (): string[] =>
+    rows().map((row) => {
+      const nameCell = row.query(By.css("[role=cell]")).nativeElement as HTMLElement;
+      const secondary = (nameCell.querySelector("[slot=secondary]")?.textContent ?? "").trim();
+      const full = (nameCell.textContent ?? "").replace(/\s+/g, " ").trim();
+      return secondary ? full.replace(secondary, "").trim() : full;
+    });
+
+  const badgesIn = (row: DebugElement): BadgeComponent[] =>
+    row.queryAll(By.directive(BadgeComponent)).map((badge) => badge.componentInstance);
+
+  /** The badge variant's default icon: the page passes no `[startIcon]`. */
+  const badgeIconsIn = (row: DebugElement): (string | undefined)[] =>
+    row.queryAll(By.directive(BadgeComponent)).map((badge) => {
+      const icon = badge.query(By.css(".bwi"));
+      if (icon == null) {
+        return undefined;
+      }
+      return [...(icon.nativeElement as HTMLElement).classList].find(
+        (name) => name.startsWith("bwi-") && name !== "bwi-fw",
+      );
+    });
+
+  const badgeLabelsIn = (row: DebugElement): string[] =>
+    row
+      .queryAll(By.directive(BadgeComponent))
+      .map((badge) => (badge.nativeElement.textContent as string).trim());
+
+  const table = (): BitTableV2Component<MemberAdoptionMemberView, MemberAdoptionTableColumn> =>
+    fixture.debugElement.query(By.directive(BitTableV2Component)).componentInstance;
+
+  const paginator = (): BitTablePaginatorComponent =>
+    fixture.debugElement.query(By.directive(BitTablePaginatorComponent)).componentInstance;
+
+  const filterMenu = (key: string): FilterMenuComponent => {
+    const menu = fixture.debugElement
+      .queryAll(By.directive(FilterMenuComponent))
+      .map((found) => found.componentInstance as FilterMenuComponent)
+      .find((candidate) => candidate.key() === key);
+    if (menu == null) {
+      throw new Error(`No filter menu for ${key}`);
+    }
+    return menu;
+  };
+
+  const emptyIcon = (): unknown =>
+    (
+      fixture.debugElement.query(By.directive(SvgComponent)).componentInstance as SvgComponent
+    ).content();
+
+  const retryButton = (): DebugElement =>
+    fixture.debugElement.query(By.css("#member-adoption-report_button_retry"));
+
+  /** Page size past twelve, so a sort's last row is the last row overall. */
+  const showEveryRow = (): void => {
+    paginator().pageSize.set(100);
+    fixture.detectChanges();
+  };
+
+  const sortBy = (column: MemberAdoptionTableColumn, direction: SortDirection): void => {
+    table().sort.set({ column, direction });
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    apiService = mock<MemberAdoptionReportApiService>();
+    logService = mock<LogService>();
+    fileDownloadService = mock<FileDownloadService>();
+
+    const i18nService = mock<I18nService>();
+    // Returns the key itself; a key with placeholders reads as `key(arg)`.
+    i18nService.t.mockImplementation((id: string, ...args: unknown[]) => {
+      // `I18nPipe` always passes three positional arguments, so only the filled ones count.
+      const supplied = args.filter((arg) => arg != null);
+      return supplied.length > 0 ? `${id}(${supplied.join(", ")})` : id;
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [MemberAdoptionReportComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ organizationId: ORGANIZATION_ID }),
+            data: of({ titleId: "memberAdoptionReport" }),
+            queryParams: of({}),
+          },
+        },
+        { provide: MemberAdoptionReportApiService, useValue: apiService },
+        { provide: I18nService, useValue: i18nService },
+        { provide: LogService, useValue: logService },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: FileDownloadService, useValue: fileDownloadService },
+      ],
+    })
+      // Keeps the web chrome out of the test.
+      .overrideComponent(WebHeaderComponent, { set: { template: "", imports: [] } })
+      .compileComponents();
+  });
+
+  describe("tiles", () => {
+    it("shows the active member count beside the sponsored plan usage", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      // 8 of 12 active members, 3 of 12 redeemed plans.
+      expect(tileValues()).toEqual(["8", "25%"]);
+    });
+
+    it("shows 0% rather than NaN% for an organization with no members", async () => {
+      await render(emptyPayload);
+
+      expect(tileValues()).toEqual(["0", "0%"]);
+    });
+
+    it("groups a large count for the locale", async () => {
+      await render(payloadWithTotals({ totalMemberCount: 11999, activeMemberCount: 11999 }));
+
+      expect(tileValues()[0]).toBe("11,999");
+    });
+
+    it("groups a large count for a locale that separates thousands differently", async () => {
+      TestBed.overrideProvider(LOCALE_ID, { useValue: "de-DE" });
+
+      await render(payloadWithTotals({ totalMemberCount: 11999, activeMemberCount: 11999 }));
+
+      expect(tileValues()[0]).toBe("11.999");
+    });
+
+    it("floors a non-zero percentage that rounds to zero, so 0% still means nobody", async () => {
+      await render(
+        payloadWithTotals({
+          totalMemberCount: 1000,
+          activeMemberCount: 0,
+          sponsoredFamiliesRedeemedCount: 1,
+        }),
+      );
+
+      expect(tileValues()[1]).toBe("lessThanPercent(1%)");
+    });
+
+    it("caps a percentage that rounds to the whole while a member falls short", async () => {
+      await render(
+        payloadWithTotals({
+          totalMemberCount: 1000,
+          activeMemberCount: 0,
+          sponsoredFamiliesRedeemedCount: 999,
+        }),
+      );
+
+      expect(tileValues()[1]).toBe("moreThanPercent(99%)");
+    });
+
+    it("uses the singular unit for exactly one active member", async () => {
+      await render(payloadWithTotals({ totalMemberCount: 12, activeMemberCount: 1 }));
+
+      expect(tileUnits()[0]).toBe("memberLower");
+    });
+
+    it("uses the plural unit for any other active member count", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      expect(tileUnits()[0]).toBe("membersLower");
+    });
+  });
+
+  describe("table", () => {
+    it("falls back to the email for a member with no name", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      const row = rowFor("invited@example.com");
+      // Once, as the primary line.
+      expect((row.nativeElement.textContent as string).match(/invited@example\.com/g)).toHaveLength(
+        1,
+      );
+    });
+
+    it("badges a member with a recent login and an extension as a success", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      const badges = badgesIn(rowFor("atanaka@example.com"));
+
+      expect(badges.map((badge) => badge.variant())).toEqual(["success", "success"]);
+      expect(badgeIconsIn(rowFor("atanaka@example.com"))).toEqual([
+        "bwi-check-circle",
+        "bwi-check-circle",
+      ]);
+      expect(badgeLabelsIn(rowFor("atanaka@example.com"))).toEqual(["yes", "yes"]);
+    });
+
+    it("badges a missing recent login as a warning, not a failure", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      const badges = badgesIn(rowFor("bwilliams@example.com"));
+
+      expect(badges.map((badge) => badge.variant())).toEqual(["warning", "success"]);
+      expect(badgeIconsIn(rowFor("bwilliams@example.com"))).toEqual([
+        "bwi-exclamation-triangle",
+        "bwi-check-circle",
+      ]);
+      expect(badgeLabelsIn(rowFor("bwilliams@example.com"))).toEqual(["no", "yes"]);
+    });
+
+    it("renders no selection column, so there is nothing to check off", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      expect(
+        fixture.debugElement.queryAll(
+          By.css("bit-row input[type=checkbox], bit-header-row input[type=checkbox]"),
+        ),
+      ).toHaveLength(0);
+      expect(table().selectionModel()).toBeUndefined();
+      expect(rowFor("atanaka@example.com").queryAll(By.css("[role=cell]"))).toHaveLength(5);
+    });
+  });
+
+  describe("column headers", () => {
+    it("labels every column, the shared items one included", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      expect(headerLabels()).toEqual([
+        "name",
+        "recentLogin",
+        "extensionUsed",
+        "vaultItems",
+        "sharedItems",
+      ]);
+    });
+
+    it("sorts by shared items from its own header", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      sharedItemsSortButton().click();
+      fixture.detectChanges();
+
+      expect(table().sort()).toEqual({ column: "itemsSharedWithThem", direction: "asc" });
+      expect(headerCells()[4].nativeElement.getAttribute("aria-sort")).toBe("ascending");
+    });
+  });
+
+  describe("sorting", () => {
+    // Every column is synthetic: none of these names is a field on the row, so each needs a `sortFn`.
+    const cases: {
+      column: MemberAdoptionTableColumn;
+      direction: SortDirection;
+      first: string;
+      last: string;
+    }[] = [
+      { column: "name", direction: "asc", first: "Aiko Tanaka", last: "Tomas Krause" },
+      { column: "name", direction: "desc", first: "Tomas Krause", last: "Aiko Tanaka" },
+      { column: "recentLogin", direction: "asc", first: "Beth Williams", last: "Owen Byrne" },
+      { column: "recentLogin", direction: "desc", first: "Sarah Johnson", last: "Nadia Haddad" },
+      {
+        column: "extensionInstalled",
+        direction: "asc",
+        first: "James Lull",
+        last: "Nadia Haddad",
+      },
+      {
+        column: "extensionInstalled",
+        direction: "desc",
+        first: "Sarah Johnson",
+        last: "Marcus Reed",
+      },
+      {
+        column: "vaultItems",
+        direction: "asc",
+        first: "invited@example.com",
+        last: "Aiko Tanaka",
+      },
+      {
+        column: "vaultItems",
+        direction: "desc",
+        first: "Aiko Tanaka",
+        last: "invited@example.com",
+      },
+      {
+        column: "itemsSharedWithThem",
+        direction: "asc",
+        first: "Beth Williams",
+        last: "Aiko Tanaka",
+      },
+      {
+        column: "itemsSharedWithThem",
+        direction: "desc",
+        first: "Aiko Tanaka",
+        last: "invited@example.com",
+      },
+    ];
+
+    it.each(cases)(
+      "orders $column $direction from $first to $last",
+      async ({ column, direction, first, last }) => {
+        await render(memberAdoptionReportPayloadMock);
+        showEveryRow();
+
+        sortBy(column, direction);
+
+        const ordered = renderedNames();
+        expect(ordered).toHaveLength(12);
+        expect(ordered[0]).toBe(first);
+        expect(ordered[ordered.length - 1]).toBe(last);
+      },
+    );
+
+    it("orders each count column by its own field rather than the other's", async () => {
+      await render(memberAdoptionReportPayloadMock);
+      showEveryRow();
+
+      sortBy("vaultItems", "asc");
+      const byVaultItems = renderedNames();
+
+      sortBy("itemsSharedWithThem", "asc");
+      const bySharedItems = renderedNames();
+
+      expect(byVaultItems).toEqual([
+        "invited@example.com",
+        "Marcus Reed",
+        "Beth Williams",
+        "Nadia Haddad",
+        "James Lull",
+        "Tomas Krause",
+        "Owen Byrne",
+        "Sarah Johnson",
+        "Lena Fischer",
+        "Priya Nair",
+        "Ray Williams",
+        "Aiko Tanaka",
+      ]);
+      expect(bySharedItems).toEqual([
+        "Beth Williams",
+        "invited@example.com",
+        "Marcus Reed",
+        "Nadia Haddad",
+        "James Lull",
+        "Owen Byrne",
+        "Tomas Krause",
+        "Sarah Johnson",
+        "Lena Fischer",
+        "Priya Nair",
+        "Ray Williams",
+        "Aiko Tanaka",
+      ]);
+    });
+  });
+
+  describe("filters", () => {
+    const applyFilter = (key: string, value: string): void => {
+      filterMenu(key).toggle(value);
+      fixture.detectChanges();
+    };
+
+    it("narrows the rows to members without a recent login", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      applyFilter("recentLogin", "no");
+
+      expect(renderedNames()).toEqual([
+        "Beth Williams",
+        "invited@example.com",
+        "Marcus Reed",
+        "Nadia Haddad",
+      ]);
+    });
+
+    it("narrows the rows to members with the extension installed", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      applyFilter("extensionInstalled", "yes");
+
+      expect(rows()).toHaveLength(8);
+    });
+
+    it("combines both chips", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      applyFilter("recentLogin", "no");
+      applyFilter("extensionInstalled", "yes");
+
+      expect(renderedNames()).toEqual(["Beth Williams", "Nadia Haddad"]);
+    });
+
+    it("restores every row when a chip is cleared back to its null cleared value", async () => {
+      await render(memberAdoptionReportPayloadMock);
+      applyFilter("recentLogin", "no");
+
+      filterMenu("recentLogin").clear();
+      fixture.detectChanges();
+
+      // `null`, not `undefined` — the predicate's `filter == null` is what has to catch it.
+      expect(filterMenu("recentLogin").value()).toBeNull();
+      expect(filterMenu("recentLogin").clearedValue()).toBeNull();
+      expect(rows()).toHaveLength(10);
+    });
+  });
+
+  describe("search", () => {
+    // `SearchComponent` is not exported, so `bit-search` is reached by selector.
+    const search = (term: string): void => {
+      const input = fixture.debugElement.query(By.css("bit-search")).componentInstance as {
+        onChange(term: string): void;
+      };
+      input.onChange(term);
+      fixture.detectChanges();
+    };
+
+    it("narrows the rows to a matching email", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      search("nhaddad");
+
+      expect(rows()).toHaveLength(1);
+      expect(rows()[0].nativeElement.textContent).toContain("nhaddad@example.com");
+    });
+
+    it("narrows the rows to a matching name", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      search("sarah");
+
+      expect(rows()).toHaveLength(1);
+      expect(rows()[0].nativeElement.textContent).toContain("Sarah Johnson");
+    });
+
+    it("shows the empty state when nothing matches", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      search("nobody-by-that-name");
+
+      expect(rows()).toHaveLength(0);
+      expect(fixture.nativeElement.textContent).toContain("noMatchingItems");
+      expect(fixture.nativeElement.textContent).toContain("clearFiltersOrTryAnother");
+      expect(emptyIcon()).toBe(NoResults);
+    });
+  });
+
+  describe("pagination", () => {
+    it("pages the members ten at a time", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      expect(rows()).toHaveLength(10);
+      expect(renderedNames()[0]).toBe("Aiko Tanaka");
+    });
+
+    it("shows the remaining members on the next page", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      const next = fixture.debugElement.query(By.css("button[bitIconButton='bwi-angle-right']"));
+      (next.nativeElement as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(renderedNames()).toEqual(["Sarah Johnson", "Tomas Krause"]);
+    });
+
+    it("shows every member once a larger page size is chosen", async () => {
+      await render(memberAdoptionReportPayloadMock);
+
+      fixture.debugElement.query(By.css("bit-select")).triggerEventHandler("ngModelChange", 25);
+      fixture.detectChanges();
+
+      expect(rows()).toHaveLength(12);
+      expect(paginator().pageSize()).toBe(25);
+    });
+  });
+
+  describe("export", () => {
+    it("downloads every member as a CSV for the organization on screen", async () => {
+      await render(memberAdoptionReportPayloadMock);
+      apiService.getMemberAdoptionData.mockClear();
+
+      await click("member-adoption-report_button_export");
+
+      expect(apiService.getMemberAdoptionData).toHaveBeenCalledWith(ORGANIZATION_ID);
+      expect(fileDownloadService.download).toHaveBeenCalledTimes(1);
+
+      const download = fileDownloadService.download.mock.calls[0][0];
+      expect(download.fileName).toMatch(/^bitwarden_member-adoption_export_\d{14}\.csv$/);
+      expect(download.blobOptions).toEqual({ type: "text/plain" });
+      expect(download.blobData).toContain(
+        "Name,Email,Recent login,Extension used,Vault items,Shared items",
+      );
+      expect(download.blobData).toContain("Sarah Johnson,sjohnson@example.com,yes,yes,42,12");
+    });
+  });
+
+  describe("empty state", () => {
+    it("tells the admin there are no members when the organization has none", async () => {
+      await render(emptyPayload);
+
+      expect(rows()).toHaveLength(0);
+      expect(fixture.nativeElement.textContent).toContain("memberAdoptionNoMembers");
+      expect(fixture.nativeElement.textContent).toContain("memberAdoptionNoMembersDesc");
+      expect(emptyIcon()).toBe(RegistrationUserAddIcon);
+    });
+
+    it("offers no retry when the report loaded and simply has nothing to show", async () => {
+      await render(emptyPayload);
+
+      expect((retryButton().nativeElement as HTMLElement).classList).toContain("tw-hidden");
+    });
+  });
+
+  describe("load failure", () => {
+    it("logs the organization it failed for, and no member data", async () => {
+      await renderFailure();
+
+      expect(logService.error).toHaveBeenCalled();
+      const logged = logService.error.mock.calls[0].map((arg) => String(arg)).join(" ");
+      expect(logged).toContain(ORGANIZATION_ID);
+      expect(logged).not.toContain("@");
+      expect(logged).not.toContain("Sarah Johnson");
+    });
+
+    it("leaves the table empty and reports nothing as a measured zero", async () => {
+      await renderFailure();
+
+      expect(rows()).toHaveLength(0);
+      expect(fixture.nativeElement.textContent).not.toContain("0%");
+    });
+
+    it("holds every tile at a skeleton rather than formatting an absent report", async () => {
+      await renderFailure();
+
+      expect(tileSkeletons()).toHaveLength(2);
+      expect(tileValues()).toHaveLength(0);
+    });
+
+    it("says the report is missing and offers a retry", async () => {
+      await renderFailure();
+
+      expect(fixture.nativeElement.textContent).toContain("memberAdoptionLoadError");
+      expect(fixture.nativeElement.textContent).toContain("memberAdoptionLoadErrorDesc");
+      expect(emptyIcon()).toBe(AccountWarning);
+      expect((retryButton().nativeElement as HTMLElement).classList).not.toContain("tw-hidden");
+    });
+
+    it("clears the failure and shows the report once a retry succeeds", async () => {
+      await renderFailure();
+      apiService.getMemberAdoptionData.mockResolvedValue(
+        new MemberAdoptionReportResponse(memberAdoptionReportPayloadMock),
+      );
+
+      await click("member-adoption-report_button_retry");
+
+      expect(tileSkeletons()).toHaveLength(0);
+      expect(tileValues()).toEqual(["8", "25%"]);
+      expect(rows()).toHaveLength(10);
+    });
+  });
+});

--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.spec.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.spec.ts
@@ -132,25 +132,23 @@ describe("MemberAdoptionReportComponent", () => {
       return secondary ? full.replace(secondary, "").trim() : full;
     });
 
-  const badgesIn = (row: DebugElement): BadgeComponent[] =>
-    row.queryAll(By.directive(BadgeComponent)).map((badge) => badge.componentInstance);
-
   /** The badge variant's default icon: the page passes no `[startIcon]`. */
-  const badgeIconsIn = (row: DebugElement): (string | undefined)[] =>
-    row.queryAll(By.directive(BadgeComponent)).map((badge) => {
-      const icon = badge.query(By.css(".bwi"));
-      if (icon == null) {
-        return undefined;
-      }
-      return [...(icon.nativeElement as HTMLElement).classList].find(
-        (name) => name.startsWith("bwi-") && name !== "bwi-fw",
-      );
-    });
+  const badgeIcon = (badge: DebugElement): string | undefined => {
+    const icon = badge.query(By.css(".bwi"));
+    if (icon == null) {
+      return undefined;
+    }
+    return [...(icon.nativeElement as HTMLElement).classList].find(
+      (name) => name.startsWith("bwi-") && name !== "bwi-fw",
+    );
+  };
 
-  const badgeLabelsIn = (row: DebugElement): string[] =>
-    row
-      .queryAll(By.directive(BadgeComponent))
-      .map((badge) => (badge.nativeElement.textContent as string).trim());
+  const badgesIn = (row: DebugElement) =>
+    row.queryAll(By.directive(BadgeComponent)).map((badge) => ({
+      variant: (badge.componentInstance as BadgeComponent).variant(),
+      label: (badge.nativeElement.textContent as string).trim(),
+      icon: badgeIcon(badge),
+    }));
 
   const table = (): BitTableV2Component<MemberAdoptionMemberView, MemberAdoptionTableColumn> =>
     fixture.debugElement.query(By.directive(BitTableV2Component)).componentInstance;
@@ -305,27 +303,19 @@ describe("MemberAdoptionReportComponent", () => {
     it("badges a member with a recent login and an extension as a success", async () => {
       await render(memberAdoptionReportPayloadMock);
 
-      const badges = badgesIn(rowFor("atanaka@example.com"));
-
-      expect(badges.map((badge) => badge.variant())).toEqual(["success", "success"]);
-      expect(badgeIconsIn(rowFor("atanaka@example.com"))).toEqual([
-        "bwi-check-circle",
-        "bwi-check-circle",
+      expect(badgesIn(rowFor("atanaka@example.com"))).toEqual([
+        { variant: "success", label: "yes", icon: "bwi-check-circle" },
+        { variant: "success", label: "yes", icon: "bwi-check-circle" },
       ]);
-      expect(badgeLabelsIn(rowFor("atanaka@example.com"))).toEqual(["yes", "yes"]);
     });
 
     it("badges a missing recent login as a warning, not a failure", async () => {
       await render(memberAdoptionReportPayloadMock);
 
-      const badges = badgesIn(rowFor("bwilliams@example.com"));
-
-      expect(badges.map((badge) => badge.variant())).toEqual(["warning", "success"]);
-      expect(badgeIconsIn(rowFor("bwilliams@example.com"))).toEqual([
-        "bwi-exclamation-triangle",
-        "bwi-check-circle",
+      expect(badgesIn(rowFor("bwilliams@example.com"))).toEqual([
+        { variant: "warning", label: "no", icon: "bwi-exclamation-triangle" },
+        { variant: "success", label: "yes", icon: "bwi-check-circle" },
       ]);
-      expect(badgeLabelsIn(rowFor("bwilliams@example.com"))).toEqual(["no", "yes"]);
     });
 
     it("renders no selection column, so there is nothing to check off", async () => {

--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.ts
@@ -1,0 +1,346 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  LOCALE_ID,
+  signal,
+  TrackByFunction,
+  untracked,
+} from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { ActivatedRoute } from "@angular/router";
+import { map } from "rxjs";
+
+import { AccountWarning, NoResults, RegistrationUserAddIcon } from "@bitwarden/assets/svg";
+import { FileDownloadService } from "@bitwarden/common/platform/abstractions/file-download/file-download.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { OrganizationId } from "@bitwarden/common/types/guid";
+import {
+  AsyncActionsModule,
+  BadgeComponent,
+  BitCellComponent,
+  BitCellDefDirective,
+  BitColumnComponent,
+  BitHeaderCellComponent,
+  BitTablePaginatorComponent,
+  BitTableToolbarComponent,
+  BitTableV2Component,
+  ButtonModule,
+  defineTable,
+  FilterMenuModule,
+  SearchModule,
+  SortFn,
+  StatusLockupComponent,
+  SvgComponent,
+  ToastService,
+  TypographyModule,
+} from "@bitwarden/components";
+import { I18nPipe, safeProvider } from "@bitwarden/ui-common";
+import { ExportHelper } from "@bitwarden/vault-export-core";
+
+import { HeaderModule } from "../../../../../layouts/header/header.module";
+import { MemberAdoptionTileComponent } from "../../../components/member-adoption-tile/member-adoption-tile.component";
+import { exportToCSV } from "../../../report-utils";
+
+import { MemberAdoptionReportBreadcrumbsComponent } from "./member-adoption-report-breadcrumbs.component";
+import { MemberAdoptionReportApiService } from "./services/member-adoption-report-api.service";
+import { MemberAdoptionReportServiceAbstraction } from "./services/member-adoption-report.abstraction";
+import { MemberAdoptionReportService } from "./services/member-adoption-report.service";
+import {
+  memberAdoptionExportHeaders,
+  MemberAdoptionMemberView,
+  MemberAdoptionReportView,
+} from "./view/member-adoption-report.view";
+
+/** Column names do not map to row fields, so every column needs an explicit `sortFn`. */
+export const MEMBER_ADOPTION_COLUMNS = Object.freeze([
+  "name",
+  "recentLogin",
+  "extensionInstalled",
+  "vaultItems",
+  "itemsSharedWithThem",
+] as const);
+
+export type MemberAdoptionTableColumn = (typeof MEMBER_ADOPTION_COLUMNS)[number];
+
+/** A filter chip's value: string-valued so it survives the URL round trip, locale-independent. */
+export type MemberAdoptionBooleanFilter = "yes" | "no";
+
+export type MemberAdoptionTableFilters = {
+  /** Reserved key — the table adopts the projected `bit-search` under it automatically. */
+  search?: string;
+  recentLogin?: MemberAdoptionBooleanFilter;
+  extensionInstalled?: MemberAdoptionBooleanFilter;
+};
+
+const DEFAULT_PAGE_SIZE = 10;
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+function displayName(member: MemberAdoptionMemberView): string {
+  return member.name || member.email;
+}
+
+function matchesBoolean(value: boolean, filter: MemberAdoptionBooleanFilter | undefined): boolean {
+  return filter == null || (filter === "yes") === value;
+}
+
+/**
+ * Organization adoption: two headline tiles over a table of every confirmed member.
+ *
+ * The endpoint returns the whole member list, so search, sort, and pagination run client-side.
+ */
+@Component({
+  selector: "dirt-member-adoption-report",
+  templateUrl: "./member-adoption-report.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    AsyncActionsModule,
+    BadgeComponent,
+    BitCellComponent,
+    BitCellDefDirective,
+    BitColumnComponent,
+    BitHeaderCellComponent,
+    BitTablePaginatorComponent,
+    BitTableToolbarComponent,
+    BitTableV2Component,
+    ButtonModule,
+    FilterMenuModule,
+    HeaderModule,
+    I18nPipe,
+    MemberAdoptionReportBreadcrumbsComponent,
+    MemberAdoptionTileComponent,
+    SearchModule,
+    StatusLockupComponent,
+    SvgComponent,
+    TypographyModule,
+  ],
+  providers: [
+    safeProvider({
+      provide: MemberAdoptionReportServiceAbstraction,
+      useClass: MemberAdoptionReportService,
+      deps: [MemberAdoptionReportApiService, I18nService],
+    }),
+  ],
+})
+export class MemberAdoptionReportComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly reportService = inject(MemberAdoptionReportServiceAbstraction);
+  private readonly fileDownloadService = inject(FileDownloadService);
+  private readonly i18nService = inject(I18nService);
+  private readonly logService = inject(LogService);
+  private readonly toastService = inject(ToastService);
+
+  private readonly locale = inject(LOCALE_ID);
+
+  private readonly percentFormat = new Intl.NumberFormat(this.locale, {
+    style: "percent",
+    maximumFractionDigits: 0,
+  });
+
+  private readonly countFormat = new Intl.NumberFormat(this.locale);
+
+  private readonly organizationId = toSignal(
+    this.route.params.pipe(map((params) => params.organizationId as OrganizationId | undefined)),
+  );
+
+  private readonly report = signal<MemberAdoptionReportView | undefined>(undefined);
+
+  protected readonly loading = signal(true);
+
+  /** Whether the last load threw, so failed metrics read as missing rather than as 0%. */
+  protected readonly loadFailed = signal(false);
+
+  protected readonly members = computed<MemberAdoptionMemberView[]>(
+    () => this.report()?.members ?? [],
+  );
+
+  protected readonly table = defineTable<MemberAdoptionMemberView, MemberAdoptionTableColumn>(
+    this.members,
+  );
+
+  protected readonly trackByOrganizationUser: TrackByFunction<MemberAdoptionMemberView> = (
+    _index,
+    member,
+  ) => member.organizationUserId;
+
+  protected readonly pageSize = DEFAULT_PAGE_SIZE;
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
+
+  /** Separates "filtered down to nothing" from "this organization has no members". */
+  private readonly hasMembers = computed(() => this.members().length > 0);
+
+  /** One `slot="empty"` for all three cases: projection matches static top-level nodes only. */
+  protected readonly emptyTitleKey = computed(() => {
+    if (this.loadFailed()) {
+      return "memberAdoptionLoadError";
+    }
+    return this.hasMembers() ? "noMatchingItems" : "memberAdoptionNoMembers";
+  });
+
+  protected readonly emptyDescriptionKey = computed(() => {
+    if (this.loadFailed()) {
+      return "memberAdoptionLoadErrorDesc";
+    }
+    return this.hasMembers() ? "clearFiltersOrTryAnother" : "memberAdoptionNoMembersDesc";
+  });
+
+  protected readonly emptyIcon = computed(() => {
+    if (this.loadFailed()) {
+      return AccountWarning;
+    }
+    return this.hasMembers() ? NoResults : RegistrationUserAddIcon;
+  });
+
+  protected readonly activeMemberCount = computed(() =>
+    this.countFormat.format(this.report()?.activeMemberCount ?? 0),
+  );
+
+  /** The tile formats nothing of its own, so the count's unit is pluralised here. */
+  protected readonly activeMemberUnitKey = computed(() =>
+    (this.report()?.activeMemberCount ?? 0) === 1 ? "memberLower" : "membersLower",
+  );
+
+  protected readonly sponsoredFamiliesPercent = computed(() =>
+    this.formatPercent(
+      this.report()?.sponsoredFamiliesRedeemedCount ?? 0,
+      this.report()?.totalMemberCount ?? 0,
+    ),
+  );
+
+  protected formatCount(value: number): string {
+    return this.countFormat.format(value);
+  }
+
+  protected readonly displayName = displayName;
+
+  /** Empty when the member has no name: `displayName` already shows their email. */
+  protected secondaryEmail(member: MemberAdoptionMemberView): string {
+    return member.name ? member.email : "";
+  }
+
+  protected readonly sortByName: SortFn = (
+    a: MemberAdoptionMemberView,
+    b: MemberAdoptionMemberView,
+  ) => displayName(a).localeCompare(displayName(b));
+
+  protected readonly sortByRecentLogin: SortFn = (
+    a: MemberAdoptionMemberView,
+    b: MemberAdoptionMemberView,
+  ) => Number(a.hasRecentLogin) - Number(b.hasRecentLogin);
+
+  protected readonly sortByExtensionInstalled: SortFn = (
+    a: MemberAdoptionMemberView,
+    b: MemberAdoptionMemberView,
+  ) => Number(a.hasExtensionInstalled) - Number(b.hasExtensionInstalled);
+
+  protected readonly sortByVaultItems: SortFn = (
+    a: MemberAdoptionMemberView,
+    b: MemberAdoptionMemberView,
+  ) => a.vaultItemCount - b.vaultItemCount;
+
+  protected readonly sortBySharedItems: SortFn = (
+    a: MemberAdoptionMemberView,
+    b: MemberAdoptionMemberView,
+  ) => a.sharedItemCount - b.sharedItemCount;
+
+  protected readonly filter = (
+    member: MemberAdoptionMemberView,
+    values: MemberAdoptionTableFilters,
+  ): boolean =>
+    this.matchesSearch(member, values.search) &&
+    matchesBoolean(member.hasRecentLogin, values.recentLogin) &&
+    matchesBoolean(member.hasExtensionInstalled, values.extensionInstalled);
+
+  constructor() {
+    effect(() => {
+      const organizationId = this.organizationId();
+      if (organizationId == null) {
+        return;
+      }
+      // The load writes the signals this effect would otherwise re-read.
+      untracked(() => {
+        void this.load(organizationId);
+      });
+    });
+  }
+
+  protected readonly exportReport = async (): Promise<void> => {
+    const organizationId = this.organizationId();
+    if (organizationId == null) {
+      return;
+    }
+
+    const exportItems = await this.reportService.getMemberAdoptionExportItems(organizationId);
+
+    this.fileDownloadService.download({
+      fileName: ExportHelper.getFileName("member-adoption"),
+      blobData: exportToCSV(exportItems, memberAdoptionExportHeaders),
+      blobOptions: { type: "text/plain" },
+    });
+  };
+
+  protected readonly retryLoad = async (): Promise<void> => {
+    const organizationId = this.organizationId();
+    if (organizationId == null) {
+      return;
+    }
+
+    await this.load(organizationId);
+  };
+
+  private async load(organizationId: OrganizationId): Promise<void> {
+    this.loading.set(true);
+    this.loadFailed.set(false);
+    try {
+      this.report.set(await this.reportService.getMemberAdoptionReport(organizationId));
+    } catch (error: unknown) {
+      // Ids only: no member data reaches the log.
+      this.logService.error(
+        `[MemberAdoptionReportComponent] Failed to load the member adoption report for organization ${organizationId}`,
+        error,
+      );
+      this.report.set(undefined);
+      this.loadFailed.set(true);
+      this.toastService.showToast({
+        variant: "error",
+        title: "",
+        message: this.i18nService.t("errorOccurred"),
+      });
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  /**
+   * A whole percent of `total`, in the user's locale. Never NaN, and never a clean 0% or 100%
+   * while any member falls the other way.
+   */
+  private formatPercent(part: number, total: number): string {
+    if (total <= 0) {
+      return this.percentFormat.format(0);
+    }
+
+    const ratio = part / total;
+    const rounded = Math.round(ratio * 100);
+
+    if (rounded === 0 && part > 0) {
+      return this.i18nService.t("lessThanPercent", this.percentFormat.format(0.01));
+    }
+    if (rounded === 100 && part < total) {
+      return this.i18nService.t("moreThanPercent", this.percentFormat.format(0.99));
+    }
+
+    return this.percentFormat.format(ratio);
+  }
+
+  private matchesSearch(member: MemberAdoptionMemberView, search: string | undefined): boolean {
+    const term = search?.trim().toLowerCase();
+    if (!term) {
+      return true;
+    }
+    return member.name.toLowerCase().includes(term) || member.email.toLowerCase().includes(term);
+  }
+}

--- a/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.ts
+++ b/apps/web/src/app/dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component.ts
@@ -56,7 +56,7 @@ import {
 } from "./view/member-adoption-report.view";
 
 /** Column names do not map to row fields, so every column needs an explicit `sortFn`. */
-export const MEMBER_ADOPTION_COLUMNS = Object.freeze([
+const MEMBER_ADOPTION_COLUMNS = Object.freeze([
   "name",
   "recentLogin",
   "extensionInstalled",
@@ -79,13 +79,27 @@ export type MemberAdoptionTableFilters = {
 const DEFAULT_PAGE_SIZE = 10;
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 
-function displayName(member: MemberAdoptionMemberView): string {
-  return member.name || member.email;
-}
-
 function matchesBoolean(value: boolean, filter: MemberAdoptionBooleanFilter | undefined): boolean {
   return filter == null || (filter === "yes") === value;
 }
+
+const EMPTY_STATES = Object.freeze({
+  loadFailed: {
+    titleKey: "memberAdoptionLoadError",
+    descriptionKey: "memberAdoptionLoadErrorDesc",
+    icon: AccountWarning,
+  },
+  noMatches: {
+    titleKey: "noMatchingItems",
+    descriptionKey: "clearFiltersOrTryAnother",
+    icon: NoResults,
+  },
+  noMembers: {
+    titleKey: "memberAdoptionNoMembers",
+    descriptionKey: "memberAdoptionNoMembersDesc",
+    icon: RegistrationUserAddIcon,
+  },
+} as const);
 
 /**
  * Organization adoption: two headline tiles over a table of every confirmed member.
@@ -173,25 +187,11 @@ export class MemberAdoptionReportComponent {
   private readonly hasMembers = computed(() => this.members().length > 0);
 
   /** One `slot="empty"` for all three cases: projection matches static top-level nodes only. */
-  protected readonly emptyTitleKey = computed(() => {
+  protected readonly emptyState = computed(() => {
     if (this.loadFailed()) {
-      return "memberAdoptionLoadError";
+      return EMPTY_STATES.loadFailed;
     }
-    return this.hasMembers() ? "noMatchingItems" : "memberAdoptionNoMembers";
-  });
-
-  protected readonly emptyDescriptionKey = computed(() => {
-    if (this.loadFailed()) {
-      return "memberAdoptionLoadErrorDesc";
-    }
-    return this.hasMembers() ? "clearFiltersOrTryAnother" : "memberAdoptionNoMembersDesc";
-  });
-
-  protected readonly emptyIcon = computed(() => {
-    if (this.loadFailed()) {
-      return AccountWarning;
-    }
-    return this.hasMembers() ? NoResults : RegistrationUserAddIcon;
+    return this.hasMembers() ? EMPTY_STATES.noMatches : EMPTY_STATES.noMembers;
   });
 
   protected readonly activeMemberCount = computed(() =>
@@ -214,7 +214,9 @@ export class MemberAdoptionReportComponent {
     return this.countFormat.format(value);
   }
 
-  protected readonly displayName = displayName;
+  protected displayName(member: MemberAdoptionMemberView): string {
+    return member.name || member.email;
+  }
 
   /** Empty when the member has no name: `displayName` already shows their email. */
   protected secondaryEmail(member: MemberAdoptionMemberView): string {
@@ -224,7 +226,7 @@ export class MemberAdoptionReportComponent {
   protected readonly sortByName: SortFn = (
     a: MemberAdoptionMemberView,
     b: MemberAdoptionMemberView,
-  ) => displayName(a).localeCompare(displayName(b));
+  ) => this.displayName(a).localeCompare(this.displayName(b));
 
   protected readonly sortByRecentLogin: SortFn = (
     a: MemberAdoptionMemberView,

--- a/apps/web/src/app/dirt/reports/reports.ts
+++ b/apps/web/src/app/dirt/reports/reports.ts
@@ -1,6 +1,7 @@
 import {
   TwoFactorAuthWebAuthnIcon,
   NoCredentialsIcon,
+  RegistrationUserAddIcon,
   ReportBreach,
   ReportExposedPasswords,
   ReportUnsecuredWebsites,
@@ -22,6 +23,7 @@ export enum ReportType {
   DataBreach = "dataBreach",
   MemberAccessReport = "memberAccessReport",
   PasskeyLogin = "passkeyLogin",
+  MemberAdoptionReport = "memberAdoptionReport",
 }
 
 type ReportWithoutVariant = Omit<ReportEntry, "variant">;
@@ -74,5 +76,11 @@ export const reports: Record<ReportType, ReportWithoutVariant> = {
     description: "passkeyLoginReportMenuDesc",
     route: "passkey-report",
     icon: TwoFactorAuthWebAuthnIcon,
+  },
+  [ReportType.MemberAdoptionReport]: {
+    title: "memberAdoptionReport",
+    description: "memberAdoptionReportDesc",
+    route: "member-adoption-report",
+    icon: RegistrationUserAddIcon,
   },
 };

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -1794,9 +1794,6 @@
   "launchWebsite": {
     "message": "Launch website"
   },
-  "launchWebsite": {
-    "message": "Launch website"
-  },
   "me": {
     "message": "Me"
   },
@@ -1879,9 +1876,6 @@
   },
   "clearAll": {
     "message": "Clear all"
-  },
-  "done": {
-    "message": "Done"
   },
   "filtersSelected": {
     "message": "$COUNT$ selected",
@@ -17585,5 +17579,89 @@
         "example": "Unknown organization"
       }
     }
+  },
+  "memberAdoptionReport": {
+    "message": "Member adoption"
+  },
+  "memberAdoptionReportDesc": {
+    "message": "Track member adoption of Bitwarden with metrics on recent logins, browser extension use, and number of vault items."
+  },
+  "activeMembers": {
+    "message": "Active members"
+  },
+  "sponsoredFamiliesPlanUsage": {
+    "message": "Sponsored Families Plan usage"
+  },
+  "ofMembers": {
+    "message": "of members"
+  },
+  "membersLower": {
+    "message": "members",
+    "description": "Lowercase 'members' used as the unit beside a count, e.g. '8 members'."
+  },
+  "memberLower": {
+    "message": "member",
+    "description": "Lowercase 'member' used as the unit beside a count of one, e.g. '1 member'."
+  },
+  "loggedInOverLast30Days": {
+    "message": "Logged in over last 30 days"
+  },
+  "redeemedPlan": {
+    "message": "Redeemed plan"
+  },
+  "recentLogin": {
+    "message": "Recent login"
+  },
+  "extensionUsed": {
+    "message": "Extension used",
+    "description": "Table column and filter label. Yes means the member has signed in with the browser extension, which does not prove it is still installed."
+  },
+  "sharedItems": {
+    "message": "Shared items",
+    "description": "Table column label for the number of items other members have shared with this member."
+  },
+  "memberAdoptionNoMembers": {
+    "message": "No members to display"
+  },
+  "memberAdoptionNoMembersDesc": {
+    "message": "Members appear here once they join your organization."
+  },
+  "memberAdoptionLoadError": {
+    "message": "Unable to load the member adoption report"
+  },
+  "memberAdoptionLoadErrorDesc": {
+    "message": "The report did not load, so no numbers are shown. Check your connection and try again."
+  },
+  "lessThanPercent": {
+    "message": "<$PERCENT$",
+    "description": "A percentage that rounded down to zero, shown as an upper bound instead, e.g. '<1%'.",
+    "placeholders": {
+      "percent": {
+        "content": "$1",
+        "example": "1%"
+      }
+    }
+  },
+  "moreThanPercent": {
+    "message": ">$PERCENT$",
+    "description": "A percentage that rounded up to the whole, shown as a lower bound instead, e.g. '>99%'.",
+    "placeholders": {
+      "percent": {
+        "content": "$1",
+        "example": "99%"
+      }
+    }
+  },
+  "activeMembersPopoverTitle": {
+    "message": "Measuring active members"
+  },
+  "activeMembersPopoverBody": {
+    "message": "This metric is based on the number of confirmed members who have logged into their vault in the last 30 days."
+  },
+  "sponsoredFamiliesPlanUsagePopoverTitle": {
+    "message": "Measuring plan usage"
+  },
+  "sponsoredFamiliesPlanUsagePopoverBody": {
+    "message": "Sponsored Families Plan usage is based on the number of confirmed users who have redeemed this plan out of your organization's total confirmed licensed seats."
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-35924

## 📔 Objective

Adds the member adoption report page: two stat tiles over a searchable, filterable, paginated member table built on `bit-table-v2`.

- Columns are synthetic, so each carries an explicit `sortFn`. The default accessor would read the column name off the row and sort on `undefined`.
- `Recent login` and `Extension used` render as **warning** badges when false, not danger. A member who has not signed in recently is a nudge, not a failure.
- `Extension used` rather than "installed": the signal comes from devices that have authenticated, so it cannot prove an extension is still installed.
- On a failed load the tiles hold their skeletons and the empty state offers a retry. Without that, the page renders 0% and "no members" for a real organization, which reads as a genuine adoption problem.
- Percentages floor and ceiling to `<1%` and `>99%`, so a rollout is never reported as a clean 0 or 100 while any member falls the other way.

Third of a 4 PR stack, on `api-client`. `flag` sits on this.

## 📸 Screenshots

Captured at 1440x1000 on this branch, against a seeded local organization of 18 confirmed members.

### Report page

| Member adoption report |
|---|
| <img src="https://gist.githubusercontent.com/maxkpower/df960c8b22970f362385eca486224b53/raw/member-adoption-report.png" alt="member adoption report" width="900"> |

### Breadcrumb

| Header |
|---|
| <img src="https://gist.githubusercontent.com/maxkpower/df960c8b22970f362385eca486224b53/raw/breadcrumb.png" alt="breadcrumb" width="460"> |

The page title appears twice because `VFO1Foundation` is off in this environment. With it on, `BreadcrumbsComponent` promotes the active crumb into the `h1` and `bit-header` suppresses its own. That is shared header behaviour, not specific to this page.
