### PR TITLE
Web: Surface the member adoption report behind a feature flag

### DIFF
--- a/apps/web/src/app/admin-console/organizations/reporting/organization-reporting-routing.module.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/reporting/organization-reporting-routing.module.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from "@angular/core/testing";
 import {
   ActivatedRouteSnapshot,
   CanActivateFn,
+  convertToParamMap,
   provideRouter,
   Route,
   Router,
@@ -10,11 +11,23 @@ import {
   UrlTree,
 } from "@angular/router";
 import { mock, MockProxy } from "jest-mock-extended";
+import { of } from "rxjs";
 
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { OrganizationUserType } from "@bitwarden/common/admin-console/enums";
+import { PermissionsApi } from "@bitwarden/common/admin-console/models/api/permissions.api";
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { ProductTierType } from "@bitwarden/common/billing/enums";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
-import { DialogService } from "@bitwarden/components";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
+import { mockAccountServiceWith } from "@bitwarden/common/spec";
+import { UserId } from "@bitwarden/common/types/guid";
+import { SyncService } from "@bitwarden/common/vault/abstractions/sync/sync.service.abstraction";
+import { DialogService, ToastService } from "@bitwarden/components";
 
 import {
   canAccessMemberAdoptionReport,
@@ -25,6 +38,9 @@ const organizationId = "6a3b4c2d-0000-4000-8000-1c9e5f7a2b31";
 
 const snapshotFor = (id: string) =>
   ({ params: { organizationId: id } }) as unknown as ActivatedRouteSnapshot;
+
+const emptyState = () =>
+  ({ root: { queryParamMap: convertToParamMap({}) } }) as unknown as RouterStateSnapshot;
 
 describe("canAccessMemberAdoptionReport", () => {
   let configService: MockProxy<ConfigService>;
@@ -50,7 +66,7 @@ describe("canAccessMemberAdoptionReport", () => {
 
   const run = () =>
     runInInjectionContext(injector, () =>
-      canAccessMemberAdoptionReport()(snapshotFor(organizationId), {} as RouterStateSnapshot),
+      canAccessMemberAdoptionReport()(snapshotFor(organizationId), emptyState()),
     );
 
   it("activates the route when the feature flag is on", async () => {
@@ -95,12 +111,45 @@ describe("canAccessMemberAdoptionReport", () => {
 describe("member adoption report route", () => {
   let configService: MockProxy<ConfigService>;
   let dialogService: MockProxy<DialogService>;
+  let organizationService: MockProxy<OrganizationService>;
+  let syncService: MockProxy<SyncService>;
   let injector: EnvironmentInjector;
+  let router: Router;
   let route: Route;
+
+  const userId = Utils.newGuid() as UserId;
+
+  const orgFactory = (props: Partial<Organization> = {}) =>
+    Object.assign(
+      new Organization(),
+      {
+        id: organizationId,
+        enabled: true,
+        type: OrganizationUserType.Admin,
+        permissions: new PermissionsApi(),
+        productTierType: ProductTierType.Enterprise,
+        useEvents: true,
+      },
+      props,
+    ) as Organization;
+
+  /** A custom role holding accessEventLogs but not accessReports: it clears the reporting tab but not this report. */
+  const eventLogsOnlyMember = (props: Partial<Organization> = {}) =>
+    orgFactory({
+      type: OrganizationUserType.Custom,
+      permissions: Object.assign(new PermissionsApi(), {
+        accessEventLogs: true,
+        accessReports: false,
+      }),
+      ...props,
+    });
 
   beforeEach(() => {
     configService = mock<ConfigService>();
     dialogService = mock<DialogService>();
+    organizationService = mock<OrganizationService>();
+    syncService = mock<SyncService>();
+    syncService.getLastSync.mockResolvedValue(new Date());
 
     TestBed.configureTestingModule({
       imports: [OrganizationReportingRoutingModule],
@@ -108,11 +157,17 @@ describe("member adoption report route", () => {
         { provide: ConfigService, useValue: configService },
         { provide: LogService, useValue: mock<LogService>() },
         { provide: DialogService, useValue: dialogService },
+        { provide: OrganizationService, useValue: organizationService },
+        { provide: AccountService, useValue: mockAccountServiceWith(userId) },
+        { provide: SyncService, useValue: syncService },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: I18nService, useValue: mock<I18nService>() },
         provideRouter([]),
       ],
     });
 
     injector = TestBed.inject(EnvironmentInjector);
+    router = TestBed.inject(Router);
 
     const findRoute = (routes: Route[]): Route | undefined => {
       for (const candidate of routes) {
@@ -127,24 +182,74 @@ describe("member adoption report route", () => {
       return undefined;
     };
 
-    route = findRoute(TestBed.inject(Router).config) as Route;
+    route = findRoute(router.config) as Route;
   });
+
+  /**
+   * Runs the route's registered guards in order, stopping at the first one that does not return
+   * true, the way the router composes them. Returns that guard's result, or true if all pass.
+   */
+  const activate = async (organization: Organization) => {
+    organizationService.organizations$.mockReturnValue(of([organization]));
+
+    for (const guard of (route.canActivate ?? []) as CanActivateFn[]) {
+      const result = await runInInjectionContext(injector, () =>
+        guard(snapshotFor(organizationId), emptyState()),
+      );
+      if (result !== true) {
+        return result;
+      }
+    }
+
+    return true;
+  };
 
   it("is registered under the path its sibling reports use", () => {
     expect(route).toBeDefined();
   });
 
+  it("activates for a member with report access when the feature flag is on", async () => {
+    configService.getFeatureFlag.mockResolvedValue(true);
+
+    await expect(activate(orgFactory())).resolves.toBe(true);
+  });
+
+  it("blocks members without report access before reading the feature flag", async () => {
+    configService.getFeatureFlag.mockResolvedValue(true);
+
+    const result = await activate(eventLogsOnlyMember());
+
+    expect(router.serializeUrl(result as UrlTree)).toBe(`/organizations/${organizationId}`);
+    expect(configService.getFeatureFlag).not.toHaveBeenCalled();
+  });
+
+  it("does not disclose the product tier to members without report access", async () => {
+    configService.getFeatureFlag.mockResolvedValue(true);
+
+    const result = await activate(eventLogsOnlyMember({ productTierType: ProductTierType.Teams }));
+
+    expect(result).not.toBe(true);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
+
+  it("redirects a permitted member to the organization reports page when the flag is off", async () => {
+    configService.getFeatureFlag.mockResolvedValue(false);
+
+    const result = await activate(orgFactory());
+
+    expect(router.serializeUrl(result as UrlTree)).toBe(
+      `/organizations/${organizationId}/reporting/reports`,
+    );
+  });
+
   it("evaluates the feature flag before the product tier guard", async () => {
     configService.getFeatureFlag.mockResolvedValue(false);
 
-    const guards = (route.canActivate ?? []) as CanActivateFn[];
-    expect(guards).toHaveLength(2);
+    const result = await activate(orgFactory({ productTierType: ProductTierType.Teams }));
 
-    const result = await runInInjectionContext(injector, () =>
-      guards[0](snapshotFor(organizationId), {} as RouterStateSnapshot),
+    expect(router.serializeUrl(result as UrlTree)).toBe(
+      `/organizations/${organizationId}/reporting/reports`,
     );
-
-    expect(result).toBeInstanceOf(UrlTree);
     expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/admin-console/organizations/reporting/organization-reporting-routing.module.spec.ts
+++ b/apps/web/src/app/admin-console/organizations/reporting/organization-reporting-routing.module.spec.ts
@@ -1,0 +1,150 @@
+import { EnvironmentInjector, runInInjectionContext } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import {
+  ActivatedRouteSnapshot,
+  CanActivateFn,
+  provideRouter,
+  Route,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from "@angular/router";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
+import { DialogService } from "@bitwarden/components";
+
+import {
+  canAccessMemberAdoptionReport,
+  OrganizationReportingRoutingModule,
+} from "./organization-reporting-routing.module";
+
+const organizationId = "6a3b4c2d-0000-4000-8000-1c9e5f7a2b31";
+
+const snapshotFor = (id: string) =>
+  ({ params: { organizationId: id } }) as unknown as ActivatedRouteSnapshot;
+
+describe("canAccessMemberAdoptionReport", () => {
+  let configService: MockProxy<ConfigService>;
+  let logService: MockProxy<LogService>;
+  let injector: EnvironmentInjector;
+  let router: Router;
+
+  beforeEach(() => {
+    configService = mock<ConfigService>();
+    logService = mock<LogService>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConfigService, useValue: configService },
+        { provide: LogService, useValue: logService },
+        provideRouter([]),
+      ],
+    });
+
+    injector = TestBed.inject(EnvironmentInjector);
+    router = TestBed.inject(Router);
+  });
+
+  const run = () =>
+    runInInjectionContext(injector, () =>
+      canAccessMemberAdoptionReport()(snapshotFor(organizationId), {} as RouterStateSnapshot),
+    );
+
+  it("activates the route when the feature flag is on", async () => {
+    configService.getFeatureFlag.mockResolvedValue(true);
+
+    await expect(run()).resolves.toBe(true);
+    expect(configService.getFeatureFlag).toHaveBeenCalledWith(FeatureFlag.MemberAdoptionReport);
+  });
+
+  it("redirects to the organization reports page when the feature flag is off", async () => {
+    configService.getFeatureFlag.mockResolvedValue(false);
+
+    const result = await run();
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(router.serializeUrl(result as UrlTree)).toBe(
+      `/organizations/${organizationId}/reporting/reports`,
+    );
+  });
+
+  it("does not redirect to the individual vault reports page", async () => {
+    configService.getFeatureFlag.mockResolvedValue(false);
+
+    const result = await run();
+
+    expect(router.serializeUrl(result as UrlTree)).not.toBe("/reports");
+  });
+
+  it("fails closed to the organization reports page when the flag cannot be read", async () => {
+    const error = new Error("config unavailable");
+    configService.getFeatureFlag.mockRejectedValue(error);
+
+    const result = await run();
+
+    expect(router.serializeUrl(result as UrlTree)).toBe(
+      `/organizations/${organizationId}/reporting/reports`,
+    );
+    expect(logService.error).toHaveBeenCalledWith(error);
+  });
+});
+
+describe("member adoption report route", () => {
+  let configService: MockProxy<ConfigService>;
+  let dialogService: MockProxy<DialogService>;
+  let injector: EnvironmentInjector;
+  let route: Route;
+
+  beforeEach(() => {
+    configService = mock<ConfigService>();
+    dialogService = mock<DialogService>();
+
+    TestBed.configureTestingModule({
+      imports: [OrganizationReportingRoutingModule],
+      providers: [
+        { provide: ConfigService, useValue: configService },
+        { provide: LogService, useValue: mock<LogService>() },
+        { provide: DialogService, useValue: dialogService },
+        provideRouter([]),
+      ],
+    });
+
+    injector = TestBed.inject(EnvironmentInjector);
+
+    const findRoute = (routes: Route[]): Route | undefined => {
+      for (const candidate of routes) {
+        if (candidate.path === "member-adoption-report") {
+          return candidate;
+        }
+        const child = candidate.children == null ? undefined : findRoute(candidate.children);
+        if (child != null) {
+          return child;
+        }
+      }
+      return undefined;
+    };
+
+    route = findRoute(TestBed.inject(Router).config) as Route;
+  });
+
+  it("is registered under the path its sibling reports use", () => {
+    expect(route).toBeDefined();
+  });
+
+  it("evaluates the feature flag before the product tier guard", async () => {
+    configService.getFeatureFlag.mockResolvedValue(false);
+
+    const guards = (route.canActivate ?? []) as CanActivateFn[];
+    expect(guards).toHaveLength(2);
+
+    const result = await runInInjectionContext(injector, () =>
+      guards[0](snapshotFor(organizationId), {} as RouterStateSnapshot),
+    );
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/admin-console/organizations/reporting/organization-reporting-routing.module.ts
+++ b/apps/web/src/app/admin-console/organizations/reporting/organization-reporting-routing.module.ts
@@ -137,7 +137,11 @@ const routes: Routes = [
             data: {
               titleId: "memberAdoptionReport",
             },
-            canActivate: [canAccessMemberAdoptionReport(), isEnterpriseOrgGuard()],
+            canActivate: [
+              organizationPermissionsGuard((org) => org.canAccessReports),
+              canAccessMemberAdoptionReport(),
+              isEnterpriseOrgGuard(),
+            ],
           },
         ],
       },

--- a/apps/web/src/app/admin-console/organizations/reporting/organization-reporting-routing.module.ts
+++ b/apps/web/src/app/admin-console/organizations/reporting/organization-reporting-routing.module.ts
@@ -1,10 +1,18 @@
-import { NgModule } from "@angular/core";
-import { RouterModule, Routes } from "@angular/router";
+import { inject, NgModule } from "@angular/core";
+import {
+  ActivatedRouteSnapshot,
+  CanActivateFn,
+  Router,
+  RouterModule,
+  Routes,
+} from "@angular/router";
 
 import { canAccessFeature } from "@bitwarden/angular/platform/guard/feature-flag.guard";
 import { canAccessReportingTab } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { EventsComponent } from "@bitwarden/web-vault/app/dirt/event-logs";
 
 // eslint-disable-next-line no-restricted-imports
@@ -19,11 +27,36 @@ import { ReusedPasswordsReportComponent } from "../../../dirt/reports/pages/orga
 import { UnsecuredWebsitesReportComponent } from "../../../dirt/reports/pages/organizations/unsecured-websites-report.component";
 // eslint-disable-next-line no-restricted-imports
 import { WeakPasswordsReportComponent } from "../../../dirt/reports/pages/organizations/weak-passwords-report.component";
+import { isEnterpriseOrgGuard } from "../guards/is-enterprise-org.guard";
 import { isPaidOrgGuard } from "../guards/is-paid-org.guard";
 import { organizationPermissionsGuard } from "../guards/org-permissions.guard";
 import { organizationRedirectGuard } from "../guards/org-redirect.guard";
 
 import { ReportsHomeComponent } from "./reports-home.component";
+
+/** Feature-flag gate for the member adoption report; the redirect target needs the org id. */
+export function canAccessMemberAdoptionReport(): CanActivateFn {
+  return async (route: ActivatedRouteSnapshot) => {
+    const configService = inject(ConfigService);
+    const logService = inject(LogService);
+    const router = inject(Router);
+
+    const organizationReports = router.createUrlTree([
+      "/organizations",
+      route.params.organizationId,
+      "reporting",
+      "reports",
+    ]);
+
+    try {
+      const enabled = await configService.getFeatureFlag(FeatureFlag.MemberAdoptionReport);
+      return enabled === true ? true : organizationReports;
+    } catch (e) {
+      logService.error(e);
+      return organizationReports;
+    }
+  };
+}
 
 const routes: Routes = [
   {
@@ -94,6 +127,17 @@ const routes: Routes = [
               isPaidOrgGuard(),
               canAccessFeature(FeatureFlag.PasskeyLoginReport, true, "../reports", false),
             ],
+          },
+          {
+            path: "member-adoption-report",
+            loadComponent: () =>
+              import("../../../dirt/reports/pages/organizations/member-adoption-report/member-adoption-report.component").then(
+                (mod) => mod.MemberAdoptionReportComponent,
+              ),
+            data: {
+              titleId: "memberAdoptionReport",
+            },
+            canActivate: [canAccessMemberAdoptionReport(), isEnterpriseOrgGuard()],
           },
         ],
       },

--- a/apps/web/src/app/admin-console/organizations/reporting/reports-home.component.html
+++ b/apps/web/src/app/admin-console/organizations/reporting/reports-home.component.html
@@ -9,6 +9,9 @@
 <router-outlet></router-outlet>
 
 @if (!(homepage$ | async)) {
+  <!-- Clearance for the back button, which is fixed to the viewport outside this scroll region. -->
+  <div class="tw-h-16"></div>
+
   <!-- Focus bridge: redirects Tab to the overlay back button (which is outside cdkTrapFocus) -->
   <span
     tabindex="0"

--- a/apps/web/src/app/admin-console/organizations/reporting/reports-home.component.ts
+++ b/apps/web/src/app/admin-console/organizations/reporting/reports-home.component.ts
@@ -165,6 +165,20 @@ export class ReportsHomeComponent implements OnInit, AfterViewInit, OnDestroy {
       });
     }
 
+    const memberAdoptionReportEnabled = await firstValueFrom(
+      this.configService.getFeatureFlag$(FeatureFlag.MemberAdoptionReport),
+    );
+
+    if (memberAdoptionReportEnabled) {
+      reportsArray.push({
+        ...reports[ReportType.MemberAdoptionReport],
+        variant:
+          productType == ProductTierType.Enterprise
+            ? ReportVariant.Enabled
+            : ReportVariant.RequiresEnterprise,
+      });
+    }
+
     return reportsArray;
   }
 

--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -92,6 +92,7 @@ export enum FeatureFlag {
   AccessIntelligenceReportFileStorage = "pm-31920-access-intelligence-azure-file-storage",
   AccessIntelligenceAdoptionUxImprovements = "pm-34723-access-intelligence-adoption-ux-improvements",
   BrowserExtensionHealthReport = "pm-35928-premium-user-health-reports",
+  MemberAdoptionReport = "pm-35924-member-adoption-report",
 
   /* Vault */
   PM32009NewItemTypes = "pm-32009-new-item-types",
@@ -182,6 +183,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.AccessIntelligenceReportFileStorage]: FALSE,
   [FeatureFlag.AccessIntelligenceAdoptionUxImprovements]: FALSE,
   [FeatureFlag.BrowserExtensionHealthReport]: FALSE,
+  [FeatureFlag.MemberAdoptionReport]: FALSE,
 
   /* Vault */
   [FeatureFlag.PM32009NewItemTypes]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

PM-35924

## 📔 Objective

Surfaces the member adoption report behind `FeatureFlag.MemberAdoptionReport`, for Enterprise organizations.

- Two independent gates: the route guard, and the card in `ReportsHomeComponent.buildReports()`. Both are required, or the card renders and links to a blocked route.
- The flag guard runs **before** the tier guard, so a kill switch is evaluated ahead of an upsell modal.
- The redirect is built from the activated route rather than passed as a static string, because the target contains the organization id. Note the sibling passkey route passes `"../reports"` into the shared guard, which resolves to the individual vault reports page instead.
- Adds a spacer to `reports-home.component.html` so the floating "Back to reports" overlay stops sitting on top of whatever ends the page. The overlay is `position: fixed` at `z-index: 2000`, outside the scrolling region.

Top of a 4 PR stack, on `page`.

## 📸 Screenshots

Screenshots are on the `page` PR, which produces the visible change.
