### PR TITLE
[PM-43057] fix: use a fixed-length mask for hidden custom fields

### DIFF
--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.html
@@ -42,7 +42,7 @@
                 readonly
                 bitInput
                 type="password"
-                [value]="field.value ?? ''"
+                [value]="field.maskedValue ?? ''"
                 aria-readonly="true"
                 [attr.aria-label]="emptyFieldAriaLabel(field)"
                 class="tw-font-mono"

--- a/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.spec.ts
+++ b/libs/vault/src/cipher-view/custom-fields/custom-fields-v2.component.spec.ts
@@ -4,8 +4,9 @@ import { mock } from "jest-mock-extended";
 
 import { EventCollectionService } from "@bitwarden/common/dirt/event-logs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { CipherType } from "@bitwarden/common/vault/enums";
+import { CipherType, FieldType } from "@bitwarden/common/vault/enums";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { FieldView } from "@bitwarden/common/vault/models/view/field.view";
 import { IdentityView } from "@bitwarden/common/vault/models/view/identity.view";
 import { LoginView } from "@bitwarden/common/vault/models/view/login.view";
 
@@ -60,5 +61,25 @@ describe("CustomFieldV2Component", () => {
     fixture.detectChanges();
 
     expect(component.fieldOptions).toEqual(IdentityView.prototype.linkedFieldOptions);
+  });
+
+  it("uses a fixed-length mask for hidden field values", () => {
+    const hiddenField = new FieldView();
+    hiddenField.name = "API key";
+    hiddenField.type = FieldType.Hidden;
+    hiddenField.value = "a-value-with-a-variable-length";
+
+    const cipher = new CipherView();
+    cipher.type = CipherType.Login;
+    cipher.viewPassword = false;
+    cipher.fields = [hiddenField];
+    component.cipher = cipher;
+    fixture.detectChanges();
+
+    const hiddenFieldInput = fixture.nativeElement.querySelector(
+      'input[type="password"]',
+    ) as HTMLInputElement;
+
+    expect(hiddenFieldInput.value).toBe(hiddenField.maskedValue);
   });
 });


### PR DESCRIPTION
## Tracking

Fixes https://github.com/bitwarden/clients/issues/22910

## Objective

Hidden custom fields were bound directly to their raw value while hidden. Because browser password inputs render one dot per character, this exposed the length of the secret.

Use the existing `FieldView.maskedValue` property for hidden custom fields so unrevealed values always display the fixed mask `••••••••`.

Added a regression test verifying that hidden custom-field inputs use `maskedValue`.

## Screenshots
### Before
<img width="749" height="702" alt="Screenshot 2026-09-04 at 10 41 49 AM" src="https://github.com/user-attachments/assets/43975597-d354-4f34-a4c9-442db4005dcf" />
<img width="760" height="696" alt="Screenshot 2026-09-04 at 10 41 37 AM" src="https://github.com/user-attachments/assets/6ff85280-0998-4809-bb47-beaf48feb775" />

### After
<img width="737" height="616" alt="Screenshot 2026-09-04 at 10 34 07 AM" src="https://github.com/user-attachments/assets/def77962-f3be-4ef3-934f-8b29ced85926" />


## Validation

- Verified the original behavior locally: masked values had different visible lengths.
- Verified the fix locally: short and long hidden values both display the same fixed-length mask.
- Confirmed the reveal control still shows the original value.
- Added a focused unit test for the mask binding.
- Prettier and ESLint completed successfully through the commit hook.