### PR TITLE
A failed list load renders as the empty state on all three rotation tabs

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19174,6 +19174,12 @@
   "pamRotationConfigEmptyStateDescription": {
     "message": "Add a managed credential to start rotating it automatically."
   },
+  "pamRotationListLoadErrorTitle": {
+    "message": "Unable to load this list"
+  },
+  "pamRotationListLoadErrorDescription": {
+    "message": "Check your connection and try again. If the problem continues, refresh the page."
+  },
   "pamRotationConfigNoTargetSystems": {
     "message": "Set up a target system before you can rotate credentials. A target system defines where a credential lives and how Bitwarden rotates it."
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -8,6 +8,24 @@
 
 @if (loading()) {
   <bit-spinner />
+} @else if (loadError()) {
+  <div role="alert" data-testid="daemons-load-error">
+    <bit-status-lockup>
+      <bit-svg slot="graphic" [content]="loadErrorIcon"></bit-svg>
+      <span slot="title">{{ "pamRotationListLoadErrorTitle" | i18n }}</span>
+      <span slot="description">{{ "pamRotationListLoadErrorDescription" | i18n }}</span>
+      <button
+        slot="button"
+        type="button"
+        bitButton
+        buttonType="primary"
+        id="daemons-tab_button_retry-load"
+        (click)="retryLoad()"
+      >
+        {{ "tryAgain" | i18n }}
+      </button>
+    </bit-status-lockup>
+  </div>
 } @else if (totalRows() === 0) {
   <bit-status-lockup>
     <bit-svg slot="graphic" [content]="noItemsIcon"></bit-svg>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -9,23 +9,7 @@
 @if (loading()) {
   <bit-spinner />
 } @else if (loadError()) {
-  <div role="alert" data-testid="daemons-load-error">
-    <bit-status-lockup>
-      <bit-svg slot="graphic" [content]="loadErrorIcon"></bit-svg>
-      <span slot="title">{{ "pamRotationListLoadErrorTitle" | i18n }}</span>
-      <span slot="description">{{ "pamRotationListLoadErrorDescription" | i18n }}</span>
-      <button
-        slot="button"
-        type="button"
-        bitButton
-        buttonType="primary"
-        id="daemons-tab_button_retry-load"
-        (click)="retryLoad()"
-      >
-        {{ "tryAgain" | i18n }}
-      </button>
-    </bit-status-lockup>
-  </div>
+  <pam-rotation-load-error (retry)="retryLoad()" />
 } @else if (totalRows() === 0) {
   <bit-status-lockup>
     <bit-svg slot="graphic" [content]="noItemsIcon"></bit-svg>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
@@ -23,6 +24,7 @@ describe("DaemonsTabComponent", () => {
 
   const rows$ = new BehaviorSubject<DaemonRow[]>([]);
   const loading$ = new BehaviorSubject<boolean>(false);
+  const loadError$ = new BehaviorSubject<unknown | null>(null);
 
   function makeDaemonRow(overrides: Partial<DaemonRow> = {}): DaemonRow {
     return {
@@ -47,6 +49,7 @@ describe("DaemonsTabComponent", () => {
   beforeEach(async () => {
     daemonsService = {
       loading$: loading$.asObservable(),
+      loadError$: loadError$.asObservable(),
       rows$: rows$.asObservable(),
       load: jest.fn().mockResolvedValue(undefined),
       registerCompleted: jest.fn().mockResolvedValue(undefined),
@@ -209,5 +212,62 @@ describe("DaemonsTabComponent", () => {
     await component.unassign(daemon, sysId("ts-1"), "Prod");
 
     expect(daemonsService.unassign).toHaveBeenCalledWith(daemon, sysId("ts-1"));
+  });
+
+  describe("load error state", () => {
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+      loadError$.next(null);
+      rows$.next([]);
+      loading$.next(false);
+
+      await TestBed.configureTestingModule({
+        imports: [DaemonsTabComponent, NoopAnimationsModule],
+        providers: [
+          provideRouter([]),
+          { provide: DaemonsService, useValue: daemonsService },
+          { provide: TargetSystemsService, useValue: targetSystemsService },
+          { provide: DialogService, useValue: dialogService },
+          { provide: ToastService, useValue: toastService },
+          { provide: I18nService, useValue: i18nService },
+          {
+            provide: ActivatedRoute,
+            useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
+          },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(DaemonsTabComponent);
+      fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      loadError$.next(null);
+    });
+
+    it("renders the load-error state instead of the empty state", () => {
+      loadError$.next(new Error("boom"));
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('[data-testid="daemons-load-error"]')).not.toBeNull();
+      expect(el.textContent).toContain("pamRotationListLoadErrorTitle");
+      expect(el.textContent).not.toContain("pamDaemonEmptyStateTitle");
+    });
+
+    it("retries both loads from the error state", async () => {
+      loadError$.next(new Error("boom"));
+      fixture.detectChanges();
+      (daemonsService.load as jest.Mock).mockClear();
+      (targetSystemsService.load as jest.Mock).mockClear();
+
+      (fixture.nativeElement as HTMLElement)
+        .querySelector<HTMLButtonElement>("#daemons-tab_button_retry-load")!
+        .click();
+      await fixture.whenStable();
+
+      expect(daemonsService.load).toHaveBeenCalledWith(ORGANIZATION_ID);
+      expect(targetSystemsService.load).toHaveBeenCalledWith(ORGANIZATION_ID);
+    });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -46,6 +46,35 @@ describe("DaemonsTabComponent", () => {
     };
   }
 
+  async function createComponent({ renderTemplate = false } = {}) {
+    if (!renderTemplate) {
+      // Override the template to avoid CDK overlay and other browser-only concerns
+      // in tests focused on component logic and service interactions.
+      TestBed.overrideComponent(DaemonsTabComponent, { set: { template: "" } });
+    }
+
+    await TestBed.configureTestingModule({
+      imports: [DaemonsTabComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        { provide: DaemonsService, useValue: daemonsService },
+        { provide: TargetSystemsService, useValue: targetSystemsService },
+        { provide: DialogService, useValue: dialogService },
+        { provide: ToastService, useValue: toastService },
+        { provide: I18nService, useValue: i18nService },
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DaemonsTabComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
   beforeEach(async () => {
     daemonsService = {
       loading$: loading$.asObservable(),
@@ -70,30 +99,7 @@ describe("DaemonsTabComponent", () => {
       t: (key: string) => key,
     } as unknown as jest.Mocked<I18nService>;
 
-    // Overrides the template to avoid CDK overlay and other browser-only concerns in these
-    // logic-focused tests.
-    TestBed.overrideComponent(DaemonsTabComponent, { set: { template: "" } });
-
-    await TestBed.configureTestingModule({
-      imports: [DaemonsTabComponent],
-      providers: [
-        provideRouter([]),
-        { provide: DaemonsService, useValue: daemonsService },
-        { provide: TargetSystemsService, useValue: targetSystemsService },
-        { provide: DialogService, useValue: dialogService },
-        { provide: ToastService, useValue: toastService },
-        { provide: I18nService, useValue: i18nService },
-        {
-          provide: ActivatedRoute,
-          useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
-        },
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(DaemonsTabComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await createComponent();
   });
 
   it("calls daemonsService.load on init", async () => {
@@ -221,24 +227,7 @@ describe("DaemonsTabComponent", () => {
       rows$.next([]);
       loading$.next(false);
 
-      await TestBed.configureTestingModule({
-        imports: [DaemonsTabComponent, NoopAnimationsModule],
-        providers: [
-          provideRouter([]),
-          { provide: DaemonsService, useValue: daemonsService },
-          { provide: TargetSystemsService, useValue: targetSystemsService },
-          { provide: DialogService, useValue: dialogService },
-          { provide: ToastService, useValue: toastService },
-          { provide: I18nService, useValue: i18nService },
-          {
-            provide: ActivatedRoute,
-            useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
-          },
-        ],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(DaemonsTabComponent);
-      fixture.detectChanges();
+      await createComponent({ renderTemplate: true });
     });
 
     afterEach(() => {
@@ -250,7 +239,7 @@ describe("DaemonsTabComponent", () => {
       fixture.detectChanges();
 
       const el = fixture.nativeElement as HTMLElement;
-      expect(el.querySelector('[data-testid="daemons-load-error"]')).not.toBeNull();
+      expect(el.querySelector("pam-rotation-load-error")).not.toBeNull();
       expect(el.textContent).toContain("pamRotationListLoadErrorTitle");
       expect(el.textContent).not.toContain("pamDaemonEmptyStateTitle");
     });
@@ -262,7 +251,7 @@ describe("DaemonsTabComponent", () => {
       (targetSystemsService.load as jest.Mock).mockClear();
 
       (fixture.nativeElement as HTMLElement)
-        .querySelector<HTMLButtonElement>("#daemons-tab_button_retry-load")!
+        .querySelector<HTMLButtonElement>("#rotation-load-error_button_retry")!
         .click();
       await fixture.whenStable();
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -5,7 +5,7 @@ import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 
-import { NoResults, ReportBreach } from "@bitwarden/assets/svg";
+import { NoResults } from "@bitwarden/assets/svg";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
@@ -30,6 +30,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { AccessConnector, DaemonStatus, TargetSystemId, TargetSystem } from "../rotation";
+import { RotationLoadErrorComponent } from "../rotation-load-error.component";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 
 import { AssignTargetDialogComponent } from "./assign-target-dialog.component";
@@ -55,6 +56,7 @@ import { DaemonRow, DaemonsService } from "./daemons.service";
     StatusLockupComponent,
     SvgComponent,
     TableModule,
+    RotationLoadErrorComponent,
     I18nPipe,
   ],
 })
@@ -63,7 +65,6 @@ export class DaemonsTabComponent {
   protected readonly DaemonStatus = DaemonStatus;
 
   protected readonly noItemsIcon = NoResults;
-  protected readonly loadErrorIcon = ReportBreach;
 
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
@@ -74,9 +75,7 @@ export class DaemonsTabComponent {
   private readonly i18nService = inject(I18nService);
 
   protected readonly loading = toSignal(this.daemonsService.loading$, { initialValue: true });
-  protected readonly loadError = toSignal(this.daemonsService.loadError$, {
-    initialValue: null as unknown,
-  });
+  protected readonly loadError = toSignal(this.daemonsService.loadError$, { initialValue: null });
   private readonly rows = toSignal(this.daemonsService.rows$, { initialValue: [] as DaemonRow[] });
   private readonly activeAutomaticSystems = toSignal(
     this.targetSystemsService.activeAutomaticSystems$,
@@ -94,11 +93,7 @@ export class DaemonsTabComponent {
 
   constructor() {
     effect(() => {
-      const organizationId = this.organizationId();
-      void this.daemonsService.load(organizationId);
-      // Assignment badges and assign-dialog options join against the target-systems map; loads
-      // it too, in case this tab is visited first.
-      void this.targetSystemsService.load(organizationId);
+      void this.loadAll(this.organizationId());
     });
 
     effect(() => {
@@ -113,14 +108,23 @@ export class DaemonsTabComponent {
 
   protected readonly totalRows = computed(() => this.rows().length);
 
-  /** Re-runs the same pair of loads the init effect runs, so a retry matches a fresh navigation. */
-  protected readonly retryLoad = async (): Promise<void> => {
-    const organizationId = this.organizationId();
+  /**
+   * The assignment badges and the assign-dialog options join against the target-systems map, so
+   * this tab loads it alongside its own list, in case it is visited first (the shell-scoped
+   * TargetSystemsService instance starts empty).
+   */
+  /**
+   * Assignment badges and assign-dialog options join against the target-systems map, so that loads
+   * too, in case this tab is visited first.
+   */
+  private async loadAll(organizationId: OrganizationId): Promise<void> {
     await Promise.all([
       this.daemonsService.load(organizationId),
       this.targetSystemsService.load(organizationId),
     ]);
-  };
+  }
+
+  protected readonly retryLoad = (): Promise<void> => this.loadAll(this.organizationId());
 
   /** Navigate to the daemon detail page (sibling of the shell). */
   protected readonly openDetail = (row: DaemonRow): Promise<boolean> =>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -5,7 +5,7 @@ import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 
-import { NoResults } from "@bitwarden/assets/svg";
+import { NoResults, ReportBreach } from "@bitwarden/assets/svg";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
@@ -63,6 +63,7 @@ export class DaemonsTabComponent {
   protected readonly DaemonStatus = DaemonStatus;
 
   protected readonly noItemsIcon = NoResults;
+  protected readonly loadErrorIcon = ReportBreach;
 
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
@@ -73,6 +74,9 @@ export class DaemonsTabComponent {
   private readonly i18nService = inject(I18nService);
 
   protected readonly loading = toSignal(this.daemonsService.loading$, { initialValue: true });
+  protected readonly loadError = toSignal(this.daemonsService.loadError$, {
+    initialValue: null as unknown,
+  });
   private readonly rows = toSignal(this.daemonsService.rows$, { initialValue: [] as DaemonRow[] });
   private readonly activeAutomaticSystems = toSignal(
     this.targetSystemsService.activeAutomaticSystems$,
@@ -108,6 +112,15 @@ export class DaemonsTabComponent {
   }
 
   protected readonly totalRows = computed(() => this.rows().length);
+
+  /** Re-runs the same pair of loads the init effect runs, so a retry matches a fresh navigation. */
+  protected readonly retryLoad = async (): Promise<void> => {
+    const organizationId = this.organizationId();
+    await Promise.all([
+      this.daemonsService.load(organizationId),
+      this.targetSystemsService.load(organizationId),
+    ]);
+  };
 
   /** Navigate to the daemon detail page (sibling of the shell). */
   protected readonly openDetail = (row: DaemonRow): Promise<boolean> =>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.spec.ts
@@ -78,6 +78,26 @@ describe("DaemonsService", () => {
       const loading = await firstValue(service.loading$);
       expect(loading).toBe(false);
     });
+
+    it("records the failure and clears loading when the API throws", async () => {
+      const failure = new Error("network fail");
+      rotationSdk.listConnectors.mockRejectedValue(failure);
+
+      await expect(service.load(orgId)).resolves.toBeUndefined();
+
+      expect(await firstValue(service.loading$)).toBe(false);
+      expect(await firstValue(service.loadError$)).toBe(failure);
+    });
+
+    it("clears a previous failure at the start of the next load", async () => {
+      rotationSdk.listConnectors.mockRejectedValueOnce(new Error("network fail"));
+      await service.load(orgId);
+      rotationSdk.listConnectors.mockResolvedValue([makeDaemon()]);
+
+      await service.load(orgId);
+
+      expect(await firstValue(service.loadError$)).toBeNull();
+    });
   });
 
   describe("rows$ projection", () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.spec.ts
@@ -33,9 +33,11 @@ describe("DaemonsService", () => {
   let rotationSdk: jest.Mocked<RotationSdkService>;
   let targetSystemsService: jest.Mocked<TargetSystemsService>;
   let systemById$: BehaviorSubject<Map<TargetSystemId, TargetSystem>>;
+  let targetSystemsLoadError$: BehaviorSubject<unknown | null>;
 
   beforeEach(() => {
     systemById$ = new BehaviorSubject<Map<TargetSystemId, TargetSystem>>(new Map());
+    targetSystemsLoadError$ = new BehaviorSubject<unknown | null>(null);
 
     rotationSdk = {
       listConnectors: jest.fn().mockResolvedValue([]),
@@ -48,6 +50,7 @@ describe("DaemonsService", () => {
 
     targetSystemsService = {
       systemById$: systemById$.asObservable(),
+      loadError$: targetSystemsLoadError$.asObservable(),
     } as unknown as jest.Mocked<TargetSystemsService>;
 
     TestBed.configureTestingModule({
@@ -97,6 +100,15 @@ describe("DaemonsService", () => {
       await service.load(orgId);
 
       expect(await firstValue(service.loadError$)).toBeNull();
+    });
+
+    it("reports a target-systems failure even when the daemon list loads", async () => {
+      const failure = new Error("target systems fail");
+
+      await service.load(orgId);
+      targetSystemsLoadError$.next(failure);
+
+      expect(await firstValue(service.loadError$)).toBe(failure);
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
@@ -52,9 +52,13 @@ export class DaemonsService {
 
   private readonly _daemons$ = new BehaviorSubject<AccessConnector[]>([]);
   private readonly _loading$ = new BehaviorSubject<boolean>(true);
+  private readonly _loadError$ = new BehaviorSubject<unknown | null>(null);
 
   readonly daemons$: Observable<AccessConnector[]> = this._daemons$.asObservable();
   readonly loading$: Observable<boolean> = this._loading$.asObservable();
+
+  /** The error from the last {@link load}, or null when it succeeded. */
+  readonly loadError$: Observable<unknown | null> = this._loadError$.asObservable();
 
   /** Daemons projected into presentation rows, joined with target-system names; updates with either source. */
   readonly rows$: Observable<DaemonRow[]> = combineLatest([
@@ -62,12 +66,20 @@ export class DaemonsService {
     this.targetSystemsService.systemById$,
   ]).pipe(map(([daemons, systemById]) => this.buildRows(daemons, systemById)));
 
-  /** Fetch the org's daemons, replacing local state. */
+  /**
+   * Fetch the org's daemons, replacing local state.
+   *
+   * Records a failure on {@link loadError$} rather than rejecting: every caller invokes this as
+   * `void load(...)`, so a rejection would leave the tab rendering its empty state.
+   */
   async load(organizationId: OrganizationId): Promise<void> {
     this.organizationId = organizationId;
     this._loading$.next(true);
+    this._loadError$.next(null);
     try {
       this._daemons$.next(await this.rotationSdk.listConnectors(organizationId));
+    } catch (e) {
+      this._loadError$.next(e);
     } finally {
       this._loading$.next(false);
     }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
@@ -57,8 +57,16 @@ export class DaemonsService {
   readonly daemons$: Observable<AccessConnector[]> = this._daemons$.asObservable();
   readonly loading$: Observable<boolean> = this._loading$.asObservable();
 
-  /** The error from the last {@link load}, or null when it succeeded. */
-  readonly loadError$: Observable<unknown | null> = this._loadError$.asObservable();
+  /**
+   * The error from the last {@link load}, or null when it succeeded. Covers the target-systems
+   * fetch too: it records its own failure instead of rejecting, so nothing else reports it, and
+   * without it {@link rows$} renders every assignment as a raw id and the assign dialog offers no
+   * targets.
+   */
+  readonly loadError$: Observable<unknown | null> = combineLatest([
+    this._loadError$,
+    this.targetSystemsService.loadError$,
+  ]).pipe(map(([own, targetSystemsError]) => own ?? targetSystemsError));
 
   /** Daemons projected into presentation rows, joined with target-system names; updates with either source. */
   readonly rows$: Observable<DaemonRow[]> = combineLatest([

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -1,23 +1,7 @@
 @if (loading()) {
   <bit-spinner />
 } @else if (loadError()) {
-  <div role="alert" data-testid="managed-credentials-load-error">
-    <bit-status-lockup>
-      <bit-svg slot="graphic" [content]="loadErrorIcon"></bit-svg>
-      <span slot="title">{{ "pamRotationListLoadErrorTitle" | i18n }}</span>
-      <span slot="description">{{ "pamRotationListLoadErrorDescription" | i18n }}</span>
-      <button
-        slot="button"
-        type="button"
-        bitButton
-        buttonType="primary"
-        id="managed-credentials-tab_button_retry-load"
-        (click)="retryLoad()"
-      >
-        {{ "tryAgain" | i18n }}
-      </button>
-    </bit-status-lockup>
-  </div>
+  <pam-rotation-load-error (retry)="retryLoad()" />
 } @else if (!hasTargetSystems()) {
   <bit-status-lockup>
     <bit-svg slot="graphic" [content]="noItemsIcon"></bit-svg>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -1,5 +1,23 @@
 @if (loading()) {
   <bit-spinner />
+} @else if (loadError()) {
+  <div role="alert" data-testid="managed-credentials-load-error">
+    <bit-status-lockup>
+      <bit-svg slot="graphic" [content]="loadErrorIcon"></bit-svg>
+      <span slot="title">{{ "pamRotationListLoadErrorTitle" | i18n }}</span>
+      <span slot="description">{{ "pamRotationListLoadErrorDescription" | i18n }}</span>
+      <button
+        slot="button"
+        type="button"
+        bitButton
+        buttonType="primary"
+        id="managed-credentials-tab_button_retry-load"
+        (click)="retryLoad()"
+      >
+        {{ "tryAgain" | i18n }}
+      </button>
+    </bit-status-lockup>
+  </div>
 } @else if (!hasTargetSystems()) {
   <bit-status-lockup>
     <bit-svg slot="graphic" [content]="noItemsIcon"></bit-svg>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -114,7 +114,7 @@ describe("ManagedCredentialsTabComponent", () => {
       fixture.detectChanges();
 
       const el = fixture.nativeElement as HTMLElement;
-      expect(el.querySelector('[data-testid="managed-credentials-load-error"]')).not.toBeNull();
+      expect(el.querySelector("pam-rotation-load-error")).not.toBeNull();
       expect(el.textContent).toContain("pamRotationListLoadErrorTitle");
       expect(el.textContent).not.toContain("pamNoTargetSystemsYetTitle");
       expect(el.textContent).not.toContain("pamRotationConfigEmptyState");
@@ -125,10 +125,9 @@ describe("ManagedCredentialsTabComponent", () => {
       configsService.loadError$.next(new Error("boom"));
       fixture.detectChanges();
 
-      const retry = (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
-        "#managed-credentials-tab_button_retry-load",
-      );
-      retry!.click();
+      (fixture.nativeElement as HTMLElement)
+        .querySelector<HTMLButtonElement>("#rotation-load-error_button_retry")!
+        .click();
       await fixture.whenStable();
 
       expect(configsService.load).toHaveBeenCalledTimes(2);

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -37,6 +37,7 @@ function makeRow(
 function makeConfigsServiceStub(rows: RotationConfigRow[] = [makeRow()]) {
   return {
     loading$: new BehaviorSubject(false),
+    loadError$: new BehaviorSubject<unknown | null>(null),
     rows$: new BehaviorSubject(rows),
     configs$: new BehaviorSubject(rows.map((r) => r.config)),
     awaitingManualCount$: new BehaviorSubject(0),
@@ -57,7 +58,11 @@ describe("ManagedCredentialsTabComponent", () => {
   let toastService: { showToast: jest.Mock };
   let dialogService: { openSimpleDialog: jest.Mock };
 
-  function setupTestBed(dialogResult = true, targetSystems: unknown[] = [{ id: "ts-1" }]) {
+  function setupTestBed(
+    dialogResult = true,
+    targetSystems: unknown[] = [{ id: "ts-1" }],
+    renderTemplate = false,
+  ) {
     configsService = makeConfigsServiceStub();
     targetSystemsService = {
       systems$: new BehaviorSubject<unknown[]>(targetSystems),
@@ -66,9 +71,11 @@ describe("ManagedCredentialsTabComponent", () => {
     toastService = { showToast: jest.fn() };
     dialogService = { openSimpleDialog: jest.fn().mockResolvedValue(dialogResult) };
 
-    TestBed.overrideComponent(ManagedCredentialsTabComponent, {
-      set: { template: "<div>stub</div>", imports: [] },
-    });
+    if (!renderTemplate) {
+      TestBed.overrideComponent(ManagedCredentialsTabComponent, {
+        set: { template: "<div>stub</div>", imports: [] },
+      });
+    }
 
     TestBed.configureTestingModule({
       imports: [ManagedCredentialsTabComponent],
@@ -97,6 +104,35 @@ describe("ManagedCredentialsTabComponent", () => {
     it("also loads target systems so the empty state can gate on them", () => {
       setupTestBed();
       expect(targetSystemsService.load).toHaveBeenCalledWith(ORGANIZATION_ID);
+    });
+  });
+
+  describe("load error state", () => {
+    it("renders the load-error state instead of the empty state", () => {
+      setupTestBed(true, [], true);
+      configsService.loadError$.next(new Error("boom"));
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('[data-testid="managed-credentials-load-error"]')).not.toBeNull();
+      expect(el.textContent).toContain("pamRotationListLoadErrorTitle");
+      expect(el.textContent).not.toContain("pamNoTargetSystemsYetTitle");
+      expect(el.textContent).not.toContain("pamRotationConfigEmptyState");
+    });
+
+    it("retries both loads from the error state", async () => {
+      setupTestBed(true, [], true);
+      configsService.loadError$.next(new Error("boom"));
+      fixture.detectChanges();
+
+      const retry = (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>(
+        "#managed-credentials-tab_button_retry-load",
+      );
+      retry!.click();
+      await fixture.whenStable();
+
+      expect(configsService.load).toHaveBeenCalledTimes(2);
+      expect(targetSystemsService.load).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
@@ -5,7 +5,7 @@ import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 
-import { NoResults } from "@bitwarden/assets/svg";
+import { NoResults, ReportBreach } from "@bitwarden/assets/svg";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
@@ -63,6 +63,7 @@ import { RotationConfigsService } from "./rotation-configs.service";
 })
 export class ManagedCredentialsTabComponent {
   protected readonly noItemsIcon = NoResults;
+  protected readonly loadErrorIcon = ReportBreach;
 
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
@@ -73,6 +74,9 @@ export class ManagedCredentialsTabComponent {
   private readonly i18nService = inject(I18nService);
 
   protected readonly loading = toSignal(this.configsService.loading$, { initialValue: true });
+  protected readonly loadError = toSignal(this.configsService.loadError$, {
+    initialValue: null as unknown,
+  });
 
   private readonly rows = toSignal(this.configsService.rows$, {
     initialValue: [] as RotationConfigRow[],
@@ -129,6 +133,15 @@ export class ManagedCredentialsTabComponent {
   protected readonly noResults = computed(
     () => !this.loading() && this.rows().length > 0 && this.processedRows().length === 0,
   );
+
+  /** Re-runs the same pair of loads the init effect runs, so a retry matches a fresh navigation. */
+  protected readonly retryLoad = async (): Promise<void> => {
+    const organizationId = this.organizationId();
+    await Promise.all([
+      this.configsService.load(organizationId),
+      this.targetSystemsService.load(organizationId),
+    ]);
+  };
 
   protected readonly openCreate = (): Promise<boolean> =>
     this.router.navigate(["..", "managed-credentials", "new"], { relativeTo: this.route });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
@@ -5,7 +5,7 @@ import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 
-import { NoResults, ReportBreach } from "@bitwarden/assets/svg";
+import { NoResults } from "@bitwarden/assets/svg";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
@@ -28,6 +28,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { TargetSystemMethod, TargetSystem } from "../rotation";
+import { RotationLoadErrorComponent } from "../rotation-load-error.component";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 
 import { RotationConfigRow } from "./rotation-config-row";
@@ -58,12 +59,12 @@ import { RotationConfigsService } from "./rotation-configs.service";
     SvgComponent,
     TableModule,
     TooltipDirective,
+    RotationLoadErrorComponent,
     I18nPipe,
   ],
 })
 export class ManagedCredentialsTabComponent {
   protected readonly noItemsIcon = NoResults;
-  protected readonly loadErrorIcon = ReportBreach;
 
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
@@ -74,9 +75,7 @@ export class ManagedCredentialsTabComponent {
   private readonly i18nService = inject(I18nService);
 
   protected readonly loading = toSignal(this.configsService.loading$, { initialValue: true });
-  protected readonly loadError = toSignal(this.configsService.loadError$, {
-    initialValue: null as unknown,
-  });
+  protected readonly loadError = toSignal(this.configsService.loadError$, { initialValue: null });
 
   private readonly rows = toSignal(this.configsService.rows$, {
     initialValue: [] as RotationConfigRow[],
@@ -106,10 +105,7 @@ export class ManagedCredentialsTabComponent {
 
   constructor() {
     effect(() => {
-      const organizationId = this.organizationId();
-      void this.configsService.load(organizationId);
-      // Also loads target systems so the empty state can tell if one must be set up first.
-      void this.targetSystemsService.load(organizationId);
+      void this.loadAll(this.organizationId());
     });
 
     effect(() => {
@@ -134,14 +130,19 @@ export class ManagedCredentialsTabComponent {
     () => !this.loading() && this.rows().length > 0 && this.processedRows().length === 0,
   );
 
-  /** Re-runs the same pair of loads the init effect runs, so a retry matches a fresh navigation. */
-  protected readonly retryLoad = async (): Promise<void> => {
-    const organizationId = this.organizationId();
+  /**
+   * Target systems are loaded alongside the configs so the empty state can tell whether the user
+   * must set one up first (the shell-scoped instance may be empty if this tab is visited before
+   * the others).
+   */
+  private async loadAll(organizationId: OrganizationId): Promise<void> {
     await Promise.all([
       this.configsService.load(organizationId),
       this.targetSystemsService.load(organizationId),
     ]);
-  };
+  }
+
+  protected readonly retryLoad = (): Promise<void> => this.loadAll(this.organizationId());
 
   protected readonly openCreate = (): Promise<boolean> =>
     this.router.navigate(["..", "managed-credentials", "new"], { relativeTo: this.route });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-configs.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-configs.service.spec.ts
@@ -40,6 +40,7 @@ describe("RotationConfigsService", () => {
     load: jest.Mock;
     systems$: BehaviorSubject<TargetSystem[]>;
     loading$: BehaviorSubject<boolean>;
+    lastLoadError: unknown;
   };
   let orgCiphersService: {
     cipherNameById$: BehaviorSubject<Map<CipherId, string>>;
@@ -74,6 +75,7 @@ describe("RotationConfigsService", () => {
       load: jest.fn().mockResolvedValue(undefined),
       systems$: new BehaviorSubject([target]),
       loading$: new BehaviorSubject(false),
+      lastLoadError: null as unknown,
     };
 
     orgCiphersService = {
@@ -101,6 +103,34 @@ describe("RotationConfigsService", () => {
     expect(rotationSdk.listConfigs).toHaveBeenCalledWith(ORG_ID);
     expect(targetSystemsService.load).toHaveBeenCalledWith(ORG_ID);
     expect(orgCiphersService.load).toHaveBeenCalledWith(ORG_ID);
+  });
+
+  it("records the failure and clears loading when listConfigs throws", async () => {
+    const failure = new Error("network fail");
+    rotationSdk.listConfigs.mockRejectedValue(failure);
+
+    await expect(service.load(ORG_ID)).resolves.toBeUndefined();
+
+    expect(await firstValueFrom(service.loading$)).toBe(false);
+    expect(await firstValueFrom(service.loadError$)).toBe(failure);
+  });
+
+  it("clears a previous failure at the start of the next load", async () => {
+    rotationSdk.listConfigs.mockRejectedValueOnce(new Error("network fail"));
+    await service.load(ORG_ID);
+
+    await service.load(ORG_ID);
+
+    expect(await firstValueFrom(service.loadError$)).toBeNull();
+  });
+
+  it("reports a target-systems failure as its own load error", async () => {
+    const failure = new Error("target systems unavailable");
+    targetSystemsService.lastLoadError = failure;
+
+    await service.load(ORG_ID);
+
+    expect(await firstValueFrom(service.loadError$)).toBe(failure);
   });
 
   it("exposes loaded configs via configs$", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-configs.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-configs.service.spec.ts
@@ -40,7 +40,7 @@ describe("RotationConfigsService", () => {
     load: jest.Mock;
     systems$: BehaviorSubject<TargetSystem[]>;
     loading$: BehaviorSubject<boolean>;
-    lastLoadError: unknown;
+    loadError$: BehaviorSubject<unknown | null>;
   };
   let orgCiphersService: {
     cipherNameById$: BehaviorSubject<Map<CipherId, string>>;
@@ -75,7 +75,7 @@ describe("RotationConfigsService", () => {
       load: jest.fn().mockResolvedValue(undefined),
       systems$: new BehaviorSubject([target]),
       loading$: new BehaviorSubject(false),
-      lastLoadError: null as unknown,
+      loadError$: new BehaviorSubject<unknown | null>(null),
     };
 
     orgCiphersService = {
@@ -126,7 +126,7 @@ describe("RotationConfigsService", () => {
 
   it("reports a target-systems failure as its own load error", async () => {
     const failure = new Error("target systems unavailable");
-    targetSystemsService.lastLoadError = failure;
+    targetSystemsService.loadError$.next(failure);
 
     await service.load(ORG_ID);
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-configs.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-configs.service.ts
@@ -28,9 +28,13 @@ export class RotationConfigsService {
 
   private readonly _configs$ = new BehaviorSubject<RotationConfig[]>([]);
   private readonly _loading$ = new BehaviorSubject<boolean>(true);
+  private readonly _loadError$ = new BehaviorSubject<unknown | null>(null);
 
   readonly configs$: Observable<RotationConfig[]> = this._configs$.asObservable();
   readonly loading$: Observable<boolean> = this._loading$.asObservable();
+
+  /** The error from the last {@link load}, or null when it succeeded. */
+  readonly loadError$: Observable<unknown | null> = this._loadError$.asObservable();
 
   /** Count of configs currently awaiting a manual rotation from the operator. */
   readonly awaitingManualCount$: Observable<number> = this._configs$.pipe(
@@ -71,10 +75,14 @@ export class RotationConfigsService {
    * Load the org's rotation configs and kick off sibling loads for target systems and
    * org ciphers in parallel. All three fetches must complete before the loading spinner
    * clears — the rows depend on all three.
+   *
+   * Records a failure on {@link loadError$} rather than rejecting: every caller invokes this as
+   * `void load(...)`, so a rejection would leave the tab rendering its empty state.
    */
   async load(organizationId: OrganizationId): Promise<void> {
     this.organizationId = organizationId;
     this._loading$.next(true);
+    this._loadError$.next(null);
     try {
       const [configs] = await Promise.all([
         this.rotationSdk.listConfigs(organizationId),
@@ -82,6 +90,13 @@ export class RotationConfigsService {
         this.orgCiphers.load(organizationId),
       ]);
       this._configs$.next(configs);
+      // `TargetSystemsService.load` records its own failure instead of rejecting, so `Promise.all`
+      // resolves even when the target systems this tab's rows and empty state depend on are missing.
+      if (this.targetSystems.lastLoadError != null) {
+        this._loadError$.next(this.targetSystems.lastLoadError);
+      }
+    } catch (e) {
+      this._loadError$.next(e);
     } finally {
       this._loading$.next(false);
     }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-configs.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-configs.service.ts
@@ -33,8 +33,16 @@ export class RotationConfigsService {
   readonly configs$: Observable<RotationConfig[]> = this._configs$.asObservable();
   readonly loading$: Observable<boolean> = this._loading$.asObservable();
 
-  /** The error from the last {@link load}, or null when it succeeded. */
-  readonly loadError$: Observable<unknown | null> = this._loadError$.asObservable();
+  /**
+   * The error from the last {@link load}, or null when it succeeded. Covers the target-systems
+   * fetch too: it records its own failure instead of rejecting, so the `Promise.all` in
+   * {@link load} resolves even when the rows and the empty state have no target systems to work
+   * with.
+   */
+  readonly loadError$: Observable<unknown | null> = combineLatest([
+    this._loadError$,
+    this.targetSystems.loadError$,
+  ]).pipe(map(([own, targetSystemsError]) => own ?? targetSystemsError));
 
   /** Count of configs currently awaiting a manual rotation from the operator. */
   readonly awaitingManualCount$: Observable<number> = this._configs$.pipe(
@@ -90,11 +98,6 @@ export class RotationConfigsService {
         this.orgCiphers.load(organizationId),
       ]);
       this._configs$.next(configs);
-      // `TargetSystemsService.load` records its own failure instead of rejecting, so `Promise.all`
-      // resolves even when the target systems this tab's rows and empty state depend on are missing.
-      if (this.targetSystems.lastLoadError != null) {
-        this._loadError$.next(this.targetSystems.lastLoadError);
-      }
     } catch (e) {
       this._loadError$.next(e);
     } finally {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-load-error.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-load-error.component.html
@@ -1,0 +1,15 @@
+<bit-status-lockup>
+  <bit-svg slot="graphic" [content]="icon"></bit-svg>
+  <span slot="title">{{ "pamRotationListLoadErrorTitle" | i18n }}</span>
+  <span slot="description">{{ "pamRotationListLoadErrorDescription" | i18n }}</span>
+  <button
+    slot="button"
+    type="button"
+    bitButton
+    buttonType="primary"
+    id="rotation-load-error_button_retry"
+    (click)="retry.emit()"
+  >
+    {{ "tryAgain" | i18n }}
+  </button>
+</bit-status-lockup>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-load-error.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-load-error.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+
+import { RotationLoadErrorComponent } from "./rotation-load-error.component";
+
+describe("RotationLoadErrorComponent", () => {
+  let fixture: ComponentFixture<RotationLoadErrorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RotationLoadErrorComponent, NoopAnimationsModule],
+      providers: [{ provide: I18nService, useValue: { t: (id: string) => id } }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RotationLoadErrorComponent);
+    fixture.detectChanges();
+  });
+
+  it("renders the failure copy as an alert", () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.getAttribute("role")).toBe("alert");
+    expect(el.textContent).toContain("pamRotationListLoadErrorTitle");
+    expect(el.textContent).toContain("pamRotationListLoadErrorDescription");
+  });
+
+  it("emits retry when the button is clicked", () => {
+    const spy = jest.fn();
+    fixture.componentInstance.retry.subscribe(spy);
+
+    (
+      fixture.nativeElement.querySelector("#rotation-load-error_button_retry") as HTMLButtonElement
+    ).click();
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-load-error.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-load-error.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, output } from "@angular/core";
+
+import { ReportBreach } from "@bitwarden/assets/svg";
+import { ButtonModule, StatusLockupComponent, SvgComponent } from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+/**
+ * Shown by a rotation tab when its list could not be fetched, in place of the tab's empty state.
+ * Emits {@link retry}; the parent owns re-running whichever loads that tab needs.
+ */
+@Component({
+  selector: "pam-rotation-load-error",
+  templateUrl: "./rotation-load-error.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonModule, StatusLockupComponent, SvgComponent, I18nPipe],
+  host: {
+    class: "tw-block",
+    role: "alert",
+  },
+})
+export class RotationLoadErrorComponent {
+  readonly retry = output<void>();
+
+  protected readonly icon = ReportBreach;
+}

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.html
@@ -1,22 +1,6 @@
 @if (!loading()) {
   @if (loadError()) {
-    <div role="alert" data-testid="target-systems-load-error">
-      <bit-status-lockup>
-        <bit-svg slot="graphic" [content]="loadErrorIcon"></bit-svg>
-        <span slot="title">{{ "pamRotationListLoadErrorTitle" | i18n }}</span>
-        <span slot="description">{{ "pamRotationListLoadErrorDescription" | i18n }}</span>
-        <button
-          slot="button"
-          type="button"
-          bitButton
-          buttonType="primary"
-          id="target-systems-tab_button_retry-load"
-          (click)="retryLoad()"
-        >
-          {{ "tryAgain" | i18n }}
-        </button>
-      </bit-status-lockup>
-    </div>
+    <pam-rotation-load-error (retry)="retryLoad()" />
   } @else if (dataSource.data.length > 0 || searchControl.value) {
     <div class="tw-mb-4">
       <bit-search

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.html
@@ -1,5 +1,23 @@
 @if (!loading()) {
-  @if (dataSource.data.length > 0 || searchControl.value) {
+  @if (loadError()) {
+    <div role="alert" data-testid="target-systems-load-error">
+      <bit-status-lockup>
+        <bit-svg slot="graphic" [content]="loadErrorIcon"></bit-svg>
+        <span slot="title">{{ "pamRotationListLoadErrorTitle" | i18n }}</span>
+        <span slot="description">{{ "pamRotationListLoadErrorDescription" | i18n }}</span>
+        <button
+          slot="button"
+          type="button"
+          bitButton
+          buttonType="primary"
+          id="target-systems-tab_button_retry-load"
+          (click)="retryLoad()"
+        >
+          {{ "tryAgain" | i18n }}
+        </button>
+      </bit-status-lockup>
+    </div>
+  } @else if (dataSource.data.length > 0 || searchControl.value) {
     <div class="tw-mb-4">
       <bit-search
         class="tw-max-w-md"

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
@@ -40,6 +40,7 @@ describe("TargetSystemsTabComponent", () => {
   let component: TargetSystemsTabComponent;
   let targetSystemsService: {
     loading$: BehaviorSubject<boolean>;
+    loadError$: BehaviorSubject<unknown | null>;
     systems$: BehaviorSubject<TargetSystem[]>;
     systemById$: BehaviorSubject<Map<string, TargetSystem>>;
     activeAutomaticSystems$: BehaviorSubject<TargetSystem[]>;
@@ -55,6 +56,7 @@ describe("TargetSystemsTabComponent", () => {
   beforeEach(async () => {
     targetSystemsService = {
       loading$: new BehaviorSubject<boolean>(false),
+      loadError$: new BehaviorSubject<unknown | null>(null),
       systems$: new BehaviorSubject<TargetSystem[]>([]),
       systemById$: new BehaviorSubject(new Map()),
       activeAutomaticSystems$: new BehaviorSubject<TargetSystem[]>([]),
@@ -269,5 +271,58 @@ describe("TargetSystemsTabComponent", () => {
       );
       expect(daemonsService.forgetTargetSystem).not.toHaveBeenCalled();
     }));
+  });
+
+  describe("load error state", () => {
+    beforeEach(async () => {
+      TestBed.resetTestingModule();
+
+      await TestBed.configureTestingModule({
+        imports: [TargetSystemsTabComponent, ReactiveFormsModule, NoopAnimationsModule],
+        providers: [
+          provideRouter([]),
+          { provide: TargetSystemsService, useValue: targetSystemsService },
+          { provide: DaemonsService, useValue: daemonsService },
+          { provide: I18nService, useValue: i18nFake },
+          { provide: DialogService, useValue: dialogService },
+          { provide: ToastService, useValue: toastService },
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              params: of({ organizationId: ORGANIZATION_ID }),
+              snapshot: { params: { organizationId: ORGANIZATION_ID } },
+            },
+          },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TargetSystemsTabComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it("renders the load-error state instead of the empty state", () => {
+      targetSystemsService.loadError$.next(new Error("boom"));
+      fixture.detectChanges();
+
+      const el = fixture.nativeElement as HTMLElement;
+      expect(el.querySelector('[data-testid="target-systems-load-error"]')).not.toBeNull();
+      expect(el.textContent).toContain("pamRotationListLoadErrorTitle");
+      expect(el.textContent).not.toContain("pamNoTargetSystemsYetTitle");
+      expect(el.textContent).not.toContain("pamTargetSystemsStartFromTemplate");
+    });
+
+    it("retries the load from the error state", async () => {
+      targetSystemsService.loadError$.next(new Error("boom"));
+      fixture.detectChanges();
+      targetSystemsService.load.mockClear();
+
+      (fixture.nativeElement as HTMLElement)
+        .querySelector<HTMLButtonElement>("#target-systems-tab_button_retry-load")!
+        .click();
+      await fixture.whenStable();
+
+      expect(targetSystemsService.load).toHaveBeenCalledWith(ORGANIZATION_ID);
+    });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
@@ -53,26 +53,13 @@ describe("TargetSystemsTabComponent", () => {
   let dialogService: ReturnType<typeof mock<DialogService>>;
   let toastService: ReturnType<typeof mock<ToastService>>;
 
-  beforeEach(async () => {
-    targetSystemsService = {
-      loading$: new BehaviorSubject<boolean>(false),
-      loadError$: new BehaviorSubject<unknown | null>(null),
-      systems$: new BehaviorSubject<TargetSystem[]>([]),
-      systemById$: new BehaviorSubject(new Map()),
-      activeAutomaticSystems$: new BehaviorSubject<TargetSystem[]>([]),
-      load: jest.fn().mockResolvedValue(undefined),
-      setEnabled: jest.fn().mockResolvedValue(undefined),
-      delete: jest.fn().mockResolvedValue(undefined),
-    };
-    daemonsService = { forgetTargetSystem: jest.fn() };
-    dialogService = mock<DialogService>();
-    dialogService.openSimpleDialog.mockResolvedValue(false);
-    toastService = mock<ToastService>();
-
-    // Overrides the template AND imports to avoid pulling in HeaderModule → SharedModule →
-    // DialogModule, which would override the test mock DialogService. Must come before
-    // configureTestingModule.
-    TestBed.overrideComponent(TargetSystemsTabComponent, { set: { template: "", imports: [] } });
+  async function createComponent({ renderTemplate = false } = {}) {
+    if (!renderTemplate) {
+      // Override the template AND imports to avoid pulling in HeaderModule → SharedModule → DialogModule
+      // which would provide a real DialogService, overriding our test mock.
+      // Must come before configureTestingModule.
+      TestBed.overrideComponent(TargetSystemsTabComponent, { set: { template: "", imports: [] } });
+    }
 
     await TestBed.configureTestingModule({
       imports: [TargetSystemsTabComponent, ReactiveFormsModule, NoopAnimationsModule],
@@ -99,6 +86,25 @@ describe("TargetSystemsTabComponent", () => {
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    targetSystemsService = {
+      loading$: new BehaviorSubject<boolean>(false),
+      loadError$: new BehaviorSubject<unknown | null>(null),
+      systems$: new BehaviorSubject<TargetSystem[]>([]),
+      systemById$: new BehaviorSubject(new Map()),
+      activeAutomaticSystems$: new BehaviorSubject<TargetSystem[]>([]),
+      load: jest.fn().mockResolvedValue(undefined),
+      setEnabled: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    daemonsService = { forgetTargetSystem: jest.fn() };
+    dialogService = mock<DialogService>();
+    dialogService.openSimpleDialog.mockResolvedValue(false);
+    toastService = mock<ToastService>();
+
+    await createComponent();
   });
 
   it("calls load with the organization id on init", () => {
@@ -277,28 +283,7 @@ describe("TargetSystemsTabComponent", () => {
     beforeEach(async () => {
       TestBed.resetTestingModule();
 
-      await TestBed.configureTestingModule({
-        imports: [TargetSystemsTabComponent, ReactiveFormsModule, NoopAnimationsModule],
-        providers: [
-          provideRouter([]),
-          { provide: TargetSystemsService, useValue: targetSystemsService },
-          { provide: DaemonsService, useValue: daemonsService },
-          { provide: I18nService, useValue: i18nFake },
-          { provide: DialogService, useValue: dialogService },
-          { provide: ToastService, useValue: toastService },
-          {
-            provide: ActivatedRoute,
-            useValue: {
-              params: of({ organizationId: ORGANIZATION_ID }),
-              snapshot: { params: { organizationId: ORGANIZATION_ID } },
-            },
-          },
-        ],
-      }).compileComponents();
-
-      fixture = TestBed.createComponent(TargetSystemsTabComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
+      await createComponent({ renderTemplate: true });
     });
 
     it("renders the load-error state instead of the empty state", () => {
@@ -306,7 +291,7 @@ describe("TargetSystemsTabComponent", () => {
       fixture.detectChanges();
 
       const el = fixture.nativeElement as HTMLElement;
-      expect(el.querySelector('[data-testid="target-systems-load-error"]')).not.toBeNull();
+      expect(el.querySelector("pam-rotation-load-error")).not.toBeNull();
       expect(el.textContent).toContain("pamRotationListLoadErrorTitle");
       expect(el.textContent).not.toContain("pamNoTargetSystemsYetTitle");
       expect(el.textContent).not.toContain("pamTargetSystemsStartFromTemplate");
@@ -318,7 +303,7 @@ describe("TargetSystemsTabComponent", () => {
       targetSystemsService.load.mockClear();
 
       (fixture.nativeElement as HTMLElement)
-        .querySelector<HTMLButtonElement>("#target-systems-tab_button_retry-load")!
+        .querySelector<HTMLButtonElement>("#rotation-load-error_button_retry")!
         .click();
       await fixture.whenStable();
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
@@ -5,17 +5,21 @@ import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 
+import { ReportBreach } from "@bitwarden/assets/svg";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   BadgeModule,
+  ButtonModule,
   DialogService,
   IconButtonModule,
   IconModule,
   MenuModule,
   SearchModule,
   SpinnerComponent,
+  StatusLockupComponent,
+  SvgComponent,
   TableDataSource,
   TableModule,
   ToastService,
@@ -63,11 +67,14 @@ export type TargetSystemRow = {
     CommonModule,
     ReactiveFormsModule,
     BadgeModule,
+    ButtonModule,
     IconButtonModule,
     IconModule,
     MenuModule,
     SearchModule,
     SpinnerComponent,
+    StatusLockupComponent,
+    SvgComponent,
     TableModule,
     TargetSystemsEmptyStateComponent,
     I18nPipe,
@@ -88,9 +95,14 @@ export class TargetSystemsTabComponent {
   );
 
   protected readonly loading = toSignal(this.targetSystemsService.loading$, { initialValue: true });
+  protected readonly loadError = toSignal(this.targetSystemsService.loadError$, {
+    initialValue: null as unknown,
+  });
   private readonly systems = toSignal(this.targetSystemsService.systems$, {
     initialValue: [] as TargetSystem[],
   });
+
+  protected readonly loadErrorIcon = ReportBreach;
 
   protected readonly dataSource = new TableDataSource<TargetSystemRow>();
   protected readonly searchControl = new FormControl("", { nonNullable: true });
@@ -118,6 +130,11 @@ export class TargetSystemsTabComponent {
         (row.kindLabel?.toLowerCase().includes(text) ?? false);
     });
   }
+
+  /** Re-runs the same load the init effect runs, so a retry matches a fresh navigation. */
+  protected readonly retryLoad = async (): Promise<void> => {
+    await this.targetSystemsService.load(this.organizationId());
+  };
 
   /** Navigate to the create page (sibling of the shell), shown from the empty state. */
   protected readonly openCreate = (): Promise<boolean> =>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
@@ -5,21 +5,17 @@ import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
 import { map } from "rxjs";
 
-import { ReportBreach } from "@bitwarden/assets/svg";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   BadgeModule,
-  ButtonModule,
   DialogService,
   IconButtonModule,
   IconModule,
   MenuModule,
   SearchModule,
   SpinnerComponent,
-  StatusLockupComponent,
-  SvgComponent,
   TableDataSource,
   TableModule,
   ToastService,
@@ -34,6 +30,7 @@ import {
   TargetSystemStatus,
   TargetSystem,
 } from "../rotation";
+import { RotationLoadErrorComponent } from "../rotation-load-error.component";
 
 import {
   TargetSystemsEmptyStateComponent,
@@ -67,15 +64,13 @@ export type TargetSystemRow = {
     CommonModule,
     ReactiveFormsModule,
     BadgeModule,
-    ButtonModule,
     IconButtonModule,
     IconModule,
     MenuModule,
     SearchModule,
     SpinnerComponent,
-    StatusLockupComponent,
-    SvgComponent,
     TableModule,
+    RotationLoadErrorComponent,
     TargetSystemsEmptyStateComponent,
     I18nPipe,
   ],
@@ -96,13 +91,11 @@ export class TargetSystemsTabComponent {
 
   protected readonly loading = toSignal(this.targetSystemsService.loading$, { initialValue: true });
   protected readonly loadError = toSignal(this.targetSystemsService.loadError$, {
-    initialValue: null as unknown,
+    initialValue: null,
   });
   private readonly systems = toSignal(this.targetSystemsService.systems$, {
     initialValue: [] as TargetSystem[],
   });
-
-  protected readonly loadErrorIcon = ReportBreach;
 
   protected readonly dataSource = new TableDataSource<TargetSystemRow>();
   protected readonly searchControl = new FormControl("", { nonNullable: true });
@@ -131,10 +124,8 @@ export class TargetSystemsTabComponent {
     });
   }
 
-  /** Re-runs the same load the init effect runs, so a retry matches a fresh navigation. */
-  protected readonly retryLoad = async (): Promise<void> => {
-    await this.targetSystemsService.load(this.organizationId());
-  };
+  protected readonly retryLoad = (): Promise<void> =>
+    this.targetSystemsService.load(this.organizationId());
 
   /** Navigate to the create page (sibling of the shell), shown from the empty state. */
   protected readonly openCreate = (): Promise<boolean> =>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.spec.ts
@@ -58,7 +58,6 @@ describe("TargetSystemsService", () => {
 
       expect(await firstValueFrom(service.loading$)).toBe(false);
       expect(await firstValueFrom(service.loadError$)).toBe(failure);
-      expect(service.lastLoadError).toBe(failure);
     });
 
     it("clears a previous failure at the start of the next load", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.spec.ts
@@ -50,12 +50,25 @@ describe("TargetSystemsService", () => {
       expect(systems[0].id).toBe(sysId("sys-abc"));
     });
 
-    it("sets loading false even when the API throws", async () => {
-      rotationSdk.listTargetSystems.mockRejectedValue(new Error("network fail"));
-      await expect(service.load(ORG_ID)).rejects.toThrow("network fail");
+    it("records the failure and clears loading when the API throws", async () => {
+      const failure = new Error("network fail");
+      rotationSdk.listTargetSystems.mockRejectedValue(failure);
 
-      const loading = await firstValueFrom(service.loading$);
-      expect(loading).toBe(false);
+      await expect(service.load(ORG_ID)).resolves.toBeUndefined();
+
+      expect(await firstValueFrom(service.loading$)).toBe(false);
+      expect(await firstValueFrom(service.loadError$)).toBe(failure);
+      expect(service.lastLoadError).toBe(failure);
+    });
+
+    it("clears a previous failure at the start of the next load", async () => {
+      rotationSdk.listTargetSystems.mockRejectedValueOnce(new Error("network fail"));
+      await service.load(ORG_ID);
+      rotationSdk.listTargetSystems.mockResolvedValue([makeSystem()]);
+
+      await service.load(ORG_ID);
+
+      expect(await firstValueFrom(service.loadError$)).toBeNull();
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.spec.ts
@@ -69,6 +69,19 @@ describe("TargetSystemsService", () => {
 
       expect(await firstValueFrom(service.loadError$)).toBeNull();
     });
+
+    it("does not latch a concurrent load's failure over a later success", async () => {
+      rotationSdk.listTargetSystems
+        .mockRejectedValueOnce(new Error("network fail"))
+        .mockResolvedValueOnce([makeSystem()]);
+
+      const failing = service.load(ORG_ID);
+      const succeeding = service.load(ORG_ID);
+      await Promise.all([failing, succeeding]);
+
+      expect(await firstValueFrom(service.systems$)).toHaveLength(1);
+      expect(await firstValueFrom(service.loadError$)).toBeNull();
+    });
   });
 
   describe("systemById$", () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.ts
@@ -55,6 +55,10 @@ export class TargetSystemsService {
    *
    * Records a failure on {@link loadError$} rather than rejecting: every caller invokes this as
    * `void load(...)`, so a rejection would leave the tab rendering its empty state.
+   *
+   * The managed-credentials tab runs two of these concurrently, so the outcome is recorded on
+   * success as well as on failure — clearing only on entry would latch the losing call's error
+   * over the winning call's data.
    */
   async load(organizationId: OrganizationId): Promise<void> {
     this.organizationId = organizationId;
@@ -62,6 +66,7 @@ export class TargetSystemsService {
     this._loadError$.next(null);
     try {
       this._systems$.next(await this.rotationSdk.listTargetSystems(organizationId));
+      this._loadError$.next(null);
     } catch (e) {
       this._loadError$.next(e);
     } finally {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.ts
@@ -34,14 +34,6 @@ export class TargetSystemsService {
   /** The error from the last {@link load}, or null when it succeeded. */
   readonly loadError$: Observable<unknown | null> = this._loadError$.asObservable();
 
-  /**
-   * Synchronous read of the last load's outcome, for services that load this one as a dependency
-   * and must reflect its failure in their own error state.
-   */
-  get lastLoadError(): unknown | null {
-    return this._loadError$.value;
-  }
-
   /** A map from targetSystemId → TargetSystem for O(1) lookups in derived services. */
   readonly systemById$: Observable<Map<TargetSystemId, TargetSystem>> = this._systems$.pipe(
     map((systems) => new Map(systems.map((s) => [s.id, s]))),

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems.service.ts
@@ -26,9 +26,21 @@ export class TargetSystemsService {
 
   private readonly _systems$ = new BehaviorSubject<TargetSystem[]>([]);
   private readonly _loading$ = new BehaviorSubject<boolean>(true);
+  private readonly _loadError$ = new BehaviorSubject<unknown | null>(null);
 
   readonly systems$: Observable<TargetSystem[]> = this._systems$.asObservable();
   readonly loading$: Observable<boolean> = this._loading$.asObservable();
+
+  /** The error from the last {@link load}, or null when it succeeded. */
+  readonly loadError$: Observable<unknown | null> = this._loadError$.asObservable();
+
+  /**
+   * Synchronous read of the last load's outcome, for services that load this one as a dependency
+   * and must reflect its failure in their own error state.
+   */
+  get lastLoadError(): unknown | null {
+    return this._loadError$.value;
+  }
 
   /** A map from targetSystemId → TargetSystem for O(1) lookups in derived services. */
   readonly systemById$: Observable<Map<TargetSystemId, TargetSystem>> = this._systems$.pipe(
@@ -46,12 +58,20 @@ export class TargetSystemsService {
     ),
   );
 
-  /** Fetch the org's target systems, replacing local state. */
+  /**
+   * Fetch the org's target systems, replacing local state.
+   *
+   * Records a failure on {@link loadError$} rather than rejecting: every caller invokes this as
+   * `void load(...)`, so a rejection would leave the tab rendering its empty state.
+   */
   async load(organizationId: OrganizationId): Promise<void> {
     this.organizationId = organizationId;
     this._loading$.next(true);
+    this._loadError$.next(null);
     try {
       this._systems$.next(await this.rotationSdk.listTargetSystems(organizationId));
+    } catch (e) {
+      this._loadError$.next(e);
     } finally {
       this._loading$.next(false);
     }


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`. Not tracked in Jira: this fix originates from code-review finding `uat-rotux-load-failure-shows-empty-state`, which has no associated ticket.

## 📔 Objective

Makes a failed rotation-list fetch render a distinct error state instead of silently falling through to the empty state on all three rotation tabs.

- `DaemonsService`, `RotationConfigsService`, and `TargetSystemsService` catch their SDK list call and record the failure on a new `loadError$`, instead of a rejection escaping the `void load(...)` callers.
- `DaemonsService` and `RotationConfigsService` fold in `TargetSystemsService.loadError$` too, so a target-systems failure surfaces even when their own list call succeeds.
- `TargetSystemsService.load` clears `loadError$` on entry and on success, so a losing concurrent call's failure cannot latch over a later successful load.
- A shared `RotationLoadErrorComponent` (`role="alert"`, status-lockup with a "Try again" button) renders in all three tab templates ahead of the empty-state branch; retry re-runs the same loads the tab's init effect runs.
- Adds two locale keys for the error copy.

Sits directly on `pam/uat` (bottom of the stack); `pam/rotux-assign-dialog-no-eligible-targets` sits on top of it.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation (Managed credentials, Target systems, Daemons)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-load-failure-shows-empty-state.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-load-failure-shows-empty-state.png" alt="after" width="460"> |

## Copy not yet approved

This PR adds user-facing wording the designer has not signed off on:

- `pamRotationListLoadErrorTitle`: "Unable to load this list"
- `pamRotationListLoadErrorDescription`: "Check your connection and try again. If the problem continues, refresh the page."

Treat both as proposed, not final.

## Known gaps

- The per-tab test hooks originally planned (`data-testid="managed-credentials-load-error"` etc., and a `<tab>-tab_button_retry-load` retry id) were not built. All three tabs render the same shared component, and its retry button has one fixed id, `rotation-load-error_button_retry`, on every tab. User-visible behavior is unaffected; only automated-test selectors differ from the original plan.
- `test:types` fails on this branch (12 errors), but all 12 pre-exist on `pam/uat`: 11 are in files this diff does not touch, and the 12th (`target-systems.service.spec.ts`) is a pre-existing `kind: null` fixture line that only shifted line number because of the new tests added above it. This diff does not make `test:types` worse, but it also does not turn it green.
- A mirror-image concurrency race in `TargetSystemsService.load` is still open: if the winning concurrent call succeeds and the losing call then rejects afterward, `loadError$` ends up holding an error over data that is actually present and displayed.
