### PR TITLE
'Assign to target' tells a first-time admin everything is already assigned

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19036,6 +19036,12 @@
   "pamDaemonAssignNoOptions": {
     "message": "All active automatic target systems are already assigned to this daemon."
   },
+  "pamDaemonAssignNoTargetSystems": {
+    "message": "There are no active automatic target systems to assign. Create one on the Target systems tab, or set an existing one to active."
+  },
+  "pamDaemonAssignGoToTargetSystems": {
+    "message": "Go to Target systems"
+  },
   "pamDaemonAssignConfirm": {
     "message": "Assign"
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.html
@@ -5,20 +5,18 @@
   </ng-container>
 
   <div bitDialogContent>
-    @if (params.options.length === 0) {
-      @if (params.noEligibleTargets) {
-        <p class="tw-text-muted">{{ "pamDaemonAssignNoTargetSystems" | i18n }}</p>
-        <a
-          bitLink
-          linkType="primary"
-          [routerLink]="targetSystemsRoute"
-          (click)="cancel()"
-          id="assign-target-dialog_anchor_target-systems"
-          >{{ "pamDaemonAssignGoToTargetSystems" | i18n }}</a
-        >
-      } @else {
-        <p class="tw-text-muted">{{ "pamDaemonAssignNoOptions" | i18n }}</p>
-      }
+    @if (params.noActiveAutomaticSystems) {
+      <p class="tw-text-muted">{{ "pamDaemonAssignNoTargetSystems" | i18n }}</p>
+      <a
+        bitLink
+        linkType="primary"
+        [routerLink]="targetSystemsRoute"
+        (click)="cancel()"
+        id="assign-target-dialog_anchor_target-systems"
+        >{{ "pamDaemonAssignGoToTargetSystems" | i18n }}</a
+      >
+    } @else if (params.options.length === 0) {
+      <p class="tw-text-muted">{{ "pamDaemonAssignNoOptions" | i18n }}</p>
     } @else {
       <bit-form-field>
         <bit-label>{{ "pamDaemonAssignTargetLabel" | i18n }}</bit-label>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.html
@@ -6,7 +6,19 @@
 
   <div bitDialogContent>
     @if (params.options.length === 0) {
-      <p class="tw-text-muted">{{ "pamDaemonAssignNoOptions" | i18n }}</p>
+      @if (params.noEligibleTargets) {
+        <p class="tw-text-muted">{{ "pamDaemonAssignNoTargetSystems" | i18n }}</p>
+        <a
+          bitLink
+          linkType="primary"
+          [routerLink]="targetSystemsRoute"
+          (click)="cancel()"
+          id="assign-target-dialog_anchor_target-systems"
+          >{{ "pamDaemonAssignGoToTargetSystems" | i18n }}</a
+        >
+      } @else {
+        <p class="tw-text-muted">{{ "pamDaemonAssignNoOptions" | i18n }}</p>
+      }
     } @else {
       <bit-form-field>
         <bit-label>{{ "pamDaemonAssignTargetLabel" | i18n }}</bit-label>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.spec.ts
@@ -33,8 +33,14 @@ describe("AssignTargetDialogComponent", () => {
     assignments: [],
   } as unknown as AccessConnector;
 
-  function createComponent(options: TargetSystem[], noEligibleTargets?: boolean): Promise<void> {
-    const params: AssignTargetDialogParams = { daemon, options, noEligibleTargets };
+  const targetSystemsLink = () =>
+    fixture.nativeElement.querySelector("#assign-target-dialog_anchor_target-systems");
+
+  function createComponent(
+    options: TargetSystem[],
+    noActiveAutomaticSystems = false,
+  ): Promise<void> {
+    const params: AssignTargetDialogParams = { daemon, options, noActiveAutomaticSystems };
     dialogRef = {
       close: jest.fn().mockReturnValue(Promise.resolve()),
     } as unknown as jest.Mocked<DialogRef<string | undefined>>;
@@ -83,18 +89,14 @@ describe("AssignTargetDialogComponent", () => {
 
   it("links to the Target systems tab when none exist", async () => {
     await createComponent([], true);
-    const anchor = fixture.nativeElement.querySelector(
-      "#assign-target-dialog_anchor_target-systems",
-    ) as HTMLAnchorElement | null;
-    expect(anchor?.getAttribute("href")).toBe("/organizations/org-1/pam/rotation/target-systems");
+    expect(targetSystemsLink().getAttribute("href")).toBe(
+      "/organizations/org-1/pam/rotation/target-systems",
+    );
   });
 
   it("dismisses the dialog when the Target systems link is followed", async () => {
     await createComponent([], true);
-    const anchor = fixture.nativeElement.querySelector(
-      "#assign-target-dialog_anchor_target-systems",
-    ) as HTMLAnchorElement;
-    anchor.click();
+    targetSystemsLink().click();
     expect(dialogRef.close).toHaveBeenCalledWith(undefined);
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { provideRouter } from "@angular/router";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DIALOG_DATA, DialogRef } from "@bitwarden/components";
@@ -27,12 +28,13 @@ describe("AssignTargetDialogComponent", () => {
 
   const daemon = {
     id: "d-1",
+    organizationId: "org-1",
     name: "My Daemon",
     assignments: [],
   } as unknown as AccessConnector;
 
-  function createComponent(options: TargetSystem[]): Promise<void> {
-    const params: AssignTargetDialogParams = { daemon, options };
+  function createComponent(options: TargetSystem[], noEligibleTargets?: boolean): Promise<void> {
+    const params: AssignTargetDialogParams = { daemon, options, noEligibleTargets };
     dialogRef = {
       close: jest.fn().mockReturnValue(Promise.resolve()),
     } as unknown as jest.Mocked<DialogRef<string | undefined>>;
@@ -40,6 +42,10 @@ describe("AssignTargetDialogComponent", () => {
     return TestBed.configureTestingModule({
       imports: [AssignTargetDialogComponent, NoopAnimationsModule],
       providers: [
+        // The link's target, so clicking it navigates rather than logging an unmatched-route error.
+        provideRouter([
+          { path: "organizations/:organizationId/pam/rotation/target-systems", children: [] },
+        ]),
         { provide: DIALOG_DATA, useValue: params },
         { provide: DialogRef, useValue: dialogRef },
         { provide: I18nService, useValue: i18nStub },
@@ -61,10 +67,35 @@ describe("AssignTargetDialogComponent", () => {
     expect(select).toBeTruthy();
   });
 
-  it("shows an empty-options message when there are no options", async () => {
+  it("shows the all-assigned message when every eligible target is already assigned", async () => {
     await createComponent([]);
-    const html = fixture.nativeElement.textContent as string;
-    expect(html).toContain("pamDaemonAssignNoOptions");
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("pamDaemonAssignNoOptions");
+    expect(text).not.toContain("pamDaemonAssignNoTargetSystems");
+  });
+
+  it("shows the no-target-systems message when none exist", async () => {
+    await createComponent([], true);
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain("pamDaemonAssignNoTargetSystems");
+    expect(text).not.toContain("pamDaemonAssignNoOptions");
+  });
+
+  it("links to the Target systems tab when none exist", async () => {
+    await createComponent([], true);
+    const anchor = fixture.nativeElement.querySelector(
+      "#assign-target-dialog_anchor_target-systems",
+    ) as HTMLAnchorElement | null;
+    expect(anchor?.getAttribute("href")).toBe("/organizations/org-1/pam/rotation/target-systems");
+  });
+
+  it("dismisses the dialog when the Target systems link is followed", async () => {
+    await createComponent([], true);
+    const anchor = fixture.nativeElement.querySelector(
+      "#assign-target-dialog_anchor_target-systems",
+    ) as HTMLAnchorElement;
+    anchor.click();
+    expect(dialogRef.close).toHaveBeenCalledWith(undefined);
   });
 
   it("closes with undefined on cancel", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.ts
@@ -28,10 +28,10 @@ export type AssignTargetDialogParams = {
   options: TargetSystem[];
   /**
    * True when the organization has no active automatic target system at all, as opposed to
-   * having some that are all already assigned to this daemon. Optional: a caller that does not
-   * know gets the existing, weaker message.
+   * having some that are all already assigned to this daemon. `options` is empty either way,
+   * so only the caller can tell the two apart.
    */
-  noEligibleTargets?: boolean;
+  noActiveAutomaticSystems: boolean;
 };
 
 /**
@@ -60,6 +60,9 @@ export type AssignTargetDialogResult = string | undefined;
 })
 export class AssignTargetDialogComponent {
   protected readonly params = inject<AssignTargetDialogParams>(DIALOG_DATA);
+  private readonly dialogRef = inject<DialogRef<AssignTargetDialogResult>>(DialogRef);
+  private readonly fb = inject(FormBuilder);
+
   protected readonly targetSystemsRoute = [
     "/organizations",
     this.params.daemon.organizationId,
@@ -67,8 +70,6 @@ export class AssignTargetDialogComponent {
     "rotation",
     "target-systems",
   ];
-  private readonly dialogRef = inject<DialogRef<AssignTargetDialogResult>>(DialogRef);
-  private readonly fb = inject(FormBuilder);
 
   protected readonly form = this.fb.nonNullable.group({
     targetSystemId: ["", [Validators.required]],

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { ReactiveFormsModule, Validators, FormBuilder } from "@angular/forms";
+import { RouterLink } from "@angular/router";
 
 import {
   ButtonModule,
@@ -9,6 +10,7 @@ import {
   DialogRef,
   DialogService,
   FormFieldModule,
+  LinkModule,
   SelectModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
@@ -24,6 +26,12 @@ export type AssignTargetDialogParams = {
    * `activeAutomaticSystems$` filtered against `daemon.assignedTargetSystemIds`.
    */
   options: TargetSystem[];
+  /**
+   * True when the organization has no active automatic target system at all, as opposed to
+   * having some that are all already assigned to this daemon. Optional: a caller that does not
+   * know gets the existing, weaker message.
+   */
+  noEligibleTargets?: boolean;
 };
 
 /**
@@ -41,15 +49,24 @@ export type AssignTargetDialogResult = string | undefined;
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ReactiveFormsModule,
+    RouterLink,
     ButtonModule,
     DialogModule,
     FormFieldModule,
+    LinkModule,
     SelectModule,
     I18nPipe,
   ],
 })
 export class AssignTargetDialogComponent {
   protected readonly params = inject<AssignTargetDialogParams>(DIALOG_DATA);
+  protected readonly targetSystemsRoute = [
+    "/organizations",
+    this.params.daemon.organizationId,
+    "pam",
+    "rotation",
+    "target-systems",
+  ];
   private readonly dialogRef = inject<DialogRef<AssignTargetDialogResult>>(DialogRef);
   private readonly fb = inject(FormBuilder);
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -25,6 +25,7 @@ describe("DaemonsTabComponent", () => {
   const rows$ = new BehaviorSubject<DaemonRow[]>([]);
   const loading$ = new BehaviorSubject<boolean>(false);
   const loadError$ = new BehaviorSubject<unknown | null>(null);
+  const targetSystemsLoadError$ = new BehaviorSubject<unknown | null>(null);
 
   function makeDaemonRow(overrides: Partial<DaemonRow> = {}): DaemonRow {
     return {
@@ -88,8 +89,10 @@ describe("DaemonsTabComponent", () => {
       delete: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<DaemonsService>;
 
+    targetSystemsLoadError$.next(null);
     targetSystemsService = {
       activeAutomaticSystems$: of([] as TargetSystem[]),
+      loadError$: targetSystemsLoadError$.asObservable(),
       load: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<TargetSystemsService>;
 
@@ -218,6 +221,63 @@ describe("DaemonsTabComponent", () => {
     await component.unassign(daemon, sysId("ts-1"), "Prod");
 
     expect(daemonsService.unassign).toHaveBeenCalledWith(daemon, sysId("ts-1"));
+  });
+
+  describe("openAssignDialog", () => {
+    const activeSystem = { id: sysId("ts-1"), name: "Prod DB" } as unknown as TargetSystem;
+
+    function daemonWithAssignments(...ids: TargetSystemId[]): DaemonRow {
+      const row = makeDaemonRow();
+      return {
+        ...row,
+        daemon: { ...row.daemon, assignedTargetSystemIds: ids } as unknown as AccessConnector,
+      };
+    }
+
+    async function openWith(systems: TargetSystem[], row: DaemonRow): Promise<void> {
+      TestBed.resetTestingModule();
+      targetSystemsService = {
+        activeAutomaticSystems$: of(systems),
+        loadError$: targetSystemsLoadError$.asObservable(),
+        load: jest.fn().mockResolvedValue(undefined),
+      } as unknown as jest.Mocked<TargetSystemsService>;
+      await createComponent();
+
+      (dialogService.open as jest.Mock).mockReturnValue({ closed: of(undefined) });
+      const component = fixture.componentInstance as unknown as {
+        openAssignDialog: (row: DaemonRow) => Promise<void>;
+      };
+      await component.openAssignDialog(row);
+    }
+
+    function dialogData(): { options: TargetSystem[]; noActiveAutomaticSystems: boolean } {
+      return (dialogService.open as jest.Mock).mock.calls[0][1].data;
+    }
+
+    it("flags that the org has no active automatic target system", async () => {
+      await openWith([], daemonWithAssignments());
+
+      expect(dialogData().options).toEqual([]);
+      expect(dialogData().noActiveAutomaticSystems).toBe(true);
+    });
+
+    it("does not flag when the only active system is already assigned to this daemon", async () => {
+      await openWith([activeSystem], daemonWithAssignments(activeSystem.id));
+
+      expect(dialogData().options).toEqual([]);
+      expect(dialogData().noActiveAutomaticSystems).toBe(false);
+    });
+
+    it("surfaces the error instead of opening the dialog when the target-systems load failed", async () => {
+      targetSystemsLoadError$.next(new Error("boom"));
+
+      await openWith([], daemonWithAssignments());
+
+      expect(dialogService.open).not.toHaveBeenCalled();
+      expect(toastService.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error" }),
+      );
+    });
   });
 
   describe("load error state", () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -150,11 +150,12 @@ export class DaemonsTabComponent {
   };
 
   protected readonly openAssignDialog = async (row: DaemonRow): Promise<void> => {
+    const activeSystems = this.activeAutomaticSystems();
     const assigned = new Set(row.daemon.assignedTargetSystemIds);
-    const options = this.activeAutomaticSystems().filter((s) => !assigned.has(s.id));
+    const options = activeSystems.filter((s) => !assigned.has(s.id));
 
     const ref = AssignTargetDialogComponent.open(this.dialogService, {
-      data: { daemon: row.daemon, options },
+      data: { daemon: row.daemon, options, noEligibleTargets: activeSystems.length === 0 },
     });
     const targetSystemId = await ref.closed.toPromise();
     if (!targetSystemId) {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -81,6 +81,9 @@ export class DaemonsTabComponent {
     this.targetSystemsService.activeAutomaticSystems$,
     { initialValue: [] as TargetSystem[] },
   );
+  private readonly targetSystemsLoadError = toSignal(this.targetSystemsService.loadError$, {
+    initialValue: null as unknown | null,
+  });
 
   protected readonly dataSource = new TableDataSource<DaemonRow>();
   protected readonly searchControl = new FormControl("", { nonNullable: true });
@@ -149,7 +152,18 @@ export class DaemonsTabComponent {
     }
   };
 
+  /**
+   * A failed target-systems load leaves the shared list empty, which is indistinguishable from an
+   * org that genuinely has none — so the failure is surfaced rather than letting the dialog assert
+   * the org has no active automatic target system.
+   */
   protected readonly openAssignDialog = async (row: DaemonRow): Promise<void> => {
+    const targetSystemsError = this.targetSystemsLoadError();
+    if (targetSystemsError) {
+      this.showError(targetSystemsError);
+      return;
+    }
+
     const activeSystems = this.activeAutomaticSystems();
     const assigned = new Set(row.daemon.assignedTargetSystemIds);
     const options = activeSystems.filter((s) => !assigned.has(s.id));

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -155,7 +155,7 @@ export class DaemonsTabComponent {
     const options = activeSystems.filter((s) => !assigned.has(s.id));
 
     const ref = AssignTargetDialogComponent.open(this.dialogService, {
-      data: { daemon: row.daemon, options, noEligibleTargets: activeSystems.length === 0 },
+      data: { daemon: row.daemon, options, noActiveAutomaticSystems: activeSystems.length === 0 },
     });
     const targetSystemId = await ref.closed.toPromise();
     if (!targetSystemId) {


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`. Not tracked in Jira: this fix originates from code-review finding `uat-rotux-assign-dialog-false-empty-message`, which has no associated ticket.

## 📔 Objective

Replaces the misleading "all already assigned" message in the `Assign to target` dialog with accurate copy when an organization has zero active automatic target systems.

- Adds a required `noActiveAutomaticSystems` field to `AssignTargetDialogParams`, set in `daemons-tab.component.ts` from `activeAutomaticSystems().length === 0`.
- `assign-target-dialog.component.html` checks that flag ahead of the existing `options.length === 0` branch, rendering new copy plus a `Go to Target systems` link.
- The link routes to `/organizations/:organizationId/pam/rotation/target-systems`, built from `params.daemon.organizationId`, and closes the dialog on click.
- Adds locale keys `pamDaemonAssignNoTargetSystems` and `pamDaemonAssignGoToTargetSystems`.
- `openAssignDialog` also reads `TargetSystemsService.loadError$`; on a failed load it shows an error toast and returns instead of opening the dialog.

Sits on the PR for `pam/rotux-load-failure-error-state`; `pam/rotux-row-actions-inflight-disable` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Daemons -> row menu -> Assign to target

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-assign-dialog-false-empty-message.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-assign-dialog-false-empty-message.png" alt="after" width="460"> |

## Copy not yet approved

This PR adds user-facing wording the designer has not signed off on:

- `pamDaemonAssignNoTargetSystems`: "There are no active automatic target systems to assign. Create one on the Target systems tab, or set an existing one to active."
- `pamDaemonAssignGoToTargetSystems`: "Go to Target systems"

Treat both as proposed, not final.

## Known gaps

- Visual QA on the assembled stack tip found that `noActiveAutomaticSystems` was made required rather than optional, and a second call site, `daemon-detail.component.ts:238` (added by a different, neighboring ticket), does not pass it. That fails `tsc` (`TS2741: Property 'noActiveAutomaticSystems' is missing`) at the assembled tip, and in the running app that connector-detail entry point still shows the old, false "already assigned" copy this ticket exists to remove.
- `TargetSystemsService.loading$` is not consulted, so clicking `Assign to target` while the target-systems list is still loading can still render the "no active automatic target systems" message.
- After a failed target-systems load, the click now shows a generic error toast rather than a retryable tab-level error state; that state belongs to the base branch, `pam/rotux-load-failure-error-state`.
- The "some active automatic target systems exist, but all are already assigned" branch was not re-verified against this exact code path during visual QA; its rendered output (the unchanged `pamDaemonAssignNoOptions` copy, no link) was only observed via the neighboring entry point above.
- `test:types` fails on the assembled stack tip, but all failures pre-exist on `pam/uat` except the one described in the first bullet above, which this diff introduces.
