### PR TITLE
Row menu mutations have no in-flight disable and can be fired twice

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -98,7 +98,12 @@
           ></button>
           <bit-menu #rowMenu>
             @if (r.canAssign) {
-              <button type="button" bitMenuItem (click)="openAssignDialog(r)">
+              <button
+                type="button"
+                bitMenuItem
+                [disabled]="isRowBusy(r.id)"
+                (click)="openAssignDialog(r)"
+              >
                 <bit-icon name="bwi-plus-circle" class="tw-text-muted"></bit-icon>
                 {{ "pamDaemonAssignTarget" | i18n }}
               </button>
@@ -112,6 +117,7 @@
                 <button
                   type="button"
                   bitMenuItem
+                  [disabled]="isRowBusy(r.id)"
                   (click)="unassign(r.daemon, assignmentId, r.assignmentNames[i])"
                 >
                   <bit-icon name="bwi-minus-circle" class="tw-text-muted"></bit-icon>
@@ -120,17 +126,22 @@
               }
             }
             @if (r.enabled) {
-              <button type="button" bitMenuItem (click)="disable(r)">
+              <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="disable(r)">
                 <bit-icon name="bwi-circle" class="tw-text-muted"></bit-icon>
                 {{ "pamDaemonDisable" | i18n }}
               </button>
             } @else {
-              <button type="button" bitMenuItem (click)="enable(r)">
+              <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="enable(r)">
                 <bit-icon name="bwi-check-circle" class="tw-text-muted"></bit-icon>
                 {{ "pamDaemonEnable" | i18n }}
               </button>
             }
-            <button type="button" bitMenuItem (click)="confirmDelete(r)">
+            <button
+              type="button"
+              bitMenuItem
+              [disabled]="isRowBusy(r.id)"
+              (click)="confirmDelete(r)"
+            >
               <bit-icon name="bwi-trash" class="tw-text-danger"></bit-icon>
               <span class="tw-text-danger">{{ "delete" | i18n }}</span>
             </button>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -118,7 +118,7 @@
                   type="button"
                   bitMenuItem
                   [disabled]="isRowBusy(r.id)"
-                  (click)="unassign(r.daemon, assignmentId, r.assignmentNames[i])"
+                  (click)="unassign(r, assignmentId, r.assignmentNames[i])"
                 >
                   <bit-icon name="bwi-minus-circle" class="tw-text-muted"></bit-icon>
                   {{ "pamDaemonUnassign" | i18n: r.assignmentNames[i] }}

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -7,8 +7,9 @@ import { BehaviorSubject, of } from "rxjs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 
-import type { AccessConnector, TargetSystemId, TargetSystem } from "../rotation";
+import type { AccessConnector, AccessConnectorId, TargetSystemId, TargetSystem } from "../rotation";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
+import { deferred } from "../testing/deferred";
 import { ORGANIZATION_ID, connectorId, sysId } from "../testing/rotation-builders";
 
 import { DaemonsTabComponent } from "./daemons-tab.component";
@@ -227,14 +228,8 @@ describe("DaemonsTabComponent", () => {
     type Guarded = {
       disable: (row: DaemonRow) => Promise<void>;
       confirmDelete: (row: DaemonRow) => Promise<void>;
-      isRowBusy: (rowId: string) => boolean;
+      isRowBusy: (rowId: AccessConnectorId) => boolean;
     };
-
-    function deferred(): { promise: Promise<void>; settle: () => void } {
-      let settle!: () => void;
-      const promise = new Promise<void>((resolve) => (settle = () => resolve()));
-      return { promise, settle };
-    }
 
     function guarded(): Guarded {
       return fixture.componentInstance as unknown as Guarded;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -223,6 +223,88 @@ describe("DaemonsTabComponent", () => {
     expect(daemonsService.unassign).toHaveBeenCalledWith(daemon, sysId("ts-1"));
   });
 
+  describe("in-flight row guard", () => {
+    type Guarded = {
+      disable: (row: DaemonRow) => Promise<void>;
+      confirmDelete: (row: DaemonRow) => Promise<void>;
+      isRowBusy: (rowId: string) => boolean;
+    };
+
+    function deferred(): { promise: Promise<void>; settle: () => void } {
+      let settle!: () => void;
+      const promise = new Promise<void>((resolve) => (settle = () => resolve()));
+      return { promise, settle };
+    }
+
+    function guarded(): Guarded {
+      return fixture.componentInstance as unknown as Guarded;
+    }
+
+    beforeEach(() => {
+      (dialogService.openSimpleDialog as jest.Mock).mockResolvedValue(true);
+    });
+
+    it("does not dispatch a second setEnabled while the first is unsettled", async () => {
+      const pending = deferred();
+      (daemonsService.setEnabled as jest.Mock).mockReturnValue(pending.promise);
+      const row = makeDaemonRow();
+      const component = guarded();
+
+      const first = component.disable(row);
+      const second = component.disable(row);
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(daemonsService.setEnabled).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not dispatch a second delete while the first is unsettled", async () => {
+      const pending = deferred();
+      (daemonsService.delete as jest.Mock).mockReturnValue(pending.promise);
+      const row = makeDaemonRow();
+      const component = guarded();
+
+      const first = component.confirmDelete(row);
+      const second = component.confirmDelete(row);
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(daemonsService.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-enables the row once the request settles", async () => {
+      const pending = deferred();
+      (daemonsService.setEnabled as jest.Mock).mockReturnValue(pending.promise);
+      const row = makeDaemonRow();
+      const component = guarded();
+
+      const first = component.disable(row);
+      expect(component.isRowBusy(row.id)).toBe(true);
+
+      pending.settle();
+      await first;
+      expect(component.isRowBusy(row.id)).toBe(false);
+
+      await component.disable(row);
+      expect(daemonsService.setEnabled).toHaveBeenCalledTimes(2);
+    });
+
+    it("allows a second action on a different row while one is in flight", async () => {
+      const pending = deferred();
+      (daemonsService.setEnabled as jest.Mock).mockReturnValue(pending.promise);
+      const rowA = makeDaemonRow({ id: connectorId("1") });
+      const rowB = makeDaemonRow({ id: connectorId("2") });
+      const component = guarded();
+
+      const first = component.disable(rowA);
+      const second = component.disable(rowB);
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(daemonsService.setEnabled).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe("openAssignDialog", () => {
     const activeSystem = { id: sysId("ts-1"), name: "Prod DB" } as unknown as TargetSystem;
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -29,22 +29,25 @@ describe("DaemonsTabComponent", () => {
   const targetSystemsLoadError$ = new BehaviorSubject<unknown | null>(null);
 
   function makeDaemonRow(overrides: Partial<DaemonRow> = {}): DaemonRow {
+    const id = overrides.id ?? connectorId("daemon-1");
+    const name = overrides.name ?? "Test Daemon";
     return {
-      id: connectorId("daemon-1"),
-      name: "Test Daemon",
+      id,
+      name,
       statusLabelKey: "pamDaemonStatusEnabled",
       isConnected: true,
       assignmentNames: [],
       enabled: true,
       canAssign: true,
+      ...overrides,
       daemon: {
-        id: connectorId("daemon-1"),
-        name: "Test Daemon",
+        id,
+        name,
         assignments: [],
         status: 0,
         isConnected: true,
+        ...(overrides.daemon ?? {}),
       } as unknown as AccessConnector,
-      ...overrides,
     };
   }
 
@@ -214,20 +217,21 @@ describe("DaemonsTabComponent", () => {
 
   it("calls daemonsService.unassign after confirmation", async () => {
     (dialogService.openSimpleDialog as jest.Mock).mockResolvedValue(true);
-    const daemon = makeDaemonRow().daemon;
+    const row = makeDaemonRow();
 
     const component = fixture.componentInstance as unknown as {
-      unassign: (daemon: AccessConnector, targetId: TargetSystemId, name: string) => Promise<void>;
+      unassign: (row: DaemonRow, targetId: TargetSystemId, name: string) => Promise<void>;
     };
-    await component.unassign(daemon, sysId("ts-1"), "Prod");
+    await component.unassign(row, sysId("ts-1"), "Prod");
 
-    expect(daemonsService.unassign).toHaveBeenCalledWith(daemon, sysId("ts-1"));
+    expect(daemonsService.unassign).toHaveBeenCalledWith(row.daemon, sysId("ts-1"));
   });
 
   describe("in-flight row guard", () => {
     type Guarded = {
       disable: (row: DaemonRow) => Promise<void>;
       confirmDelete: (row: DaemonRow) => Promise<void>;
+      unassign: (row: DaemonRow, targetId: TargetSystemId, name: string) => Promise<void>;
       isRowBusy: (rowId: AccessConnectorId) => boolean;
     };
 
@@ -282,6 +286,20 @@ describe("DaemonsTabComponent", () => {
 
       await component.disable(row);
       expect(daemonsService.setEnabled).toHaveBeenCalledTimes(2);
+    });
+
+    it("marks the row busy under the id the row menu binds, on every action", async () => {
+      const pending = deferred();
+      (daemonsService.unassign as jest.Mock).mockReturnValue(pending.promise);
+      const row = makeDaemonRow({ id: connectorId("row-key") });
+      const component = guarded();
+
+      const first = component.unassign(row, sysId("ts-1"), "Prod");
+      expect(component.isRowBusy(row.id)).toBe(true);
+
+      pending.settle();
+      await first;
+      expect(component.isRowBusy(row.id)).toBe(false);
     });
 
     it("allows a second action on a different row while one is in flight", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -1,5 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -153,120 +160,150 @@ export class DaemonsTabComponent {
   };
 
   /**
+   * Ids of the rows with a mutation in flight. Clicking a bitMenuItem closes the menu and the
+   * overlay disposes its view, so a per-button flag would not survive the reopen-and-click-again
+   * path this guards against; the state has to live on the component.
+   */
+  private readonly busyRowIds = signal<ReadonlySet<string>>(new Set<string>());
+
+  protected readonly isRowBusy = (rowId: string): boolean => this.busyRowIds().has(rowId);
+
+  private async runForRow(rowId: string, action: () => Promise<void>): Promise<void> {
+    if (this.busyRowIds().has(rowId)) {
+      return;
+    }
+    this.busyRowIds.update((ids) => new Set(ids).add(rowId));
+    try {
+      await action();
+    } finally {
+      this.busyRowIds.update((ids) => {
+        const next = new Set(ids);
+        next.delete(rowId);
+        return next;
+      });
+    }
+  }
+
+  /**
    * A failed target-systems load leaves the shared list empty, which is indistinguishable from an
    * org that genuinely has none — so the failure is surfaced rather than letting the dialog assert
    * the org has no active automatic target system.
    */
-  protected readonly openAssignDialog = async (row: DaemonRow): Promise<void> => {
-    const targetSystemsError = this.targetSystemsLoadError();
-    if (targetSystemsError) {
-      this.showError(targetSystemsError);
-      return;
-    }
+  protected readonly openAssignDialog = async (row: DaemonRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      const targetSystemsError = this.targetSystemsLoadError();
+      if (targetSystemsError) {
+        this.showError(targetSystemsError);
+        return;
+      }
 
-    const activeSystems = this.activeAutomaticSystems();
-    const assigned = new Set(row.daemon.assignedTargetSystemIds);
-    const options = activeSystems.filter((s) => !assigned.has(s.id));
+      const activeSystems = this.activeAutomaticSystems();
+      const assigned = new Set(row.daemon.assignedTargetSystemIds);
+      const options = activeSystems.filter((s) => !assigned.has(s.id));
 
-    const ref = AssignTargetDialogComponent.open(this.dialogService, {
-      data: { daemon: row.daemon, options, noActiveAutomaticSystems: activeSystems.length === 0 },
-    });
-    const targetSystemId = await ref.closed.toPromise();
-    if (!targetSystemId) {
-      return;
-    }
-    try {
-      await this.daemonsService.assign(row.daemon, asUuid<TargetSystemId>(targetSystemId));
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamDaemonAssigned"),
+      const ref = AssignTargetDialogComponent.open(this.dialogService, {
+        data: { daemon: row.daemon, options, noActiveAutomaticSystems: activeSystems.length === 0 },
       });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
+      const targetSystemId = await ref.closed.toPromise();
+      if (!targetSystemId) {
+        return;
+      }
+      try {
+        await this.daemonsService.assign(row.daemon, asUuid<TargetSystemId>(targetSystemId));
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamDaemonAssigned"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
 
   protected readonly unassign = async (
     daemon: AccessConnector,
     targetSystemId: string,
     targetName: string,
-  ): Promise<void> => {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonUnassignConfirmTitle" },
-      content: { key: "pamDaemonUnassignConfirmContent", placeholders: [targetName] },
-      acceptButtonText: { key: "remove" },
-      cancelButtonText: { key: "cancel" },
-      type: "warning",
+  ): Promise<void> =>
+    this.runForRow(daemon.id, async () => {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamDaemonUnassignConfirmTitle" },
+        content: { key: "pamDaemonUnassignConfirmContent", placeholders: [targetName] },
+        acceptButtonText: { key: "remove" },
+        cancelButtonText: { key: "cancel" },
+        type: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+      try {
+        await this.daemonsService.unassign(daemon, asUuid<TargetSystemId>(targetSystemId));
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamDaemonUnassigned"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
     });
-    if (!confirmed) {
-      return;
-    }
-    try {
-      await this.daemonsService.unassign(daemon, asUuid<TargetSystemId>(targetSystemId));
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamDaemonUnassigned"),
-      });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
 
-  protected readonly disable = async (row: DaemonRow): Promise<void> => {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonDisableConfirmTitle" },
-      content: { key: "pamDaemonDisableConfirmContent", placeholders: [row.name] },
-      acceptButtonText: { key: "pamDaemonDisable" },
-      cancelButtonText: { key: "cancel" },
-      type: "warning",
+  protected readonly disable = async (row: DaemonRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamDaemonDisableConfirmTitle" },
+        content: { key: "pamDaemonDisableConfirmContent", placeholders: [row.name] },
+        acceptButtonText: { key: "pamDaemonDisable" },
+        cancelButtonText: { key: "cancel" },
+        type: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+      try {
+        await this.daemonsService.setEnabled(row.daemon, false);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamDaemonDisabled"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
     });
-    if (!confirmed) {
-      return;
-    }
-    try {
-      await this.daemonsService.setEnabled(row.daemon, false);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamDaemonDisabled"),
-      });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
 
-  protected readonly enable = async (row: DaemonRow): Promise<void> => {
-    try {
-      await this.daemonsService.setEnabled(row.daemon, true);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamDaemonEnabled"),
-      });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
-
-  protected readonly confirmDelete = async (row: DaemonRow): Promise<void> => {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonDeleteConfirmTitle" },
-      content: { key: "pamDaemonDeleteConfirmContent", placeholders: [row.name] },
-      acceptButtonText: { key: "delete" },
-      cancelButtonText: { key: "cancel" },
-      type: "danger",
+  protected readonly enable = async (row: DaemonRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      try {
+        await this.daemonsService.setEnabled(row.daemon, true);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamDaemonEnabled"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
     });
-    if (!confirmed) {
-      return;
-    }
-    try {
-      await this.daemonsService.delete(row.daemon);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamDaemonDeleted"),
+
+  protected readonly confirmDelete = async (row: DaemonRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamDaemonDeleteConfirmTitle" },
+        content: { key: "pamDaemonDeleteConfirmContent", placeholders: [row.name] },
+        acceptButtonText: { key: "delete" },
+        cancelButtonText: { key: "cancel" },
+        type: "danger",
       });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
+      if (!confirmed) {
+        return;
+      }
+      try {
+        await this.daemonsService.delete(row.daemon);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamDaemonDeleted"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
 
   private showError(e: unknown): void {
     const message =

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -29,13 +29,7 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
-import {
-  AccessConnector,
-  AccessConnectorId,
-  DaemonStatus,
-  TargetSystemId,
-  TargetSystem,
-} from "../rotation";
+import { AccessConnectorId, DaemonStatus, TargetSystemId, TargetSystem } from "../rotation";
 import { RotationLoadErrorComponent } from "../rotation-load-error.component";
 import { RowBusyTracker } from "../row-busy-tracker";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
@@ -199,11 +193,11 @@ export class DaemonsTabComponent {
     });
 
   protected readonly unassign = (
-    daemon: AccessConnector,
+    row: DaemonRow,
     targetSystemId: string,
     targetName: string,
   ): Promise<void> =>
-    this.busyRows.run(daemon.id, async () => {
+    this.busyRows.run(row.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamDaemonUnassignConfirmTitle" },
         content: { key: "pamDaemonUnassignConfirmContent", placeholders: [targetName] },
@@ -215,7 +209,7 @@ export class DaemonsTabComponent {
         return;
       }
       try {
-        await this.daemonsService.unassign(daemon, asUuid<TargetSystemId>(targetSystemId));
+        await this.daemonsService.unassign(row.daemon, asUuid<TargetSystemId>(targetSystemId));
         this.toastService.showToast({
           variant: "success",
           message: this.i18nService.t("pamDaemonUnassigned"),

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -1,12 +1,5 @@
 import { CommonModule } from "@angular/common";
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  inject,
-  signal,
-} from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -36,8 +29,15 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
-import { AccessConnector, DaemonStatus, TargetSystemId, TargetSystem } from "../rotation";
+import {
+  AccessConnector,
+  AccessConnectorId,
+  DaemonStatus,
+  TargetSystemId,
+  TargetSystem,
+} from "../rotation";
 import { RotationLoadErrorComponent } from "../rotation-load-error.component";
+import { RowBusyTracker } from "../row-busy-tracker";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 
 import { AssignTargetDialogComponent } from "./assign-target-dialog.component";
@@ -101,6 +101,10 @@ export class DaemonsTabComponent {
     { requireSync: true },
   );
 
+  private readonly busyRows = new RowBusyTracker<AccessConnectorId>();
+
+  protected readonly isRowBusy = this.busyRows.isBusy;
+
   constructor() {
     effect(() => {
       void this.loadAll(this.organizationId());
@@ -160,37 +164,12 @@ export class DaemonsTabComponent {
   };
 
   /**
-   * Ids of the rows with a mutation in flight. Clicking a bitMenuItem closes the menu and the
-   * overlay disposes its view, so a per-button flag would not survive the reopen-and-click-again
-   * path this guards against; the state has to live on the component.
-   */
-  private readonly busyRowIds = signal<ReadonlySet<string>>(new Set<string>());
-
-  protected readonly isRowBusy = (rowId: string): boolean => this.busyRowIds().has(rowId);
-
-  private async runForRow(rowId: string, action: () => Promise<void>): Promise<void> {
-    if (this.busyRowIds().has(rowId)) {
-      return;
-    }
-    this.busyRowIds.update((ids) => new Set(ids).add(rowId));
-    try {
-      await action();
-    } finally {
-      this.busyRowIds.update((ids) => {
-        const next = new Set(ids);
-        next.delete(rowId);
-        return next;
-      });
-    }
-  }
-
-  /**
    * A failed target-systems load leaves the shared list empty, which is indistinguishable from an
    * org that genuinely has none — so the failure is surfaced rather than letting the dialog assert
    * the org has no active automatic target system.
    */
-  protected readonly openAssignDialog = async (row: DaemonRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly openAssignDialog = (row: DaemonRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       const targetSystemsError = this.targetSystemsLoadError();
       if (targetSystemsError) {
         this.showError(targetSystemsError);
@@ -219,12 +198,12 @@ export class DaemonsTabComponent {
       }
     });
 
-  protected readonly unassign = async (
+  protected readonly unassign = (
     daemon: AccessConnector,
     targetSystemId: string,
     targetName: string,
   ): Promise<void> =>
-    this.runForRow(daemon.id, async () => {
+    this.busyRows.run(daemon.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamDaemonUnassignConfirmTitle" },
         content: { key: "pamDaemonUnassignConfirmContent", placeholders: [targetName] },
@@ -246,8 +225,8 @@ export class DaemonsTabComponent {
       }
     });
 
-  protected readonly disable = async (row: DaemonRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly disable = (row: DaemonRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamDaemonDisableConfirmTitle" },
         content: { key: "pamDaemonDisableConfirmContent", placeholders: [row.name] },
@@ -269,8 +248,8 @@ export class DaemonsTabComponent {
       }
     });
 
-  protected readonly enable = async (row: DaemonRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly enable = (row: DaemonRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       try {
         await this.daemonsService.setEnabled(row.daemon, true);
         this.toastService.showToast({
@@ -282,8 +261,8 @@ export class DaemonsTabComponent {
       }
     });
 
-  protected readonly confirmDelete = async (row: DaemonRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly confirmDelete = (row: DaemonRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamDaemonDeleteConfirmTitle" },
         content: { key: "pamDaemonDeleteConfirmContent", placeholders: [row.name] },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -148,7 +148,7 @@
           ></button>
           <bit-menu #rowMenu>
             @if (r.canRotateNow) {
-              <button type="button" bitMenuItem (click)="rotateNow(r)">
+              <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="rotateNow(r)">
                 <bit-icon name="bwi-refresh" class="tw-text-muted"></bit-icon>
                 {{ "pamRotationConfigRotateNow" | i18n }}
               </button>
@@ -165,7 +165,12 @@
               </button>
             }
             @if (r.canRecordManual) {
-              <button type="button" bitMenuItem (click)="confirmRecordManual(r)">
+              <button
+                type="button"
+                bitMenuItem
+                [disabled]="isRowBusy(r.id)"
+                (click)="confirmRecordManual(r)"
+              >
                 <bit-icon name="bwi-pencil-square" class="tw-text-muted"></bit-icon>
                 {{ "pamRotationConfigRecordManual" | i18n }}
               </button>
@@ -175,13 +180,13 @@
               {{ "edit" | i18n }}
             </button>
             @if (r.canPause) {
-              <button type="button" bitMenuItem (click)="pause(r)">
+              <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="pause(r)">
                 <bit-icon name="bwi-circle" class="tw-text-muted"></bit-icon>
                 {{ "pamRotationConfigPause" | i18n }}
               </button>
             }
             @if (r.canResume) {
-              <button type="button" bitMenuItem (click)="resume(r)">
+              <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="resume(r)">
                 <bit-icon name="bwi-check-circle" class="tw-text-muted"></bit-icon>
                 {{ "pamRotationConfigResume" | i18n }}
               </button>
@@ -197,7 +202,12 @@
                 {{ "delete" | i18n }}
               </button>
             } @else {
-              <button type="button" bitMenuItem (click)="confirmDelete(r)">
+              <button
+                type="button"
+                bitMenuItem
+                [disabled]="isRowBusy(r.id)"
+                (click)="confirmDelete(r)"
+              >
                 <bit-icon name="bwi-trash" class="tw-text-danger"></bit-icon>
                 <span class="tw-text-danger">{{ "delete" | i18n }}</span>
               </button>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -9,6 +9,7 @@ import type { RotationConfig } from "../rotation";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 import {
   ORGANIZATION_ID,
+  configId,
   rotationConfigDescription,
   rotationConfig,
 } from "../testing/rotation-builders";
@@ -240,6 +241,72 @@ describe("ManagedCredentialsTabComponent", () => {
       expect(toastService.showToast).toHaveBeenCalledWith(
         expect.objectContaining({ variant: "success" }),
       );
+    });
+  });
+
+  describe("in-flight row guard", () => {
+    beforeEach(() => setupTestBed(true));
+
+    function deferred(): { promise: Promise<void>; settle: () => void } {
+      let settle!: () => void;
+      const promise = new Promise<void>((resolve) => (settle = () => resolve()));
+      return { promise, settle };
+    }
+
+    it("does not dispatch a second rotateNow while the first is unsettled", async () => {
+      const pending = deferred();
+      configsService.rotateNow.mockReturnValue(pending.promise);
+      const row = makeRow();
+
+      const first = component.rotateNow(row);
+      const second = component.rotateNow(row);
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(configsService.rotateNow).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not dispatch a second pause while the first is unsettled", async () => {
+      const pending = deferred();
+      configsService.pause.mockReturnValue(pending.promise);
+      const row = makeRow();
+
+      const first = component.pause(row);
+      const second = component.pause(row);
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(configsService.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-enables the row once the request settles", async () => {
+      const pending = deferred();
+      configsService.rotateNow.mockReturnValue(pending.promise);
+      const row = makeRow();
+
+      const first = component.rotateNow(row);
+      expect(component.isRowBusy(row.id)).toBe(true);
+
+      pending.settle();
+      await first;
+      expect(component.isRowBusy(row.id)).toBe(false);
+
+      await component.rotateNow(row);
+      expect(configsService.rotateNow).toHaveBeenCalledTimes(2);
+    });
+
+    it("allows a second action on a different row while one is in flight", async () => {
+      const pending = deferred();
+      configsService.pause.mockReturnValue(pending.promise);
+      const rowA = makeRow();
+      const rowB = makeRow({ id: configId("7") });
+
+      const first = component.pause(rowA);
+      const second = component.pause(rowB);
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(configsService.pause).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -7,6 +7,7 @@ import { DialogService, ToastService } from "@bitwarden/components";
 
 import type { RotationConfig } from "../rotation";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
+import { deferred } from "../testing/deferred";
 import {
   ORGANIZATION_ID,
   configId,
@@ -246,12 +247,6 @@ describe("ManagedCredentialsTabComponent", () => {
 
   describe("in-flight row guard", () => {
     beforeEach(() => setupTestBed(true));
-
-    function deferred(): { promise: Promise<void>; settle: () => void } {
-      let settle!: () => void;
-      const promise = new Promise<void>((resolve) => (settle = () => resolve()));
-      return { promise, settle };
-    }
 
     it("does not dispatch a second rotateNow while the first is unsettled", async () => {
       const pending = deferred();

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
@@ -1,12 +1,5 @@
 import { CommonModule } from "@angular/common";
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  inject,
-  signal,
-} from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -34,8 +27,9 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
-import { TargetSystemMethod, TargetSystem } from "../rotation";
+import { RotationConfigId, TargetSystemMethod, TargetSystem } from "../rotation";
 import { RotationLoadErrorComponent } from "../rotation-load-error.component";
+import { RowBusyTracker } from "../row-busy-tracker";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 
 import { RotationConfigRow } from "./rotation-config-row";
@@ -110,6 +104,10 @@ export class ManagedCredentialsTabComponent {
   /** Expose for template. */
   protected readonly TargetSystemMethod = TargetSystemMethod;
 
+  private readonly busyRows = new RowBusyTracker<RotationConfigId>();
+
+  protected readonly isRowBusy = this.busyRows.isBusy;
+
   constructor() {
     effect(() => {
       void this.loadAll(this.organizationId());
@@ -161,33 +159,8 @@ export class ManagedCredentialsTabComponent {
   protected readonly openEdit = (row: RotationConfigRow): Promise<boolean> =>
     this.router.navigate(["..", "managed-credentials", row.id], { relativeTo: this.route });
 
-  /**
-   * Ids of the rows with a mutation in flight. Clicking a bitMenuItem closes the menu and the
-   * overlay disposes its view, so a per-button flag would not survive the reopen-and-click-again
-   * path this guards against; the state has to live on the component.
-   */
-  private readonly busyRowIds = signal<ReadonlySet<string>>(new Set<string>());
-
-  protected readonly isRowBusy = (rowId: string): boolean => this.busyRowIds().has(rowId);
-
-  private async runForRow(rowId: string, action: () => Promise<void>): Promise<void> {
-    if (this.busyRowIds().has(rowId)) {
-      return;
-    }
-    this.busyRowIds.update((ids) => new Set(ids).add(rowId));
-    try {
-      await action();
-    } finally {
-      this.busyRowIds.update((ids) => {
-        const next = new Set(ids);
-        next.delete(rowId);
-        return next;
-      });
-    }
-  }
-
-  protected readonly rotateNow = async (row: RotationConfigRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly rotateNow = (row: RotationConfigRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       try {
         await this.configsService.rotateNow(row.config);
         this.toastService.showToast({
@@ -199,8 +172,8 @@ export class ManagedCredentialsTabComponent {
       }
     });
 
-  protected readonly confirmRecordManual = async (row: RotationConfigRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly confirmRecordManual = (row: RotationConfigRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamRotationConfigRecordManualTitle" },
         content: { key: "pamRotationConfigRecordManualContent" },
@@ -222,8 +195,8 @@ export class ManagedCredentialsTabComponent {
       }
     });
 
-  protected readonly pause = async (row: RotationConfigRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly pause = (row: RotationConfigRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       try {
         await this.configsService.pause(row.config);
         this.toastService.showToast({
@@ -235,8 +208,8 @@ export class ManagedCredentialsTabComponent {
       }
     });
 
-  protected readonly resume = async (row: RotationConfigRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly resume = (row: RotationConfigRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       try {
         await this.configsService.resume(row.config);
         this.toastService.showToast({
@@ -248,8 +221,8 @@ export class ManagedCredentialsTabComponent {
       }
     });
 
-  protected readonly confirmDelete = async (row: RotationConfigRow): Promise<void> =>
-    this.runForRow(row.id, async () => {
+  protected readonly confirmDelete = (row: RotationConfigRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamRotationConfigDeleteConfirmTitle" },
         content: { key: "pamRotationConfigDeleteConfirmContent" },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
@@ -1,5 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -154,85 +161,115 @@ export class ManagedCredentialsTabComponent {
   protected readonly openEdit = (row: RotationConfigRow): Promise<boolean> =>
     this.router.navigate(["..", "managed-credentials", row.id], { relativeTo: this.route });
 
-  protected readonly rotateNow = async (row: RotationConfigRow): Promise<void> => {
-    try {
-      await this.configsService.rotateNow(row.config);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamRotationConfigRotateNowSuccess"),
-      });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
+  /**
+   * Ids of the rows with a mutation in flight. Clicking a bitMenuItem closes the menu and the
+   * overlay disposes its view, so a per-button flag would not survive the reopen-and-click-again
+   * path this guards against; the state has to live on the component.
+   */
+  private readonly busyRowIds = signal<ReadonlySet<string>>(new Set<string>());
 
-  protected readonly confirmRecordManual = async (row: RotationConfigRow): Promise<void> => {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamRotationConfigRecordManualTitle" },
-      content: { key: "pamRotationConfigRecordManualContent" },
-      acceptButtonText: { key: "pamRotationConfigRecordManualConfirm" },
-      cancelButtonText: { key: "cancel" },
-      type: "info",
-    });
-    if (!confirmed) {
+  protected readonly isRowBusy = (rowId: string): boolean => this.busyRowIds().has(rowId);
+
+  private async runForRow(rowId: string, action: () => Promise<void>): Promise<void> {
+    if (this.busyRowIds().has(rowId)) {
       return;
     }
+    this.busyRowIds.update((ids) => new Set(ids).add(rowId));
     try {
-      await this.configsService.recordManual(row.config);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamRotationConfigRecordManualSuccess"),
+      await action();
+    } finally {
+      this.busyRowIds.update((ids) => {
+        const next = new Set(ids);
+        next.delete(rowId);
+        return next;
       });
-    } catch (e) {
-      this.showError(e);
     }
-  };
+  }
 
-  protected readonly pause = async (row: RotationConfigRow): Promise<void> => {
-    try {
-      await this.configsService.pause(row.config);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamRotationConfigPauseSuccess"),
-      });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
-
-  protected readonly resume = async (row: RotationConfigRow): Promise<void> => {
-    try {
-      await this.configsService.resume(row.config);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamRotationConfigResumeSuccess"),
-      });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
-
-  protected readonly confirmDelete = async (row: RotationConfigRow): Promise<void> => {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamRotationConfigDeleteConfirmTitle" },
-      content: { key: "pamRotationConfigDeleteConfirmContent" },
-      acceptButtonText: { key: "delete" },
-      cancelButtonText: { key: "cancel" },
-      type: "warning",
+  protected readonly rotateNow = async (row: RotationConfigRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      try {
+        await this.configsService.rotateNow(row.config);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamRotationConfigRotateNowSuccess"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
     });
-    if (!confirmed) {
-      return;
-    }
-    try {
-      await this.configsService.delete(row.config);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamRotationConfigDeleteSuccess"),
+
+  protected readonly confirmRecordManual = async (row: RotationConfigRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamRotationConfigRecordManualTitle" },
+        content: { key: "pamRotationConfigRecordManualContent" },
+        acceptButtonText: { key: "pamRotationConfigRecordManualConfirm" },
+        cancelButtonText: { key: "cancel" },
+        type: "info",
       });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
+      if (!confirmed) {
+        return;
+      }
+      try {
+        await this.configsService.recordManual(row.config);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamRotationConfigRecordManualSuccess"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
+
+  protected readonly pause = async (row: RotationConfigRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      try {
+        await this.configsService.pause(row.config);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamRotationConfigPauseSuccess"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
+
+  protected readonly resume = async (row: RotationConfigRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      try {
+        await this.configsService.resume(row.config);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamRotationConfigResumeSuccess"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
+
+  protected readonly confirmDelete = async (row: RotationConfigRow): Promise<void> =>
+    this.runForRow(row.id, async () => {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamRotationConfigDeleteConfirmTitle" },
+        content: { key: "pamRotationConfigDeleteConfirmContent" },
+        acceptButtonText: { key: "delete" },
+        cancelButtonText: { key: "cancel" },
+        type: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+      try {
+        await this.configsService.delete(row.config);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamRotationConfigDeleteSuccess"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
 
   private showError(e: unknown): void {
     const message =

--- a/bitwarden_license/bit-web/src/app/pam/rotation/row-busy-tracker.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/row-busy-tracker.ts
@@ -1,0 +1,30 @@
+import { signal } from "@angular/core";
+
+/**
+ * Tracks which table rows have a mutation in flight and drops a repeat call for a row already busy.
+ *
+ * Clicking a `bitMenuItem` closes the menu and the overlay disposes its view, so a per-button flag
+ * (`bitAction`) would not survive the reopen-and-click-again path this guards against; the state has
+ * to outlive the menu.
+ */
+export class RowBusyTracker<TRowId> {
+  private readonly busyIds = signal<ReadonlySet<TRowId>>(new Set<TRowId>());
+
+  readonly isBusy = (rowId: TRowId): boolean => this.busyIds().has(rowId);
+
+  async run(rowId: TRowId, action: () => Promise<void>): Promise<void> {
+    if (this.isBusy(rowId)) {
+      return;
+    }
+    this.busyIds.update((ids) => new Set(ids).add(rowId));
+    try {
+      await action();
+    } finally {
+      this.busyIds.update((ids) => {
+        const next = new Set(ids);
+        next.delete(rowId);
+        return next;
+      });
+    }
+  }
+}

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.html
@@ -71,17 +71,32 @@
                 {{ "edit" | i18n }}
               </button>
               @if (r.active) {
-                <button type="button" bitMenuItem (click)="disable(r.system)">
+                <button
+                  type="button"
+                  bitMenuItem
+                  [disabled]="isRowBusy(r.system.id)"
+                  (click)="disable(r.system)"
+                >
                   <bit-icon name="bwi-circle" class="tw-text-muted"></bit-icon>
                   {{ "pamTargetSystemDisable" | i18n }}
                 </button>
               } @else {
-                <button type="button" bitMenuItem (click)="enable(r.system)">
+                <button
+                  type="button"
+                  bitMenuItem
+                  [disabled]="isRowBusy(r.system.id)"
+                  (click)="enable(r.system)"
+                >
                   <bit-icon name="bwi-check-circle" class="tw-text-muted"></bit-icon>
                   {{ "pamTargetSystemEnable" | i18n }}
                 </button>
               }
-              <button type="button" bitMenuItem (click)="confirmDelete(r.system)">
+              <button
+                type="button"
+                bitMenuItem
+                [disabled]="isRowBusy(r.system.id)"
+                (click)="confirmDelete(r.system)"
+              >
                 <bit-icon name="bwi-trash" class="tw-text-danger"></bit-icon>
                 <span class="tw-text-danger">{{ "delete" | i18n }}</span>
               </button>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
@@ -9,8 +9,9 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { DialogService, ToastService } from "@bitwarden/components";
 
 import { DaemonsService } from "../daemons/daemons.service";
-import type { TargetSystem } from "../rotation";
+import type { TargetSystem, TargetSystemId } from "../rotation";
 import { TargetSystemKind, TargetSystemMethod, TargetSystemStatus } from "../rotation";
+import { deferred } from "../testing/deferred";
 import { ORGANIZATION_ID, sysId } from "../testing/rotation-builders";
 
 import { TargetSystemsTabComponent } from "./target-systems-tab.component";
@@ -277,6 +278,81 @@ describe("TargetSystemsTabComponent", () => {
       );
       expect(daemonsService.forgetTargetSystem).not.toHaveBeenCalled();
     }));
+  });
+
+  describe("in-flight row guard", () => {
+    type Guarded = {
+      disable: (s: TargetSystem) => Promise<void>;
+      enable: (s: TargetSystem) => Promise<void>;
+      confirmDelete: (s: TargetSystem) => Promise<void>;
+      isRowBusy: (rowId: TargetSystemId) => boolean;
+    };
+
+    function guarded(): Guarded {
+      return component as unknown as Guarded;
+    }
+
+    beforeEach(() => {
+      dialogService.openSimpleDialog.mockResolvedValue(true);
+    });
+
+    it("does not dispatch a second setEnabled while the first is unsettled", async () => {
+      const pending = deferred();
+      targetSystemsService.setEnabled.mockReturnValue(pending.promise);
+      const sys = makeSystem({ status: TargetSystemStatus.Active });
+      const comp = guarded();
+
+      const first = comp.disable(sys);
+      const second = comp.disable(sys);
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(targetSystemsService.setEnabled).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not dispatch a second delete while the first is unsettled", async () => {
+      const pending = deferred();
+      targetSystemsService.delete.mockReturnValue(pending.promise);
+      const sys = makeSystem();
+      const comp = guarded();
+
+      const first = comp.confirmDelete(sys);
+      const second = comp.confirmDelete(sys);
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(targetSystemsService.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-enables the row once the request settles", async () => {
+      const pending = deferred();
+      targetSystemsService.setEnabled.mockReturnValue(pending.promise);
+      const sys = makeSystem({ status: TargetSystemStatus.Disabled });
+      const comp = guarded();
+
+      const first = comp.enable(sys);
+      expect(comp.isRowBusy(sys.id)).toBe(true);
+
+      pending.settle();
+      await first;
+      expect(comp.isRowBusy(sys.id)).toBe(false);
+
+      await comp.enable(sys);
+      expect(targetSystemsService.setEnabled).toHaveBeenCalledTimes(2);
+    });
+
+    it("allows a second action on a different row while one is in flight", async () => {
+      const pending = deferred();
+      targetSystemsService.setEnabled.mockReturnValue(pending.promise);
+      const comp = guarded();
+
+      const first = comp.disable(makeSystem({ id: sysId("sys-1") }));
+      const second = comp.disable(makeSystem({ id: sysId("sys-2") }));
+      pending.settle();
+      await Promise.all([first, second]);
+
+      expect(targetSystemsService.setEnabled).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("load error state", () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
@@ -31,6 +31,7 @@ import {
   TargetSystem,
 } from "../rotation";
 import { RotationLoadErrorComponent } from "../rotation-load-error.component";
+import { RowBusyTracker } from "../row-busy-tracker";
 
 import {
   TargetSystemsEmptyStateComponent,
@@ -106,6 +107,10 @@ export class TargetSystemsTabComponent {
   protected readonly TargetSystemStatus = TargetSystemStatus;
   protected readonly TargetSystemMethod = TargetSystemMethod;
 
+  private readonly busyRows = new RowBusyTracker<TargetSystemId>();
+
+  protected readonly isRowBusy = this.busyRows.isBusy;
+
   constructor() {
     effect(() => {
       void this.targetSystemsService.load(this.organizationId());
@@ -143,40 +148,42 @@ export class TargetSystemsTabComponent {
     this.router.navigate(["..", "target-systems", system.id], { relativeTo: this.route });
 
   /** Disable a target system after confirming with the operator. */
-  protected readonly disable = async (system: TargetSystem): Promise<void> => {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamTargetSystemDisableTitle" },
-      content: { key: "pamTargetSystemDisableContent" },
-      acceptButtonText: { key: "pamTargetSystemDisableConfirm" },
-      cancelButtonText: { key: "cancel" },
-      type: "warning",
-    });
-    if (!confirmed) {
-      return;
-    }
-    try {
-      await this.targetSystemsService.setEnabled(system, false);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamTargetSystemDisableSuccess"),
+  protected readonly disable = (system: TargetSystem): Promise<void> =>
+    this.busyRows.run(system.id, async () => {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamTargetSystemDisableTitle" },
+        content: { key: "pamTargetSystemDisableContent" },
+        acceptButtonText: { key: "pamTargetSystemDisableConfirm" },
+        cancelButtonText: { key: "cancel" },
+        type: "warning",
       });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
+      if (!confirmed) {
+        return;
+      }
+      try {
+        await this.targetSystemsService.setEnabled(system, false);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamTargetSystemDisableSuccess"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
 
   /** Re-enable a disabled target system. */
-  protected readonly enable = async (system: TargetSystem): Promise<void> => {
-    try {
-      await this.targetSystemsService.setEnabled(system, true);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamTargetSystemEnableSuccess"),
-      });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
+  protected readonly enable = (system: TargetSystem): Promise<void> =>
+    this.busyRows.run(system.id, async () => {
+      try {
+        await this.targetSystemsService.setEnabled(system, true);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamTargetSystemEnableSuccess"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
 
   /**
    * Permanently delete a target system after confirming with the operator.
@@ -185,30 +192,31 @@ export class TargetSystemsTabComponent {
    * any rotation config still names the target, surfaced as an ordinary error for
    * {@link showError}. Offering the action unconditionally keeps one authority on the rule.
    */
-  protected readonly confirmDelete = async (system: TargetSystem): Promise<void> => {
-    const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamTargetSystemDeleteTitle" },
-      content: { key: "pamTargetSystemDeleteContent", placeholders: [system.name] },
-      acceptButtonText: { key: "delete" },
-      cancelButtonText: { key: "cancel" },
-      type: "danger",
-    });
-    if (!confirmed) {
-      return;
-    }
-    try {
-      await this.targetSystemsService.delete(system);
-      // The server drops the connector assignments with the target; mirror that locally so the
-      // daemons tab does not keep projecting the dangling ID.
-      this.daemonsService.forgetTargetSystem(system.id);
-      this.toastService.showToast({
-        variant: "success",
-        message: this.i18nService.t("pamTargetSystemDeleteSuccess"),
+  protected readonly confirmDelete = (system: TargetSystem): Promise<void> =>
+    this.busyRows.run(system.id, async () => {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamTargetSystemDeleteTitle" },
+        content: { key: "pamTargetSystemDeleteContent", placeholders: [system.name] },
+        acceptButtonText: { key: "delete" },
+        cancelButtonText: { key: "cancel" },
+        type: "danger",
       });
-    } catch (e) {
-      this.showError(e);
-    }
-  };
+      if (!confirmed) {
+        return;
+      }
+      try {
+        await this.targetSystemsService.delete(system);
+        // The server drops the connector assignments with the target; mirror that locally so the
+        // daemons tab does not keep projecting the dangling ID.
+        this.daemonsService.forgetTargetSystem(system.id);
+        this.toastService.showToast({
+          variant: "success",
+          message: this.i18nService.t("pamTargetSystemDeleteSuccess"),
+        });
+      } catch (e) {
+        this.showError(e);
+      }
+    });
 
   private buildRows(systems: TargetSystem[]): TargetSystemRow[] {
     return systems.map((system) => ({

--- a/bitwarden_license/bit-web/src/app/pam/rotation/testing/deferred.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/testing/deferred.ts
@@ -1,0 +1,9 @@
+/**
+ * A promise plus the handle that settles it, for holding a stubbed request in flight while the
+ * spec makes a second call against it.
+ */
+export function deferred(): { promise: Promise<void>; settle: () => void } {
+  let settle!: () => void;
+  const promise = new Promise<void>((resolve) => (settle = resolve));
+  return { promise, settle };
+}


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Adds an in-flight guard to the row-menu mutations on the PAM rotation tabs so a repeat click can no longer fire the same action twice.

- Adds a shared `RowBusyTracker` (`rotation/row-busy-tracker.ts`) that marks a row id busy for the duration of its action and drops a repeat call against that row.
- `DaemonsTabComponent` and `ManagedCredentialsTabComponent` wrap mutating handlers in `busyRows.run(...)` and bind `[disabled]="isRowBusy(...)"` on the affected menu items.
- Extends the identical fix to `TargetSystemsTabComponent`'s enable, disable and delete items, found to share the defect during review.
- Fixes a key mismatch in `daemons-tab`: `unassign` now claims `row.id`, the id the `[disabled]` binding reads, instead of a separately typed `daemon.id` that only matched by coincidence.
- Adds a `deferred()` test helper (`rotation/testing/deferred.ts`) for specs to hold a request in flight.

Sits on the PR for `pam/rotux-assign-dialog-no-eligible-targets`; `pam/rotux-assign-disabled-not-hidden` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Daemons and Managed credentials row menus

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-row-actions-no-inflight-disable.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-row-actions-no-inflight-disable.png" alt="after" width="460"> |

## Known gaps

- Visual QA found that the disabled state on `Remove managed credential` (and the equivalent delete items) greys the button but its inner `tw-text-danger` icon and label stay full danger red, so the item still reads as an available destructive action while sibling items grey out normally. Not fixed here; fixable consumer-side by binding the danger classes off `isRowBusy()`.
- The `[disabled]` bindings on the row-menu items are not covered by an automated test: `bit-menu` projects into a CDK overlay that only exists after the trigger is clicked, and the existing specs stub the template out rather than mounting it, so asserting these bindings directly would need a larger harness change than this ticket makes.
- `target-systems-tab.component.ts` is also touched by `target-delete-names-reversible-option` later in the same lane's stack, which repoints `confirmDelete`'s `content` key; that change will need to land one indent deeper, inside this PR's `busyRows.run(system.id, async () => { ... })`.
- `test:types` fails locally with 12 `typescript-strict-plugin` errors, but all 12 are pre-existing on `pam/uat` (six files byte-identical, the seventh only shifted line numbers from a lower stack ticket); nothing in this diff is implicated.
