### PR TITLE
'Assign to target' vanishes for a disabled connector with no explanation

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19027,6 +19027,9 @@
   "pamDaemonAssignTarget": {
     "message": "Assign to target"
   },
+  "pamDaemonAssignTargetDisabled": {
+    "message": "Can't assign a target system while this connector is disabled. Enable it first."
+  },
   "pamDaemonAssignTargetTitle": {
     "message": "Assign target system"
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -103,7 +103,8 @@
               [disabled]="isRowBusy(r.id)"
               [attr.aria-disabled]="r.canAssign ? null : true"
               [bitTooltip]="r.canAssign ? '' : ('pamDaemonAssignTargetDisabled' | i18n)"
-              (click)="openAssignDialog(r)"
+              [addTooltipToDescribedby]="!r.canAssign"
+              (click)="r.canAssign ? openAssignDialog(r) : $event.stopPropagation()"
               id="daemons-tab_button_assign-{{ r.id }}"
             >
               <bit-icon name="bwi-plus-circle" class="tw-text-muted"></bit-icon>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -103,7 +103,8 @@
               [disabled]="isRowBusy(r.id)"
               [attr.aria-disabled]="r.canAssign ? null : true"
               [bitTooltip]="r.canAssign ? '' : ('pamDaemonAssignTargetDisabled' | i18n)"
-              (click)="r.canAssign && openAssignDialog(r)"
+              (click)="openAssignDialog(r)"
+              id="daemons-tab_button_assign-{{ r.id }}"
             >
               <bit-icon name="bwi-plus-circle" class="tw-text-muted"></bit-icon>
               {{ "pamDaemonAssignTarget" | i18n }}

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -97,17 +97,17 @@
             id="daemons-tab_button_menu-{{ r.id }}"
           ></button>
           <bit-menu #rowMenu>
-            @if (r.canAssign) {
-              <button
-                type="button"
-                bitMenuItem
-                [disabled]="isRowBusy(r.id)"
-                (click)="openAssignDialog(r)"
-              >
-                <bit-icon name="bwi-plus-circle" class="tw-text-muted"></bit-icon>
-                {{ "pamDaemonAssignTarget" | i18n }}
-              </button>
-            }
+            <button
+              type="button"
+              bitMenuItem
+              [disabled]="isRowBusy(r.id)"
+              [attr.aria-disabled]="r.canAssign ? null : true"
+              [bitTooltip]="r.canAssign ? '' : ('pamDaemonAssignTargetDisabled' | i18n)"
+              (click)="r.canAssign && openAssignDialog(r)"
+            >
+              <bit-icon name="bwi-plus-circle" class="tw-text-muted"></bit-icon>
+              {{ "pamDaemonAssignTarget" | i18n }}
+            </button>
             @if (r.daemon.assignedTargetSystemIds.length > 0) {
               @for (
                 assignmentId of r.daemon.assignedTargetSystemIds;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -375,6 +375,61 @@ describe("DaemonsTabComponent", () => {
     });
   });
 
+  describe("assign availability", () => {
+    function assignRow(canAssign: boolean): DaemonRow {
+      return makeDaemonRow({
+        canAssign,
+        enabled: canAssign,
+        daemon: { assignedTargetSystemIds: [] } as unknown as AccessConnector,
+      });
+    }
+
+    /**
+     * `bit-menu` projects its content through an `ng-template` into a CDK overlay, so the items
+     * live outside the fixture and only while the menu is open.
+     */
+    async function openRowMenu(canAssign: boolean): Promise<HTMLButtonElement> {
+      TestBed.resetTestingModule();
+      rows$.next([assignRow(canAssign)]);
+      await createComponent({ renderTemplate: true });
+
+      (fixture.nativeElement as HTMLElement)
+        .querySelector<HTMLButtonElement>('button[id^="daemons-tab_button_menu-"]')!
+        .click();
+      fixture.detectChanges();
+
+      return document.querySelector<HTMLButtonElement>(
+        '.bit-menu-panel [id^="daemons-tab_button_assign-"]',
+      )!;
+    }
+
+    afterEach(() => {
+      rows$.next([]);
+    });
+
+    it("renders the assign item without aria-disabled when the connector is enabled", async () => {
+      const item = await openRowMenu(true);
+
+      expect(item.getAttribute("aria-disabled")).toBeNull();
+    });
+
+    it("keeps the assign item visible and aria-disabled when the connector is disabled", async () => {
+      const item = await openRowMenu(false);
+
+      expect(item).not.toBeNull();
+      expect(item.getAttribute("aria-disabled")).toBe("true");
+      // The native attribute would suppress the hover and focus events the tooltip listens on.
+      expect(item.hasAttribute("disabled")).toBe(false);
+    });
+
+    it("does not open the assign dialog when the connector is disabled", async () => {
+      (await openRowMenu(false)).click();
+      await fixture.whenStable();
+
+      expect(dialogService.open).not.toHaveBeenCalled();
+    });
+  });
+
   describe("load error state", () => {
     beforeEach(async () => {
       TestBed.resetTestingModule();
@@ -413,127 +468,5 @@ describe("DaemonsTabComponent", () => {
       expect(daemonsService.load).toHaveBeenCalledWith(ORGANIZATION_ID);
       expect(targetSystemsService.load).toHaveBeenCalledWith(ORGANIZATION_ID);
     });
-  });
-});
-
-describe("DaemonsTabComponent assign availability", () => {
-  let fixture: ComponentFixture<DaemonsTabComponent>;
-  let dialogService: jest.Mocked<DialogService>;
-
-  function daemonRow(overrides: Partial<DaemonRow> = {}): DaemonRow {
-    const id = overrides.id ?? connectorId("assign-row");
-    const name = overrides.name ?? "Prod connector";
-    return {
-      id,
-      name,
-      statusLabelKey: "pamDaemonStatusEnabled",
-      isConnected: true,
-      assignmentNames: [],
-      enabled: true,
-      canAssign: true,
-      ...overrides,
-      daemon: {
-        id,
-        name,
-        assignedTargetSystemIds: [],
-        status: 0,
-        isConnected: true,
-      } as unknown as AccessConnector,
-    };
-  }
-
-  /**
-   * The open menu panel. `bit-menu` projects its content through an `ng-template` into a CDK
-   * overlay, so the items live outside the fixture and only while the menu is open.
-   */
-  function menuPanel(): HTMLElement | null {
-    return document.querySelector(".bit-menu-panel");
-  }
-
-  function menuItem(label: string): HTMLButtonElement | undefined {
-    return Array.from(menuPanel()?.querySelectorAll<HTMLButtonElement>("[bitMenuItem]") ?? []).find(
-      (button) => button.textContent?.includes(label),
-    );
-  }
-
-  function openMenu(): void {
-    (fixture.nativeElement as HTMLElement)
-      .querySelector<HTMLButtonElement>('button[id^="daemons-tab_button_menu-"]')!
-      .click();
-    fixture.detectChanges();
-  }
-
-  async function renderRow(row: DaemonRow): Promise<void> {
-    await TestBed.configureTestingModule({
-      imports: [DaemonsTabComponent, NoopAnimationsModule],
-      providers: [
-        provideRouter([]),
-        {
-          provide: DaemonsService,
-          useValue: {
-            loading$: of(false),
-            loadError$: of(null),
-            rows$: of([row]),
-            load: jest.fn().mockResolvedValue(undefined),
-          } as unknown as DaemonsService,
-        },
-        {
-          provide: TargetSystemsService,
-          useValue: {
-            activeAutomaticSystems$: of([] as TargetSystem[]),
-            loadError$: of(null),
-            load: jest.fn().mockResolvedValue(undefined),
-          } as unknown as TargetSystemsService,
-        },
-        { provide: DialogService, useValue: dialogService },
-        { provide: ToastService, useValue: mock<ToastService>() },
-        { provide: I18nService, useValue: { t: (key: string) => key } as unknown as I18nService },
-        {
-          provide: ActivatedRoute,
-          useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
-        },
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(DaemonsTabComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
-  }
-
-  beforeEach(() => {
-    dialogService = mock<DialogService>();
-  });
-
-  it("renders the assign item without aria-disabled when the connector is enabled", async () => {
-    await renderRow(daemonRow());
-    openMenu();
-
-    expect(menuItem("pamDaemonAssignTarget")!.getAttribute("aria-disabled")).toBeNull();
-  });
-
-  it("keeps the assign item visible and aria-disabled when the connector is disabled", async () => {
-    await renderRow(
-      daemonRow({ enabled: false, canAssign: false, statusLabelKey: "pamDaemonStatusDisabled" }),
-    );
-    openMenu();
-
-    const item = menuItem("pamDaemonAssignTarget")!;
-    expect(item).toBeDefined();
-    expect(item.getAttribute("aria-disabled")).toBe("true");
-    // The native attribute would suppress the hover and focus events the tooltip listens on.
-    expect(item.hasAttribute("disabled")).toBe(false);
-  });
-
-  it("does not open the assign dialog when the connector is disabled", async () => {
-    await renderRow(
-      daemonRow({ enabled: false, canAssign: false, statusLabelKey: "pamDaemonStatusDisabled" }),
-    );
-    openMenu();
-
-    menuItem("pamDaemonAssignTarget")!.click();
-    await fixture.whenStable();
-
-    expect(dialogService.open).not.toHaveBeenCalled();
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -415,3 +415,125 @@ describe("DaemonsTabComponent", () => {
     });
   });
 });
+
+describe("DaemonsTabComponent assign availability", () => {
+  let fixture: ComponentFixture<DaemonsTabComponent>;
+  let dialogService: jest.Mocked<DialogService>;
+
+  function daemonRow(overrides: Partial<DaemonRow> = {}): DaemonRow {
+    const id = overrides.id ?? connectorId("assign-row");
+    const name = overrides.name ?? "Prod connector";
+    return {
+      id,
+      name,
+      statusLabelKey: "pamDaemonStatusEnabled",
+      isConnected: true,
+      assignmentNames: [],
+      enabled: true,
+      canAssign: true,
+      ...overrides,
+      daemon: {
+        id,
+        name,
+        assignedTargetSystemIds: [],
+        status: 0,
+        isConnected: true,
+      } as unknown as AccessConnector,
+    };
+  }
+
+  /**
+   * The open menu panel. `bit-menu` projects its content through an `ng-template` into a CDK
+   * overlay, so the items live outside the fixture and only while the menu is open.
+   */
+  function menuPanel(): HTMLElement | null {
+    return document.querySelector(".bit-menu-panel");
+  }
+
+  function menuItem(label: string): HTMLButtonElement | undefined {
+    return Array.from(menuPanel()?.querySelectorAll<HTMLButtonElement>("[bitMenuItem]") ?? []).find(
+      (button) => button.textContent?.includes(label),
+    );
+  }
+
+  function openMenu(): void {
+    (fixture.nativeElement as HTMLElement)
+      .querySelector<HTMLButtonElement>('button[id^="daemons-tab_button_menu-"]')!
+      .click();
+    fixture.detectChanges();
+  }
+
+  async function renderRow(row: DaemonRow): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [DaemonsTabComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        {
+          provide: DaemonsService,
+          useValue: {
+            loading$: of(false),
+            loadError$: of(null),
+            rows$: of([row]),
+            load: jest.fn().mockResolvedValue(undefined),
+          } as unknown as DaemonsService,
+        },
+        {
+          provide: TargetSystemsService,
+          useValue: {
+            activeAutomaticSystems$: of([] as TargetSystem[]),
+            loadError$: of(null),
+            load: jest.fn().mockResolvedValue(undefined),
+          } as unknown as TargetSystemsService,
+        },
+        { provide: DialogService, useValue: dialogService },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: I18nService, useValue: { t: (key: string) => key } as unknown as I18nService },
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DaemonsTabComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    dialogService = mock<DialogService>();
+  });
+
+  it("renders the assign item without aria-disabled when the connector is enabled", async () => {
+    await renderRow(daemonRow());
+    openMenu();
+
+    expect(menuItem("pamDaemonAssignTarget")!.getAttribute("aria-disabled")).toBeNull();
+  });
+
+  it("keeps the assign item visible and aria-disabled when the connector is disabled", async () => {
+    await renderRow(
+      daemonRow({ enabled: false, canAssign: false, statusLabelKey: "pamDaemonStatusDisabled" }),
+    );
+    openMenu();
+
+    const item = menuItem("pamDaemonAssignTarget")!;
+    expect(item).toBeDefined();
+    expect(item.getAttribute("aria-disabled")).toBe("true");
+    // The native attribute would suppress the hover and focus events the tooltip listens on.
+    expect(item.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("does not open the assign dialog when the connector is disabled", async () => {
+    await renderRow(
+      daemonRow({ enabled: false, canAssign: false, statusLabelKey: "pamDaemonStatusDisabled" }),
+    );
+    openMenu();
+
+    menuItem("pamDaemonAssignTarget")!.click();
+    await fixture.whenStable();
+
+    expect(dialogService.open).not.toHaveBeenCalled();
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -428,6 +428,35 @@ describe("DaemonsTabComponent", () => {
 
       expect(dialogService.open).not.toHaveBeenCalled();
     });
+
+    it("keeps the row menu open when the disabled assign item is clicked", async () => {
+      (await openRowMenu(false)).click();
+      fixture.detectChanges();
+
+      expect(document.querySelector(".bit-menu-panel")).not.toBeNull();
+    });
+
+    it("closes the row menu when the enabled assign item is clicked", async () => {
+      const item = await openRowMenu(true);
+      (dialogService.open as jest.Mock).mockReturnValue({ closed: of(undefined) });
+
+      item.click();
+      fixture.detectChanges();
+
+      expect(document.querySelector(".bit-menu-panel")).toBeNull();
+    });
+
+    it("describes the disabled assign item with the tooltip explaining why", async () => {
+      const item = await openRowMenu(false);
+
+      expect(item.getAttribute("aria-describedby")).toMatch(/^bit-tooltip-\d+$/);
+    });
+
+    it("leaves the enabled assign item undescribed", async () => {
+      const item = await openRowMenu(true);
+
+      expect(item.getAttribute("aria-describedby")).toBeNull();
+    });
   });
 
   describe("load error state", () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -26,6 +26,7 @@ import {
   TableDataSource,
   TableModule,
   ToastService,
+  TooltipDirective,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
@@ -57,6 +58,7 @@ import { DaemonRow, DaemonsService } from "./daemons.service";
     StatusLockupComponent,
     SvgComponent,
     TableModule,
+    TooltipDirective,
     RotationLoadErrorComponent,
     I18nPipe,
   ],

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -164,11 +164,8 @@ export class DaemonsTabComponent {
    * org that genuinely has none — so the failure is surfaced rather than letting the dialog assert
    * the org has no active automatic target system.
    */
-  protected readonly openAssignDialog = async (row: DaemonRow): Promise<void> => {
-    if (!row.canAssign) {
-      return;
-    }
-    await this.busyRows.run(row.id, async () => {
+  protected readonly openAssignDialog = (row: DaemonRow): Promise<void> =>
+    this.busyRows.run(row.id, async () => {
       const targetSystemsError = this.targetSystemsLoadError();
       if (targetSystemsError) {
         this.showError(targetSystemsError);
@@ -196,7 +193,6 @@ export class DaemonsTabComponent {
         this.showError(e);
       }
     });
-  };
 
   protected readonly unassign = (
     row: DaemonRow,

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -164,8 +164,11 @@ export class DaemonsTabComponent {
    * org that genuinely has none — so the failure is surfaced rather than letting the dialog assert
    * the org has no active automatic target system.
    */
-  protected readonly openAssignDialog = (row: DaemonRow): Promise<void> =>
-    this.busyRows.run(row.id, async () => {
+  protected readonly openAssignDialog = async (row: DaemonRow): Promise<void> => {
+    if (!row.canAssign) {
+      return;
+    }
+    await this.busyRows.run(row.id, async () => {
       const targetSystemsError = this.targetSystemsLoadError();
       if (targetSystemsError) {
         this.showError(targetSystemsError);
@@ -193,6 +196,7 @@ export class DaemonsTabComponent {
         this.showError(e);
       }
     });
+  };
 
   protected readonly unassign = (
     row: DaemonRow,


### PR DESCRIPTION
## 🎟️ Tracking

This is from the PAM UAT review, part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Keeps `Assign to target` visible in the daemon row menu for a disabled connector, and explains why it can't be used instead of making it disappear.

- `daemons-tab.component.html` drops the `@if (r.canAssign)` wrapper so the menu item always renders.
- A disabled connector gets `[attr.aria-disabled]="true"` plus `[bitTooltip]` (not the native `[disabled]`), because `bitMenuItem`'s native `disabled` attribute would suppress the hover/focus events the tooltip needs.
- Click on the disabled item calls `$event.stopPropagation()` so the row menu and tooltip stay open instead of closing.
- `[addTooltipToDescribedby]` is bound conditionally on `!r.canAssign` so an enabled row never gets a dangling `aria-describedby`.
- Adds one new locale key, `pamDaemonAssignTargetDisabled`, and imports `TooltipDirective` into `daemons-tab.component.ts`.

Sits on the PR for `pam/rotux-row-actions-inflight-disable`; `pam/rotux-rotate-on-access-end-text-label` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Daemons -> row menu

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-assign-hidden-when-disabled.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-assign-hidden-when-disabled.png" alt="after" width="460"> |

## Copy not yet approved

This PR adds one user-facing string that the designer has not signed off on:

- `pamDaemonAssignTargetDisabled`: "Can't assign a target system while this connector is disabled. Enable it first." (proposed)

## Known gaps

- `test:types` (typescript-strict-plugin pass) fails with 12 pre-existing errors, none in this ticket's files (`daemons-tab.component.html`/`.ts`/`.spec.ts`, `apps/web/src/locales/en/messages.json`). No trunk baseline was run for comparison, since that would require checking out `pam/uat` in this worktree.
- `aria-describedby` on the disabled item points at an id that only exists in the DOM while the tooltip is shown. A durable fix would need `TooltipDirective` to render into a persistent hidden node, which is inside `libs/components/` and out of scope for this ticket.
- The two similar disabled controls in `managed-credentials-tab.component.html` still have no equivalent guard; that belongs to a different ticket.
