### PR TITLE
The rotate-on-access-end column is an unlabelled icon when true

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -115,9 +115,19 @@
         </td>
         <td bitCell>
           @if (r.rotateOnAccessEnd) {
-            <bit-icon name="bwi-check" class="tw-text-success"></bit-icon>
+            <div
+              class="tw-flex tw-items-center tw-gap-1"
+              [id]="'managed-credentials-tab_rotate-on-access-end_' + r.id"
+            >
+              <bit-icon name="bwi-check" class="tw-text-success"></bit-icon>
+              <span>{{ "yes" | i18n }}</span>
+            </div>
           } @else {
-            <span class="tw-text-muted">&mdash;</span>
+            <span
+              class="tw-text-muted"
+              [id]="'managed-credentials-tab_rotate-on-access-end_' + r.id"
+              >{{ "no" | i18n }}</span
+            >
           }
         </td>
         <td bitCell>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -114,21 +114,16 @@
           }
         </td>
         <td bitCell>
-          @if (r.rotateOnAccessEnd) {
-            <div
-              class="tw-flex tw-items-center tw-gap-1"
-              [id]="'managed-credentials-tab_rotate-on-access-end_' + r.id"
-            >
+          <span
+            class="tw-inline-flex tw-items-center tw-gap-1"
+            [class.tw-text-muted]="!r.rotateOnAccessEnd"
+            [id]="'managed-credentials-tab_rotate-on-access-end_' + r.id"
+          >
+            @if (r.rotateOnAccessEnd) {
               <bit-icon name="bwi-check" class="tw-text-success"></bit-icon>
-              <span>{{ "yes" | i18n }}</span>
-            </div>
-          } @else {
-            <span
-              class="tw-text-muted"
-              [id]="'managed-credentials-tab_rotate-on-access-end_' + r.id"
-              >{{ "no" | i18n }}</span
-            >
-          }
+            }
+            {{ (r.rotateOnAccessEnd ? "yes" : "no") | i18n }}
+          </span>
         </td>
         <td bitCell>
           @if (r.lastRotationAt) {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -317,4 +317,39 @@ describe("ManagedCredentialsTabComponent", () => {
       );
     });
   });
+
+  describe("rotate-on-access-end cell", () => {
+    const rotates = () => makeRow({ rotateOnAccessEnd: true });
+    const doesNotRotate = () => makeRow({ rotateOnAccessEnd: false, id: configId("7") });
+
+    function renderCells(rows: RotationConfigRow[]): HTMLElement[] {
+      setupTestBed(true, [{ id: "ts-1" }], true);
+      configsService.rows$.next(rows);
+      fixture.detectChanges();
+
+      return Array.from(
+        (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>(
+          '[id^="managed-credentials-tab_rotate-on-access-end_"]',
+        ),
+      );
+    }
+
+    it("reads as text, not only a check icon, when the credential rotates on access end", () => {
+      const [cell] = renderCells([rotates()]);
+      expect(cell.textContent).toContain("yes");
+      expect(cell.querySelector(".bwi-check")).not.toBeNull();
+    });
+
+    it("reads as text when the credential does not rotate on access end", () => {
+      const [cell] = renderCells([doesNotRotate()]);
+      expect(cell.textContent).toContain("no");
+      expect(cell.querySelector(".bwi-check")).toBeNull();
+    });
+
+    it("leaves no cell in the column empty", () => {
+      const cells = renderCells([rotates(), doesNotRotate()]);
+      expect(cells).toHaveLength(2);
+      expect(cells.map((cell) => cell.textContent!.trim())).toEqual(["yes", "no"]);
+    });
+  });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -348,7 +348,6 @@ describe("ManagedCredentialsTabComponent", () => {
 
     it("leaves no cell in the column empty", () => {
       const cells = renderCells([rotates(), doesNotRotate()]);
-      expect(cells).toHaveLength(2);
       expect(cells.map((cell) => cell.textContent!.trim())).toEqual(["yes", "no"]);
     });
   });


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Gives the `Rotate on access end` column a text label in both states instead of encoding the value by icon and colour alone.

- `managed-credentials-tab.component.html`: the true-state cell now renders `{{ "yes" | i18n }}` next to the existing `bwi-check` icon (icon kept as decoration).
- The false-state cell replaces the `&mdash;` with `{{ "no" | i18n }}` in a `tw-text-muted` span.
- Both states share one wrapping span with a stable per-row `id` (`managed-credentials-tab_rotate-on-access-end_<row id>`).
- Reuses the existing global `yes`/`no` i18n keys; no `messages.json` change.
- `managed-credentials-tab.component.spec.ts` adds a `rotate-on-access-end cell` describe block asserting both cells carry text and the true cell still carries the icon.

Sits on the PR for `pam/rotux-assign-disabled-not-hidden`; `pam/rotux-managed-credentials-table-overflow` sits on top of it.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Managed credentials table

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-rotate-on-access-end-icon-only.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-rotate-on-access-end-icon-only.png" alt="after" width="460"> |

## Known gaps

- `test:types` fails with 12 pre-existing `typescript-strict-plugin` errors on this branch, none in either file this ticket touched (six are byte-identical to `pam/uat`, the seventh predates this ticket in the stack). Not verified against a `test:types` run directly on `pam/uat` (read-only stage, no baseline run taken).
