### PR TITLE
Below about 1100px the managed-credentials page scrolls sideways

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -43,190 +43,201 @@
     ></bit-search>
   </div>
 
-  <bit-table [dataSource]="dataSource">
-    <ng-container header>
-      <tr>
-        <th bitCell bitSortable="cipherName">{{ "pamRotationConfigColumnCredential" | i18n }}</th>
-        <th bitCell>{{ "pamRotationConfigColumnTargetSystem" | i18n }}</th>
-        <th bitCell bitSortable="statusLabelKey">{{ "status" | i18n }}</th>
-        <th bitCell>{{ "pamRotationConfigColumnSchedule" | i18n }}</th>
-        <th bitCell>{{ "pamRotationConfigColumnRotateOnAccessEnd" | i18n }}</th>
-        <th bitCell bitSortable="lastRotationAtMs">
-          {{ "pamRotationConfigColumnLastRotation" | i18n }}
-        </th>
-        <th bitCell bitSortable="nextRotationAtMs">
-          {{ "pamRotationConfigColumnNextRotation" | i18n }}
-        </th>
-        <th bitCell class="tw-w-0"></th>
-      </tr>
-    </ng-container>
-    <ng-template body let-rows$>
-      <tr bitRow *ngFor="let r of rows$ | async">
-        <td bitCell>
-          <button
-            type="button"
-            bitLink
-            linkType="primary"
-            class="tw-font-bold"
-            (click)="openEdit(r)"
-          >
-            {{ r.cipherName }}
-          </button>
-        </td>
-        <td bitCell>
-          <div class="tw-flex tw-items-center tw-gap-1">
-            <span>{{ r.targetSystemName }}</span>
-            <span
-              bitBadge
-              [variant]="
-                r.config.targetSystemMethod === TargetSystemMethod.Automatic ? 'primary' : 'subtle'
-              "
+  <div class="tw-overflow-x-auto">
+    <bit-table [dataSource]="dataSource">
+      <ng-container header>
+        <tr class="tw-whitespace-nowrap">
+          <th bitCell bitSortable="cipherName">{{ "pamRotationConfigColumnCredential" | i18n }}</th>
+          <th bitCell>{{ "pamRotationConfigColumnTargetSystem" | i18n }}</th>
+          <th bitCell bitSortable="statusLabelKey">{{ "status" | i18n }}</th>
+          <th bitCell>{{ "pamRotationConfigColumnSchedule" | i18n }}</th>
+          <th bitCell>{{ "pamRotationConfigColumnRotateOnAccessEnd" | i18n }}</th>
+          <th bitCell bitSortable="lastRotationAtMs">
+            {{ "pamRotationConfigColumnLastRotation" | i18n }}
+          </th>
+          <th bitCell bitSortable="nextRotationAtMs">
+            {{ "pamRotationConfigColumnNextRotation" | i18n }}
+          </th>
+          <th bitCell class="tw-w-0"></th>
+        </tr>
+      </ng-container>
+      <ng-template body let-rows$>
+        <tr bitRow *ngFor="let r of rows$ | async">
+          <td bitCell>
+            <button
+              type="button"
+              bitLink
+              linkType="primary"
+              class="tw-font-bold"
+              (click)="openEdit(r)"
             >
-              {{ r.methodLabelKey | i18n }}
-            </span>
-          </div>
-        </td>
-        <td bitCell>
-          <div class="tw-flex tw-flex-wrap tw-gap-1">
-            @if (r.config.enabled) {
-              <span bitBadge variant="success">{{ r.statusLabelKey | i18n }}</span>
-            } @else {
-              <span bitBadge variant="subtle">{{ r.statusLabelKey | i18n }}</span>
-            }
-            @if (r.hasActiveJob) {
-              <span bitBadge variant="secondary">{{ "pamRotationConfigInProgress" | i18n }}</span>
-            }
-            @if (r.awaitingManualRotation) {
-              <span bitBadge variant="warning">{{ "pamRotationConfigManualDue" | i18n }}</span>
-            }
-          </div>
-        </td>
-        <td bitCell>
-          @if (r.scheduleLabelKeyOrCron === "pamRotationScheduleNone") {
-            <span class="tw-text-muted">&mdash;</span>
-          } @else if (
-            r.config.scheduleCron === null || r.scheduleLabelKeyOrCron === r.config.scheduleCron
-          ) {
-            <!-- Custom cron: show raw expression verbatim -->
-            <code class="tw-text-xs">{{ r.scheduleLabelKeyOrCron }}</code>
-          } @else {
-            {{ r.scheduleLabelKeyOrCron | i18n }}
-          }
-        </td>
-        <td bitCell>
-          <span
-            class="tw-inline-flex tw-items-center tw-gap-1"
-            [class.tw-text-muted]="!r.rotateOnAccessEnd"
-            [id]="'managed-credentials-tab_rotate-on-access-end_' + r.id"
-          >
-            @if (r.rotateOnAccessEnd) {
-              <bit-icon name="bwi-check" class="tw-text-success"></bit-icon>
-            }
-            {{ (r.rotateOnAccessEnd ? "yes" : "no") | i18n }}
-          </span>
-        </td>
-        <td bitCell>
-          @if (r.lastRotationAt) {
-            <span class="tw-text-sm" [title]="r.lastRotationAt | date: 'medium'">
-              {{ r.lastRotationAt | date: "mediumDate" }}
-            </span>
-          } @else {
-            <span class="tw-text-muted">&mdash;</span>
-          }
-        </td>
-        <td bitCell>
-          @if (r.nextRotationAt) {
-            <span class="tw-text-sm" [title]="r.nextRotationAt | date: 'medium'">
-              {{ r.nextRotationAt | date: "mediumDate" }}
-            </span>
-          } @else {
-            <span class="tw-text-muted">&mdash;</span>
-          }
-        </td>
-        <td bitCell>
-          <button
-            type="button"
-            bitIconButton="bwi-ellipsis-h"
-            [bitMenuTriggerFor]="rowMenu"
-            label="{{ 'options' | i18n }}"
-            [id]="'managed-credentials-tab_menu-trigger_' + r.id"
-          ></button>
-          <bit-menu #rowMenu>
-            @if (r.canRotateNow) {
-              <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="rotateNow(r)">
-                <bit-icon name="bwi-refresh" class="tw-text-muted"></bit-icon>
-                {{ "pamRotationConfigRotateNow" | i18n }}
-              </button>
-            }
-            @if (!r.canRotateNow && r.config.targetSystemMethod === TargetSystemMethod.Automatic) {
-              <button
-                type="button"
-                bitMenuItem
-                disabled
-                title="{{ 'pamRotationConfigRotateNowDisabledTitle' | i18n }}"
-              >
-                <bit-icon name="bwi-refresh" class="tw-text-muted"></bit-icon>
-                {{ "pamRotationConfigRotateNow" | i18n }}
-              </button>
-            }
-            @if (r.canRecordManual) {
-              <button
-                type="button"
-                bitMenuItem
-                [disabled]="isRowBusy(r.id)"
-                (click)="confirmRecordManual(r)"
-              >
-                <bit-icon name="bwi-pencil-square" class="tw-text-muted"></bit-icon>
-                {{ "pamRotationConfigRecordManual" | i18n }}
-              </button>
-            }
-            <button type="button" bitMenuItem (click)="openEdit(r)">
-              <bit-icon name="bwi-pencil-square" class="tw-text-muted"></bit-icon>
-              {{ "edit" | i18n }}
+              {{ r.cipherName }}
             </button>
-            @if (r.canPause) {
-              <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="pause(r)">
-                <bit-icon name="bwi-circle" class="tw-text-muted"></bit-icon>
-                {{ "pamRotationConfigPause" | i18n }}
-              </button>
-            }
-            @if (r.canResume) {
-              <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="resume(r)">
-                <bit-icon name="bwi-check-circle" class="tw-text-muted"></bit-icon>
-                {{ "pamRotationConfigResume" | i18n }}
-              </button>
-            }
-            @if (r.mutationsLocked) {
-              <button
-                type="button"
-                bitMenuItem
-                disabled
-                [bitTooltip]="'pamRotationConfigDeleteLockedTitle' | i18n"
+          </td>
+          <td bitCell>
+            <div class="tw-flex tw-items-center tw-gap-1">
+              <span>{{ r.targetSystemName }}</span>
+              <span
+                bitBadge
+                [variant]="
+                  r.config.targetSystemMethod === TargetSystemMethod.Automatic
+                    ? 'primary'
+                    : 'subtle'
+                "
               >
-                <bit-icon name="bwi-trash" class="tw-text-muted"></bit-icon>
-                {{ "delete" | i18n }}
-              </button>
+                {{ r.methodLabelKey | i18n }}
+              </span>
+            </div>
+          </td>
+          <td bitCell>
+            <div class="tw-flex tw-flex-wrap tw-gap-1">
+              @if (r.config.enabled) {
+                <span bitBadge variant="success">{{ r.statusLabelKey | i18n }}</span>
+              } @else {
+                <span bitBadge variant="subtle">{{ r.statusLabelKey | i18n }}</span>
+              }
+              @if (r.hasActiveJob) {
+                <span bitBadge variant="secondary">{{ "pamRotationConfigInProgress" | i18n }}</span>
+              }
+              @if (r.awaitingManualRotation) {
+                <span bitBadge variant="warning">{{ "pamRotationConfigManualDue" | i18n }}</span>
+              }
+            </div>
+          </td>
+          <td bitCell>
+            @if (r.scheduleLabelKeyOrCron === "pamRotationScheduleNone") {
+              <span class="tw-text-muted">&mdash;</span>
+            } @else if (
+              r.config.scheduleCron === null || r.scheduleLabelKeyOrCron === r.config.scheduleCron
+            ) {
+              <!-- Custom cron: show raw expression verbatim -->
+              <code class="tw-text-xs">{{ r.scheduleLabelKeyOrCron }}</code>
             } @else {
-              <button
-                type="button"
-                bitMenuItem
-                [disabled]="isRowBusy(r.id)"
-                (click)="confirmDelete(r)"
-              >
-                <bit-icon name="bwi-trash" class="tw-text-danger"></bit-icon>
-                <span class="tw-text-danger">{{ "delete" | i18n }}</span>
-              </button>
+              {{ r.scheduleLabelKeyOrCron | i18n }}
             }
-          </bit-menu>
-        </td>
-      </tr>
-      @if (noResults()) {
-        <tr bitRow>
-          <td bitCell colspan="8" class="tw-py-6 tw-text-center tw-text-muted">
-            {{ "pamRotationConfigNoResults" | i18n }}
+          </td>
+          <td bitCell>
+            <span
+              class="tw-inline-flex tw-items-center tw-gap-1"
+              [class.tw-text-muted]="!r.rotateOnAccessEnd"
+              [id]="'managed-credentials-tab_rotate-on-access-end_' + r.id"
+            >
+              @if (r.rotateOnAccessEnd) {
+                <bit-icon name="bwi-check" class="tw-text-success"></bit-icon>
+              }
+              {{ (r.rotateOnAccessEnd ? "yes" : "no") | i18n }}
+            </span>
+          </td>
+          <td bitCell>
+            @if (r.lastRotationAt) {
+              <span class="tw-text-sm" [title]="r.lastRotationAt | date: 'medium'">
+                {{ r.lastRotationAt | date: "mediumDate" }}
+              </span>
+            } @else {
+              <span class="tw-text-muted">&mdash;</span>
+            }
+          </td>
+          <td bitCell>
+            @if (r.nextRotationAt) {
+              <span class="tw-text-sm" [title]="r.nextRotationAt | date: 'medium'">
+                {{ r.nextRotationAt | date: "mediumDate" }}
+              </span>
+            } @else {
+              <span class="tw-text-muted">&mdash;</span>
+            }
+          </td>
+          <td bitCell>
+            <button
+              type="button"
+              bitIconButton="bwi-ellipsis-h"
+              [bitMenuTriggerFor]="rowMenu"
+              label="{{ 'options' | i18n }}"
+              [id]="'managed-credentials-tab_menu-trigger_' + r.id"
+            ></button>
+            <bit-menu #rowMenu>
+              @if (r.canRotateNow) {
+                <button
+                  type="button"
+                  bitMenuItem
+                  [disabled]="isRowBusy(r.id)"
+                  (click)="rotateNow(r)"
+                >
+                  <bit-icon name="bwi-refresh" class="tw-text-muted"></bit-icon>
+                  {{ "pamRotationConfigRotateNow" | i18n }}
+                </button>
+              }
+              @if (
+                !r.canRotateNow && r.config.targetSystemMethod === TargetSystemMethod.Automatic
+              ) {
+                <button
+                  type="button"
+                  bitMenuItem
+                  disabled
+                  title="{{ 'pamRotationConfigRotateNowDisabledTitle' | i18n }}"
+                >
+                  <bit-icon name="bwi-refresh" class="tw-text-muted"></bit-icon>
+                  {{ "pamRotationConfigRotateNow" | i18n }}
+                </button>
+              }
+              @if (r.canRecordManual) {
+                <button
+                  type="button"
+                  bitMenuItem
+                  [disabled]="isRowBusy(r.id)"
+                  (click)="confirmRecordManual(r)"
+                >
+                  <bit-icon name="bwi-pencil-square" class="tw-text-muted"></bit-icon>
+                  {{ "pamRotationConfigRecordManual" | i18n }}
+                </button>
+              }
+              <button type="button" bitMenuItem (click)="openEdit(r)">
+                <bit-icon name="bwi-pencil-square" class="tw-text-muted"></bit-icon>
+                {{ "edit" | i18n }}
+              </button>
+              @if (r.canPause) {
+                <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="pause(r)">
+                  <bit-icon name="bwi-circle" class="tw-text-muted"></bit-icon>
+                  {{ "pamRotationConfigPause" | i18n }}
+                </button>
+              }
+              @if (r.canResume) {
+                <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="resume(r)">
+                  <bit-icon name="bwi-check-circle" class="tw-text-muted"></bit-icon>
+                  {{ "pamRotationConfigResume" | i18n }}
+                </button>
+              }
+              @if (r.mutationsLocked) {
+                <button
+                  type="button"
+                  bitMenuItem
+                  disabled
+                  [bitTooltip]="'pamRotationConfigDeleteLockedTitle' | i18n"
+                >
+                  <bit-icon name="bwi-trash" class="tw-text-muted"></bit-icon>
+                  {{ "delete" | i18n }}
+                </button>
+              } @else {
+                <button
+                  type="button"
+                  bitMenuItem
+                  [disabled]="isRowBusy(r.id)"
+                  (click)="confirmDelete(r)"
+                >
+                  <bit-icon name="bwi-trash" class="tw-text-danger"></bit-icon>
+                  <span class="tw-text-danger">{{ "delete" | i18n }}</span>
+                </button>
+              }
+            </bit-menu>
           </td>
         </tr>
-      }
-    </ng-template>
-  </bit-table>
+        @if (noResults()) {
+          <tr bitRow>
+            <td bitCell colspan="8" class="tw-py-6 tw-text-center tw-text-muted">
+              {{ "pamRotationConfigNoResults" | i18n }}
+            </td>
+          </tr>
+        }
+      </ng-template>
+    </bit-table>
+  </div>
 }


### PR DESCRIPTION
## 🎟️ Tracking

From the PAM UAT review, part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Wraps the managed-credentials table in its own horizontal scroll container so the page body no longer scrolls sideways below about 1100px.

- `managed-credentials-tab.component.html` wraps `<bit-table>` in `<div class="tw-overflow-x-auto">`, the same shape already used in `access-rules.component.html` and `access-audit.component.html`.
- The header `<tr>` gets `tw-whitespace-nowrap`, so all eight `<th>` labels sit on one line instead of wrapping to four.
- Two prettier reflows (a `[variant]` ternary and an `@if` condition) fall out of the added indent level; no logic changes.
- Single file, consumer-side only: `libs/components` table markup is untouched.

Sits on `pam/rotux-rotate-on-access-end-text-label`; `pam/rotux-managed-credential-delete-one-name` sits on top of it.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Managed credentials table

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-table-overflows-page-horizontally.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-table-overflows-page-horizontally.png" alt="after" width="460"> |

## Known gaps

- `test:types` fails, but with 12 errors confined to files this ticket's diff never touches; treated as a pre-existing `trunk` condition, not a regression from this branch.
- Visual QA confirmed the fix at 1024x768 (`scrollWidth === clientWidth === 1024` on the page body, overflow contained inside `div.tw-overflow-x-auto`, row menu still anchors correctly when scrolled). No independent re-run of `test:types` against the base branch was done to prove the 12 errors predate the stack; that conclusion is inferred from the diff instead.
