### PR TITLE
One delete action is called three different things

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19282,13 +19282,7 @@
   "pamRotationConfigHistoryEmpty": {
     "message": "No rotations have run yet."
   },
-  "pamRotationConfigRemoveManagedCredentialHeading": {
-    "message": "Remove managed credential"
-  },
   "pamRotationConfigRemoveManagedCredential": {
-    "message": "Remove managed credential"
-  },
-  "pamRotationConfigRemoveAction": {
     "message": "Remove managed credential"
   },
   "pamRotationConfigRemoveLockedContent": {

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19282,11 +19282,14 @@
   "pamRotationConfigHistoryEmpty": {
     "message": "No rotations have run yet."
   },
-  "pamRotationConfigRemoveHeading": {
-    "message": "Remove rotation"
+  "pamRotationConfigRemoveManagedCredentialHeading": {
+    "message": "Remove managed credential"
   },
-  "pamRotationConfigRemove": {
-    "message": "Remove rotation configuration"
+  "pamRotationConfigRemoveManagedCredential": {
+    "message": "Remove managed credential"
+  },
+  "pamRotationConfigRemoveAction": {
+    "message": "Remove managed credential"
   },
   "pamRotationConfigRemoveLockedContent": {
     "message": "A rotation job is currently in progress. You can remove the rotation configuration once the daemon finishes it — or once it times out. Pausing only stops new jobs; it does not cancel the one already running."

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -214,7 +214,7 @@
                   [bitTooltip]="'pamRotationConfigDeleteLockedTitle' | i18n"
                 >
                   <bit-icon name="bwi-trash" class="tw-text-muted"></bit-icon>
-                  {{ "delete" | i18n }}
+                  {{ "pamRotationConfigRemoveAction" | i18n }}
                 </button>
               } @else {
                 <button
@@ -224,7 +224,7 @@
                   (click)="confirmDelete(r)"
                 >
                   <bit-icon name="bwi-trash" class="tw-text-danger"></bit-icon>
-                  <span class="tw-text-danger">{{ "delete" | i18n }}</span>
+                  <span class="tw-text-danger">{{ "pamRotationConfigRemoveAction" | i18n }}</span>
                 </button>
               }
             </bit-menu>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -214,7 +214,7 @@
                   [bitTooltip]="'pamRotationConfigDeleteLockedTitle' | i18n"
                 >
                   <bit-icon name="bwi-trash" class="tw-text-muted"></bit-icon>
-                  {{ "pamRotationConfigRemoveAction" | i18n }}
+                  {{ "pamRotationConfigRemoveManagedCredential" | i18n }}
                 </button>
               } @else {
                 <button
@@ -224,7 +224,9 @@
                   (click)="confirmDelete(r)"
                 >
                   <bit-icon name="bwi-trash" class="tw-text-danger"></bit-icon>
-                  <span class="tw-text-danger">{{ "pamRotationConfigRemoveAction" | i18n }}</span>
+                  <span class="tw-text-danger">{{
+                    "pamRotationConfigRemoveManagedCredential" | i18n
+                  }}</span>
                 </button>
               }
             </bit-menu>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
@@ -226,7 +226,7 @@ export class ManagedCredentialsTabComponent {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamRotationConfigDeleteConfirmTitle" },
         content: { key: "pamRotationConfigDeleteConfirmContent" },
-        acceptButtonText: { key: "delete" },
+        acceptButtonText: { key: "remove" },
         cancelButtonText: { key: "cancel" },
         type: "warning",
       });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
@@ -244,7 +244,7 @@
       <!-- Remove managed credential (keeps the credential) -->
       <bit-section>
         <bit-section-header>
-          <h2 bitTypography="h5">{{ "pamRotationConfigRemoveManagedCredentialHeading" | i18n }}</h2>
+          <h2 bitTypography="h5">{{ "pamRotationConfigRemoveManagedCredential" | i18n }}</h2>
         </bit-section-header>
         <bit-card>
           <p bitTypography="body2" class="tw-mt-0 tw-text-muted">

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
@@ -241,10 +241,10 @@
         }
       </bit-section>
 
-      <!-- Remove rotation (keeps the credential) -->
+      <!-- Remove managed credential (keeps the credential) -->
       <bit-section>
         <bit-section-header>
-          <h2 bitTypography="h5">{{ "pamRotationConfigRemoveHeading" | i18n }}</h2>
+          <h2 bitTypography="h5">{{ "pamRotationConfigRemoveManagedCredentialHeading" | i18n }}</h2>
         </bit-section-header>
         <bit-card>
           <p bitTypography="body2" class="tw-mt-0 tw-text-muted">
@@ -263,7 +263,7 @@
             [disabled]="detail.config.hasActiveJob"
             id="rotation-config-edit_button_remove"
           >
-            {{ "pamRotationConfigRemove" | i18n }}
+            {{ "pamRotationConfigRemoveManagedCredential" | i18n }}
           </button>
         </bit-card>
       </bit-section>


### PR DESCRIPTION
## 🎟️ Tracking

From the PAM UAT review, part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Standardises the "remove a rotation configuration" action on one label, `Remove managed credential`, across both places it appears.

- Row menu button in `managed-credentials-tab.component.html` now reads `Remove managed credential` instead of the global `delete` key.
- Edit page section heading and button in `rotation-config-edit.component.html` now use the same `pamRotationConfigRemoveManagedCredential` key instead of `pamRotationConfigRemoveHeading` / `pamRotationConfigRemove`.
- Confirm dialog's accept button in `managed-credentials-tab.component.ts` changed from key `delete` to `remove`, so its label matches the dialog title (`Remove managed credential`) on both trigger paths.
- `messages.json`: added `pamRotationConfigRemoveManagedCredential`, removed the now-unused `pamRotationConfigRemoveHeading` and `pamRotationConfigRemove`.

Stacked on `pam/rotux-managed-credentials-table-overflow`; `pam/rotux-target-delete-names-reversible-option` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Managed credentials (row menu and edit page)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-delete-action-three-names.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-delete-action-three-names.png" alt="after" width="460"> |

## Known gaps

- `test:types` fails on this branch (12 typescript-strict-plugin errors), but this is inherited from `pam/uat`: none of the erroring files are touched by this ticket's diff, and the one overlapping file (`target-systems.service.spec.ts`, touched by a lower ticket) has its erroring line blamed to a pre-existing trunk commit.
- The `acceptButtonText` key rename (`delete` to `remove`) in `managed-credentials-tab.component.ts` has no direct test assertion; the existing spec only checks that the dialog opens, not its button keys.
- This finding has no evidence screenshot in `uat-report-build/findings.json`, so route/reproduce steps were derived from the routing modules rather than a case file.
- Cosmetic only: at 1440px the wider row-menu label now sits close to the viewport's right edge (no clipping, no horizontal scroll); worth a glance if a narrower viewport is in scope.
