### PR TITLE
Disable and Delete sit side by side with no steer on which to use

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18886,8 +18886,8 @@
   "pamTargetSystemDeleteTitle": {
     "message": "Delete target system?"
   },
-  "pamTargetSystemDeleteContent": {
-    "message": "Deleting $NAME$ is permanent. Any managed credentials that rotate against it must be removed first.",
+  "pamTargetSystemDeleteContentDisableInstead": {
+    "message": "Deleting $NAME$ is permanent. Any managed credentials that rotate against it must be removed first. To stop rotations without losing the target system, disable it instead. Disabling holds pending jobs and can be undone.",
     "placeholders": {
       "name": {
         "content": "$1",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
@@ -229,7 +229,7 @@ describe("TargetSystemsTabComponent", () => {
       );
     }));
 
-    it("confirms with a danger dialog naming the target system", fakeAsync(() => {
+    it("confirms with a danger dialog naming the target system and the reversible alternative", fakeAsync(() => {
       const sys = makeSystem({ id: sysId("sys-1"), name: "Prod Entra" });
       dialogService.openSimpleDialog.mockResolvedValue(true);
 
@@ -239,7 +239,7 @@ describe("TargetSystemsTabComponent", () => {
       expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "danger",
-          content: { key: "pamTargetSystemDeleteContent", placeholders: ["Prod Entra"] },
+          content: { key: "pamTargetSystemDeleteContentDisableInstead", placeholders: ["Prod Entra"] },
         }),
       );
     }));

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
@@ -239,7 +239,10 @@ describe("TargetSystemsTabComponent", () => {
       expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "danger",
-          content: { key: "pamTargetSystemDeleteContentDisableInstead", placeholders: ["Prod Entra"] },
+          content: {
+            key: "pamTargetSystemDeleteContentDisableInstead",
+            placeholders: ["Prod Entra"],
+          },
         }),
       );
     }));

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
@@ -196,7 +196,7 @@ export class TargetSystemsTabComponent {
     this.busyRows.run(system.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamTargetSystemDeleteTitle" },
-        content: { key: "pamTargetSystemDeleteContent", placeholders: [system.name] },
+        content: { key: "pamTargetSystemDeleteContentDisableInstead", placeholders: [system.name] },
         acceptButtonText: { key: "delete" },
         cancelButtonText: { key: "cancel" },
         type: "danger",


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

This is part of the PAM UAT review, a stack of per-ticket fixes rooted on `pam/uat`.

Adds the missing steer to the target system delete confirmation dialog: it now names `disable` as the reversible alternative and says what disabling does instead of deleting.

- Renames the delete dialog's content key from `pamTargetSystemDeleteContent` to `pamTargetSystemDeleteContentDisableInstead` and repoints `confirmDelete()` at it in `target-systems-tab.component.ts`.
- The new message keeps the original two sentences verbatim and appends two more: "To stop rotations without losing the target system, disable it instead. Disabling holds pending jobs and can be undone."
- The old `pamTargetSystemDeleteContent` key is removed from `messages.json`; it has no remaining consumers.
- Updates the spec's assertion and test name in `target-systems-tab.component.spec.ts` to match the new key.

Stack: sits on the PR for `pam/rotux-managed-credential-delete-one-name`; the PR for `pam/rotux-policy-requires-character-class` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Target systems -> row menu

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-disable-vs-delete-no-guidance.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-disable-vs-delete-no-guidance.png" alt="after" width="460"> |

## Copy not yet approved

The designer has not signed off on this wording. Treat it as proposed, not settled.

- `pamTargetSystemDeleteContentDisableInstead`: "Deleting $NAME$ is permanent. Any managed credentials that rotate against it must be removed first. To stop rotations without losing the target system, disable it instead. Disabling holds pending jobs and can be undone."

## Known gaps

- `test:types` (typescript-strict-plugin) fails with 12 pre-existing errors, none in the two files this PR touches. Six of the seven erroring files are byte-identical to `pam/uat`; the seventh differs only by line-shift above an unrelated trunk line. Not introduced by this change, not fixed by it.
- No findings.json entry or evidence screenshot exists for this finding (it is a code-review finding, not a pam-qa tracker one), and no UAT case file covers any rotation surface, so the route and click path here were written from `rotation.routes.ts`. Both gaps are logged in `ROTATION-UX-DECISIONS.md` under an UNRESOLVED heading.
