### PR TITLE
A password policy with no character classes saves successfully

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18949,6 +18949,9 @@
   "pamTargetSystemPolicyMinExceedsMax": {
     "message": "Minimum length must be less than or equal to maximum length."
   },
+  "pamTargetSystemPolicyNoCharacterClass": {
+    "message": "Include at least one character type."
+  },
   "pamTargetSystemPolicyUppercase": {
     "message": "Include uppercase letters"
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
@@ -78,6 +78,12 @@
         />
         <bit-label>{{ "pamTargetSystemPolicySymbols" | i18n }}</bit-label>
       </bit-form-control>
+      @if (policyForm.errors?.["noCharacterClass"] && policyForm.touched) {
+        <!-- BitErrorComponent host-binds its own generated id, so the stable one goes on a wrapper -->
+        <div id="target-system-edit_error_character-class">
+          <bit-error>{{ "pamTargetSystemPolicyNoCharacterClass" | i18n }}</bit-error>
+        </div>
+      }
 
       <!-- Session termination (Automatic only): intrinsic for native integrations, opt-in for custom scripts -->
       @if (isAutomatic()) {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormGroup } from "@angular/forms";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
@@ -47,6 +48,17 @@ function makeSystem(overrides: Partial<TargetSystem> = {}): TargetSystem {
     supportsSessionTermination: true,
     ...overrides,
   } as TargetSystem;
+}
+
+const NO_CHARACTER_CLASSES = {
+  includeUppercase: false,
+  includeLowercase: false,
+  includeDigits: false,
+  includeSymbols: false,
+};
+
+function policyFormOf(fixture: ComponentFixture<TargetSystemEditComponent>): FormGroup {
+  return (fixture.componentInstance as unknown as { policyForm: FormGroup }).policyForm;
 }
 
 /** Build a configured TestBed for create mode (no targetSystemId). */
@@ -224,42 +236,16 @@ describe("TargetSystemEditComponent — create mode", () => {
   });
 
   it("marks the policy invalid when every character class is cleared", () => {
-    const policyForm = (
-      fixture.componentInstance as unknown as {
-        policyForm: {
-          patchValue: (v: unknown) => void;
-          invalid: boolean;
-          errors: Record<string, unknown> | null;
-        };
-      }
-    ).policyForm;
-    policyForm.patchValue({
-      includeUppercase: false,
-      includeLowercase: false,
-      includeDigits: false,
-      includeSymbols: false,
-    });
+    const policyForm = policyFormOf(fixture);
+    policyForm.patchValue(NO_CHARACTER_CLASSES);
 
     expect(policyForm.invalid).toBe(true);
     expect(policyForm.errors?.["noCharacterClass"]).toBe(true);
   });
 
   it("clears the character-class error when one class is re-enabled", () => {
-    const policyForm = (
-      fixture.componentInstance as unknown as {
-        policyForm: {
-          patchValue: (v: unknown) => void;
-          valid: boolean;
-          errors: Record<string, unknown> | null;
-        };
-      }
-    ).policyForm;
-    policyForm.patchValue({
-      includeUppercase: false,
-      includeLowercase: false,
-      includeDigits: false,
-      includeSymbols: false,
-    });
+    const policyForm = policyFormOf(fixture);
+    policyForm.patchValue(NO_CHARACTER_CLASSES);
     policyForm.patchValue({ includeSymbols: true });
 
     expect(policyForm.errors).toBeNull();
@@ -272,7 +258,6 @@ describe("TargetSystemEditComponent — create mode", () => {
 
     const comp = fixture.componentInstance as unknown as {
       createForm: { patchValue: (v: unknown) => void };
-      policyForm: { patchValue: (v: unknown) => void };
       submitCreate: () => Promise<void>;
     };
     comp.createForm.patchValue({
@@ -280,13 +265,7 @@ describe("TargetSystemEditComponent — create mode", () => {
       method: TargetSystemMethod.Automatic,
       kind: TargetSystemKind.Entra,
     });
-    comp.policyForm.patchValue({
-      includeUppercase: false,
-      includeLowercase: false,
-      includeDigits: false,
-      includeSymbols: false,
-    });
-    fixture.detectChanges();
+    policyFormOf(fixture).patchValue(NO_CHARACTER_CLASSES);
     await comp.submitCreate();
 
     expect(rotationSdk.createTargetSystem).not.toHaveBeenCalled();
@@ -484,17 +463,8 @@ describe("TargetSystemEditComponent — create mode (rendered)", () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.querySelector("#target-system-edit_error_character-class")).toBeNull();
 
-    const policyForm = (
-      fixture.componentInstance as unknown as {
-        policyForm: { patchValue: (v: unknown) => void; markAllAsTouched: () => void };
-      }
-    ).policyForm;
-    policyForm.patchValue({
-      includeUppercase: false,
-      includeLowercase: false,
-      includeDigits: false,
-      includeSymbols: false,
-    });
+    const policyForm = policyFormOf(fixture);
+    policyForm.patchValue(NO_CHARACTER_CLASSES);
     policyForm.markAllAsTouched();
     fixture.detectChanges();
 
@@ -567,17 +537,10 @@ describe("TargetSystemEditComponent — edit mode", () => {
   it("does not save when every character class is cleared", async () => {
     rotationSdk.updateTargetSystem.mockResolvedValue(undefined);
 
-    const comp = fixture.componentInstance as unknown as {
-      policyForm: { patchValue: (v: unknown) => void };
-      submitEdit: () => Promise<void>;
-    };
-    comp.policyForm.patchValue({
-      includeUppercase: false,
-      includeLowercase: false,
-      includeDigits: false,
-      includeSymbols: false,
-    });
-    await comp.submitEdit();
+    policyFormOf(fixture).patchValue(NO_CHARACTER_CLASSES);
+    await (
+      fixture.componentInstance as unknown as { submitEdit: () => Promise<void> }
+    ).submitEdit();
 
     expect(rotationSdk.updateTargetSystem).not.toHaveBeenCalled();
   });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -223,6 +223,75 @@ describe("TargetSystemEditComponent — create mode", () => {
     expect(rotationSdk.createTargetSystem).not.toHaveBeenCalled();
   });
 
+  it("marks the policy invalid when every character class is cleared", () => {
+    const policyForm = (
+      fixture.componentInstance as unknown as {
+        policyForm: {
+          patchValue: (v: unknown) => void;
+          invalid: boolean;
+          errors: Record<string, unknown> | null;
+        };
+      }
+    ).policyForm;
+    policyForm.patchValue({
+      includeUppercase: false,
+      includeLowercase: false,
+      includeDigits: false,
+      includeSymbols: false,
+    });
+
+    expect(policyForm.invalid).toBe(true);
+    expect(policyForm.errors?.["noCharacterClass"]).toBe(true);
+  });
+
+  it("clears the character-class error when one class is re-enabled", () => {
+    const policyForm = (
+      fixture.componentInstance as unknown as {
+        policyForm: {
+          patchValue: (v: unknown) => void;
+          valid: boolean;
+          errors: Record<string, unknown> | null;
+        };
+      }
+    ).policyForm;
+    policyForm.patchValue({
+      includeUppercase: false,
+      includeLowercase: false,
+      includeDigits: false,
+      includeSymbols: false,
+    });
+    policyForm.patchValue({ includeSymbols: true });
+
+    expect(policyForm.errors).toBeNull();
+    expect(policyForm.valid).toBe(true);
+  });
+
+  it("does not create a target system when every character class is cleared", async () => {
+    rotationSdk.createTargetSystem.mockResolvedValue(makeSystem());
+    jest.spyOn(router, "navigate").mockResolvedValue(true);
+
+    const comp = fixture.componentInstance as unknown as {
+      createForm: { patchValue: (v: unknown) => void };
+      policyForm: { patchValue: (v: unknown) => void };
+      submitCreate: () => Promise<void>;
+    };
+    comp.createForm.patchValue({
+      name: "No classes",
+      method: TargetSystemMethod.Automatic,
+      kind: TargetSystemKind.Entra,
+    });
+    comp.policyForm.patchValue({
+      includeUppercase: false,
+      includeLowercase: false,
+      includeDigits: false,
+      includeSymbols: false,
+    });
+    fixture.detectChanges();
+    await comp.submitCreate();
+
+    expect(rotationSdk.createTargetSystem).not.toHaveBeenCalled();
+  });
+
   it("seeds Manual method from the ?template=manual query param", async () => {
     TestBed.resetTestingModule();
     const comp = await setupCreateWithTemplate("manual");
@@ -410,6 +479,27 @@ describe("TargetSystemEditComponent — create mode (rendered)", () => {
     patchKind(TargetSystemKind.CustomScript);
     expect(el.querySelector("#target-system-edit_checkbox_session-termination")).toBeTruthy();
   });
+
+  it("renders the character-class error only once every class is cleared", () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector("#target-system-edit_error_character-class")).toBeNull();
+
+    const policyForm = (
+      fixture.componentInstance as unknown as {
+        policyForm: { patchValue: (v: unknown) => void; markAllAsTouched: () => void };
+      }
+    ).policyForm;
+    policyForm.patchValue({
+      includeUppercase: false,
+      includeLowercase: false,
+      includeDigits: false,
+      includeSymbols: false,
+    });
+    policyForm.markAllAsTouched();
+    fixture.detectChanges();
+
+    expect(el.querySelector("#target-system-edit_error_character-class")).toBeTruthy();
+  });
 });
 
 describe("TargetSystemEditComponent — edit mode", () => {
@@ -472,6 +562,24 @@ describe("TargetSystemEditComponent — edit mode", () => {
         passwordPolicy: expect.any(Object),
       }),
     );
+  });
+
+  it("does not save when every character class is cleared", async () => {
+    rotationSdk.updateTargetSystem.mockResolvedValue(undefined);
+
+    const comp = fixture.componentInstance as unknown as {
+      policyForm: { patchValue: (v: unknown) => void };
+      submitEdit: () => Promise<void>;
+    };
+    comp.policyForm.patchValue({
+      includeUppercase: false,
+      includeLowercase: false,
+      includeDigits: false,
+      includeSymbols: false,
+    });
+    await comp.submitEdit();
+
+    expect(rotationSdk.updateTargetSystem).not.toHaveBeenCalled();
   });
 
   // Retirement — a target system has no delete route, so taking one out of service is disable.

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
@@ -71,6 +71,19 @@ const minMaxValidator: ValidatorFn = (control: AbstractControl): ValidationError
   return min > max ? { minExceedsMax: true } : null;
 };
 
+/** Cross-field validator: at least one character class must be enabled. */
+const characterClassValidator: ValidatorFn = (
+  control: AbstractControl,
+): ValidationErrors | null => {
+  const group = control as PolicyGroup;
+  const anyEnabled =
+    group.controls.includeUppercase.value ||
+    group.controls.includeLowercase.value ||
+    group.controls.includeDigits.value ||
+    group.controls.includeSymbols.value;
+  return anyEnabled ? null : { noCharacterClass: true };
+};
+
 function buildPolicyGroup(fb: FormBuilder): PolicyGroup {
   return new FormGroup<PolicyControls>(
     {
@@ -90,7 +103,7 @@ function buildPolicyGroup(fb: FormBuilder): PolicyGroup {
       includeSymbols: fb.nonNullable.control(true),
       supportsSessionTermination: fb.nonNullable.control(false),
     },
-    { validators: [minMaxValidator] },
+    { validators: [minMaxValidator, characterClassValidator] },
   );
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Stops a rotation target system's password policy from saving when every character class is unchecked.

- Adds a group-level `characterClassValidator` to the policy `FormGroup`, returning `{ noCharacterClass: true }` when `includeUppercase`, `includeLowercase`, `includeDigits`, and `includeSymbols` are all `false`.
- `submitCreate` and `submitEdit` already return early on `policyForm.invalid`, so both create and edit now refuse to save an all-false policy with no handler changes.
- Adds a `bit-error` block to the shared `#policyCard` template, gated on `policyForm.errors?.["noCharacterClass"] && policyForm.touched`, mirroring the existing `minExceedsMax` error.
- Adds one locale key, `pamTargetSystemPolicyNoCharacterClass`.
- Adds 5 tests: the validator firing, it clearing when a class is re-enabled, the error rendering, and both submit paths refusing to save.

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`. It sits on the PR for `pam/rotux-target-delete-names-reversible-option`; the PR for `pam/rotux-target-edit-id-case-insensitive` sits on top of it.

## Copy not yet approved

- `pamTargetSystemPolicyNoCharacterClass`: "Include at least one character type." Proposed wording, not yet reviewed by design.

## Known gaps

- The new error renders with no visible text. `BitErrorComponent` (`libs/components/src/form-field/error.component.ts`) discards projected content and only shows its `displayError` input, which nothing here binds, so the element is present but empty (a bare icon). The same is true of the pre-existing `minExceedsMax` error on this same card, so this ticket inherits rather than introduces the defect. Confirmed in both light and dark themes.
- This finding has no evidence screenshot in `pam-qa` `findings.json`, and no UAT case file covers the rotation surface. Route and repro were derived from `rotation.routes.ts` and `rotation-shell.component.html`.
- `npm run test:types` fails on this branch, but all 12 errors trace to code this diff does not touch: 9 are in files outside the diff, and the other 3 are pre-existing `kind: null` / `supportsSessionTermination: null` lines in the spec file that this ticket did not write (per `git blame`), just shifted down by the lines this ticket added. The base branch itself was not run to confirm the baseline is red, since that would require checking out outside this read-only worktree.

## 📸 Screenshots

Captured at 1440x1024. Before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Target systems -> new and edit

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-policy-allows-no-character-classes.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-policy-allows-no-character-classes.png" alt="after" width="460"> |
