### PR TITLE
An edit URL with an uppercase id silently bounces back to the list

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { asUuid, uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 
 import type { TargetSystem, TargetSystemId } from "../rotation";
@@ -123,7 +123,7 @@ async function setupCreateWithTemplate(template: string): Promise<
 /** Build a configured TestBed for edit mode (with targetSystemId). */
 async function setupEdit(
   rotationSdk: ReturnType<typeof mock<RotationSdkService>>,
-  routeTargetSystemId: string = sysId("sys-1"),
+  routeTargetSystemId: string = uuidAsString(sysId("sys-1")),
 ) {
   TestBed.overrideComponent(TargetSystemEditComponent, { set: { template: "" } });
   await TestBed.configureTestingModule({
@@ -737,11 +737,11 @@ describe("TargetSystemEditComponent — edit mode", () => {
   });
 
   const mixedCaseIdCases: [string, TargetSystemId, string][] = [
-    ["the route id is uppercase", sysId("sys-1"), sysId("sys-1").toUpperCase()],
+    ["the route id is uppercase", sysId("sys-1"), uuidAsString(sysId("sys-1")).toUpperCase()],
     [
       "the stored id is uppercase and the route id is lower case",
-      asUuid<TargetSystemId>(sysId("sys-1").toUpperCase()),
-      sysId("sys-1"),
+      asUuid<TargetSystemId>(uuidAsString(sysId("sys-1")).toUpperCase()),
+      uuidAsString(sysId("sys-1")),
     ],
   ];
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -11,7 +11,7 @@ import { DialogService, ToastService } from "@bitwarden/components";
 import type { TargetSystem, TargetSystemId } from "../rotation";
 import { TargetSystemKind, TargetSystemMethod, TargetSystemStatus } from "../rotation";
 import { RotationSdkService } from "../rotation-sdk.service";
-import { ORGANIZATION_ID, id, sysId } from "../testing/rotation-builders";
+import { ORGANIZATION_ID, sysId } from "../testing/rotation-builders";
 
 import { TargetSystemEditComponent } from "./target-system-edit.component";
 
@@ -60,6 +60,10 @@ const NO_CHARACTER_CLASSES = {
 
 function policyFormOf(fixture: ComponentFixture<TargetSystemEditComponent>): FormGroup {
   return (fixture.componentInstance as unknown as { policyForm: FormGroup }).policyForm;
+}
+
+function nameFormOf(fixture: ComponentFixture<TargetSystemEditComponent>): FormGroup {
+  return (fixture.componentInstance as unknown as { nameForm: FormGroup }).nameForm;
 }
 
 /** Build a configured TestBed for create mode (no targetSystemId). */
@@ -119,7 +123,7 @@ async function setupCreateWithTemplate(template: string): Promise<
 /** Build a configured TestBed for edit mode (with targetSystemId). */
 async function setupEdit(
   rotationSdk: ReturnType<typeof mock<RotationSdkService>>,
-  routeTargetSystemId: string = id("sys-1"),
+  routeTargetSystemId: string = sysId("sys-1"),
 ) {
   TestBed.overrideComponent(TargetSystemEditComponent, { set: { template: "" } });
   await TestBed.configureTestingModule({
@@ -732,49 +736,34 @@ describe("TargetSystemEditComponent — edit mode", () => {
     );
   });
 
-  it("loads the record when the route id is uppercase", async () => {
-    TestBed.resetTestingModule();
-    const rotationSdk2 = mock<RotationSdkService>();
-    const toastService2 = mock<ToastService>();
-    rotationSdk2.listTargetSystems.mockResolvedValue([makeSystem()]);
-    await setupEdit(rotationSdk2, id("sys-1").toUpperCase());
-    TestBed.overrideProvider(ToastService, { useValue: toastService2 });
-    const nav = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
+  const mixedCaseIdCases: [string, TargetSystemId, string][] = [
+    ["the route id is uppercase", sysId("sys-1"), sysId("sys-1").toUpperCase()],
+    [
+      "the stored id is uppercase and the route id is lower case",
+      asUuid<TargetSystemId>(sysId("sys-1").toUpperCase()),
+      sysId("sys-1"),
+    ],
+  ];
 
-    const fixture2 = TestBed.createComponent(TargetSystemEditComponent);
-    fixture2.detectChanges();
-    await fixture2.whenStable();
-    fixture2.detectChanges();
+  it.each(mixedCaseIdCases)(
+    "loads the record when %s",
+    async (_case, storedId, routeTargetSystemId) => {
+      TestBed.resetTestingModule();
+      const caseSdk = mock<RotationSdkService>();
+      const caseToast = mock<ToastService>();
+      caseSdk.listTargetSystems.mockResolvedValue([makeSystem({ id: storedId })]);
+      await setupEdit(caseSdk, routeTargetSystemId);
+      TestBed.overrideProvider(ToastService, { useValue: caseToast });
+      const nav = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
 
-    const nameForm = (
-      fixture2.componentInstance as unknown as { nameForm: { getRawValue: () => { name: string } } }
-    ).nameForm;
-    expect(nameForm.getRawValue().name).toBe("Prod Entra");
-    expect(nav).not.toHaveBeenCalled();
-    expect(toastService2.showToast).not.toHaveBeenCalled();
-  });
+      const fx = TestBed.createComponent(TargetSystemEditComponent);
+      fx.detectChanges();
+      await fx.whenStable();
+      fx.detectChanges();
 
-  it("loads the record when the stored id is uppercase and the route id is lower case", async () => {
-    TestBed.resetTestingModule();
-    const rotationSdk3 = mock<RotationSdkService>();
-    const toastService3 = mock<ToastService>();
-    rotationSdk3.listTargetSystems.mockResolvedValue([
-      makeSystem({ id: asUuid<TargetSystemId>(id("sys-1").toUpperCase()) }),
-    ]);
-    await setupEdit(rotationSdk3, id("sys-1"));
-    TestBed.overrideProvider(ToastService, { useValue: toastService3 });
-    const nav = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
-
-    const fixture3 = TestBed.createComponent(TargetSystemEditComponent);
-    fixture3.detectChanges();
-    await fixture3.whenStable();
-    fixture3.detectChanges();
-
-    const nameForm = (
-      fixture3.componentInstance as unknown as { nameForm: { getRawValue: () => { name: string } } }
-    ).nameForm;
-    expect(nameForm.getRawValue().name).toBe("Prod Entra");
-    expect(nav).not.toHaveBeenCalled();
-    expect(toastService3.showToast).not.toHaveBeenCalled();
-  });
+      expect(nameFormOf(fx).getRawValue().name).toBe("Prod Entra");
+      expect(nav).not.toHaveBeenCalled();
+      expect(caseToast.showToast).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -5,12 +5,13 @@ import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 
-import type { TargetSystem } from "../rotation";
+import type { TargetSystem, TargetSystemId } from "../rotation";
 import { TargetSystemKind, TargetSystemMethod, TargetSystemStatus } from "../rotation";
 import { RotationSdkService } from "../rotation-sdk.service";
-import { ORGANIZATION_ID, sysId } from "../testing/rotation-builders";
+import { ORGANIZATION_ID, id, sysId } from "../testing/rotation-builders";
 
 import { TargetSystemEditComponent } from "./target-system-edit.component";
 
@@ -116,7 +117,10 @@ async function setupCreateWithTemplate(template: string): Promise<
 }
 
 /** Build a configured TestBed for edit mode (with targetSystemId). */
-async function setupEdit(rotationSdk: ReturnType<typeof mock<RotationSdkService>>) {
+async function setupEdit(
+  rotationSdk: ReturnType<typeof mock<RotationSdkService>>,
+  routeTargetSystemId: string = id("sys-1"),
+) {
   TestBed.overrideComponent(TargetSystemEditComponent, { set: { template: "" } });
   await TestBed.configureTestingModule({
     imports: [TargetSystemEditComponent, NoopAnimationsModule],
@@ -129,7 +133,7 @@ async function setupEdit(rotationSdk: ReturnType<typeof mock<RotationSdkService>
       {
         provide: ActivatedRoute,
         useValue: {
-          snapshot: { params: { organizationId: ORG_ID, targetSystemId: sysId("sys-1") } },
+          snapshot: { params: { organizationId: ORG_ID, targetSystemId: routeTargetSystemId } },
         },
       },
     ],
@@ -726,5 +730,51 @@ describe("TargetSystemEditComponent — edit mode", () => {
     expect(toastService2.showToast).toHaveBeenCalledWith(
       expect.objectContaining({ variant: "error" }),
     );
+  });
+
+  it("loads the record when the route id is uppercase", async () => {
+    TestBed.resetTestingModule();
+    const rotationSdk2 = mock<RotationSdkService>();
+    const toastService2 = mock<ToastService>();
+    rotationSdk2.listTargetSystems.mockResolvedValue([makeSystem()]);
+    await setupEdit(rotationSdk2, id("sys-1").toUpperCase());
+    TestBed.overrideProvider(ToastService, { useValue: toastService2 });
+    const nav = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
+
+    const fixture2 = TestBed.createComponent(TargetSystemEditComponent);
+    fixture2.detectChanges();
+    await fixture2.whenStable();
+    fixture2.detectChanges();
+
+    const nameForm = (
+      fixture2.componentInstance as unknown as { nameForm: { getRawValue: () => { name: string } } }
+    ).nameForm;
+    expect(nameForm.getRawValue().name).toBe("Prod Entra");
+    expect(nav).not.toHaveBeenCalled();
+    expect(toastService2.showToast).not.toHaveBeenCalled();
+  });
+
+  it("loads the record when the stored id is uppercase and the route id is lower case", async () => {
+    TestBed.resetTestingModule();
+    const rotationSdk3 = mock<RotationSdkService>();
+    const toastService3 = mock<ToastService>();
+    rotationSdk3.listTargetSystems.mockResolvedValue([
+      makeSystem({ id: asUuid<TargetSystemId>(id("sys-1").toUpperCase()) }),
+    ]);
+    await setupEdit(rotationSdk3, id("sys-1"));
+    TestBed.overrideProvider(ToastService, { useValue: toastService3 });
+    const nav = jest.spyOn(TestBed.inject(Router), "navigate").mockResolvedValue(true);
+
+    const fixture3 = TestBed.createComponent(TargetSystemEditComponent);
+    fixture3.detectChanges();
+    await fixture3.whenStable();
+    fixture3.detectChanges();
+
+    const nameForm = (
+      fixture3.componentInstance as unknown as { nameForm: { getRawValue: () => { name: string } } }
+    ).nameForm;
+    expect(nameForm.getRawValue().name).toBe("Prod Entra");
+    expect(nav).not.toHaveBeenCalled();
+    expect(toastService3.showToast).not.toHaveBeenCalled();
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
@@ -15,7 +15,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { asUuid, uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   AsyncActionsModule,
@@ -292,7 +292,8 @@ export class TargetSystemEditComponent {
   private async loadSystem(): Promise<void> {
     try {
       const systems = await this.rotationSdk.listTargetSystems(this.organizationId);
-      const system = systems.find((s) => s.id === this.targetSystemId);
+      const routeId = uuidAsString(this.targetSystemId!).toLowerCase();
+      const system = systems.find((s) => uuidAsString(s.id).toLowerCase() === routeId);
       if (system == null) {
         this.toastService.showToast({
           variant: "error",


### PR DESCRIPTION
## 🎟️ Tracking

Not tracked in Jira. From the PAM UAT review, finding `uat-rotux-edit-url-id-case-sensitive`.

## 📔 Objective

Part of the PAM UAT review's stack of per-ticket fixes rooted on `pam/uat`.

Makes the target-system edit page find its record regardless of the case of the id in the URL or the case of the stored id.

- `loadSystem()` in `target-system-edit.component.ts` now compares `uuidAsString(this.targetSystemId!).toLowerCase()` against `uuidAsString(s.id).toLowerCase()`, replacing the previous exact-case `===` compare.
- Imports `uuidAsString` alongside the existing `asUuid` from `@bitwarden/common/platform/abstractions/sdk/sdk.service`.
- `target-system-edit.component.spec.ts` adds two `it.each` cases (uppercase route id, uppercase stored id) asserting the record loads with no navigation and no error toast.
- Adds a `nameFormOf` test helper and an optional `routeTargetSystemId` parameter on `setupEdit` to support the new cases.
- Sits on top of the PR for `pam/rotux-policy-requires-character-class`; the PR for `pam/rotux-target-method-choice-consequence-hint` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024. Before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Target systems -> edit

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-edit-url-id-case-sensitive.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-edit-url-id-case-sensitive.png" alt="after" width="460"> |

## Known gaps

- `npm run test:types` is already failing on `pam/uat` (12 pre-existing errors). This branch's diff is confined to `target-system-edit.component.ts` and its spec, and neither introduces nor fixes any of those errors.
- Changing only the `:targetSystemId` route param via a same-document hash navigation does not re-resolve the record, because `targetSystemId` is read once in a field initializer and Angular reuses the component instance. This is pre-existing on `pam/uat`, not a regression from this change, and a full document load resolves correctly.
