### PR TITLE
Automatic versus Manual is presented without its consequence

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18904,6 +18904,12 @@
   "pamTargetSystemMethodManual": {
     "message": "Manual"
   },
+  "pamTargetSystemMethodAutomaticHint": {
+    "message": "A registered access connector performs the rotations on the schedule you set."
+  },
+  "pamTargetSystemMethodManualHint": {
+    "message": "No rotation job is created. You rotate the credential by hand and record each rotation."
+  },
   "pamTargetSystemKindEntra": {
     "message": "Entra"
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18905,7 +18905,7 @@
     "message": "Manual"
   },
   "pamTargetSystemMethodAutomaticHint": {
-    "message": "A registered access connector performs the rotations on the schedule you set."
+    "message": "Rotations run on the schedule you set, once you finish the setup steps shown after saving."
   },
   "pamTargetSystemMethodManualHint": {
     "message": "No rotation job is created. You rotate the credential by hand and record each rotation."

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
@@ -147,19 +147,21 @@
             />
           </bit-form-field>
 
-          <bit-radio-group formControlName="method">
+          <bit-radio-group formControlName="method" [block]="true">
             <bit-label>{{ "pamTargetSystemMethodLabel" | i18n }}</bit-label>
             <bit-radio-button
               id="target-system-edit_radio_automatic"
               [value]="TargetSystemMethod.Automatic"
             >
               <bit-label>{{ "pamTargetSystemMethodAutomatic" | i18n }}</bit-label>
+              <bit-hint>{{ "pamTargetSystemMethodAutomaticHint" | i18n }}</bit-hint>
             </bit-radio-button>
             <bit-radio-button
               id="target-system-edit_radio_manual"
               [value]="TargetSystemMethod.Manual"
             >
               <bit-label>{{ "pamTargetSystemMethodManual" | i18n }}</bit-label>
+              <bit-hint>{{ "pamTargetSystemMethodManualHint" | i18n }}</bit-hint>
             </bit-radio-button>
           </bit-radio-group>
         </bit-card>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -433,6 +433,16 @@ describe("TargetSystemEditComponent — create mode (rendered)", () => {
     expect(el.querySelector("#target-system-edit_radio_manual")).toBeTruthy();
   });
 
+  it("renders a consequence hint under each method radio", () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector("#target-system-edit_radio_automatic bit-hint")?.textContent).toContain(
+      "pamTargetSystemMethodAutomaticHint",
+    );
+    expect(el.querySelector("#target-system-edit_radio_manual bit-hint")?.textContent).toContain(
+      "pamTargetSystemMethodManualHint",
+    );
+  });
+
   it("shows the Integration (kind) select only for the Automatic method", () => {
     const el = fixture.nativeElement as HTMLElement;
     // Automatic is the default: kind select is present.


### PR DESCRIPTION
## 🎟️ Tracking

From the PAM UAT review, finding `uat-rotux-method-choice-no-consequence`. No Jira ticket exists for this finding.

## 📔 Objective

Adds a consequence hint under each Automatic/Manual radio option on the target system creation form, so the effect of the choice is visible before saving instead of only in the post-save setup callout.

- `[block]="true"` added to the `bit-radio-group` in `target-system-edit.component.html`, stacking the two options instead of leaving them side by side.
- A `<bit-hint>` added inside each `bit-radio-button`, backed by two new `messages.json` keys: `pamTargetSystemMethodAutomaticHint` and `pamTargetSystemMethodManualHint`.
- One rendered-template test added in `target-system-edit.component.spec.ts` asserting both hints render.
- No changes under `libs/components/` and no new TypeScript imports: `bit-radio-button` already projects `bit-hint`.

This is part of the PAM UAT review fix stack rooted on `pam/uat`, one PR per finding. It sits on the PR for `pam/rotux-target-edit-id-case-insensitive`; the PR for `pam/rotux-rotation-form-discard-guard` sits on top of it.

### Copy not yet approved

The hint strings are proposed wording, not designer-approved:

- `pamTargetSystemMethodAutomaticHint`: "Rotations run on the schedule you set, once you finish the setup steps shown after saving."
- `pamTargetSystemMethodManualHint`: "No rotation job is created. You rotate the credential by hand and record each rotation."

The Automatic hint deliberately names neither "access connector" nor "daemon" to avoid adding a third term for the same concept ahead of a separate terminology cleanup elsewhere in the stack. As a result it no longer states what performs the rotation.

### Known gaps

- The Automatic hint's wording is unapproved and, per above, does not name what performs the rotation. The surrounding screen still mixes "access connector" and "daemon" vocabulary; this PR only avoids adding to it.
- `npm run test:types` fails with 12 pre-existing tsc-strict errors, all present on `pam/uat` and unrelated to this diff (SDK-level `TargetSystem`/`TargetSystemKind` nullability). Not fixed here per instructions; flagged as a trunk-level issue.
- One full-suite jest run hit a worker SIGSEGV in an unrelated spec file (`pam/abstractions/api-error.spec.ts`); it passes in isolation. Infrastructure flake, not in this diff.
- No UAT case file or evidence screenshot exists for this PAM Rotation surface; the route and click path were authored from the routing code rather than a case file.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Target systems -> new

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-method-choice-no-consequence.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-method-choice-no-consequence.png" alt="after" width="460"> |
