### PR TITLE
No unsaved-changes warning on any rotation form

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19006,6 +19006,9 @@
   "pamTargetSystemNotFound": {
     "message": "Target system not found."
   },
+  "pamTargetSystemDiscardTitle": {
+    "message": "Discard target system"
+  },
   "pamDaemonSearch": {
     "message": "Search daemons"
   },
@@ -19350,6 +19353,9 @@
   },
   "pamRotationConfigNotFound": {
     "message": "Managed credential not found."
+  },
+  "pamRotationConfigDiscardTitle": {
+    "message": "Discard managed credential"
   },
   "pamRotationConfigCreated": {
     "message": "Managed credential created."

--- a/bitwarden_license/bit-web/src/app/pam/helpers/discard-confirm.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/discard-confirm.spec.ts
@@ -1,0 +1,27 @@
+import { discardConfirmOptions } from "./discard-confirm";
+
+describe("discardConfirmOptions", () => {
+  it("names the record being abandoned while creating", () => {
+    expect(
+      discardConfirmOptions({ editing: false, createTitleKey: "pamTargetSystemDiscardTitle" }),
+    ).toEqual({
+      title: { key: "pamTargetSystemDiscardTitle" },
+      content: { key: "pamAccessRuleDiscardContent" },
+      acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
+      cancelButtonText: { key: "cancel" },
+      type: "warning",
+    });
+  });
+
+  it("asks about the edits, not the record, while editing", () => {
+    expect(
+      discardConfirmOptions({ editing: true, createTitleKey: "pamTargetSystemDiscardTitle" }),
+    ).toEqual({
+      title: { key: "discardEditsTitle" },
+      content: { key: "discardEditsConfirmation" },
+      acceptButtonText: { key: "discardEdits" },
+      cancelButtonText: { key: "keepEditing" },
+      type: "warning",
+    });
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/helpers/discard-confirm.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/discard-confirm.ts
@@ -1,0 +1,32 @@
+import { SimpleDialogOptions } from "@bitwarden/components";
+
+/**
+ * Confirmation copy for leaving a PAM create/edit form that still holds unsaved input.
+ *
+ * Creating names the thing being abandoned, so the caller supplies that title; the rest of the
+ * create wording is the same question wherever it is asked. Editing loses only the edits — the
+ * record itself survives — so it takes the repo's shared discard-edits copy instead.
+ */
+export function discardConfirmOptions({
+  editing,
+  createTitleKey,
+}: {
+  editing: boolean;
+  createTitleKey: string;
+}): SimpleDialogOptions {
+  return editing
+    ? {
+        title: { key: "discardEditsTitle" },
+        content: { key: "discardEditsConfirmation" },
+        acceptButtonText: { key: "discardEdits" },
+        cancelButtonText: { key: "keepEditing" },
+        type: "warning",
+      }
+    : {
+        title: { key: createTitleKey },
+        content: { key: "pamAccessRuleDiscardContent" },
+        acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
+        cancelButtonText: { key: "cancel" },
+        type: "warning",
+      };
+}

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.spec.ts
@@ -357,10 +357,43 @@ describe("RotationConfigEditComponent — discard guard", () => {
     expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
   });
 
+  // RotationScheduleInputComponent resolves its preset table from the SDK and emits the resolved
+  // cron once it lands. That emission reaches scheduleCron through the value accessor, which
+  // Angular treats as a view change and marks the control dirty — with nothing typed. The stubbed
+  // template here never binds the sub-editor, so these two reproduce the emission by hand.
+  it("leaves a create form the schedule editor only re-emitted into without asking", async () => {
+    const { component, fixture, dialogService } = setup();
+    await fixture.whenStable();
+    component.createForm.controls.scheduleCron.setValue(null);
+    component.createForm.controls.scheduleCron.markAsDirty();
+
+    await expect(runGuard(component)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
+
+  it("leaves an edit form the schedule editor only re-emitted into without asking", async () => {
+    const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
+    await fixture.whenStable();
+    component.settingsForm.controls.scheduleCron.setValue("0 0 0 * * ?");
+    component.settingsForm.controls.scheduleCron.markAsDirty();
+
+    await expect(runGuard(component)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
+
+  it("asks about a changed schedule", async () => {
+    const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
+    await fixture.whenStable();
+    component.settingsForm.controls.scheduleCron.setValue("0 0 */4 * * ?");
+
+    await expect(runGuard(component)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(EDIT_DIALOG);
+  });
+
   it("asks about an abandoned new managed credential", async () => {
     const { component, fixture, dialogService } = setup();
     await fixture.whenStable();
-    component.createForm.controls.accountIdentity.markAsDirty();
+    component.createForm.controls.accountIdentity.setValue("admin@example.com");
 
     await expect(runGuard(component)).resolves.toBe(true);
     expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(CREATE_DIALOG);
@@ -369,7 +402,7 @@ describe("RotationConfigEditComponent — discard guard", () => {
   it("asks about unsaved edits made in either card", async () => {
     const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
     await fixture.whenStable();
-    component.accountForm.controls.accountIdentity.markAsDirty();
+    component.accountForm.controls.accountIdentity.setValue("svc_rotation");
 
     await expect(runGuard(component)).resolves.toBe(true);
     expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(EDIT_DIALOG);
@@ -379,7 +412,7 @@ describe("RotationConfigEditComponent — discard guard", () => {
     const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
     await fixture.whenStable();
     dialogService.openSimpleDialog.mockResolvedValue(false);
-    component.accountForm.controls.accountIdentity.markAsDirty();
+    component.accountForm.controls.accountIdentity.setValue("svc_rotation");
 
     await expect(runGuard(component)).resolves.toBe(false);
   });
@@ -388,7 +421,6 @@ describe("RotationConfigEditComponent — discard guard", () => {
     const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
     await fixture.whenStable();
     component.accountForm.controls.accountIdentity.setValue("svc_rotation");
-    component.accountForm.controls.accountIdentity.markAsDirty();
 
     await component.submitEdit();
 
@@ -399,7 +431,7 @@ describe("RotationConfigEditComponent — discard guard", () => {
   it("does not ask again after the credential is removed", async () => {
     const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
     await fixture.whenStable();
-    component.accountForm.controls.accountIdentity.markAsDirty();
+    component.accountForm.controls.accountIdentity.setValue("svc_rotation");
 
     await component.removeRotation();
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.spec.ts
@@ -21,7 +21,10 @@ import {
   targetSystem,
 } from "../testing/rotation-builders";
 
-import { RotationConfigEditComponent } from "./rotation-config-edit.component";
+import {
+  RotationConfigEditComponent,
+  rotationConfigEditDiscardGuard,
+} from "./rotation-config-edit.component";
 
 const i18nFake: Pick<I18nService, "t" | "translate"> = {
   t: (id: string) => id,
@@ -317,5 +320,90 @@ describe("RotationConfigEditComponent — EDIT mode", () => {
 
     expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
     expect(rotationSdk.deleteConfig).not.toHaveBeenCalled();
+  });
+});
+
+describe("RotationConfigEditComponent — discard guard", () => {
+  const CREATE_DIALOG = {
+    title: { key: "pamRotationConfigDiscardTitle" },
+    content: { key: "pamAccessRuleDiscardContent" },
+    acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
+    cancelButtonText: { key: "cancel" },
+    type: "warning",
+  };
+
+  const EDIT_DIALOG = {
+    title: { key: "discardEditsTitle" },
+    content: { key: "discardEditsConfirmation" },
+    acceptButtonText: { key: "discardEdits" },
+    cancelButtonText: { key: "keepEditing" },
+    type: "warning",
+  };
+
+  function runGuard(component: RotationConfigEditComponent): Promise<boolean> {
+    return rotationConfigEditDiscardGuard(
+      component,
+      null as never,
+      null as never,
+      null as never,
+    ) as Promise<boolean>;
+  }
+
+  it("leaves an untouched create form without asking", async () => {
+    const { component, fixture, dialogService } = setup();
+    await fixture.whenStable();
+
+    await expect(runGuard(component)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
+
+  it("asks about an abandoned new managed credential", async () => {
+    const { component, fixture, dialogService } = setup();
+    await fixture.whenStable();
+    component.createForm.controls.accountIdentity.markAsDirty();
+
+    await expect(runGuard(component)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(CREATE_DIALOG);
+  });
+
+  it("asks about unsaved edits made in either card", async () => {
+    const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
+    await fixture.whenStable();
+    component.accountForm.controls.accountIdentity.markAsDirty();
+
+    await expect(runGuard(component)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(EDIT_DIALOG);
+  });
+
+  it("stays on the page when the operator keeps editing", async () => {
+    const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
+    await fixture.whenStable();
+    dialogService.openSimpleDialog.mockResolvedValue(false);
+    component.accountForm.controls.accountIdentity.markAsDirty();
+
+    await expect(runGuard(component)).resolves.toBe(false);
+  });
+
+  it("does not ask after a successful save", async () => {
+    const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
+    await fixture.whenStable();
+    component.accountForm.controls.accountIdentity.setValue("svc_rotation");
+    component.accountForm.controls.accountIdentity.markAsDirty();
+
+    await component.submitEdit();
+
+    await expect(runGuard(component)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
+
+  it("does not ask again after the credential is removed", async () => {
+    const { component, fixture, dialogService } = setup({ configId: configId("cfg-1") });
+    await fixture.whenStable();
+    component.accountForm.controls.accountIdentity.markAsDirty();
+
+    await component.removeRotation();
+
+    await expect(runGuard(component)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledTimes(1);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.ts
@@ -29,6 +29,7 @@ import {
 import type { CipherId } from "@bitwarden/sdk-internal";
 import { I18nPipe } from "@bitwarden/ui-common";
 
+import { discardConfirmOptions } from "../../helpers/discard-confirm";
 import { OrgCiphersService } from "../org-ciphers.service";
 import {
   RotationConfigCreateRequest,
@@ -349,7 +350,6 @@ export class RotationConfigEditComponent {
     }
   };
 
-  /** The form group that holds user input for the current mode. */
   private liveForm(): AbstractControl {
     return this.editing ? this.editForm : this.createForm;
   }
@@ -364,23 +364,12 @@ export class RotationConfigEditComponent {
       return true;
     }
 
-    // Creating: name the thing being abandoned, the managed credential itself. Editing: the
-    // credential already exists and only the edits are lost.
-    const copy = this.editing
-      ? {
-          title: { key: "discardEditsTitle" },
-          content: { key: "discardEditsConfirmation" },
-          acceptButtonText: { key: "discardEdits" },
-          cancelButtonText: { key: "keepEditing" },
-        }
-      : {
-          title: { key: "pamRotationConfigDiscardTitle" },
-          content: { key: "pamAccessRuleDiscardContent" },
-          acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
-          cancelButtonText: { key: "cancel" },
-        };
-
-    return await this.dialogService.openSimpleDialog({ ...copy, type: "warning" });
+    return await this.dialogService.openSimpleDialog(
+      discardConfirmOptions({
+        editing: this.editing,
+        createTitleKey: "pamRotationConfigDiscardTitle",
+      }),
+    );
   }
 
   protected readonly cancel = async (): Promise<void> => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.ts
@@ -185,6 +185,7 @@ export class RotationConfigEditComponent {
       }
     } finally {
       this.loading.set(false);
+      this.markSaved();
     }
   }
 
@@ -308,7 +309,7 @@ export class RotationConfigEditComponent {
         request,
       );
       this.existingConfig.set(updated);
-      this.editForm.markAsPristine();
+      this.markSaved();
       this.toastService.showToast({
         variant: "success",
         message: this.i18nService.t("pamRotationConfigSaved"),
@@ -355,12 +356,25 @@ export class RotationConfigEditComponent {
   }
 
   /**
+   * The live form's value as the admin was last shown it, serialized.
+   *
+   * The guard compares against this rather than reading `dirty`, because the schedule sub-editor
+   * emits its resolved cron back through the value accessor while the page is still initialising,
+   * and Angular marks the bound control dirty for that emission with nothing typed.
+   */
+  private readonly savedValue = signal("");
+
+  private markSaved(): void {
+    this.savedValue.set(JSON.stringify(this.liveForm().getRawValue()));
+  }
+
+  /**
    * Confirm before unsaved input is thrown away. Called both by Cancel and by the route's
    * CanDeactivate guard, which covers the breadcrumb and browser back/forward — and which is the
    * only protection on the edit view, where the footer carries no Cancel button.
    */
   async confirmDiscard(): Promise<boolean> {
-    if (!this.liveForm().dirty) {
+    if (JSON.stringify(this.liveForm().getRawValue()) === this.savedValue()) {
       return true;
     }
 
@@ -384,7 +398,7 @@ export class RotationConfigEditComponent {
   private navigateBack(): Promise<boolean> {
     // A create, a removal, a confirmed discard, or a not-found bounce is an exit the admin has
     // already agreed to, so the CanDeactivate guard must not ask a second time.
-    this.liveForm().markAsPristine();
+    this.markSaved();
     return this.router.navigate([".."], { relativeTo: this.route });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
-import { FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
-import { ActivatedRoute, Router } from "@angular/router";
+import { AbstractControl, FormBuilder, ReactiveFormsModule, Validators } from "@angular/forms";
+import { ActivatedRoute, CanDeactivateFn, Router } from "@angular/router";
 
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -307,6 +307,7 @@ export class RotationConfigEditComponent {
         request,
       );
       this.existingConfig.set(updated);
+      this.editForm.markAsPristine();
       this.toastService.showToast({
         variant: "success",
         message: this.i18nService.t("pamRotationConfigSaved"),
@@ -348,10 +349,53 @@ export class RotationConfigEditComponent {
     }
   };
 
-  protected readonly cancel = (): Promise<boolean> => this.navigateBack();
+  /** The form group that holds user input for the current mode. */
+  private liveForm(): AbstractControl {
+    return this.editing ? this.editForm : this.createForm;
+  }
+
+  /**
+   * Confirm before unsaved input is thrown away. Called both by Cancel and by the route's
+   * CanDeactivate guard, which covers the breadcrumb and browser back/forward — and which is the
+   * only protection on the edit view, where the footer carries no Cancel button.
+   */
+  async confirmDiscard(): Promise<boolean> {
+    if (!this.liveForm().dirty) {
+      return true;
+    }
+
+    // Creating: name the thing being abandoned, the managed credential itself. Editing: the
+    // credential already exists and only the edits are lost.
+    const copy = this.editing
+      ? {
+          title: { key: "discardEditsTitle" },
+          content: { key: "discardEditsConfirmation" },
+          acceptButtonText: { key: "discardEdits" },
+          cancelButtonText: { key: "keepEditing" },
+        }
+      : {
+          title: { key: "pamRotationConfigDiscardTitle" },
+          content: { key: "pamAccessRuleDiscardContent" },
+          acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
+          cancelButtonText: { key: "cancel" },
+        };
+
+    return await this.dialogService.openSimpleDialog({ ...copy, type: "warning" });
+  }
+
+  protected readonly cancel = async (): Promise<void> => {
+    if (!(await this.confirmDiscard())) {
+      return;
+    }
+
+    await this.navigateBack();
+  };
 
   /** Return to the managed-credentials tab. */
   private navigateBack(): Promise<boolean> {
+    // A create, a removal, a confirmed discard, or a not-found bounce is an exit the admin has
+    // already agreed to, so the CanDeactivate guard must not ask a second time.
+    this.liveForm().markAsPristine();
     return this.router.navigate([".."], { relativeTo: this.route });
   }
 
@@ -363,3 +407,7 @@ export class RotationConfigEditComponent {
     this.toastService.showToast({ variant: "error", message });
   }
 }
+
+export const rotationConfigEditDiscardGuard: CanDeactivateFn<RotationConfigEditComponent> = (
+  component,
+) => component.confirmDiscard();

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.routes.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.routes.ts
@@ -4,11 +4,17 @@ import { DaemonDetailComponent } from "./daemons/daemon-detail.component";
 import { DaemonsTabComponent } from "./daemons/daemons-tab.component";
 import { DaemonsService } from "./daemons/daemons.service";
 import { ManagedCredentialsTabComponent } from "./managed-credentials/managed-credentials-tab.component";
-import { RotationConfigEditComponent } from "./managed-credentials/rotation-config-edit.component";
+import {
+  RotationConfigEditComponent,
+  rotationConfigEditDiscardGuard,
+} from "./managed-credentials/rotation-config-edit.component";
 import { RotationConfigsService } from "./managed-credentials/rotation-configs.service";
 import { OrgCiphersService } from "./org-ciphers.service";
 import { RotationShellComponent } from "./rotation-shell.component";
-import { TargetSystemEditComponent } from "./target-systems/target-system-edit.component";
+import {
+  TargetSystemEditComponent,
+  targetSystemEditDiscardGuard,
+} from "./target-systems/target-system-edit.component";
 import { TargetSystemsTabComponent } from "./target-systems/target-systems-tab.component";
 import { TargetSystemsService } from "./target-systems/target-systems.service";
 
@@ -25,21 +31,25 @@ export const rotationRoutes: Routes = [
   {
     path: "managed-credentials/new",
     component: RotationConfigEditComponent,
+    canDeactivate: [rotationConfigEditDiscardGuard],
     data: { titleId: "pamRotationConfigCreateTitle" },
   },
   {
     path: "managed-credentials/:configId",
     component: RotationConfigEditComponent,
+    canDeactivate: [rotationConfigEditDiscardGuard],
     data: { titleId: "pamRotationConfigEditTitle" },
   },
   {
     path: "target-systems/new",
     component: TargetSystemEditComponent,
+    canDeactivate: [targetSystemEditDiscardGuard],
     data: { titleId: "pamTargetSystemCreateTitle" },
   },
   {
     path: "target-systems/:targetSystemId",
     component: TargetSystemEditComponent,
+    canDeactivate: [targetSystemEditDiscardGuard],
     data: { titleId: "pamTargetSystemEditTitle" },
   },
   {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -13,7 +13,10 @@ import { TargetSystemKind, TargetSystemMethod, TargetSystemStatus } from "../rot
 import { RotationSdkService } from "../rotation-sdk.service";
 import { ORGANIZATION_ID, sysId } from "../testing/rotation-builders";
 
-import { TargetSystemEditComponent } from "./target-system-edit.component";
+import {
+  TargetSystemEditComponent,
+  targetSystemEditDiscardGuard,
+} from "./target-system-edit.component";
 
 // JSDOM has no ResizeObserver
 class ResizeObserverStub {
@@ -776,4 +779,145 @@ describe("TargetSystemEditComponent — edit mode", () => {
       expect(caseToast.showToast).not.toHaveBeenCalled();
     },
   );
+});
+
+describe("TargetSystemEditComponent — discard guard", () => {
+  let rotationSdk: ReturnType<typeof mock<RotationSdkService>>;
+  let dialogService: ReturnType<typeof mock<DialogService>>;
+  let router: Router;
+
+  const CREATE_DIALOG = {
+    title: { key: "pamTargetSystemDiscardTitle" },
+    content: { key: "pamAccessRuleDiscardContent" },
+    acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
+    cancelButtonText: { key: "cancel" },
+    type: "warning",
+  };
+
+  const EDIT_DIALOG = {
+    title: { key: "discardEditsTitle" },
+    content: { key: "discardEditsConfirmation" },
+    acceptButtonText: { key: "discardEdits" },
+    cancelButtonText: { key: "keepEditing" },
+    type: "warning",
+  };
+
+  function runGuard(component: TargetSystemEditComponent): Promise<boolean> {
+    return targetSystemEditDiscardGuard(
+      component,
+      null as never,
+      null as never,
+      null as never,
+    ) as Promise<boolean>;
+  }
+
+  async function mount(mode: "create" | "edit") {
+    rotationSdk = mock<RotationSdkService>();
+    dialogService = mock<DialogService>();
+    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem()]);
+    if (mode === "create") {
+      await setupCreate(rotationSdk);
+    } else {
+      await setupEdit(rotationSdk);
+    }
+    TestBed.overrideProvider(ToastService, { useValue: mock<ToastService>() });
+    TestBed.overrideProvider(DialogService, { useValue: dialogService });
+    router = TestBed.inject(Router);
+    const fixture = TestBed.createComponent(TargetSystemEditComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it("leaves an untouched create form without asking", async () => {
+    const fixture = await mount("create");
+
+    await expect(runGuard(fixture.componentInstance)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
+
+  it("asks about an abandoned new target system", async () => {
+    const fixture = await mount("create");
+    dialogService.openSimpleDialog.mockResolvedValue(true);
+
+    (
+      fixture.componentInstance as unknown as {
+        createForm: { controls: { name: { markAsDirty: () => void } } };
+      }
+    ).createForm.controls.name.markAsDirty();
+
+    await expect(runGuard(fixture.componentInstance)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(CREATE_DIALOG);
+  });
+
+  it("asks when only the policy card was touched", async () => {
+    const fixture = await mount("create");
+    dialogService.openSimpleDialog.mockResolvedValue(true);
+
+    policyFormOf(fixture).controls.minLength.markAsDirty();
+
+    await expect(runGuard(fixture.componentInstance)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(CREATE_DIALOG);
+  });
+
+  it("asks about unsaved edits with the shared edit wording", async () => {
+    const fixture = await mount("edit");
+    dialogService.openSimpleDialog.mockResolvedValue(true);
+
+    nameFormOf(fixture).controls.name.markAsDirty();
+
+    await expect(runGuard(fixture.componentInstance)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(EDIT_DIALOG);
+  });
+
+  it("stays on the page when the operator keeps editing", async () => {
+    const fixture = await mount("edit");
+    dialogService.openSimpleDialog.mockResolvedValue(false);
+    const nav = jest.spyOn(router, "navigate").mockResolvedValue(true);
+
+    nameFormOf(fixture).patchValue({ name: "Half typed" });
+    nameFormOf(fixture).markAsDirty();
+    await (fixture.componentInstance as unknown as { cancel: () => Promise<void> }).cancel();
+
+    await expect(runGuard(fixture.componentInstance)).resolves.toBe(false);
+    expect(nav).not.toHaveBeenCalled();
+    expect(nameFormOf(fixture).getRawValue().name).toBe("Half typed");
+  });
+
+  it("does not ask after a successful save", async () => {
+    const fixture = await mount("edit");
+    rotationSdk.updateTargetSystem.mockResolvedValue(undefined);
+
+    nameFormOf(fixture).patchValue({ name: "Renamed" });
+    nameFormOf(fixture).markAsDirty();
+    await (
+      fixture.componentInstance as unknown as { submitEdit: () => Promise<void> }
+    ).submitEdit();
+
+    await expect(runGuard(fixture.componentInstance)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
+
+  it("does not ask after a successful create", async () => {
+    const fixture = await mount("create");
+    rotationSdk.createTargetSystem.mockResolvedValue(makeSystem());
+    jest.spyOn(router, "navigate").mockResolvedValue(true);
+
+    const comp = fixture.componentInstance as unknown as {
+      createForm: { patchValue: (v: unknown) => void; markAsDirty: () => void };
+      submitCreate: () => Promise<void>;
+    };
+    comp.createForm.patchValue({
+      name: "My System",
+      method: TargetSystemMethod.Automatic,
+      kind: TargetSystemKind.Entra,
+    });
+    comp.createForm.markAsDirty();
+    await comp.submitCreate();
+
+    expect(rotationSdk.createTargetSystem).toHaveBeenCalled();
+    await expect(runGuard(fixture.componentInstance)).resolves.toBe(true);
+    expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+  });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.spec.ts
@@ -69,6 +69,10 @@ function nameFormOf(fixture: ComponentFixture<TargetSystemEditComponent>): FormG
   return (fixture.componentInstance as unknown as { nameForm: FormGroup }).nameForm;
 }
 
+function createFormOf(fixture: ComponentFixture<TargetSystemEditComponent>): FormGroup {
+  return (fixture.componentInstance as unknown as { createForm: FormGroup }).createForm;
+}
+
 /** Build a configured TestBed for create mode (no targetSystemId). */
 async function setupCreate(rotationSdk: ReturnType<typeof mock<RotationSdkService>>) {
   TestBed.overrideComponent(TargetSystemEditComponent, { set: { template: "" } });
@@ -841,11 +845,7 @@ describe("TargetSystemEditComponent — discard guard", () => {
     const fixture = await mount("create");
     dialogService.openSimpleDialog.mockResolvedValue(true);
 
-    (
-      fixture.componentInstance as unknown as {
-        createForm: { controls: { name: { markAsDirty: () => void } } };
-      }
-    ).createForm.controls.name.markAsDirty();
+    createFormOf(fixture).controls.name.markAsDirty();
 
     await expect(runGuard(fixture.componentInstance)).resolves.toBe(true);
     expect(dialogService.openSimpleDialog).toHaveBeenCalledWith(CREATE_DIALOG);
@@ -904,17 +904,16 @@ describe("TargetSystemEditComponent — discard guard", () => {
     rotationSdk.createTargetSystem.mockResolvedValue(makeSystem());
     jest.spyOn(router, "navigate").mockResolvedValue(true);
 
-    const comp = fixture.componentInstance as unknown as {
-      createForm: { patchValue: (v: unknown) => void; markAsDirty: () => void };
-      submitCreate: () => Promise<void>;
-    };
-    comp.createForm.patchValue({
+    const createForm = createFormOf(fixture);
+    createForm.patchValue({
       name: "My System",
       method: TargetSystemMethod.Automatic,
       kind: TargetSystemKind.Entra,
     });
-    comp.createForm.markAsDirty();
-    await comp.submitCreate();
+    createForm.markAsDirty();
+    await (
+      fixture.componentInstance as unknown as { submitCreate: () => Promise<void> }
+    ).submitCreate();
 
     expect(rotationSdk.createTargetSystem).toHaveBeenCalled();
     await expect(runGuard(fixture.componentInstance)).resolves.toBe(true);

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
@@ -38,6 +38,7 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
+import { discardConfirmOptions } from "../../helpers/discard-confirm";
 import {
   PasswordPolicy,
   TargetSystemId,
@@ -419,8 +420,7 @@ export class TargetSystemEditComponent {
       // The write answers with no content, so re-read rather than assume the request body is now
       // the stored state.
       await this.loadSystem();
-      this.nameForm.markAsPristine();
-      this.policyForm.markAsPristine();
+      this.markLiveFormsPristine();
       this.toastService.showToast({
         variant: "success",
         message: this.i18nService.t("pamTargetSystemSaved"),
@@ -489,7 +489,11 @@ export class TargetSystemEditComponent {
    * rather than a child — `createForm.dirty` alone does not see a policy edit.
    */
   private liveForms(): AbstractControl[] {
-    return this.editing ? [this.nameForm, this.policyForm] : [this.createForm, this.policyForm];
+    return [this.editing ? this.nameForm : this.createForm, this.policyForm];
+  }
+
+  private markLiveFormsPristine(): void {
+    this.liveForms().forEach((form) => form.markAsPristine());
   }
 
   /**
@@ -502,23 +506,12 @@ export class TargetSystemEditComponent {
       return true;
     }
 
-    // Creating: name the thing being abandoned, the target system itself. Editing: the system
-    // already exists and only the edits are lost, so the repo's shared wording is the true one.
-    const copy = this.editing
-      ? {
-          title: { key: "discardEditsTitle" },
-          content: { key: "discardEditsConfirmation" },
-          acceptButtonText: { key: "discardEdits" },
-          cancelButtonText: { key: "keepEditing" },
-        }
-      : {
-          title: { key: "pamTargetSystemDiscardTitle" },
-          content: { key: "pamAccessRuleDiscardContent" },
-          acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
-          cancelButtonText: { key: "cancel" },
-        };
-
-    return await this.dialogService.openSimpleDialog({ ...copy, type: "warning" });
+    return await this.dialogService.openSimpleDialog(
+      discardConfirmOptions({
+        editing: this.editing,
+        createTitleKey: "pamTargetSystemDiscardTitle",
+      }),
+    );
   }
 
   protected readonly cancel = async (): Promise<void> => {
@@ -532,7 +525,7 @@ export class TargetSystemEditComponent {
   private navigateToList(): Promise<boolean> {
     // A create, a confirmed discard, or a not-found bounce is an exit the admin has already agreed
     // to, so the CanDeactivate guard must not ask a second time.
-    this.liveForms().forEach((form) => form.markAsPristine());
+    this.markLiveFormsPristine();
     return this.router.navigate([".."], { relativeTo: this.route });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.ts
@@ -11,7 +11,7 @@ import {
   ValidatorFn,
   Validators,
 } from "@angular/forms";
-import { ActivatedRoute, Router } from "@angular/router";
+import { ActivatedRoute, CanDeactivateFn, Router } from "@angular/router";
 
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -419,6 +419,8 @@ export class TargetSystemEditComponent {
       // The write answers with no content, so re-read rather than assume the request body is now
       // the stored state.
       await this.loadSystem();
+      this.nameForm.markAsPristine();
+      this.policyForm.markAsPristine();
       this.toastService.showToast({
         variant: "success",
         message: this.i18nService.t("pamTargetSystemSaved"),
@@ -481,9 +483,56 @@ export class TargetSystemEditComponent {
     }
   };
 
-  protected readonly cancel = (): Promise<boolean> => this.navigateToList();
+  /**
+   * The form groups that hold user input for the current mode. The policy card is rendered through
+   * an `*ngTemplateOutlet` with its own `[formGroup]`, so it is a sibling of the mode's group
+   * rather than a child — `createForm.dirty` alone does not see a policy edit.
+   */
+  private liveForms(): AbstractControl[] {
+    return this.editing ? [this.nameForm, this.policyForm] : [this.createForm, this.policyForm];
+  }
+
+  /**
+   * Confirm before unsaved input is thrown away. Called both by Cancel and by the route's
+   * CanDeactivate guard, which covers the breadcrumb and browser back/forward. A pristine form
+   * has nothing to lose, so it skips the dialog rather than asking about an empty page.
+   */
+  async confirmDiscard(): Promise<boolean> {
+    if (!this.liveForms().some((form) => form.dirty)) {
+      return true;
+    }
+
+    // Creating: name the thing being abandoned, the target system itself. Editing: the system
+    // already exists and only the edits are lost, so the repo's shared wording is the true one.
+    const copy = this.editing
+      ? {
+          title: { key: "discardEditsTitle" },
+          content: { key: "discardEditsConfirmation" },
+          acceptButtonText: { key: "discardEdits" },
+          cancelButtonText: { key: "keepEditing" },
+        }
+      : {
+          title: { key: "pamTargetSystemDiscardTitle" },
+          content: { key: "pamAccessRuleDiscardContent" },
+          acceptButtonText: { key: "pamAccessRuleDiscardConfirm" },
+          cancelButtonText: { key: "cancel" },
+        };
+
+    return await this.dialogService.openSimpleDialog({ ...copy, type: "warning" });
+  }
+
+  protected readonly cancel = async (): Promise<void> => {
+    if (!(await this.confirmDiscard())) {
+      return;
+    }
+
+    await this.navigateToList();
+  };
 
   private navigateToList(): Promise<boolean> {
+    // A create, a confirmed discard, or a not-found bounce is an exit the admin has already agreed
+    // to, so the CanDeactivate guard must not ask a second time.
+    this.liveForms().forEach((form) => form.markAsPristine());
     return this.router.navigate([".."], { relativeTo: this.route });
   }
 
@@ -495,3 +544,7 @@ export class TargetSystemEditComponent {
     this.toastService.showToast({ variant: "error", message });
   }
 }
+
+export const targetSystemEditDiscardGuard: CanDeactivateFn<TargetSystemEditComponent> = (
+  component,
+) => component.confirmDiscard();


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`. No Jira ticket is named for this finding.

## 📔 Objective

Adds an unsaved-changes confirmation dialog to all four PAM rotation forms (create/edit target system, create/edit managed credential) so navigating away with unsaved input no longer discards it silently.

- Adds `confirmDiscard()` to both edit components, wired into `cancel()` and into a new `CanDeactivateFn` on all four routes in `rotation.routes.ts`, covering the breadcrumb and browser back/forward, not just Cancel.
- Both save paths now reset form state so the guard does not prompt after a save that already succeeded.
- Target-system checks `dirty` across its two live form groups; managed-credential instead compares a serialized snapshot, because its schedule sub-editor self-dirties the form during initialisation with nothing typed.
- New shared helper `discard-confirm.ts` builds dialog copy for both; edit mode reuses existing `discardEditsTitle` / `discardEditsConfirmation`, create mode uses two new keys (see Copy below).
- No `libs/components/` or template change.

Sits on the PR for `pam/rotux-target-method-choice-consequence-hint`; the PR for `pam/rotux-rotation-tabs-setup-order` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024. Before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Target system and Managed credential forms

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-no-unsaved-changes-guard.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-no-unsaved-changes-guard.png" alt="after" width="460"> |

## Copy not yet approved

This PR adds user-facing strings that the designer has not signed off on. Treat these as proposed, not settled:

- `pamTargetSystemDiscardTitle` = "Discard target system" (create-mode dialog title for the target system form)
- `pamRotationConfigDiscardTitle` = "Discard managed credential" (create-mode dialog title for the managed credential form)

## Known gaps

- **`typesOk` is false, pre-existing.** 12 TypeScript-strict errors, all tracing to files outside this diff or to trunk port commit `46f60b63b34`. This fails on `pam/uat` today, so it will fail CI for every lane in the stack, not just this one.
- **`danglingKeysOk` is false, pre-existing.** `pamRotationConfigSaved` (referenced at `rotation-config-edit.component.ts:332`) exists in no `messages.json` in the repo. The reference sits on an unchanged context line already present on the base branch and traces to trunk port commit `46f60b63b34`; this ticket neither introduced nor could fix it.
- **Address bar during a direct URL/hash exit.** When the exit is a raw URL or hash change rather than a button click, the address bar moves to the destination while the confirmation dialog is still open (the router restores it on Cancel). Via the Cancel button and the breadcrumb, the two paths the finding's criterion names, the URL stays put as specified.
- **Unresolved: `disableSystem` / `enableSystem` leave the target-system forms dirty.** `loadSystem()` re-patches the form after either action but does not mark it pristine, so the guard can later prompt about "edits" the server values already replaced. Deliberately left alone as an out-of-scope finding from review; not fixed here.
