### PR TITLE
Tab order and the default landing tab are the reverse of the setup order

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.html
@@ -1,15 +1,15 @@
 <app-header [title]="'pamRotationTitle' | i18n">
   @switch (activeTab()) {
-    @case ("managed-credentials") {
-      @if (hasConfigs()) {
+    @case ("daemons") {
+      @if (hasDaemons()) {
         <button
           type="button"
           bitButton
           buttonType="primary"
-          [bitAction]="createManagedCredential"
-          id="rotation-shell_button_new-managed-credential"
+          [bitAction]="registerDaemon"
+          id="rotation-shell_button_new-daemon"
         >
-          {{ "pamRotationConfigNew" | i18n }}
+          {{ "pamDaemonNew" | i18n }}
         </button>
       }
     }
@@ -26,26 +26,26 @@
         </button>
       }
     }
-    @case ("daemons") {
-      @if (hasDaemons()) {
+    @case ("managed-credentials") {
+      @if (hasConfigs()) {
         <button
           type="button"
           bitButton
           buttonType="primary"
-          [bitAction]="registerDaemon"
-          id="rotation-shell_button_new-daemon"
+          [bitAction]="createManagedCredential"
+          id="rotation-shell_button_new-managed-credential"
         >
-          {{ "pamDaemonNew" | i18n }}
+          {{ "pamRotationConfigNew" | i18n }}
         </button>
       }
     }
   }
   <bit-tab-nav-bar slot="tabs" [label]="'pamRotationTitle' | i18n">
+    <bit-tab-link route="daemons">{{ "pamRotationTabDaemons" | i18n }}</bit-tab-link>
+    <bit-tab-link route="target-systems">{{ "pamRotationTabTargetSystems" | i18n }}</bit-tab-link>
     <bit-tab-link route="managed-credentials" [berryValue]="awaitingManualCount()">{{
       "pamRotationTabManagedCredentials" | i18n
     }}</bit-tab-link>
-    <bit-tab-link route="target-systems">{{ "pamRotationTabTargetSystems" | i18n }}</bit-tab-link>
-    <bit-tab-link route="daemons">{{ "pamRotationTabDaemons" | i18n }}</bit-tab-link>
   </bit-tab-nav-bar>
 </app-header>
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
@@ -86,15 +86,7 @@ describe("RotationShellComponent", () => {
     fixture.detectChanges();
   };
 
-  it("renders the three tab links", async () => {
-    await init();
-    const text = (fixture.nativeElement as HTMLElement).textContent ?? "";
-    expect(text).toContain("pamRotationTabManagedCredentials");
-    expect(text).toContain("pamRotationTabTargetSystems");
-    expect(text).toContain("pamRotationTabDaemons");
-  });
-
-  it("orders the tab links by the setup each one requires", async () => {
+  it("renders the three tab links ordered by the setup each one requires", async () => {
     await init();
     const labels = Array.from(
       (fixture.nativeElement as HTMLElement).querySelectorAll("bit-tab-link"),

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
@@ -13,6 +13,7 @@ import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.mod
 import { DaemonsService } from "./daemons/daemons.service";
 import { RotationConfigsService } from "./managed-credentials/rotation-configs.service";
 import { RotationShellComponent } from "./rotation-shell.component";
+import { rotationRoutes } from "./rotation.routes";
 import { TargetSystemsService } from "./target-systems/target-systems.service";
 import { configId } from "./testing/rotation-builders";
 
@@ -201,26 +202,21 @@ describe("RotationShellComponent (real router)", () => {
   })
   class StubComponent {}
 
-  // Mirrors rotation.routes.ts: the shell is an empty-path child of "rotation",
-  // and the create page is its sibling (not a child).
+  // Route-level providers and guards are dropped as well, so the shell resolves
+  // the TestBed doubles instead of constructing the real page-scoped services.
+  const stubEveryComponentButTheShell = (config: Routes): Routes =>
+    config.map((route) => ({
+      ...route,
+      providers: undefined,
+      canDeactivate: undefined,
+      ...(route.component && route.component !== RotationShellComponent
+        ? { component: StubComponent }
+        : {}),
+      ...(route.children ? { children: stubEveryComponentButTheShell(route.children) } : {}),
+    }));
+
   const routes: Routes = [
-    {
-      path: "rotation",
-      children: [
-        { path: "managed-credentials/new", component: StubComponent },
-        { path: "target-systems/new", component: StubComponent },
-        {
-          path: "",
-          component: RotationShellComponent,
-          children: [
-            { path: "", pathMatch: "full", redirectTo: "daemons" },
-            { path: "managed-credentials", component: StubComponent },
-            { path: "target-systems", component: StubComponent },
-            { path: "daemons", component: StubComponent },
-          ],
-        },
-      ],
-    },
+    { path: "rotation", children: stubEveryComponentButTheShell(rotationRoutes) },
   ];
 
   let harness: RouterTestingHarness;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
@@ -94,6 +94,18 @@ describe("RotationShellComponent", () => {
     expect(text).toContain("pamRotationTabDaemons");
   });
 
+  it("orders the tab links by the setup each one requires", async () => {
+    await init();
+    const labels = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll("bit-tab-link"),
+    ).map((el) => el.textContent?.trim());
+    expect(labels).toEqual([
+      "pamRotationTabDaemons",
+      "pamRotationTabTargetSystems",
+      "pamRotationTabManagedCredentials",
+    ]);
+  });
+
   it("calls load on RotationConfigsService with the organization id on init", async () => {
     await init();
     expect(loadMock).toHaveBeenCalledWith(ORG_ID);
@@ -209,7 +221,7 @@ describe("RotationShellComponent (real router)", () => {
           path: "",
           component: RotationShellComponent,
           children: [
-            { path: "", pathMatch: "full", redirectTo: "target-systems" },
+            { path: "", pathMatch: "full", redirectTo: "daemons" },
             { path: "managed-credentials", component: StubComponent },
             { path: "target-systems", component: StubComponent },
             { path: "daemons", component: StubComponent },
@@ -256,6 +268,11 @@ describe("RotationShellComponent (real router)", () => {
 
     router = TestBed.inject(Router);
     harness = await RouterTestingHarness.create();
+  });
+
+  it("lands on the daemons tab from the shell's bare path", async () => {
+    await harness.navigateByUrl("/rotation", RotationShellComponent);
+    expect(router.url).toBe("/rotation/daemons");
   });
 
   it("reports the active tab from the child route", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.ts
@@ -22,8 +22,8 @@ import { AccessConnector, RotationConfig, TargetSystem } from "./rotation";
 import { TargetSystemsService } from "./target-systems/target-systems.service";
 
 /**
- * Rotation feature shell: renders the page header and the three routed tabs (Managed
- * credentials / Target systems / Daemons); page-scoped services stay shared across tab
+ * Rotation feature shell: renders the page header and the three routed tabs (Daemons /
+ * Target systems / Managed credentials); page-scoped services stay shared across tab
  * navigation since the shell stays mounted.
  *
  * The header hosts the active tab's primary create action, driven by the active child route, so

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.routes.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.routes.ts
@@ -62,11 +62,11 @@ export const rotationRoutes: Routes = [
     component: RotationShellComponent,
     providers: [RotationConfigsService, TargetSystemsService, DaemonsService, OrgCiphersService],
     children: [
-      { path: "", pathMatch: "full", redirectTo: "managed-credentials" },
+      { path: "", pathMatch: "full", redirectTo: "daemons" },
       {
-        path: "managed-credentials",
-        component: ManagedCredentialsTabComponent,
-        data: { titleId: "pamRotationTabManagedCredentials" },
+        path: "daemons",
+        component: DaemonsTabComponent,
+        data: { titleId: "pamRotationTabDaemons" },
       },
       {
         path: "target-systems",
@@ -74,9 +74,9 @@ export const rotationRoutes: Routes = [
         data: { titleId: "pamRotationTabTargetSystems" },
       },
       {
-        path: "daemons",
-        component: DaemonsTabComponent,
-        data: { titleId: "pamRotationTabDaemons" },
+        path: "managed-credentials",
+        component: ManagedCredentialsTabComponent,
+        data: { titleId: "pamRotationTabManagedCredentials" },
       },
     ],
   },


### PR DESCRIPTION
## 🎟️ Tracking

From the PAM UAT review, part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Reorders the PAM Rotation shell's tabs and default landing tab to match the setup order (daemons, then target systems, then managed credentials) instead of the reverse.

- `rotation.routes.ts`: children reordered to `daemons`, `target-systems`, `managed-credentials`; the bare-path `redirectTo` changes from `managed-credentials` to `daemons`.
- `rotation-shell.component.html`: the three `bit-tab-link` elements and the matching `@switch`/`@case` header-button blocks are reordered to match; no attributes, labels, or i18n keys changed.
- `rotation-shell.component.ts`: doc comment updated to describe the new tab order.
- `rotation-shell.component.spec.ts`: adds a landing-tab test and a tab-order test that reads actual `bit-tab-link` order (the prior test only checked `textContent`, so it could not catch an ordering regression); the real-router describe now builds its route table from the production `rotationRoutes` via a `stubEveryComponentButTheShell` helper instead of a hand-copied, now-stale table.

Sits on top of the PR for `pam/rotux-rotation-form-discard-guard`; the PR for `pam/rotux-schedule-timezone-hint` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation (shell)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-tab-order-vs-setup-order.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-tab-order-vs-setup-order.png" alt="after" width="460"> |

## Known gaps

- `test:types` fails on this branch (12 `typescript-strict-plugin` errors), but all 12 are pre-existing on trunk `pam/uat`: 5 are byte-identical to trunk, the other 2 (in files touched by lower tickets in the stack) have the same erroring constructs on trunk at shifted line numbers. None of the 4 files this ticket touches appears among the 12.
- One Jest suite (`gated-collection-filter-indicator.host.spec.ts`, unrelated to this change) failed to run with a worker `SIGSEGV`; it passes in isolation with `--runInBand`, read as an environmental crash rather than a real failure.
- The visually-landed tab currently reads "Access connectors" rather than "Daemons"; that copy is a separate, neighboring terminology ticket and does not affect the ordering this PR fixes.
