### PR TITLE
Rotation schedules are evaluated on a clock the UI never names

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18817,6 +18817,9 @@
   "pamRotationScheduleInvalidCron": {
     "message": "Please enter a valid Quartz cron expression (6 or 7 space-separated fields)."
   },
+  "pamRotationScheduleTimezoneHint": {
+    "message": "Schedules run in UTC, not your local time zone."
+  },
   "pamTargetSystemNew": {
     "message": "New target system"
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
@@ -34,6 +34,7 @@
       [label]="'pamRotationScheduleCustom' | i18n"
     ></bit-option>
   </bit-select>
+  <bit-hint>{{ "pamRotationScheduleTimezoneHint" | i18n }}</bit-hint>
 </bit-form-field>
 
 @if (presetControl.value === QuartzSchedulePreset.Custom) {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
@@ -101,6 +101,14 @@ describe("RotationScheduleInputComponent", () => {
     ).customControl as ReturnType<typeof customCtrl>;
   }
 
+  function hintTexts(): (string | undefined)[] {
+    return [...fixture.nativeElement.querySelectorAll("bit-hint")].map((hint: HTMLElement) =>
+      hint.textContent?.trim(),
+    );
+  }
+
+  // ---- writeValue (reverse-map) ----
+
   it("maps null to None preset", async () => {
     component.writeValue(null);
     await fixture.whenStable();
@@ -212,18 +220,15 @@ describe("RotationScheduleInputComponent", () => {
   // ---- timezone hint ----
 
   it("renders the timezone hint under the preset select", () => {
-    fixture.detectChanges();
-    const hints: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll("bit-hint"));
-    expect(hints.map((h) => h.textContent?.trim())).toContain("pamRotationScheduleTimezoneHint");
+    expect(hintTexts()).toContain("pamRotationScheduleTimezoneHint");
   });
 
   it("keeps the timezone hint when the Custom preset is selected", async () => {
     presetCtrl().setValue(QuartzSchedulePreset.Custom);
     await fixture.whenStable();
     fixture.detectChanges();
-    const hints: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll("bit-hint"));
-    const text = hints.map((h) => h.textContent?.trim());
-    expect(text).toContain("pamRotationScheduleTimezoneHint");
-    expect(text).toContain("pamRotationScheduleCustomHint");
+    const hints = hintTexts();
+    expect(hints).toContain("pamRotationScheduleTimezoneHint");
+    expect(hints).toContain("pamRotationScheduleCustomHint");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
@@ -208,4 +208,22 @@ describe("RotationScheduleInputComponent", () => {
     const errors = component.validate({ value: outerControl.value } as never);
     expect(errors).toBeNull();
   });
+
+  // ---- timezone hint ----
+
+  it("renders the timezone hint under the preset select", () => {
+    fixture.detectChanges();
+    const hints: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll("bit-hint"));
+    expect(hints.map((h) => h.textContent?.trim())).toContain("pamRotationScheduleTimezoneHint");
+  });
+
+  it("keeps the timezone hint when the Custom preset is selected", async () => {
+    presetCtrl().setValue(QuartzSchedulePreset.Custom);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const hints: HTMLElement[] = Array.from(fixture.nativeElement.querySelectorAll("bit-hint"));
+    const text = hints.map((h) => h.textContent?.trim());
+    expect(text).toContain("pamRotationScheduleTimezoneHint");
+    expect(text).toContain("pamRotationScheduleCustomHint");
+  });
 });


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Adds a hint under the rotation schedule preset selector stating that schedules run in UTC.

- Adds one `<bit-hint>` as the last child of the first `bit-form-field` in `rotation-schedule-input.component.html`, right after `</bit-select>`.
- New message key `pamRotationScheduleTimezoneHint`.
- The hint shows for every preset, including alongside the existing Custom cron hint when Custom is selected.
- Adds two rendered-DOM tests in `rotation-schedule-input.component.spec.ts`, plus a `hintTexts()` helper, checking the hint's presence and its coexistence with the Custom cron hint.
- Sits on `pam/rotux-rotation-tabs-setup-order`; `pam/rotux-schedule-interval-and-time-builder` stacks on top of this.

## 📸 Screenshots

Captured at 1440x1024, before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Managed credential form -> Schedule

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-schedule-timezone-undisclosed.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-schedule-timezone-undisclosed.png" alt="after" width="460"> |

## Copy not yet approved

The designer has not signed off on this wording:

- `pamRotationScheduleTimezoneHint`: "Schedules run in UTC, not your local time zone."

Treat it as proposed, not settled.

## Known gaps

- `dotnet`/`tsc-strict` (`npm run test:types`) fails with 12 errors, all in files this branch does not touch; confirmed byte-identical to `pam/uat`, so pre-existing and not attributable here.
- Could not visually verify the edit form's Settings card: the shared QA org has no target systems or `PamRotationConfig` rows, so no `/managed-credentials/{configId}` page exists to open. Not created, to avoid changing empty states other tickets in the stack are capturing.
- Cosmetic regression caused by this change: with Custom selected, the new hint sits flush against the "Custom cron expression" label (no margin) because the host `bit-form-field` carries `disableMargin`.
