### PR TITLE
The schedule builder cannot express an interval or a time of day

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18839,10 +18839,13 @@
     "message": "Time of day (UTC)"
   },
   "pamRotationScheduleIntervalHint": {
-    "message": "Intervals are anchored to the calendar. Day intervals restart on the 1st of each month, and month intervals run on the 1st."
+    "message": "Intervals are anchored to the calendar. Day intervals restart on the 1st of each month, and month intervals run on the 1st and restart in January."
   },
   "pamRotationScheduleInvalidInterval": {
     "message": "Enter how often the rotation repeats and the time of day."
+  },
+  "pamRotationScheduleIntervalCountWholeNumber": {
+    "message": "Enter a whole number."
   },
   "pamTargetSystemNew": {
     "message": "New target system"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18820,6 +18820,30 @@
   "pamRotationScheduleTimezoneHint": {
     "message": "Schedules run in UTC, not your local time zone."
   },
+  "pamRotationScheduleInterval": {
+    "message": "Interval"
+  },
+  "pamRotationScheduleIntervalCountLabel": {
+    "message": "Repeat every"
+  },
+  "pamRotationScheduleIntervalUnitLabel": {
+    "message": "Unit"
+  },
+  "pamRotationScheduleIntervalUnitDays": {
+    "message": "Days"
+  },
+  "pamRotationScheduleIntervalUnitMonths": {
+    "message": "Months"
+  },
+  "pamRotationScheduleIntervalTimeLabel": {
+    "message": "Time of day (UTC)"
+  },
+  "pamRotationScheduleIntervalHint": {
+    "message": "Intervals are anchored to the calendar. Day intervals restart on the 1st of each month, and month intervals run on the 1st."
+  },
+  "pamRotationScheduleInvalidInterval": {
+    "message": "Enter how often the rotation repeats and the time of day."
+  },
   "pamTargetSystemNew": {
     "message": "New target system"
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
@@ -30,12 +30,65 @@
       [label]="'pamRotationScheduleMonthly' | i18n"
     ></bit-option>
     <bit-option
+      [value]="ScheduleInterval"
+      [label]="'pamRotationScheduleInterval' | i18n"
+    ></bit-option>
+    <bit-option
       [value]="QuartzSchedulePreset.Custom"
       [label]="'pamRotationScheduleCustom' | i18n"
     ></bit-option>
   </bit-select>
   <bit-hint>{{ "pamRotationScheduleTimezoneHint" | i18n }}</bit-hint>
 </bit-form-field>
+
+@if (presetControl.value === ScheduleInterval) {
+  <div class="tw-mt-4 tw-flex tw-gap-4">
+    <div class="tw-w-28">
+      <bit-form-field>
+        <bit-label>{{ "pamRotationScheduleIntervalCountLabel" | i18n }}</bit-label>
+        <input
+          bitInput
+          id="rotation-schedule-input_input_interval-count"
+          type="number"
+          min="1"
+          [attr.max]="intervalCountMax"
+          [formControl]="intervalCountControl"
+          (blur)="markTouched()"
+        />
+      </bit-form-field>
+    </div>
+    <div class="tw-flex-1">
+      <bit-form-field>
+        <bit-label>{{ "pamRotationScheduleIntervalUnitLabel" | i18n }}</bit-label>
+        <bit-select
+          id="rotation-schedule-input_select_interval-unit"
+          [formControl]="intervalUnitControl"
+          (blur)="markTouched()"
+        >
+          <bit-option
+            [value]="ScheduleIntervalUnit.Days"
+            [label]="'pamRotationScheduleIntervalUnitDays' | i18n"
+          ></bit-option>
+          <bit-option
+            [value]="ScheduleIntervalUnit.Months"
+            [label]="'pamRotationScheduleIntervalUnitMonths' | i18n"
+          ></bit-option>
+        </bit-select>
+      </bit-form-field>
+    </div>
+  </div>
+  <bit-form-field>
+    <bit-label>{{ "pamRotationScheduleIntervalTimeLabel" | i18n }}</bit-label>
+    <input
+      bitInput
+      id="rotation-schedule-input_input_interval-time"
+      type="time"
+      [formControl]="intervalTimeControl"
+      (blur)="markTouched()"
+    />
+    <bit-hint>{{ "pamRotationScheduleIntervalHint" | i18n }}</bit-hint>
+  </bit-form-field>
+}
 
 @if (presetControl.value === QuartzSchedulePreset.Custom) {
   <bit-form-field>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
@@ -434,4 +434,36 @@ describe("RotationScheduleInputComponent", () => {
 
     ids.forEach((id) => expect(fixture.nativeElement.querySelector(id)).not.toBeNull());
   });
+
+  it("puts a fractional count in error on the count field itself", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 1.5, "02:00");
+    expect(intervalCountCtrl().errors).toMatchObject({
+      notWholeNumber: { message: "pamRotationScheduleIntervalCountWholeNumber" },
+    });
+    expect(component.validate({ value: outerControl.value } as never)).toMatchObject({
+      invalidInterval: { message: "pamRotationScheduleInvalidInterval" },
+    });
+  });
+
+  it("renders the count error once the field is blurred", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 50, "02:00");
+    const count: HTMLInputElement = fixture.nativeElement.querySelector(
+      "#rotation-schedule-input_input_interval-count",
+    );
+    count.dispatchEvent(new Event("blur"));
+    fixture.detectChanges();
+
+    expect(count.closest("bit-form-field")?.querySelector("bit-error")).not.toBeNull();
+  });
+
+  it("renders the time error once the field is blurred", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 7, "");
+    const time: HTMLInputElement = fixture.nativeElement.querySelector(
+      "#rotation-schedule-input_input_interval-time",
+    );
+    time.dispatchEvent(new Event("blur"));
+    fixture.detectChanges();
+
+    expect(time.closest("bit-form-field")?.querySelector("bit-error")).not.toBeNull();
+  });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
@@ -109,20 +109,13 @@ describe("RotationScheduleInputComponent", () => {
   }
 
   /** Convenience access to the protected interval builder controls. */
-  function intervalCountCtrl(): FormControl<number | null> {
-    return (component as unknown as { intervalCountControl: FormControl<number | null> })
-      .intervalCountControl;
+  function protectedControl<T>(name: string): FormControl<T> {
+    return (component as unknown as Record<string, FormControl<T>>)[name];
   }
 
-  function intervalUnitCtrl(): FormControl<ScheduleIntervalUnit> {
-    return (component as unknown as { intervalUnitControl: FormControl<ScheduleIntervalUnit> })
-      .intervalUnitControl;
-  }
-
-  function intervalTimeCtrl(): FormControl<string> {
-    return (component as unknown as { intervalTimeControl: FormControl<string> })
-      .intervalTimeControl;
-  }
+  const intervalCountCtrl = () => protectedControl<number | null>("intervalCountControl");
+  const intervalUnitCtrl = () => protectedControl<ScheduleIntervalUnit>("intervalUnitControl");
+  const intervalTimeCtrl = () => protectedControl<string>("intervalTimeControl");
 
   function buildInterval(unit: ScheduleIntervalUnit, count: number | null, time: string): void {
     presetCtrl().setValue(SCHEDULE_INTERVAL_MODE);

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
@@ -1,12 +1,19 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormControl } from "@angular/forms";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { SelectComponent } from "@bitwarden/components";
 
 import { QuartzSchedulePreset } from "./rotation";
-import { RotationScheduleInputComponent } from "./rotation-schedule-input.component";
+import {
+  RotationScheduleInputComponent,
+  ScheduleIntervalUnit,
+  ScheduleMode,
+  SCHEDULE_INTERVAL_MODE,
+} from "./rotation-schedule-input.component";
 import { RotationSdkService } from "./rotation-sdk.service";
 
 /**
@@ -83,8 +90,8 @@ describe("RotationScheduleInputComponent", () => {
 
   /** Convenience access to the protected preset form control. */
   function presetCtrl(): {
-    value: QuartzSchedulePreset;
-    setValue: (v: QuartzSchedulePreset, opts?: { emitEvent?: boolean }) => void;
+    value: ScheduleMode;
+    setValue: (v: ScheduleMode, opts?: { emitEvent?: boolean }) => void;
   } {
     return (
       component as unknown as { presetControl: typeof presetCtrl extends () => infer R ? R : never }
@@ -99,6 +106,30 @@ describe("RotationScheduleInputComponent", () => {
     return (
       component as unknown as { customControl: typeof customCtrl extends () => infer R ? R : never }
     ).customControl as ReturnType<typeof customCtrl>;
+  }
+
+  /** Convenience access to the protected interval builder controls. */
+  function intervalCountCtrl(): FormControl<number | null> {
+    return (component as unknown as { intervalCountControl: FormControl<number | null> })
+      .intervalCountControl;
+  }
+
+  function intervalUnitCtrl(): FormControl<ScheduleIntervalUnit> {
+    return (component as unknown as { intervalUnitControl: FormControl<ScheduleIntervalUnit> })
+      .intervalUnitControl;
+  }
+
+  function intervalTimeCtrl(): FormControl<string> {
+    return (component as unknown as { intervalTimeControl: FormControl<string> })
+      .intervalTimeControl;
+  }
+
+  function buildInterval(unit: ScheduleIntervalUnit, count: number | null, time: string): void {
+    presetCtrl().setValue(SCHEDULE_INTERVAL_MODE);
+    intervalUnitCtrl().setValue(unit);
+    intervalCountCtrl().setValue(count);
+    intervalTimeCtrl().setValue(time);
+    fixture.detectChanges();
   }
 
   function hintTexts(): (string | undefined)[] {
@@ -230,5 +261,184 @@ describe("RotationScheduleInputComponent", () => {
     const hints = hintTexts();
     expect(hints).toContain("pamRotationScheduleTimezoneHint");
     expect(hints).toContain("pamRotationScheduleCustomHint");
+  });
+
+  // ---- interval builder: composition ----
+
+  it("every 1 day at 00:00 emits the midnight daily expression", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 1, "00:00");
+    expect(outerControl.value).toBe("0 0 0 * * ?");
+  });
+
+  it("every 1 day at 02:30 emits an unstepped day-of-month expression", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 1, "02:30");
+    expect(outerControl.value).toBe("0 30 2 * * ?");
+  });
+
+  it("every 7 days at 02:00 emits a stepped day-of-month expression", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 7, "02:00");
+    expect(outerControl.value).toBe("0 0 2 1/7 * ?");
+  });
+
+  it("every 30 days at 23:15 emits a stepped day-of-month expression", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 30, "23:15");
+    expect(outerControl.value).toBe("0 15 23 1/30 * ?");
+  });
+
+  it("every 1 month at 00:00 emits the monthly expression", () => {
+    buildInterval(ScheduleIntervalUnit.Months, 1, "00:00");
+    expect(outerControl.value).toBe("0 0 0 1 * ?");
+  });
+
+  it("every 3 months at 02:00 emits a stepped month expression", () => {
+    buildInterval(ScheduleIntervalUnit.Months, 3, "02:00");
+    expect(outerControl.value).toBe("0 0 2 1 1/3 ?");
+  });
+
+  it("every 12 months at 06:45 emits a stepped month expression", () => {
+    buildInterval(ScheduleIntervalUnit.Months, 12, "06:45");
+    expect(outerControl.value).toBe("0 45 6 1 1/12 ?");
+  });
+
+  // ---- interval builder: round-trip ----
+
+  it("maps a stepped day-of-month cron back into the day builder", async () => {
+    component.writeValue("0 0 2 1/7 * ?");
+    await fixture.whenStable();
+    expect(presetCtrl().value).toBe(SCHEDULE_INTERVAL_MODE);
+    expect(intervalUnitCtrl().value).toBe(ScheduleIntervalUnit.Days);
+    expect(intervalCountCtrl().value).toBe(7);
+    expect(intervalTimeCtrl().value).toBe("02:00");
+  });
+
+  it("maps a stepped month cron back into the month builder", async () => {
+    component.writeValue("0 0 2 1 1/3 ?");
+    await fixture.whenStable();
+    expect(presetCtrl().value).toBe(SCHEDULE_INTERVAL_MODE);
+    expect(intervalUnitCtrl().value).toBe(ScheduleIntervalUnit.Months);
+    expect(intervalCountCtrl().value).toBe(3);
+    expect(intervalTimeCtrl().value).toBe("02:00");
+  });
+
+  it("maps an unstepped daily cron at a non-midnight time back into the day builder", async () => {
+    component.writeValue("0 30 2 * * ?");
+    await fixture.whenStable();
+    expect(presetCtrl().value).toBe(SCHEDULE_INTERVAL_MODE);
+    expect(intervalUnitCtrl().value).toBe(ScheduleIntervalUnit.Days);
+    expect(intervalCountCtrl().value).toBe(1);
+    expect(intervalTimeCtrl().value).toBe("02:30");
+  });
+
+  it("keeps the daily preset rather than opening the builder", async () => {
+    component.writeValue(PRESET_CRONS.daily);
+    await fixture.whenStable();
+    expect(presetCtrl().value).toBe(QuartzSchedulePreset.Daily);
+  });
+
+  it("keeps the monthly preset rather than opening the builder", async () => {
+    component.writeValue(PRESET_CRONS.monthly);
+    await fixture.whenStable();
+    expect(presetCtrl().value).toBe(QuartzSchedulePreset.Monthly);
+  });
+
+  it("leaves the interval controls at their defaults for a custom cron", async () => {
+    component.writeValue("0 0 */4 * * ?");
+    await fixture.whenStable();
+    expect(presetCtrl().value).toBe(QuartzSchedulePreset.Custom);
+    expect(customCtrl().value).toBe("0 0 */4 * * ?");
+    expect(intervalUnitCtrl().value).toBe(ScheduleIntervalUnit.Days);
+    expect(intervalCountCtrl().value).toBe(1);
+    expect(intervalTimeCtrl().value).toBe("00:00");
+  });
+
+  it("falls through to Custom for a weekday cron the builder cannot represent", async () => {
+    component.writeValue("0 0 2 ? * MON-FRI");
+    await fixture.whenStable();
+    expect(presetCtrl().value).toBe(QuartzSchedulePreset.Custom);
+    expect(customCtrl().value).toBe("0 0 2 ? * MON-FRI");
+  });
+
+  it("falls through to Custom for a seven-field cron", async () => {
+    component.writeValue("0 0 2 1/7 * ? 2027");
+    await fixture.whenStable();
+    expect(presetCtrl().value).toBe(QuartzSchedulePreset.Custom);
+    expect(customCtrl().value).toBe("0 0 2 1/7 * ? 2027");
+  });
+
+  // ---- interval builder: validation ----
+
+  it("a complete interval returns no validation error", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 7, "02:00");
+    expect(component.validate({ value: outerControl.value } as never)).toBeNull();
+  });
+
+  it("a cleared count produces invalidInterval and emits null", () => {
+    buildInterval(ScheduleIntervalUnit.Days, null, "02:00");
+    expect(component.validate({ value: outerControl.value } as never)).toMatchObject({
+      invalidInterval: { message: "pamRotationScheduleInvalidInterval" },
+    });
+    expect(outerControl.value).toBeNull();
+  });
+
+  it("a day count beyond 31 produces invalidInterval", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 32, "02:00");
+    expect(component.validate({ value: outerControl.value } as never)).toMatchObject({
+      invalidInterval: { message: "pamRotationScheduleInvalidInterval" },
+    });
+  });
+
+  it("a month count beyond 12 produces invalidInterval", () => {
+    buildInterval(ScheduleIntervalUnit.Months, 13, "02:00");
+    expect(component.validate({ value: outerControl.value } as never)).toMatchObject({
+      invalidInterval: { message: "pamRotationScheduleInvalidInterval" },
+    });
+  });
+
+  it("a cleared time produces invalidInterval", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 7, "");
+    expect(component.validate({ value: outerControl.value } as never)).toMatchObject({
+      invalidInterval: { message: "pamRotationScheduleInvalidInterval" },
+    });
+  });
+
+  it("switching from days to months puts an out-of-range count in error", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 20, "02:00");
+    intervalUnitCtrl().setValue(ScheduleIntervalUnit.Months);
+    fixture.detectChanges();
+    expect(component.validate({ value: outerControl.value } as never)).toMatchObject({
+      invalidInterval: { message: "pamRotationScheduleInvalidInterval" },
+    });
+  });
+
+  // ---- interval builder: rendering ----
+
+  it("offers the interval option alongside the seven presets", () => {
+    const select: SelectComponent<ScheduleMode> = fixture.debugElement.query(
+      By.directive(SelectComponent),
+    ).componentInstance;
+    expect(select.items()?.map((option) => option.value)).toEqual([
+      QuartzSchedulePreset.None,
+      QuartzSchedulePreset.Hourly,
+      QuartzSchedulePreset.Every6Hours,
+      QuartzSchedulePreset.Daily,
+      QuartzSchedulePreset.Weekly,
+      QuartzSchedulePreset.Monthly,
+      SCHEDULE_INTERVAL_MODE,
+      QuartzSchedulePreset.Custom,
+    ]);
+  });
+
+  it("renders the builder fields only once the interval mode is selected", () => {
+    const ids = [
+      "#rotation-schedule-input_input_interval-count",
+      "#rotation-schedule-input_select_interval-unit",
+      "#rotation-schedule-input_input_interval-time",
+    ];
+    ids.forEach((id) => expect(fixture.nativeElement.querySelector(id)).toBeNull());
+
+    presetCtrl().setValue(SCHEDULE_INTERVAL_MODE);
+    fixture.detectChanges();
+
+    ids.forEach((id) => expect(fixture.nativeElement.querySelector(id)).not.toBeNull());
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
@@ -9,6 +9,7 @@ import {
   ReactiveFormsModule,
   ValidationErrors,
   Validator,
+  Validators,
 } from "@angular/forms";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -19,13 +20,42 @@ import { QuartzSchedulePreset } from "./rotation";
 import { RotationSdkService } from "./rotation-sdk.service";
 
 /**
+ * The interval builder's mode value.
+ *
+ * Deliberately not a {@link QuartzSchedulePreset}: that union is the SDK's and names expressions
+ * the SDK itself resolves. An interval is composed here, so it is a presentation mode the select
+ * carries alongside the SDK's presets.
+ */
+export const SCHEDULE_INTERVAL_MODE = "interval" as const;
+
+/** What the schedule select can hold: any SDK preset, or the interval builder. */
+export type ScheduleMode = QuartzSchedulePreset | typeof SCHEDULE_INTERVAL_MODE;
+
+/** The units the interval builder can step. Quartz steps day-of-month and month; not weeks. */
+export const ScheduleIntervalUnit = Object.freeze({
+  Days: "days",
+  Months: "months",
+} as const);
+export type ScheduleIntervalUnit = (typeof ScheduleIntervalUnit)[keyof typeof ScheduleIntervalUnit];
+
+/** Quartz day-of-month is 1-31 and month is 1-12; `1/N` beyond those is rejected. */
+const MAX_DAY_INTERVAL = 31;
+const MAX_MONTH_INTERVAL = 12;
+
+/** `<input type="time">` emits "HH:MM"; seconds are accepted and dropped. */
+const TIME_OF_DAY = /^(\d{1,2}):(\d{2})(?::\d{2})?$/;
+
+/**
  * CVA sub-editor for a Quartz cron schedule (or null for "no schedule").
  *
  * The outer value is `string | null`: `null` for None, a preset's own cron expression for that
- * preset, any other string for Custom.
+ * preset, an expression the interval builder could have composed for Interval, any other string
+ * for Custom.
  *
  * Every cron rule belongs to the SDK, not this component — which preset an expression maps to,
  * and whether a custom one is Quartz-shaped, is resolved there and re-validated asynchronously.
+ * Composing an expression from operator-chosen interval parts is the one exception, because the
+ * SDK exposes no builder.
  *
  * Client validation is advisory; the server enforces a 15-minute interval floor.
  */
@@ -65,10 +95,25 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
   /** Expose preset const for template comparisons. */
   protected readonly QuartzSchedulePreset = QuartzSchedulePreset;
 
-  protected readonly presetControl = this.fb.nonNullable.control<QuartzSchedulePreset>(
+  /** Expose the interval mode and its units for template comparisons. */
+  protected readonly ScheduleInterval = SCHEDULE_INTERVAL_MODE;
+  protected readonly ScheduleIntervalUnit = ScheduleIntervalUnit;
+
+  protected readonly presetControl = this.fb.nonNullable.control<ScheduleMode>(
     QuartzSchedulePreset.None,
   );
   protected readonly customControl = this.fb.nonNullable.control<string>("");
+  protected readonly intervalCountControl = this.fb.nonNullable.control<number | null>(1, [
+    Validators.required,
+    Validators.min(1),
+    Validators.max(MAX_DAY_INTERVAL),
+  ]);
+  protected readonly intervalUnitControl = this.fb.nonNullable.control<ScheduleIntervalUnit>(
+    ScheduleIntervalUnit.Days,
+  );
+  protected readonly intervalTimeControl = this.fb.nonNullable.control<string>("00:00", [
+    Validators.required,
+  ]);
 
   // ControlValueAccessor wiring, reassigned by Angular.
   // eslint-disable-next-line @bitwarden/components/enforce-readonly-angular-properties
@@ -90,6 +135,26 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       this.emitValue();
       void this.refreshCronShape(value);
     });
+    this.intervalCountControl.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.emitValue();
+      this.onValidatorChange();
+    });
+    this.intervalTimeControl.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.emitValue();
+      this.onValidatorChange();
+    });
+    this.intervalUnitControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((unit) => {
+      this.applyCountBounds(unit);
+      this.emitValue();
+      this.onValidatorChange();
+    });
+  }
+
+  /** The count field's ceiling for the unit currently selected. */
+  protected get intervalCountMax(): number {
+    return this.intervalUnitControl.value === ScheduleIntervalUnit.Months
+      ? MAX_MONTH_INTERVAL
+      : MAX_DAY_INTERVAL;
   }
 
   /**
@@ -132,15 +197,44 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
 
   private async applyPreset(value: string | null): Promise<void> {
     const preset = await this.rotationSdk.presetForCron(value);
-    this.presetControl.setValue(preset, { emitEvent: false });
-    if (preset === QuartzSchedulePreset.Custom) {
-      this.customControl.setValue(value ?? "", { emitEvent: false });
-      await this.refreshCronShape(value ?? "");
-    } else {
-      this.customControl.setValue("", { emitEvent: false });
+    // A named preset wins over the builder: an expression the SDK names stays a named preset.
+    if (preset !== QuartzSchedulePreset.Custom) {
+      this.presetControl.setValue(preset, { emitEvent: false });
+      this.resetCustom();
+      this.resetInterval();
       this.cronShapeValid = true;
       this.onValidatorChange();
+      return;
     }
+
+    const interval = value == null ? null : this.parseIntervalCron(value);
+    if (interval != null) {
+      this.presetControl.setValue(SCHEDULE_INTERVAL_MODE, { emitEvent: false });
+      this.resetCustom();
+      this.intervalUnitControl.setValue(interval.unit, { emitEvent: false });
+      this.applyCountBounds(interval.unit);
+      this.intervalCountControl.setValue(interval.count, { emitEvent: false });
+      this.intervalTimeControl.setValue(interval.time, { emitEvent: false });
+      this.cronShapeValid = true;
+      this.onValidatorChange();
+      return;
+    }
+
+    this.presetControl.setValue(QuartzSchedulePreset.Custom, { emitEvent: false });
+    this.resetInterval();
+    this.customControl.setValue(value ?? "", { emitEvent: false });
+    await this.refreshCronShape(value ?? "");
+  }
+
+  private resetCustom(): void {
+    this.customControl.setValue("", { emitEvent: false });
+  }
+
+  private resetInterval(): void {
+    this.intervalUnitControl.setValue(ScheduleIntervalUnit.Days, { emitEvent: false });
+    this.applyCountBounds(ScheduleIntervalUnit.Days);
+    this.intervalCountControl.setValue(1, { emitEvent: false });
+    this.intervalTimeControl.setValue("00:00", { emitEvent: false });
   }
 
   registerOnChange(fn: (value: string | null) => void): void {
@@ -155,14 +249,26 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     if (isDisabled) {
       this.presetControl.disable({ emitEvent: false });
       this.customControl.disable({ emitEvent: false });
+      this.intervalCountControl.disable({ emitEvent: false });
+      this.intervalUnitControl.disable({ emitEvent: false });
+      this.intervalTimeControl.disable({ emitEvent: false });
     } else {
       this.presetControl.enable({ emitEvent: false });
       this.customControl.enable({ emitEvent: false });
+      this.intervalCountControl.enable({ emitEvent: false });
+      this.intervalUnitControl.enable({ emitEvent: false });
+      this.intervalTimeControl.enable({ emitEvent: false });
     }
   }
 
   validate(_control: AbstractControl): ValidationErrors | null {
     const preset = this.presetControl.value;
+    if (preset === SCHEDULE_INTERVAL_MODE) {
+      // An incomplete builder emits null, which the server reads as "no scheduled rotation".
+      return this.intervalParts() == null
+        ? { invalidInterval: { message: this.i18n.t("pamRotationScheduleInvalidInterval") } }
+        : null;
+    }
     if (preset !== QuartzSchedulePreset.Custom) {
       return null;
     }
@@ -191,10 +297,117 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     if (preset === QuartzSchedulePreset.None) {
       return null;
     }
+    if (preset === SCHEDULE_INTERVAL_MODE) {
+      return this.composeIntervalCron();
+    }
     if (preset === QuartzSchedulePreset.Custom) {
       const raw = this.customControl.value.trim();
       return raw === "" ? null : raw;
     }
     return this.cronByPreset.get(preset) ?? null;
+  }
+
+  /** Quartz's own ranges: `1/N` is day-of-month 1-31 and month 1-12. */
+  private applyCountBounds(unit: ScheduleIntervalUnit): void {
+    const max = unit === ScheduleIntervalUnit.Months ? MAX_MONTH_INTERVAL : MAX_DAY_INTERVAL;
+    this.intervalCountControl.setValidators([
+      Validators.required,
+      Validators.min(1),
+      Validators.max(max),
+    ]);
+    this.intervalCountControl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  /** The builder's parts, or `null` when they cannot make an expression. */
+  private intervalParts(): {
+    count: number;
+    unit: ScheduleIntervalUnit;
+    hh: number;
+    mm: number;
+  } | null {
+    const unit = this.intervalUnitControl.value;
+    const count = this.intervalCountControl.value;
+    const max = unit === ScheduleIntervalUnit.Months ? MAX_MONTH_INTERVAL : MAX_DAY_INTERVAL;
+    if (count == null || !Number.isInteger(count) || count < 1 || count > max) {
+      return null;
+    }
+    const match = TIME_OF_DAY.exec(this.intervalTimeControl.value.trim());
+    if (match == null) {
+      return null;
+    }
+    const hh = Number(match[1]);
+    const mm = Number(match[2]);
+    if (hh > 23 || mm > 59) {
+      return null;
+    }
+    return { count, unit, hh, mm };
+  }
+
+  /**
+   * The Quartz expression for the builder's current parts, or `null` when they are incomplete.
+   *
+   * Six fields, matching the shape the SDK's own presets use. Day-of-week is always `?` because
+   * day-of-month is specified, which Quartz requires. A count of 1 emits `*` rather than `1/1`, so
+   * every 1 day at 00:00 is the SDK's own daily expression and every 1 month at 00:00 its monthly.
+   */
+  private composeIntervalCron(): string | null {
+    const parts = this.intervalParts();
+    if (parts == null) {
+      return null;
+    }
+    const { count, unit, hh, mm } = parts;
+    const step = count === 1 ? "*" : `1/${count}`;
+    return unit === ScheduleIntervalUnit.Months
+      ? `0 ${mm} ${hh} 1 ${step} ?`
+      : `0 ${mm} ${hh} ${step} * ?`;
+  }
+
+  /**
+   * The builder's controls for an expression it could have produced, or `null`.
+   *
+   * The inverse of {@link composeIntervalCron}, and deliberately strict: anything it does not
+   * recognise falls through to Custom rather than being approximated.
+   */
+  private parseIntervalCron(
+    cron: string,
+  ): { count: number; unit: ScheduleIntervalUnit; time: string } | null {
+    const fields = cron.trim().split(/\s+/);
+    if (fields.length !== 6) {
+      return null;
+    }
+    const [second, minute, hour, dom, month, dow] = fields;
+    if (second !== "0" || dow !== "?") {
+      return null;
+    }
+    if (!/^\d{1,2}$/.test(minute) || !/^\d{1,2}$/.test(hour)) {
+      return null;
+    }
+    const mm = Number(minute);
+    const hh = Number(hour);
+    if (mm > 59 || hh > 23) {
+      return null;
+    }
+    const time = `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
+    const stepOf = (field: string, max: number): number | null => {
+      if (field === "*") {
+        return 1;
+      }
+      const match = /^1\/(\d{1,2})$/.exec(field);
+      const step = match == null ? null : Number(match[1]);
+      return step != null && step >= 1 && step <= max ? step : null;
+    };
+
+    if (month === "*") {
+      if (dom === "1") {
+        return { count: 1, unit: ScheduleIntervalUnit.Months, time };
+      }
+      const count = stepOf(dom, MAX_DAY_INTERVAL);
+      return count == null ? null : { count, unit: ScheduleIntervalUnit.Days, time };
+    }
+    if (dom !== "1") {
+      return null;
+    }
+    const count = stepOf(month, MAX_MONTH_INTERVAL);
+    return count == null || count === 1 ? null : { count, unit: ScheduleIntervalUnit.Months, time };
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
@@ -9,8 +9,10 @@ import {
   ReactiveFormsModule,
   ValidationErrors,
   Validator,
+  ValidatorFn,
   Validators,
 } from "@angular/forms";
+import { merge, tap } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { FormFieldModule, SelectModule } from "@bitwarden/components";
@@ -39,11 +41,42 @@ export const ScheduleIntervalUnit = Object.freeze({
 export type ScheduleIntervalUnit = (typeof ScheduleIntervalUnit)[keyof typeof ScheduleIntervalUnit];
 
 /** Quartz day-of-month is 1-31 and month is 1-12; `1/N` beyond those is rejected. */
-const MAX_DAY_INTERVAL = 31;
-const MAX_MONTH_INTERVAL = 12;
+const MAX_INTERVAL_COUNT: Readonly<Record<ScheduleIntervalUnit, number>> = Object.freeze({
+  [ScheduleIntervalUnit.Days]: 31,
+  [ScheduleIntervalUnit.Months]: 12,
+});
+
+const MAX_HOUR = 23;
+const MAX_MINUTE = 59;
 
 /** `<input type="time">` emits "HH:MM"; seconds are accepted and dropped. */
 const TIME_OF_DAY = /^(\d{1,2}):(\d{2})(?::\d{2})?$/;
+
+function intervalCountValidators(unit: ScheduleIntervalUnit): ValidatorFn[] {
+  return [Validators.required, Validators.min(1), Validators.max(MAX_INTERVAL_COUNT[unit])];
+}
+
+/** A bare or zero-padded cron clock field, or `null` when it is not a number within `max`. */
+function clockField(field: string, max: number): number | null {
+  if (!/^\d{1,2}$/.test(field)) {
+    return null;
+  }
+  const value = Number(field);
+  return value <= max ? value : null;
+}
+
+/** The step `N` a `*` or `1/N` cron field carries, or `null` when it is neither or out of range. */
+function intervalStep(field: string, unit: ScheduleIntervalUnit): number | null {
+  if (field === "*") {
+    return 1;
+  }
+  const match = /^1\/(\d{1,2})$/.exec(field);
+  if (match == null) {
+    return null;
+  }
+  const step = Number(match[1]);
+  return step >= 1 && step <= MAX_INTERVAL_COUNT[unit] ? step : null;
+}
 
 /**
  * CVA sub-editor for a Quartz cron schedule (or null for "no schedule").
@@ -103,17 +136,24 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     QuartzSchedulePreset.None,
   );
   protected readonly customControl = this.fb.nonNullable.control<string>("");
-  protected readonly intervalCountControl = this.fb.nonNullable.control<number | null>(1, [
-    Validators.required,
-    Validators.min(1),
-    Validators.max(MAX_DAY_INTERVAL),
-  ]);
+  protected readonly intervalCountControl = this.fb.nonNullable.control<number | null>(
+    1,
+    intervalCountValidators(ScheduleIntervalUnit.Days),
+  );
   protected readonly intervalUnitControl = this.fb.nonNullable.control<ScheduleIntervalUnit>(
     ScheduleIntervalUnit.Days,
   );
   protected readonly intervalTimeControl = this.fb.nonNullable.control<string>("00:00", [
     Validators.required,
   ]);
+
+  private readonly editorControls: readonly AbstractControl[] = [
+    this.presetControl,
+    this.customControl,
+    this.intervalCountControl,
+    this.intervalUnitControl,
+    this.intervalTimeControl,
+  ];
 
   // ControlValueAccessor wiring, reassigned by Angular.
   // eslint-disable-next-line @bitwarden/components/enforce-readonly-angular-properties
@@ -135,26 +175,21 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       this.emitValue();
       void this.refreshCronShape(value);
     });
-    this.intervalCountControl.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
-      this.emitValue();
-      this.onValidatorChange();
-    });
-    this.intervalTimeControl.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
-      this.emitValue();
-      this.onValidatorChange();
-    });
-    this.intervalUnitControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((unit) => {
-      this.applyCountBounds(unit);
-      this.emitValue();
-      this.onValidatorChange();
-    });
+    merge(
+      this.intervalCountControl.valueChanges,
+      this.intervalTimeControl.valueChanges,
+      // The new unit's ceiling has to land before the count is validated against it.
+      this.intervalUnitControl.valueChanges.pipe(tap((unit) => this.applyCountBounds(unit))),
+    )
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => {
+        this.emitValue();
+        this.onValidatorChange();
+      });
   }
 
-  /** The count field's ceiling for the unit currently selected. */
   protected get intervalCountMax(): number {
-    return this.intervalUnitControl.value === ScheduleIntervalUnit.Months
-      ? MAX_MONTH_INTERVAL
-      : MAX_DAY_INTERVAL;
+    return MAX_INTERVAL_COUNT[this.intervalUnitControl.value];
   }
 
   /**
@@ -246,18 +281,12 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
   }
 
   setDisabledState(isDisabled: boolean): void {
-    if (isDisabled) {
-      this.presetControl.disable({ emitEvent: false });
-      this.customControl.disable({ emitEvent: false });
-      this.intervalCountControl.disable({ emitEvent: false });
-      this.intervalUnitControl.disable({ emitEvent: false });
-      this.intervalTimeControl.disable({ emitEvent: false });
-    } else {
-      this.presetControl.enable({ emitEvent: false });
-      this.customControl.enable({ emitEvent: false });
-      this.intervalCountControl.enable({ emitEvent: false });
-      this.intervalUnitControl.enable({ emitEvent: false });
-      this.intervalTimeControl.enable({ emitEvent: false });
+    for (const control of this.editorControls) {
+      if (isDisabled) {
+        control.disable({ emitEvent: false });
+      } else {
+        control.enable({ emitEvent: false });
+      }
     }
   }
 
@@ -307,14 +336,8 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     return this.cronByPreset.get(preset) ?? null;
   }
 
-  /** Quartz's own ranges: `1/N` is day-of-month 1-31 and month 1-12. */
   private applyCountBounds(unit: ScheduleIntervalUnit): void {
-    const max = unit === ScheduleIntervalUnit.Months ? MAX_MONTH_INTERVAL : MAX_DAY_INTERVAL;
-    this.intervalCountControl.setValidators([
-      Validators.required,
-      Validators.min(1),
-      Validators.max(max),
-    ]);
+    this.intervalCountControl.setValidators(intervalCountValidators(unit));
     this.intervalCountControl.updateValueAndValidity({ emitEvent: false });
   }
 
@@ -327,7 +350,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
   } | null {
     const unit = this.intervalUnitControl.value;
     const count = this.intervalCountControl.value;
-    const max = unit === ScheduleIntervalUnit.Months ? MAX_MONTH_INTERVAL : MAX_DAY_INTERVAL;
+    const max = MAX_INTERVAL_COUNT[unit];
     if (count == null || !Number.isInteger(count) || count < 1 || count > max) {
       return null;
     }
@@ -335,9 +358,9 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     if (match == null) {
       return null;
     }
-    const hh = Number(match[1]);
-    const mm = Number(match[2]);
-    if (hh > 23 || mm > 59) {
+    const hh = clockField(match[1], MAX_HOUR);
+    const mm = clockField(match[2], MAX_MINUTE);
+    if (hh == null || mm == null) {
       return null;
     }
     return { count, unit, hh, mm };
@@ -379,35 +402,24 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     if (second !== "0" || dow !== "?") {
       return null;
     }
-    if (!/^\d{1,2}$/.test(minute) || !/^\d{1,2}$/.test(hour)) {
-      return null;
-    }
-    const mm = Number(minute);
-    const hh = Number(hour);
-    if (mm > 59 || hh > 23) {
+    const hh = clockField(hour, MAX_HOUR);
+    const mm = clockField(minute, MAX_MINUTE);
+    if (hh == null || mm == null) {
       return null;
     }
     const time = `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
-    const stepOf = (field: string, max: number): number | null => {
-      if (field === "*") {
-        return 1;
-      }
-      const match = /^1\/(\d{1,2})$/.exec(field);
-      const step = match == null ? null : Number(match[1]);
-      return step != null && step >= 1 && step <= max ? step : null;
-    };
 
     if (month === "*") {
       if (dom === "1") {
         return { count: 1, unit: ScheduleIntervalUnit.Months, time };
       }
-      const count = stepOf(dom, MAX_DAY_INTERVAL);
+      const count = intervalStep(dom, ScheduleIntervalUnit.Days);
       return count == null ? null : { count, unit: ScheduleIntervalUnit.Days, time };
     }
     if (dom !== "1") {
       return null;
     }
-    const count = stepOf(month, MAX_MONTH_INTERVAL);
+    const count = intervalStep(month, ScheduleIntervalUnit.Months);
     return count == null || count === 1 ? null : { count, unit: ScheduleIntervalUnit.Months, time };
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
@@ -52,8 +52,15 @@ const MAX_MINUTE = 59;
 /** `<input type="time">` emits "HH:MM"; seconds are accepted and dropped. */
 const TIME_OF_DAY = /^(\d{1,2}):(\d{2})(?::\d{2})?$/;
 
-function intervalCountValidators(unit: ScheduleIntervalUnit): ValidatorFn[] {
-  return [Validators.required, Validators.min(1), Validators.max(MAX_INTERVAL_COUNT[unit])];
+/**
+ * Rejects a fractional count.
+ *
+ * `min` and `max` both accept 1.5, so without this the count reports valid while the builder
+ * refuses to compose an expression from it — a save that fails with nothing shown on any field.
+ */
+function wholeNumber(message: string): ValidatorFn {
+  return ({ value }) =>
+    value == null || Number.isInteger(value) ? null : { notWholeNumber: { message } };
 }
 
 /** A bare or zero-padded cron clock field, or `null` when it is not a number within `max`. */
@@ -138,7 +145,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
   protected readonly customControl = this.fb.nonNullable.control<string>("");
   protected readonly intervalCountControl = this.fb.nonNullable.control<number | null>(
     1,
-    intervalCountValidators(ScheduleIntervalUnit.Days),
+    this.countValidators(ScheduleIntervalUnit.Days),
   );
   protected readonly intervalUnitControl = this.fb.nonNullable.control<ScheduleIntervalUnit>(
     ScheduleIntervalUnit.Days,
@@ -336,8 +343,17 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     return this.cronByPreset.get(preset) ?? null;
   }
 
+  private countValidators(unit: ScheduleIntervalUnit): ValidatorFn[] {
+    return [
+      Validators.required,
+      Validators.min(1),
+      Validators.max(MAX_INTERVAL_COUNT[unit]),
+      wholeNumber(this.i18n.t("pamRotationScheduleIntervalCountWholeNumber")),
+    ];
+  }
+
   private applyCountBounds(unit: ScheduleIntervalUnit): void {
-    this.intervalCountControl.setValidators(intervalCountValidators(unit));
+    this.intervalCountControl.setValidators(this.countValidators(unit));
     this.intervalCountControl.updateValueAndValidity({ emitEvent: false });
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

From the PAM UAT review, part of a stack of per-ticket fixes rooted on `pam/uat`.

Adds an `Interval` option to the rotation schedule builder: a repeat count, unit and time of day, composed into a Quartz cron expression.

- `ScheduleMode` (a UI-only `interval` value) sits alongside the SDK's frozen `QuartzSchedulePreset` union; `composeIntervalCron()` and its strict inverse `parseIntervalCron()` are the only cron logic this component owns.
- Steps `days` or `months`, not weeks: Quartz has no week field, so a count steps day-of-month or month (max `31` / `12`); "every 90 days" becomes every 3 months.
- A cron this builder could have composed re-selects `Interval` with matching parts on load; anything else falls through to the unchanged Custom path.
- `validate()` gains an `invalidInterval` error so an incomplete builder can no longer emit `null`, which the server reads as "rotation off".
- `setDisabledState` now covers all five editor controls instead of two.

Sits on `pam/rotux-schedule-timezone-hint`. `pam/rotux-schedule-plain-english-echo` sits on top of it.

## Copy not yet approved

These strings are proposed wording, not designer-approved:

- `pamRotationScheduleInterval`: "Interval"
- `pamRotationScheduleIntervalCountLabel`: "Repeat every"
- `pamRotationScheduleIntervalUnitLabel`: "Unit"
- `pamRotationScheduleIntervalUnitDays`: "Days"
- `pamRotationScheduleIntervalUnitMonths`: "Months"
- `pamRotationScheduleIntervalTimeLabel`: "Time of day (UTC)"
- `pamRotationScheduleIntervalHint`: "Intervals are anchored to the calendar. Day intervals restart on the 1st of each month, and month intervals run on the 1st and restart in January."
- `pamRotationScheduleInvalidInterval`: "Enter how often the rotation repeats and the time of day."
- `pamRotationScheduleIntervalCountWholeNumber`: "Enter a whole number."

## Known gaps

- The outer `invalidInterval` error has no renderer on the parent form, and `submitCreate`/`submitEdit` still return early with no toast when it is set. Pre-existing, shared with `pamRotationScheduleInvalidCron`.
- The Save button is not disabled when the interval builder is invalid (a silent early return, by design decision, rather than a disabled control), so the "can't submit" state is invisible to the user.
- `npm run test:types` fails with 12 strict errors. All 7 erroring files are byte-identical to `pam/uat`, so this looks pre-existing, but that was checked by diffing file contents rather than by running the type check against the base commit directly.
- The three round-trip parsing cases (`interval`, `custom`, `daily`) could not be exercised against a live managed credential; no fixture exists in either reachable QA org.

## 📸 Screenshots

Captured at 1440x1024. Before is `pam/uat`, after is the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Managed credential form -> Schedule

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-schedule-no-interval-or-time.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-schedule-no-interval-or-time.png" alt="after" width="460"> |
