### PR TITLE
No plain-English echo of a schedule while it is being chosen

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18817,6 +18817,50 @@
   "pamRotationScheduleInvalidCron": {
     "message": "Please enter a valid Quartz cron expression (6 or 7 space-separated fields)."
   },
+  "pamRotationScheduleEchoNone": {
+    "message": "No scheduled rotation. This credential rotates only when you start one, or when access ends if that option is on."
+  },
+  "pamRotationScheduleEchoHourly": {
+    "message": "Rotates once an hour, on the hour."
+  },
+  "pamRotationScheduleEchoEvery6Hours": {
+    "message": "Rotates every 6 hours, on the hour."
+  },
+  "pamRotationScheduleEchoDaily": {
+    "message": "Rotates once a day, at midnight."
+  },
+  "pamRotationScheduleEchoWeekly": {
+    "message": "Rotates once a week, at midnight on Sunday."
+  },
+  "pamRotationScheduleEchoMonthly": {
+    "message": "Rotates once a month, at midnight on the 1st."
+  },
+  "pamRotationScheduleEchoInterval": {
+    "message": "Rotates every $COUNT$ $UNIT$, at $TIME$.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "90"
+      },
+      "unit": {
+        "content": "$2",
+        "example": "Days"
+      },
+      "time": {
+        "content": "$3",
+        "example": "02:00"
+      }
+    }
+  },
+  "pamRotationScheduleEchoCustom": {
+    "message": "Custom Quartz schedule: $CRON$",
+    "placeholders": {
+      "cron": {
+        "content": "$1",
+        "example": "0 0 */4 * * ?"
+      }
+    }
+  },
   "pamRotationScheduleTimezoneHint": {
     "message": "Schedules run in UTC, not your local time zone."
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18835,19 +18835,46 @@
   "pamRotationScheduleEchoMonthly": {
     "message": "Rotates once a month, at midnight on the 1st."
   },
-  "pamRotationScheduleEchoInterval": {
-    "message": "Rotates every $COUNT$ $UNIT$, at $TIME$.",
+  "pamRotationScheduleEchoIntervalDay": {
+    "message": "Rotates every day, at $TIME$.",
+    "placeholders": {
+      "time": {
+        "content": "$1",
+        "example": "02:00"
+      }
+    }
+  },
+  "pamRotationScheduleEchoIntervalDays": {
+    "message": "Rotates every $COUNT$ days, at $TIME$.",
     "placeholders": {
       "count": {
         "content": "$1",
-        "example": "90"
-      },
-      "unit": {
-        "content": "$2",
-        "example": "Days"
+        "example": "7"
       },
       "time": {
-        "content": "$3",
+        "content": "$2",
+        "example": "02:00"
+      }
+    }
+  },
+  "pamRotationScheduleEchoIntervalMonth": {
+    "message": "Rotates every month, at $TIME$.",
+    "placeholders": {
+      "time": {
+        "content": "$1",
+        "example": "02:00"
+      }
+    }
+  },
+  "pamRotationScheduleEchoIntervalMonths": {
+    "message": "Rotates every $COUNT$ months, at $TIME$.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "3"
+      },
+      "time": {
+        "content": "$2",
         "example": "02:00"
       }
     }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
@@ -104,9 +104,19 @@
   </bit-form-field>
 }
 
-<!-- Only the content is conditional: a live region created and destroyed by @if does not announce. -->
-<bit-hint role="status" aria-live="polite" data-testid="schedule-echo">
+<!--
+  Only the content is conditional: a live region created and destroyed by @if does not announce.
+  Not a bit-hint: BitHintDirective host-binds its own generated id, which would overwrite the
+  stable one this element is addressed by.
+-->
+<p
+  id="rotation-schedule-input_status_echo"
+  role="status"
+  aria-live="polite"
+  data-testid="schedule-echo"
+  class="tw-text-muted tw-font-normal tw-inline-block tw-mt-1 tw-text-xs"
+>
   @if (scheduleEcho; as echo) {
-    {{ echo.key | i18n: echo.p1 : echo.p2 : echo.p3 }}
+    {{ echo.key | i18n: echo.p1 : echo.p2 }}
   }
-</bit-hint>
+</p>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
@@ -105,13 +105,8 @@
 }
 
 <!-- Only the content is conditional: a live region created and destroyed by @if does not announce. -->
-<p
-  id="rotation-schedule-input_status_echo"
-  class="tw-mt-1 tw-inline-block tw-text-xs tw-font-normal tw-text-muted"
-  role="status"
-  aria-live="polite"
->
+<bit-hint role="status" aria-live="polite" data-testid="schedule-echo">
   @if (scheduleEcho; as echo) {
     {{ echo.key | i18n: echo.p1 : echo.p2 : echo.p3 }}
   }
-</p>
+</bit-hint>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
@@ -103,3 +103,15 @@
     <bit-hint>{{ "pamRotationScheduleCustomHint" | i18n }}</bit-hint>
   </bit-form-field>
 }
+
+<!-- Only the content is conditional: a live region created and destroyed by @if does not announce. -->
+<p
+  id="rotation-schedule-input_status_echo"
+  class="tw-mt-1 tw-inline-block tw-text-xs tw-font-normal tw-text-muted"
+  role="status"
+  aria-live="polite"
+>
+  @if (scheduleEcho; as echo) {
+    {{ echo.key | i18n: echo.p1 : echo.p2 : echo.p3 }}
+  }
+</p>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
@@ -60,7 +60,10 @@ describe("RotationScheduleInputComponent", () => {
   /** Outer FormControl wired into the CVA. */
   let outerControl: FormControl<string | null>;
 
-  const i18nService = { t: (key: string) => key };
+  const i18nService = {
+    t: (key: string, p1?: string, p2?: string, p3?: string) =>
+      [key, p1, p2, p3].filter((part) => part != null).join(":"),
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -465,5 +468,91 @@ describe("RotationScheduleInputComponent", () => {
     fixture.detectChanges();
 
     expect(time.closest("bit-form-field")?.querySelector("bit-error")).not.toBeNull();
+  });
+
+  // ---- plain-English echo ----
+
+  function echoElement(): HTMLElement {
+    return fixture.nativeElement.querySelector("#rotation-schedule-input_status_echo");
+  }
+
+  function echoText(): string {
+    return echoElement().textContent?.trim() ?? "";
+  }
+
+  async function selectCustom(cron: string): Promise<void> {
+    presetCtrl().setValue(QuartzSchedulePreset.Custom);
+    customCtrl().setValue(cron);
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it("renders the echo as a polite live region", () => {
+    const echo = echoElement();
+    expect(echo).not.toBeNull();
+    expect(echo.getAttribute("role")).toBe("status");
+    expect(echo.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("describes the None preset", () => {
+    presetCtrl().setValue(QuartzSchedulePreset.None);
+    fixture.detectChanges();
+    expect(echoText()).toBe("pamRotationScheduleEchoNone");
+  });
+
+  it("describes the Daily preset", () => {
+    presetCtrl().setValue(QuartzSchedulePreset.Daily);
+    fixture.detectChanges();
+    expect(echoText()).toBe("pamRotationScheduleEchoDaily");
+  });
+
+  it("describes the Weekly preset", () => {
+    presetCtrl().setValue(QuartzSchedulePreset.Weekly);
+    fixture.detectChanges();
+    expect(echoText()).toBe("pamRotationScheduleEchoWeekly");
+  });
+
+  it("describes an interval with its count, its unit label and its time", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 7, "02:00");
+    expect(echoText()).toBe(
+      "pamRotationScheduleEchoInterval:7:pamRotationScheduleIntervalUnitDays:02:00",
+    );
+  });
+
+  it("says nothing about an incomplete interval", () => {
+    buildInterval(ScheduleIntervalUnit.Days, null, "02:00");
+    expect(echoText()).toBe("");
+  });
+
+  it("echoes a well-shaped custom expression verbatim", async () => {
+    await selectCustom("0 0 */4 * * ?");
+    expect(echoText()).toBe("pamRotationScheduleEchoCustom:0 0 */4 * * ?");
+  });
+
+  it("says nothing about a malformed custom expression", async () => {
+    await selectCustom("not-a-cron");
+    expect(echoElement()).not.toBeNull();
+    expect(echoText()).toBe("");
+  });
+
+  it("says nothing about an empty custom expression", async () => {
+    await selectCustom("   ");
+    expect(echoText()).toBe("");
+  });
+
+  // An OnPush component with no inputs only repaints what it marks, so auto-detection is the
+  // assertion here: without markForCheck the saved schedule never reaches the view.
+  it("shows the saved schedule's sentence without the control being touched", async () => {
+    fixture.autoDetectChanges();
+    component.writeValue(PRESET_CRONS.monthly);
+    await fixture.whenStable();
+    expect(echoText()).toBe("pamRotationScheduleEchoMonthly");
+  });
+
+  it("shows a saved custom expression without the control being touched", async () => {
+    fixture.autoDetectChanges();
+    component.writeValue("0 0 */4 * * ?");
+    await fixture.whenStable();
+    expect(echoText()).toBe("pamRotationScheduleEchoCustom:0 0 */4 * * ?");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
@@ -487,6 +487,10 @@ describe("RotationScheduleInputComponent", () => {
     fixture.detectChanges();
   }
 
+  it("gives the echo a stable id rather than a generated hint id", () => {
+    expect(echoElement().id).toBe("rotation-schedule-input_status_echo");
+  });
+
   it("renders the echo as a polite live region", () => {
     const echo = echoElement();
     expect(echo).not.toBeNull();
@@ -512,16 +516,60 @@ describe("RotationScheduleInputComponent", () => {
     expect(echoText()).toBe("pamRotationScheduleEchoWeekly");
   });
 
-  it("describes an interval with its count, its unit label and its time", () => {
+  it("describes a multi-day interval with its count and its time", () => {
     buildInterval(ScheduleIntervalUnit.Days, 7, "02:00");
-    expect(echoText()).toBe(
-      "pamRotationScheduleEchoInterval:7:pamRotationScheduleIntervalUnitDays:02:00",
-    );
+    expect(echoText()).toBe("pamRotationScheduleEchoIntervalDays:7:02:00");
+  });
+
+  it("describes a one-day interval with the singular sentence", () => {
+    buildInterval(ScheduleIntervalUnit.Days, 1, "00:00");
+    expect(echoText()).toBe("pamRotationScheduleEchoIntervalDay:00:00");
+  });
+
+  it("describes a multi-month interval with its count and its time", () => {
+    buildInterval(ScheduleIntervalUnit.Months, 3, "02:00");
+    expect(echoText()).toBe("pamRotationScheduleEchoIntervalMonths:3:02:00");
+  });
+
+  it("describes a one-month interval with the singular sentence", () => {
+    buildInterval(ScheduleIntervalUnit.Months, 1, "06:45");
+    expect(echoText()).toBe("pamRotationScheduleEchoIntervalMonth:06:45");
   });
 
   it("says nothing about an incomplete interval", () => {
     buildInterval(ScheduleIntervalUnit.Days, null, "02:00");
     expect(echoText()).toBe("");
+  });
+
+  function presetCrons(): Map<QuartzSchedulePreset, string> {
+    return (component as unknown as { cronByPreset: Map<QuartzSchedulePreset, string> })
+      .cronByPreset;
+  }
+
+  it("says nothing about a named preset before its expression resolves", () => {
+    presetCrons().clear();
+    presetCtrl().setValue(QuartzSchedulePreset.Daily);
+    fixture.detectChanges();
+    expect(echoText()).toBe("");
+  });
+
+  it("describes the None preset before any expression resolves", () => {
+    presetCrons().clear();
+    presetCtrl().setValue(QuartzSchedulePreset.None);
+    fixture.detectChanges();
+    expect(echoText()).toBe("pamRotationScheduleEchoNone");
+  });
+
+  it("describes a preset once its expression resolves", async () => {
+    presetCrons().clear();
+    presetCtrl().setValue(QuartzSchedulePreset.Daily);
+    fixture.detectChanges();
+    expect(echoText()).toBe("");
+
+    fixture.autoDetectChanges();
+    await (component as unknown as { loadPresetCrons: () => Promise<void> }).loadPresetCrons();
+    await fixture.whenStable();
+    expect(echoText()).toBe("pamRotationScheduleEchoDaily");
   });
 
   it("echoes a well-shaped custom expression verbatim", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.spec.ts
@@ -61,8 +61,8 @@ describe("RotationScheduleInputComponent", () => {
   let outerControl: FormControl<string | null>;
 
   const i18nService = {
-    t: (key: string, p1?: string, p2?: string, p3?: string) =>
-      [key, p1, p2, p3].filter((part) => part != null).join(":"),
+    t: (key: string, ...params: (string | number | undefined)[]) =>
+      [key, ...params].filter((part) => part != null).join(":"),
   };
 
   beforeEach(async () => {
@@ -473,7 +473,7 @@ describe("RotationScheduleInputComponent", () => {
   // ---- plain-English echo ----
 
   function echoElement(): HTMLElement {
-    return fixture.nativeElement.querySelector("#rotation-schedule-input_status_echo");
+    return fixture.nativeElement.querySelector("[data-testid='schedule-echo']");
   }
 
   function echoText(): string {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
@@ -116,9 +116,14 @@ const INTERVAL_UNIT_KEYS: Readonly<Record<ScheduleIntervalUnit, string>> = Objec
 /** What the echo line renders: a message key, plus the parameters that message takes. */
 interface ScheduleEcho {
   key: string;
-  p1?: string;
-  p2?: string;
-  p3?: string;
+  p1?: string | number;
+  p2?: string | number;
+  p3?: string | number;
+}
+
+/** A clock reading as `<input type="time">` and the SDK's presets both spell it: zero-padded. */
+function timeOfDay(hh: number, mm: number): string {
+  return `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
 }
 
 /**
@@ -282,9 +287,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       this.presetControl.setValue(preset, { emitEvent: false });
       this.resetCustom();
       this.resetInterval();
-      this.cronShapeValid = true;
-      this.onValidatorChange();
-      this.cdr.markForCheck();
+      this.acceptKnownShape();
       return;
     }
 
@@ -296,9 +299,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       this.applyCountBounds(interval.unit);
       this.intervalCountControl.setValue(interval.count, { emitEvent: false });
       this.intervalTimeControl.setValue(interval.time, { emitEvent: false });
-      this.cronShapeValid = true;
-      this.onValidatorChange();
-      this.cdr.markForCheck();
+      this.acceptKnownShape();
       return;
     }
 
@@ -306,6 +307,13 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     this.resetInterval();
     this.customControl.setValue(value ?? "", { emitEvent: false });
     await this.refreshCronShape(value ?? "");
+  }
+
+  /** Settles a value this component recognised: nothing is left for the shape check to judge. */
+  private acceptKnownShape(): void {
+    this.cronShapeValid = true;
+    this.onValidatorChange();
+    this.cdr.markForCheck();
   }
 
   private resetCustom(): void {
@@ -397,9 +405,9 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       }
       return {
         key: "pamRotationScheduleEchoInterval",
-        p1: String(parts.count),
+        p1: parts.count,
         p2: this.i18n.t(INTERVAL_UNIT_KEYS[parts.unit]),
-        p3: `${String(parts.hh).padStart(2, "0")}:${String(parts.mm).padStart(2, "0")}`,
+        p3: timeOfDay(parts.hh, parts.mm),
       };
     }
     const key = SCHEDULE_ECHO_KEYS[preset];
@@ -493,7 +501,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     if (hh == null || mm == null) {
       return null;
     }
-    const time = `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
+    const time = timeOfDay(hh, mm);
 
     if (month === "*") {
       if (dom === "1") {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, forwardRef, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  forwardRef,
+  inject,
+} from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   AbstractControl,
@@ -86,6 +92,36 @@ function intervalStep(field: string, unit: ScheduleIntervalUnit): number | null 
 }
 
 /**
+ * Preset → the key of the sentence describing what it does.
+ *
+ * `Custom` is absent by design: an arbitrary Quartz expression cannot be described without a cron
+ * parser, and cron semantics belong to the SDK. Anything not in this table falls through to
+ * echoing the expression itself.
+ */
+const SCHEDULE_ECHO_KEYS: Partial<Record<QuartzSchedulePreset, string>> = {
+  [QuartzSchedulePreset.None]: "pamRotationScheduleEchoNone",
+  [QuartzSchedulePreset.Hourly]: "pamRotationScheduleEchoHourly",
+  [QuartzSchedulePreset.Every6Hours]: "pamRotationScheduleEchoEvery6Hours",
+  [QuartzSchedulePreset.Daily]: "pamRotationScheduleEchoDaily",
+  [QuartzSchedulePreset.Weekly]: "pamRotationScheduleEchoWeekly",
+  [QuartzSchedulePreset.Monthly]: "pamRotationScheduleEchoMonthly",
+};
+
+/** The interval echo names its unit with the builder's own option label, not fresh copy. */
+const INTERVAL_UNIT_KEYS: Readonly<Record<ScheduleIntervalUnit, string>> = Object.freeze({
+  [ScheduleIntervalUnit.Days]: "pamRotationScheduleIntervalUnitDays",
+  [ScheduleIntervalUnit.Months]: "pamRotationScheduleIntervalUnitMonths",
+});
+
+/** What the echo line renders: a message key, plus the parameters that message takes. */
+interface ScheduleEcho {
+  key: string;
+  p1?: string;
+  p2?: string;
+  p3?: string;
+}
+
+/**
  * CVA sub-editor for a Quartz cron schedule (or null for "no schedule").
  *
  * The outer value is `string | null`: `null` for None, a preset's own cron expression for that
@@ -121,6 +157,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
   private readonly fb = inject(FormBuilder);
   private readonly i18n = inject(I18nService);
   private readonly rotationSdk = inject(RotationSdkService);
+  private readonly cdr = inject(ChangeDetectorRef);
 
   /** Preset → cron expression, resolved from the SDK on construction; empty until that read lands. */
   private readonly cronByPreset = new Map<QuartzSchedulePreset, string>();
@@ -230,6 +267,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
     // An empty field is "no schedule", not a malformed one — see validate().
     this.cronShapeValid = raw === "" || (await this.rotationSdk.isLikelyQuartzCron(raw));
     this.onValidatorChange();
+    this.cdr.markForCheck();
   }
 
   writeValue(value: string | null): void {
@@ -246,6 +284,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       this.resetInterval();
       this.cronShapeValid = true;
       this.onValidatorChange();
+      this.cdr.markForCheck();
       return;
     }
 
@@ -259,6 +298,7 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       this.intervalTimeControl.setValue(interval.time, { emitEvent: false });
       this.cronShapeValid = true;
       this.onValidatorChange();
+      this.cdr.markForCheck();
       return;
     }
 
@@ -341,6 +381,36 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       return raw === "" ? null : raw;
     }
     return this.cronByPreset.get(preset) ?? null;
+  }
+
+  /**
+   * The plain-English echo rendered beneath the control, or `null` when there is nothing honest to
+   * say — an incomplete builder and an empty or malformed custom expression each describe no
+   * schedule.
+   */
+  protected get scheduleEcho(): ScheduleEcho | null {
+    const preset = this.presetControl.value;
+    if (preset === SCHEDULE_INTERVAL_MODE) {
+      const parts = this.intervalParts();
+      if (parts == null) {
+        return null;
+      }
+      return {
+        key: "pamRotationScheduleEchoInterval",
+        p1: String(parts.count),
+        p2: this.i18n.t(INTERVAL_UNIT_KEYS[parts.unit]),
+        p3: `${String(parts.hh).padStart(2, "0")}:${String(parts.mm).padStart(2, "0")}`,
+      };
+    }
+    const key = SCHEDULE_ECHO_KEYS[preset];
+    if (key != null) {
+      return { key };
+    }
+    if (!this.cronShapeValid) {
+      return null;
+    }
+    const cron = this.currentValue;
+    return cron == null ? null : { key: "pamRotationScheduleEchoCustom", p1: cron };
   }
 
   private countValidators(unit: ScheduleIntervalUnit): ValidatorFn[] {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.ts
@@ -107,18 +107,31 @@ const SCHEDULE_ECHO_KEYS: Partial<Record<QuartzSchedulePreset, string>> = {
   [QuartzSchedulePreset.Monthly]: "pamRotationScheduleEchoMonthly",
 };
 
-/** The interval echo names its unit with the builder's own option label, not fresh copy. */
-const INTERVAL_UNIT_KEYS: Readonly<Record<ScheduleIntervalUnit, string>> = Object.freeze({
-  [ScheduleIntervalUnit.Days]: "pamRotationScheduleIntervalUnitDays",
-  [ScheduleIntervalUnit.Months]: "pamRotationScheduleIntervalUnitMonths",
-});
+/**
+ * Interval unit → the sentence for a count of one, and the sentence for any other count.
+ *
+ * A whole sentence per plural form: substitution here is positional and the repository has no
+ * plural helper. The unit is not substituted into one shared sentence, because the only unit
+ * strings available are the builder's `bit-option` labels — capitalised and always plural — and
+ * lower-casing a noun in code is wrong in the languages that capitalise it.
+ */
+const INTERVAL_ECHO_KEYS: Readonly<Record<ScheduleIntervalUnit, { one: string; many: string }>> =
+  Object.freeze({
+    [ScheduleIntervalUnit.Days]: {
+      one: "pamRotationScheduleEchoIntervalDay",
+      many: "pamRotationScheduleEchoIntervalDays",
+    },
+    [ScheduleIntervalUnit.Months]: {
+      one: "pamRotationScheduleEchoIntervalMonth",
+      many: "pamRotationScheduleEchoIntervalMonths",
+    },
+  });
 
 /** What the echo line renders: a message key, plus the parameters that message takes. */
 interface ScheduleEcho {
   key: string;
   p1?: string | number;
   p2?: string | number;
-  p3?: string | number;
 }
 
 /** A clock reading as `<input type="time">` and the SDK's presets both spell it: zero-padded. */
@@ -262,8 +275,10 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
         this.cronByPreset.set(preset, cron);
       }
     });
-    // A preset selected before the table landed emitted null; re-emit now that it resolves.
+    // A preset selected before the table landed emitted null, and its echo stayed silent; re-emit
+    // and repaint now that it resolves.
     this.emitValue();
+    this.cdr.markForCheck();
   }
 
   /** Re-checks the custom expression's shape and re-validates against the new verdict. */
@@ -403,16 +418,17 @@ export class RotationScheduleInputComponent implements ControlValueAccessor, Val
       if (parts == null) {
         return null;
       }
-      return {
-        key: "pamRotationScheduleEchoInterval",
-        p1: parts.count,
-        p2: this.i18n.t(INTERVAL_UNIT_KEYS[parts.unit]),
-        p3: timeOfDay(parts.hh, parts.mm),
-      };
+      const keys = INTERVAL_ECHO_KEYS[parts.unit];
+      const time = timeOfDay(parts.hh, parts.mm);
+      return parts.count === 1
+        ? { key: keys.one, p1: time }
+        : { key: keys.many, p1: parts.count, p2: time };
     }
     const key = SCHEDULE_ECHO_KEYS[preset];
     if (key != null) {
-      return { key };
+      // Until a named preset's expression is in hand, currentValue emits null — no schedule at
+      // all — so its sentence would be describing something the form is not about to save.
+      return preset === QuartzSchedulePreset.None || this.cronByPreset.has(preset) ? { key } : null;
     }
     if (!this.cronShapeValid) {
       return null;


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Part of the PAM UAT review: this is one PR in a stack of per-ticket fixes rooted on `pam/uat`.

Adds a plain-English sentence beneath the rotation schedule control that describes what the current selection actually does.

- A new `role="status"`, `aria-live="polite"` paragraph echoes a lookup-table sentence per preset, a computed sentence for the interval builder (singular/plural, day/month), or the raw expression for `Custom`.
- The echo stays silent, not removed, for an incomplete interval, a malformed or empty custom cron, and a preset whose expression has not yet resolved from the SDK.
- `ChangeDetectorRef.markForCheck()` added in two spots so the `OnPush` component repaints once its preset-cron table resolves and after each async shape check.
- 12 new `en` locale keys, all additive, none of them wording changes to existing keys.
- Sits on `pam/rotux-schedule-interval-and-time-builder`; `pam/rotux-token-dialog-no-accidental-dismiss` sits on top.

### Copy not yet approved

The following strings are proposed by this PR and have not been reviewed by design:

- `pamRotationScheduleEchoNone`: "No scheduled rotation. This credential rotates only when you start one, or when access ends if that option is on."
- `pamRotationScheduleEchoHourly`: "Rotates once an hour, on the hour."
- `pamRotationScheduleEchoEvery6Hours`: "Rotates every 6 hours, on the hour."
- `pamRotationScheduleEchoDaily`: "Rotates once a day, at midnight."
- `pamRotationScheduleEchoWeekly`: "Rotates once a week, at midnight on Sunday."
- `pamRotationScheduleEchoMonthly`: "Rotates once a month, at midnight on the 1st."
- `pamRotationScheduleEchoIntervalDay` / `pamRotationScheduleEchoIntervalDays`: "Rotates every day, at $TIME$." / "Rotates every $COUNT$ days, at $TIME$."
- `pamRotationScheduleEchoIntervalMonth` / `pamRotationScheduleEchoIntervalMonths`: "Rotates every month, at $TIME$." / "Rotates every $COUNT$ months, at $TIME$."
- `pamRotationScheduleEchoCustom`: "Custom Quartz schedule: $CRON$"

### Known gaps

- The echo is not wired into the schedule select's `aria-describedby`. `BitFormFieldComponent` supports only one `aria-describedby` target per field, and that id lands on the `<bit-select>` host rather than the focusable combobox `ng-select` renders inside it, so a live description cannot currently join the field's existing hint. Reported, not fixed here.
- No evidence screenshot or UAT case file exists for this rotation surface; the route and repro were derived from the routing module.
- First paint of the saved sentence on an existing managed credential (`/managed-credentials/{configId}`) is unverified: no managed credential exists in any reachable org.
- Whether the managed credentials table's Schedule column still shows raw cron is unverified: the tab has no target systems in the tested org, so the table never renders.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Managed credential form -> Schedule

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-schedule-no-plain-english.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-schedule-no-plain-english.png" alt="after" width="460"> |
