### PR TITLE
The one-time connector token can be destroyed by pressing Escape

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.spec.ts
@@ -3,7 +3,7 @@ import { mock } from "jest-mock-extended";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { DIALOG_DATA, DialogRef, ToastService } from "@bitwarden/components";
+import { DIALOG_DATA, DialogRef, DialogService, ToastService } from "@bitwarden/components";
 
 import {
   DaemonTokenDialogComponent,
@@ -78,5 +78,33 @@ describe("DaemonTokenDialogComponent", () => {
   it("closes the dialog on close()", () => {
     (component as any).close();
     expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  describe("open", () => {
+    it("requests a dialog that cannot be dismissed by Escape, backdrop or the header X", () => {
+      const dialogService = mock<DialogService>();
+      const openedRef = mock<DialogRef>();
+      dialogService.open.mockReturnValue(openedRef);
+
+      const result = DaemonTokenDialogComponent.open(dialogService, { data: params });
+
+      expect(dialogService.open).toHaveBeenCalledWith(
+        DaemonTokenDialogComponent,
+        expect.objectContaining({ data: params, disableClose: true }),
+      );
+      expect(result).toBe(openedRef);
+    });
+
+    it("ignores a caller that asks for a dismissable dialog", () => {
+      const dialogService = mock<DialogService>();
+      dialogService.open.mockReturnValue(mock<DialogRef>());
+
+      DaemonTokenDialogComponent.open(dialogService, { data: params, disableClose: false });
+
+      expect(dialogService.open).toHaveBeenCalledWith(
+        DaemonTokenDialogComponent,
+        expect.objectContaining({ disableClose: true }),
+      );
+    });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.spec.ts
@@ -81,11 +81,16 @@ describe("DaemonTokenDialogComponent", () => {
   });
 
   describe("open", () => {
-    it("requests a dialog that cannot be dismissed by Escape, backdrop or the header X", () => {
-      const dialogService = mock<DialogService>();
-      const openedRef = mock<DialogRef>();
-      dialogService.open.mockReturnValue(openedRef);
+    let dialogService: jest.Mocked<DialogService>;
+    let openedRef: jest.Mocked<DialogRef>;
 
+    beforeEach(() => {
+      dialogService = mock<DialogService>();
+      openedRef = mock<DialogRef>();
+      dialogService.open.mockReturnValue(openedRef);
+    });
+
+    it("requests a dialog that cannot be dismissed by Escape, backdrop or the header X", () => {
       const result = DaemonTokenDialogComponent.open(dialogService, { data: params });
 
       expect(dialogService.open).toHaveBeenCalledWith(
@@ -96,9 +101,6 @@ describe("DaemonTokenDialogComponent", () => {
     });
 
     it("ignores a caller that asks for a dismissable dialog", () => {
-      const dialogService = mock<DialogService>();
-      dialogService.open.mockReturnValue(mock<DialogRef>());
-
       DaemonTokenDialogComponent.open(dialogService, { data: params, disableClose: false });
 
       expect(dialogService.open).toHaveBeenCalledWith(

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.ts
@@ -36,6 +36,9 @@ export type DaemonTokenDialogParams = {
  *
  * No way to re-fetch the token after this closes; a lost token means deleting and
  * re-registering the daemon.
+ *
+ * Opened with `disableClose`, so Escape, a backdrop click and the header X cannot
+ * dismiss it — the footer Close button is the only exit.
  */
 @Component({
   selector: "app-daemon-token-dialog",
@@ -66,6 +69,9 @@ export class DaemonTokenDialogComponent {
     dialogService: DialogService,
     config: DialogConfig<DaemonTokenDialogParams>,
   ): DialogRef<void> {
-    return dialogService.open<void, DaemonTokenDialogParams>(DaemonTokenDialogComponent, config);
+    return dialogService.open<void, DaemonTokenDialogParams>(DaemonTokenDialogComponent, {
+      ...config,
+      disableClose: true,
+    });
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

Part of the PAM UAT review: a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Forces the one-time connector token dialog to ignore Escape, a backdrop click and the header X, leaving the footer Close button as the only way to dismiss it.

- `DaemonTokenDialogComponent.open` now spreads the caller's `DialogConfig` and applies `disableClose: true` after the spread, so a caller cannot opt back out.
- `libs/components` already enforces `disableClose` for Escape (`dialog.component.ts`) and the header X (`dialog.component.html`), so nothing there changes.
- Adds two specs: a default call, and a caller that explicitly passes `disableClose: false`, both asserting the flag is forced to `true`.
- Adds a doc-comment on the component noting the footer Close button is now the only exit.

Sits on the PR for `pam/rotux-schedule-plain-english-echo`; the PR for `pam/rotux-await-register-dialog-close` sits on top of it.

## Known gaps

- No screenshots for this ticket: manual visual verification (Escape, backdrop click, footer Close, copy-without-closing) was done in the browser and is described in the QA notes, but no image evidence was captured, so before/after screenshots are missing here.
- `npm run test:types` fails with 12 pre-existing strict-mode errors in unrelated bit-web PAM files (managed-credentials, access-audit, story-fixtures, access-rules, target-systems). None reference `daemon-token-dialog`, and this branch's diff is limited to that component and its spec, but the failure was not confirmed against `pam/uat` directly since that would require checking out another commit in a read-only pass.
