### PR TITLE
Register and token dialogs are chained without awaiting the first close

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.spec.ts
@@ -15,6 +15,9 @@ import {
 } from "./daemon-register-dialog.component";
 import { DaemonTokenDialogComponent } from "./daemon-token-dialog.component";
 
+/** Drains the microtasks queued by the resolved SDK mock before assertions. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe("DaemonRegisterDialogComponent", () => {
   let fixture: ComponentFixture<DaemonRegisterDialogComponent>;
   let component: DaemonRegisterDialogComponent;
@@ -122,6 +125,44 @@ describe("DaemonRegisterDialogComponent", () => {
         }),
       }),
     );
+  });
+
+  it("does not open the token dialog until the register dialog has closed", async () => {
+    let resolveClose!: (value: unknown) => void;
+    dialogRef.close.mockReturnValue(new Promise((resolve) => (resolveClose = resolve)));
+    const openSpy = jest
+      .spyOn(injectedDialogService, "open")
+      .mockReturnValue({ closed: { toPromise: jest.fn() } } as any);
+
+    (component as any).form.controls.name.setValue("Good Daemon");
+    const submitted = (component as any).submit();
+    await settle();
+
+    expect(dialogRef.close).toHaveBeenCalledWith({ registered: true });
+    expect(openSpy).not.toHaveBeenCalled();
+
+    resolveClose({ closed: true });
+    await submitted;
+
+    expect(openSpy).toHaveBeenCalledWith(
+      DaemonTokenDialogComponent,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          token: fakeRegistration.token,
+          daemonName: "Good Daemon",
+        }),
+      }),
+    );
+  });
+
+  it("does not open the token dialog when registration fails", async () => {
+    rotationSdk.registerConnector.mockRejectedValue(new ErrorResponse({ Message: "boom" }, 500));
+    const openSpy = jest.spyOn(injectedDialogService, "open");
+
+    (component as any).form.controls.name.setValue("Bad Daemon");
+    await (component as any).submit();
+
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   it("shows an error toast when registration fails", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.spec.ts
@@ -4,7 +4,13 @@ import { mock } from "jest-mock-extended";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
-import { DIALOG_DATA, DialogRef, DialogService, ToastService } from "@bitwarden/components";
+import {
+  DIALOG_DATA,
+  DialogCloseRef,
+  DialogRef,
+  DialogService,
+  ToastService,
+} from "@bitwarden/components";
 
 import { RotationSdkService } from "../rotation-sdk.service";
 import { ORGANIZATION_ID, connectorId } from "../testing/rotation-builders";
@@ -14,9 +20,6 @@ import {
   DaemonRegisterDialogParams,
 } from "./daemon-register-dialog.component";
 import { DaemonTokenDialogComponent } from "./daemon-token-dialog.component";
-
-/** Drains the microtasks queued by the resolved SDK mock before assertions. */
-const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe("DaemonRegisterDialogComponent", () => {
   let fixture: ComponentFixture<DaemonRegisterDialogComponent>;
@@ -128,15 +131,18 @@ describe("DaemonRegisterDialogComponent", () => {
   });
 
   it("does not open the token dialog until the register dialog has closed", async () => {
-    let resolveClose!: (value: unknown) => void;
-    dialogRef.close.mockReturnValue(new Promise((resolve) => (resolveClose = resolve)));
+    let resolveClose!: (value: DialogCloseRef) => void;
+    dialogRef.close.mockReturnValue(
+      new Promise<DialogCloseRef>((resolve) => (resolveClose = resolve)),
+    );
     const openSpy = jest
       .spyOn(injectedDialogService, "open")
       .mockReturnValue({ closed: { toPromise: jest.fn() } } as any);
 
     (component as any).form.controls.name.setValue("Good Daemon");
     const submitted = (component as any).submit();
-    await settle();
+    // Let submit() run as far as the close it is now awaiting.
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(dialogRef.close).toHaveBeenCalledWith({ registered: true });
     expect(openSpy).not.toHaveBeenCalled();
@@ -144,15 +150,7 @@ describe("DaemonRegisterDialogComponent", () => {
     resolveClose({ closed: true });
     await submitted;
 
-    expect(openSpy).toHaveBeenCalledWith(
-      DaemonTokenDialogComponent,
-      expect.objectContaining({
-        data: expect.objectContaining({
-          token: fakeRegistration.token,
-          daemonName: "Good Daemon",
-        }),
-      }),
-    );
+    expect(openSpy).toHaveBeenCalledWith(DaemonTokenDialogComponent, expect.anything());
   });
 
   it("does not open the token dialog when registration fails", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.ts
@@ -35,8 +35,8 @@ export type DaemonRegisterDialogResult = { registered: true } | undefined;
  * Name-entry dialog for registering a new rotation daemon.
  *
  * On successful submit: calls {@link DaemonRegistrationService.register} to derive the key and
- * POST to the server, closes itself, then opens {@link DaemonTokenDialogComponent} to show the
- * one-time token.
+ * POST to the server, closes itself and waits for that teardown, then opens
+ * {@link DaemonTokenDialogComponent} to show the one-time token.
  *
  * `DaemonRegistrationService` is provided in this component's `providers`, so it only lives
  * while the dialog is open.
@@ -79,8 +79,10 @@ export class DaemonRegisterDialogComponent {
       // The SDK derives the key material, calls the server, and assembles the one-time token.
       const { token } = await this.rotationSdk.registerConnector(this.params.organizationId, name);
 
-      // Close the register dialog first, then open the token dialog.
-      void this.dialogRef.close({ registered: true });
+      // DialogRef.close() is async by contract: a closePredicate would push the overlay teardown
+      // behind an await, and this token cannot be fetched a second time if the two overlays fight
+      // over the focus trap.
+      await this.dialogRef.close({ registered: true });
 
       // Show the operator-entered name (not the daemon's GUID) as the dialog subtitle.
       DaemonTokenDialogComponent.open(this.dialogService, {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.ts
@@ -34,9 +34,10 @@ export type DaemonRegisterDialogResult = { registered: true } | undefined;
 /**
  * Name-entry dialog for registering a new rotation daemon.
  *
- * On successful submit: calls {@link DaemonRegistrationService.register} to derive the key and
- * POST to the server, closes itself and waits for that teardown, then opens
- * {@link DaemonTokenDialogComponent} to show the one-time token.
+ * On successful submit:
+ * 1. Calls {@link DaemonRegistrationService.register} to derive the key + POST to the server.
+ * 2. Closes itself and waits for the overlay to be torn down.
+ * 3. Opens {@link DaemonTokenDialogComponent} to show the one-time token.
  *
  * `DaemonRegistrationService` is provided in this component's `providers`, so it only lives
  * while the dialog is open.
@@ -79,9 +80,9 @@ export class DaemonRegisterDialogComponent {
       // The SDK derives the key material, calls the server, and assembles the one-time token.
       const { token } = await this.rotationSdk.registerConnector(this.params.organizationId, name);
 
-      // DialogRef.close() is async by contract: a closePredicate would push the overlay teardown
-      // behind an await, and this token cannot be fetched a second time if the two overlays fight
-      // over the focus trap.
+      // A closePredicate defers the overlay teardown, so opening the token dialog before this
+      // resolves leaves two overlays fighting over the focus trap. The one-time token cannot
+      // be fetched again if the token dialog is the one that loses.
       await this.dialogRef.close({ registered: true });
 
       // Show the operator-entered name (not the daemon's GUID) as the dialog subtitle.

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.ts
@@ -36,7 +36,7 @@ export type DaemonRegisterDialogResult = { registered: true } | undefined;
  *
  * On successful submit:
  * 1. Calls {@link DaemonRegistrationService.register} to derive the key + POST to the server.
- * 2. Closes itself and waits for the overlay to be torn down.
+ * 2. Closes itself, awaiting the promise {@link DialogRef.close} returns.
  * 3. Opens {@link DaemonTokenDialogComponent} to show the one-time token.
  *
  * `DaemonRegistrationService` is provided in this component's `providers`, so it only lives
@@ -80,9 +80,6 @@ export class DaemonRegisterDialogComponent {
       // The SDK derives the key material, calls the server, and assembles the one-time token.
       const { token } = await this.rotationSdk.registerConnector(this.params.organizationId, name);
 
-      // A closePredicate defers the overlay teardown, so opening the token dialog before this
-      // resolves leaves two overlays fighting over the focus trap. The one-time token cannot
-      // be fetched again if the token dialog is the one that loses.
       await this.dialogRef.close({ registered: true });
 
       // Show the operator-entered name (not the daemon's GUID) as the dialog subtitle.


### PR DESCRIPTION
## 🎟️ Tracking

Part of the PAM UAT review: a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Makes the daemon register dialog await its own close before opening the one-time token dialog, instead of discarding the close promise.

- `daemon-register-dialog.component.ts`: `void this.dialogRef.close(...)` becomes `await this.dialogRef.close(...)`, so `DaemonTokenDialogComponent.open` runs only after the register dialog's close promise settles.
- Removes the inline comment claiming a `closePredicate` defers overlay teardown; no `closePredicate` is set on this dialog, so that claim was false.
- Updates the class doc-comment's step 2 to say the close is awaited, instead of promising an ordering the code could not deliver.
- Adds two specs: the token dialog does not open until `dialogRef.close` resolves, and it does not open when registration fails.
- Explicitly does not add a branch for a refused `close()` (a not-yet-reachable case, since no `closePredicate` exists here); opening the token dialog is preferred over losing an unrecoverable one-time token.

Sits on the PR for `pam/rotux-token-dialog-no-accidental-dismiss`; the PR for `pam/rotux-connector-detail-manage-assignments` sits on top of it.

## Known gaps

- No screenshots: the visual check (submit click through to the token dialog appearing, single overlay throughout, focus landing in the token dialog) was done in the browser and is described in the QA notes, but no image evidence was captured.
- `npm run test:types` fails with 12 pre-existing errors in 7 unrelated files (rotation-config, target-system, access-audit, story-fixtures, access-rule-edit). All 7 are byte-identical to `pam/uat`, but that was checked by diffing file contents, not by running `test:types` against `pam/uat` directly in this pass.
