### PR TITLE
The connector detail page shows assignments but cannot change them

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19257,6 +19257,9 @@
   "pamDaemonActivityEmpty": {
     "message": "No rotation activity yet."
   },
+  "pamDaemonDetailAssignDisabledTooltip": {
+    "message": "Target systems can only be assigned while the status is Enabled."
+  },
   "pamDaemonStatusEnabled": {
     "message": "Enabled"
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -98,7 +98,7 @@
                     [disabled]="unassigning()"
                     label="{{ 'pamDaemonUnassign' | i18n: assignment.name }}"
                     (click)="unassign(assignment)"
-                    [id]="'daemon-detail_button_unassign-' + assignment.id"
+                    id="daemon-detail_button_unassign-{{ assignment.id }}"
                   ></button>
                 </span>
               }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -67,15 +67,40 @@
         </div>
 
         <div>
-          <p bitTypography="helper" class="tw-mb-1 tw-font-semibold">
-            {{ "pamDaemonAssignments" | i18n }}
-          </p>
-          @if (assignmentNames().length === 0) {
+          <div class="tw-mb-1 tw-flex tw-items-center tw-gap-3">
+            <p bitTypography="helper" class="tw-m-0 tw-font-semibold">
+              {{ "pamDaemonAssignments" | i18n }}
+            </p>
+            <button
+              type="button"
+              bitButton
+              buttonType="secondary"
+              size="small"
+              [bitAction]="assignTarget"
+              [disabled]="!enabled()"
+              [bitTooltip]="enabled() ? '' : ('pamDaemonDetailAssignDisabledTooltip' | i18n)"
+              id="daemon-detail_button_assign"
+            >
+              {{ "pamDaemonAssignTarget" | i18n }}
+            </button>
+          </div>
+          @if (assignments().length === 0) {
             <span class="tw-text-muted">&mdash;</span>
           } @else {
-            <div class="tw-flex tw-flex-wrap tw-gap-1">
-              @for (name of assignmentNames(); track $index) {
-                <span bitBadge variant="subtle">{{ name }}</span>
+            <div class="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+              @for (assignment of assignments(); track assignment.id) {
+                <span class="tw-inline-flex tw-items-center tw-gap-1">
+                  <span bitBadge variant="subtle">{{ assignment.name }}</span>
+                  <button
+                    type="button"
+                    bitIconButton="bwi-minus-circle"
+                    size="small"
+                    [disabled]="unassigning()"
+                    label="{{ 'pamDaemonUnassign' | i18n: assignment.name }}"
+                    (click)="unassign(assignment)"
+                    [id]="'daemon-detail_button_unassign-' + assignment.id"
+                  ></button>
+                </span>
               }
             </div>
           }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -80,6 +80,7 @@
               [disabled]="!enabled()"
               [bitTooltip]="enabled() ? '' : ('pamDaemonDetailAssignDisabledTooltip' | i18n)"
               id="daemon-detail_button_assign"
+              #assignButton
             >
               {{ "pamDaemonAssignTarget" | i18n }}
             </button>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
@@ -1,11 +1,17 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 
-import type { AccessConnector, AccessConnectorDetail, TargetSystem } from "../rotation";
+import type {
+  AccessConnector,
+  AccessConnectorDetail,
+  TargetSystem,
+  TargetSystemId,
+} from "../rotation";
 import { RotationSdkService } from "../rotation-sdk.service";
 import {
   ORGANIZATION_ID,
@@ -36,6 +42,10 @@ function makeDaemon(overrides: Partial<AccessConnector> = {}): AccessConnectorDe
 
 function makeSystem(): TargetSystem {
   return targetSystem({ id: sysId("ts-1"), name: "Prod Entra" });
+}
+
+function makeOtherSystem(): TargetSystem {
+  return targetSystem({ id: sysId("ts-2"), name: "Prod MSSQL" });
 }
 
 async function setup(
@@ -89,8 +99,114 @@ describe("DaemonDetailComponent", () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const comp = fixture.componentInstance as unknown as { assignmentNames: () => string[] };
-    expect(comp.assignmentNames()).toEqual(["Prod Entra"]);
+    const comp = fixture.componentInstance as unknown as {
+      assignments: () => { id: string; name: string }[];
+    };
+    expect(comp.assignments()).toEqual([{ id: sysId("ts-1"), name: "Prod Entra" }]);
+  });
+
+  it("assigns the selected target and patches assignments locally", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem(), makeOtherSystem()]);
+    rotationSdk.assignTarget.mockResolvedValue(undefined);
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(sysId("ts-2")) } as never);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as {
+      assignTarget: () => Promise<void>;
+      assignments: () => { id: string; name: string }[];
+    };
+    await comp.assignTarget();
+
+    expect(rotationSdk.assignTarget).toHaveBeenCalledWith(
+      ORGANIZATION_ID,
+      connectorId("daemon-1"),
+      sysId("ts-2"),
+    );
+    expect(comp.assignments().map((a) => a.name)).toEqual(["Prod Entra", "Prod MSSQL"]);
+  });
+
+  it("offers only unassigned active automatic targets to the dialog", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem(), makeOtherSystem()]);
+    rotationSdk.assignTarget.mockResolvedValue(undefined);
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(sysId("ts-2")) } as never);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
+    await comp.assignTarget();
+
+    const config = dialog.open.mock.calls[0][1] as unknown as {
+      data: { options: TargetSystem[] };
+    };
+    expect(config.data.options.map((s) => s.id)).toEqual([sysId("ts-2")]);
+  });
+
+  it("does not call assignTarget when the dialog is dismissed", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem(), makeOtherSystem()]);
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(undefined) } as never);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
+    await comp.assignTarget();
+
+    expect(rotationSdk.assignTarget).not.toHaveBeenCalled();
+  });
+
+  it("unassigns after confirmation and patches assignments locally", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+    rotationSdk.unassignTarget.mockResolvedValue(undefined);
+    const dialog = mock<DialogService>();
+    dialog.openSimpleDialog.mockResolvedValue(true);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as {
+      unassign: (assignment: { id: TargetSystemId; name: string }) => Promise<void>;
+      assignments: () => { id: string; name: string }[];
+    };
+    await comp.unassign({ id: sysId("ts-1"), name: "Prod Entra" });
+
+    expect(rotationSdk.unassignTarget).toHaveBeenCalledWith(
+      ORGANIZATION_ID,
+      connectorId("daemon-1"),
+      sysId("ts-1"),
+    );
+    expect(comp.assignments()).toEqual([]);
+  });
+
+  it("does not unassign when the confirmation is declined", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+    const dialog = mock<DialogService>();
+    dialog.openSimpleDialog.mockResolvedValue(false);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as {
+      unassign: (assignment: { id: TargetSystemId; name: string }) => Promise<void>;
+      assignments: () => { id: string; name: string }[];
+    };
+    await comp.unassign({ id: sysId("ts-1"), name: "Prod Entra" });
+
+    expect(rotationSdk.unassignTarget).not.toHaveBeenCalled();
+    expect(comp.assignments()).toHaveLength(1);
   });
 
   it("disables the daemon after confirmation and patches status", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
@@ -6,12 +6,7 @@ import { of } from "rxjs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 
-import type {
-  AccessConnector,
-  AccessConnectorDetail,
-  TargetSystem,
-  TargetSystemId,
-} from "../rotation";
+import type { AccessConnector, AccessConnectorDetail, TargetSystem } from "../rotation";
 import { RotationSdkService } from "../rotation-sdk.service";
 import {
   ORGANIZATION_ID,
@@ -22,7 +17,7 @@ import {
   targetSystem,
 } from "../testing/rotation-builders";
 
-import { DaemonDetailComponent } from "./daemon-detail.component";
+import { DaemonAssignment, DaemonDetailComponent } from "./daemon-detail.component";
 
 const i18nFake: Pick<I18nService, "t" | "translate"> = {
   t: (id: string) => id,
@@ -100,7 +95,7 @@ describe("DaemonDetailComponent", () => {
     fixture.detectChanges();
 
     const comp = fixture.componentInstance as unknown as {
-      assignments: () => { id: string; name: string }[];
+      assignments: () => DaemonAssignment[];
     };
     expect(comp.assignments()).toEqual([{ id: sysId("ts-1"), name: "Prod Entra" }]);
   });
@@ -118,7 +113,7 @@ describe("DaemonDetailComponent", () => {
 
     const comp = fixture.componentInstance as unknown as {
       assignTarget: () => Promise<void>;
-      assignments: () => { id: string; name: string }[];
+      assignments: () => DaemonAssignment[];
     };
     await comp.assignTarget();
 
@@ -177,8 +172,8 @@ describe("DaemonDetailComponent", () => {
     await fixture.whenStable();
 
     const comp = fixture.componentInstance as unknown as {
-      unassign: (assignment: { id: TargetSystemId; name: string }) => Promise<void>;
-      assignments: () => { id: string; name: string }[];
+      unassign: (assignment: DaemonAssignment) => Promise<void>;
+      assignments: () => DaemonAssignment[];
     };
     await comp.unassign({ id: sysId("ts-1"), name: "Prod Entra" });
 
@@ -200,8 +195,8 @@ describe("DaemonDetailComponent", () => {
     await fixture.whenStable();
 
     const comp = fixture.componentInstance as unknown as {
-      unassign: (assignment: { id: TargetSystemId; name: string }) => Promise<void>;
-      assignments: () => { id: string; name: string }[];
+      unassign: (assignment: DaemonAssignment) => Promise<void>;
+      assignments: () => DaemonAssignment[];
     };
     await comp.unassign({ id: sysId("ts-1"), name: "Prod Entra" });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
@@ -6,6 +6,7 @@ import { of } from "rxjs";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService, ToastService } from "@bitwarden/components";
 
+import { DaemonStatus } from "../rotation";
 import type { AccessConnector, AccessConnectorDetail, TargetSystem } from "../rotation";
 import { RotationSdkService } from "../rotation-sdk.service";
 import {
@@ -143,6 +144,53 @@ describe("DaemonDetailComponent", () => {
       data: { options: TargetSystem[] };
     };
     expect(config.data.options.map((s) => s.id)).toEqual([sysId("ts-2")]);
+  });
+
+  it("does not open the assign dialog while the daemon is disabled", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon({ status: DaemonStatus.Disabled }));
+    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem(), makeOtherSystem()]);
+    const dialog = mock<DialogService>();
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
+    await comp.assignTarget();
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(rotationSdk.assignTarget).not.toHaveBeenCalled();
+  });
+
+  it("keeps a newly assigned target when a removal overlaps the assign", async () => {
+    let resolveAssign: (() => void) | undefined;
+    const assigning = new Promise<void>((resolve) => {
+      resolveAssign = resolve;
+    });
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem(), makeOtherSystem()]);
+    rotationSdk.assignTarget.mockReturnValue(assigning);
+    rotationSdk.unassignTarget.mockResolvedValue(undefined);
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(sysId("ts-2")) } as never);
+    dialog.openSimpleDialog.mockResolvedValue(true);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as {
+      assignTarget: () => Promise<void>;
+      unassign: (assignment: DaemonAssignment) => Promise<void>;
+      assignments: () => DaemonAssignment[];
+    };
+    const assigned = comp.assignTarget();
+    const removed = comp.unassign({ id: sysId("ts-1"), name: "Prod Entra" });
+    resolveAssign?.();
+    await assigned;
+    await removed;
+
+    expect(comp.assignments().map((a) => a.id)).toEqual([sysId("ts-2")]);
   });
 
   it("does not call assignTarget when the dialog is dismissed", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -15,19 +15,29 @@ import {
   CardComponent,
   DialogService,
   HeaderComponent,
+  IconButtonModule,
   IconModule,
   SectionComponent,
   SectionHeaderComponent,
   SpinnerComponent,
   ToastService,
+  TooltipDirective,
   TypographyModule,
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { RotationHistoryComponent } from "../managed-credentials/rotation-history.component";
-import { AccessConnectorDetail, AccessConnectorId, DaemonStatus } from "../rotation";
+import {
+  AccessConnectorDetail,
+  AccessConnectorId,
+  DaemonStatus,
+  TargetSystem,
+  TargetSystemId,
+} from "../rotation";
 import { RotationSdkService } from "../rotation-sdk.service";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
+
+import { AssignTargetDialogComponent } from "./assign-target-dialog.component";
 
 /**
  * Routed detail page for a single rotation daemon — a sibling of the rotation shell, matching
@@ -49,11 +59,13 @@ import { TargetSystemsService } from "../target-systems/target-systems.service";
     ButtonModule,
     CardComponent,
     HeaderComponent,
+    IconButtonModule,
     IconModule,
     RotationHistoryComponent,
     SectionComponent,
     SectionHeaderComponent,
     SpinnerComponent,
+    TooltipDirective,
     TypographyModule,
     I18nPipe,
   ],
@@ -80,17 +92,25 @@ export class DaemonDetailComponent {
     initialValue: new Map(),
   });
 
+  private readonly activeAutomaticSystems = toSignal(
+    this.targetSystemsService.activeAutomaticSystems$,
+    { initialValue: [] as TargetSystem[] },
+  );
+
+  /** Guards the per-assignment remove buttons against re-entry; they are plain (click) handlers. */
+  protected readonly unassigning = signal(false);
+
   /** The connector itself; the detail's other half is its recent job history. */
   private readonly connector = computed(() => this.daemon()?.connector ?? null);
 
-  /** Assigned target-system display names, falling back to the raw ID when unresolved. */
-  protected readonly assignmentNames = computed(() => {
+  /** Assigned targets as id + display name, falling back to the raw ID when not yet resolved. */
+  protected readonly assignments = computed(() => {
     const connector = this.connector();
     if (connector == null) {
-      return [];
+      return [] as { id: TargetSystemId; name: string }[];
     }
     const map = this.systemById();
-    return connector.assignedTargetSystemIds.map((id) => map.get(id)?.name ?? id);
+    return connector.assignedTargetSystemIds.map((id) => ({ id, name: map.get(id)?.name ?? id }));
   });
 
   protected readonly titleText = computed(() => this.connector()?.name ?? "");
@@ -176,6 +196,69 @@ export class DaemonDetailComponent {
     }
   };
 
+  /** Assign an active automatic target system to this daemon. */
+  protected readonly assignTarget = async (): Promise<void> => {
+    const connector = this.connector();
+    if (connector == null) {
+      return;
+    }
+    const assigned = new Set(connector.assignedTargetSystemIds);
+    const options = this.activeAutomaticSystems().filter((s) => !assigned.has(s.id));
+
+    const ref = AssignTargetDialogComponent.open(this.dialogService, {
+      data: { daemon: connector, options },
+    });
+    const selected = await ref.closed.toPromise();
+    if (!selected) {
+      return;
+    }
+    const targetSystemId = asUuid<TargetSystemId>(selected);
+    try {
+      await this.rotationSdk.assignTarget(this.organizationId, connector.id, targetSystemId);
+      this.patchAssignments([...connector.assignedTargetSystemIds, targetSystemId]);
+      this.toastService.showToast({
+        variant: "success",
+        message: this.i18nService.t("pamDaemonAssigned"),
+      });
+    } catch (e) {
+      this.showError(e);
+    }
+  };
+
+  /** Remove one target-system assignment; confirms first, as the list does. */
+  protected readonly unassign = async (assignment: {
+    id: TargetSystemId;
+    name: string;
+  }): Promise<void> => {
+    const connector = this.connector();
+    if (connector == null || this.unassigning()) {
+      return;
+    }
+    this.unassigning.set(true);
+    try {
+      const confirmed = await this.dialogService.openSimpleDialog({
+        title: { key: "pamDaemonUnassignConfirmTitle" },
+        content: { key: "pamDaemonUnassignConfirmContent", placeholders: [assignment.name] },
+        acceptButtonText: { key: "remove" },
+        cancelButtonText: { key: "cancel" },
+        type: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+      await this.rotationSdk.unassignTarget(this.organizationId, connector.id, assignment.id);
+      this.patchAssignments(connector.assignedTargetSystemIds.filter((id) => id !== assignment.id));
+      this.toastService.showToast({
+        variant: "success",
+        message: this.i18nService.t("pamDaemonUnassigned"),
+      });
+    } catch (e) {
+      this.showError(e);
+    } finally {
+      this.unassigning.set(false);
+    }
+  };
+
   private async initialize(): Promise<void> {
     try {
       const [daemon] = await Promise.all([
@@ -215,6 +298,18 @@ export class DaemonDetailComponent {
       return;
     }
     this.daemon.set({ ...daemon, connector: { ...daemon.connector, status } });
+  }
+
+  /** Patch the loaded daemon's assignments locally (new reference for OnPush; jobs + fields carried over). */
+  private patchAssignments(assignedTargetSystemIds: TargetSystemId[]): void {
+    const daemon = this.daemon();
+    if (daemon == null) {
+      return;
+    }
+    this.daemon.set({
+      ...daemon,
+      connector: { ...daemon.connector, assignedTargetSystemIds },
+    });
   }
 
   private showError(e: unknown): void {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -1,5 +1,13 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  inject,
+  signal,
+  viewChild,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 
@@ -94,6 +102,17 @@ export class DaemonDetailComponent {
   protected readonly loading = signal(true);
   protected readonly daemon = signal<AccessConnectorDetail | null>(null);
 
+  /**
+   * Removing an assignment destroys the button that was clicked, which drops focus to the document
+   * body; focus moves here instead, the one assignment control that always survives the re-render.
+   */
+  private readonly assignButton = viewChild<unknown, ElementRef<HTMLButtonElement>>(
+    "assignButton",
+    {
+      read: ElementRef,
+    },
+  );
+
   private readonly systemById = toSignal(this.targetSystemsService.systemById$, {
     initialValue: new Map(),
   });
@@ -104,8 +123,9 @@ export class DaemonDetailComponent {
   );
 
   /**
-   * Holds every remove button, not just the clicked one: each removal patches the assignment list
-   * it captured when it started, so two in flight at once would resurrect each other's target.
+   * Holds every remove button, not just the clicked one: `bitIconButton` aria-disables rather than
+   * natively disabling, so without this a second click stacks a second confirmation dialog over the
+   * first and can dispatch two removals.
    */
   protected readonly unassigning = signal(false);
 
@@ -207,7 +227,7 @@ export class DaemonDetailComponent {
   /** Assign an active automatic target system to this daemon. */
   protected readonly assignTarget = async (): Promise<void> => {
     const connector = this.connector();
-    if (connector == null) {
+    if (connector == null || !this.enabled()) {
       return;
     }
     const assigned = new Set(connector.assignedTargetSystemIds);
@@ -223,7 +243,7 @@ export class DaemonDetailComponent {
     const targetSystemId = asUuid<TargetSystemId>(selected);
     try {
       await this.rotationSdk.assignTarget(this.organizationId, connector.id, targetSystemId);
-      this.patchAssignments([...connector.assignedTargetSystemIds, targetSystemId]);
+      this.patchAssignments((ids) => [...ids, targetSystemId]);
       this.toastService.showToast({
         variant: "success",
         message: this.i18nService.t("pamDaemonAssigned"),
@@ -252,7 +272,8 @@ export class DaemonDetailComponent {
         return;
       }
       await this.rotationSdk.unassignTarget(this.organizationId, connector.id, assignment.id);
-      this.patchAssignments(connector.assignedTargetSystemIds.filter((id) => id !== assignment.id));
+      this.patchAssignments((ids) => ids.filter((id) => id !== assignment.id));
+      this.assignButton()?.nativeElement.focus();
       this.toastService.showToast({
         variant: "success",
         message: this.i18nService.t("pamDaemonUnassigned"),
@@ -305,15 +326,22 @@ export class DaemonDetailComponent {
     this.daemon.set({ ...daemon, connector: { ...daemon.connector, status } });
   }
 
-  /** Patch the loaded daemon's assignments locally (new reference for OnPush; jobs + fields carried over). */
-  private patchAssignments(assignedTargetSystemIds: TargetSystemId[]): void {
+  /**
+   * Patch the loaded daemon's assignments locally (new reference for OnPush; jobs + fields carried
+   * over). The updater runs against the list as it stands when the call resolves, so an assign and
+   * a removal that overlap do not write each other's pre-request list back.
+   */
+  private patchAssignments(update: (ids: TargetSystemId[]) => TargetSystemId[]): void {
     const daemon = this.daemon();
     if (daemon == null) {
       return;
     }
     this.daemon.set({
       ...daemon,
-      connector: { ...daemon.connector, assignedTargetSystemIds },
+      connector: {
+        ...daemon.connector,
+        assignedTargetSystemIds: update(daemon.connector.assignedTargetSystemIds),
+      },
     });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -39,6 +39,12 @@ import { TargetSystemsService } from "../target-systems/target-systems.service";
 
 import { AssignTargetDialogComponent } from "./assign-target-dialog.component";
 
+/** An assigned target system, paired with the name the badge renders. */
+export type DaemonAssignment = {
+  id: TargetSystemId;
+  name: string;
+};
+
 /**
  * Routed detail page for a single rotation daemon — a sibling of the rotation shell, matching
  * the target-system / rotation-config detail pages. Reached from the daemons tab.
@@ -97,20 +103,22 @@ export class DaemonDetailComponent {
     { initialValue: [] as TargetSystem[] },
   );
 
-  /** Guards the per-assignment remove buttons against re-entry; they are plain (click) handlers. */
+  /**
+   * Holds every remove button, not just the clicked one: each removal patches the assignment list
+   * it captured when it started, so two in flight at once would resurrect each other's target.
+   */
   protected readonly unassigning = signal(false);
 
   /** The connector itself; the detail's other half is its recent job history. */
   private readonly connector = computed(() => this.daemon()?.connector ?? null);
 
   /** Assigned targets as id + display name, falling back to the raw ID when not yet resolved. */
-  protected readonly assignments = computed(() => {
-    const connector = this.connector();
-    if (connector == null) {
-      return [] as { id: TargetSystemId; name: string }[];
-    }
-    const map = this.systemById();
-    return connector.assignedTargetSystemIds.map((id) => ({ id, name: map.get(id)?.name ?? id }));
+  protected readonly assignments = computed<DaemonAssignment[]>(() => {
+    const systemById = this.systemById();
+    return (this.connector()?.assignedTargetSystemIds ?? []).map((id) => ({
+      id,
+      name: systemById.get(id)?.name ?? String(id),
+    }));
   });
 
   protected readonly titleText = computed(() => this.connector()?.name ?? "");
@@ -226,10 +234,7 @@ export class DaemonDetailComponent {
   };
 
   /** Remove one target-system assignment; confirms first, as the list does. */
-  protected readonly unassign = async (assignment: {
-    id: TargetSystemId;
-    name: string;
-  }): Promise<void> => {
+  protected readonly unassign = async (assignment: DaemonAssignment): Promise<void> => {
     const connector = this.connector();
     if (connector == null || this.unassigning()) {
       return;


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Makes the connector detail page's `Assigned targets` block interactive instead of read-only: an `Assign to target` button and a per-badge remove button now call the rotation SDK directly and patch the connector's assignment list locally.

- Adds an `Assign to target` button beside the `Assigned targets` label that opens `AssignTargetDialogComponent`, calls `rotationSdk.assignTarget`, and appends the chosen id via a local `patchAssignments` update.
- Adds a remove icon button on each assignment badge that confirms via a warning dialog, calls `rotationSdk.unassignTarget`, and removes the id locally; a `unassigning` signal guards against double-clicks because `bitIconButton` only aria-disables, it does not stop `(click)`.
- The `Assign` button aria-disables with a tooltip while the connector is `Disabled`; `assignTarget` also checks status directly in the handler, since the template binding alone does not cover a direct call.
- `patchAssignments` takes an updater function rather than a fixed snapshot, so an assign and a remove that overlap in flight cannot overwrite each other's result; on remove, focus moves to the `Assign` button before the removed badge unmounts.
- Adds one new locale key, `pamDaemonDetailAssignDisabledTooltip`; the assign/unassign confirm and toast strings are reused verbatim from the existing target list.

Sits on `pam/rotux-await-register-dialog-close`; `pam/rotux-attempt-rows-labelled-columns` sits on top of this branch.

## 📸 Screenshots

Captured at 1440x1024, before on `pam/uat` and after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Daemons -> detail

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-detail-page-cannot-change-assignments.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-detail-page-cannot-change-assignments.png" alt="after" width="460"> |

## Copy not yet approved

- `pamDaemonDetailAssignDisabledTooltip`: "Target systems can only be assigned while the status is Enabled." Proposed by the plan agent, not yet reviewed by a designer.

## Known gaps

- `npm run test:types` fails on this branch. The evidence points to a pre-existing `pam/uat` SDK skew (a missing `LockService` export from `@bitwarden/auth/common`) touching files this stack does not modify, but that was not confirmed by actually running the type check on trunk, so treat the attribution as inference, not a measured baseline.
- The assembled stack tip does not typecheck: this ticket passes `data: { daemon: connector, options }` to `AssignTargetDialogComponent`, while the neighboring `rotux-assign-dialog-false-empty-message` ticket elsewhere in the stack made `assign-target-dialog.component.ts`'s corresponding field required instead of the optional one the design doc called for. The mismatch (TS2741) only appears once both branches are combined, not in this PR alone.
- The focus-on-remove fix ships without a dedicated unit test.
- Two concurrent assigns of the same target could append its id twice.
- The `Disabled` check now lives in two places: the template binding on the `Assign` button and the `assignTarget` handler.
