### PR TITLE
Attempt rows put timestamps under the Created and Attempts column headers

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19536,6 +19536,12 @@
   "pamRotationAttemptInProgress": {
     "message": "In progress"
   },
+  "pamRotationAttemptStarted": {
+    "message": "Started"
+  },
+  "pamRotationAttemptEnded": {
+    "message": "Ended"
+  },
   "pamRotationSyncStateTargetUnchanged": {
     "message": "Target unchanged"
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
@@ -20,7 +20,6 @@
     </thead>
     <tbody>
       @for (job of sortedJobs(); track job.id) {
-        <!-- Job row -->
         <tr class="tw-border-b tw-border-secondary-100" data-testid="rotation-history-job-row">
           <td class="tw-py-2 tw-pr-4">{{ sourceLabelKey(job.source) | i18n }}</td>
           <td class="tw-py-2 tw-pr-4">
@@ -34,15 +33,14 @@
           <td class="tw-py-2 tw-text-muted">{{ job.attempts.length }}</td>
         </tr>
 
-        <!-- Attempt rows (nested, indented) -->
         @for (attempt of job.attempts; track attempt.id) {
           <tr
             class="tw-border-b tw-border-secondary-100 tw-bg-background-alt"
             data-testid="rotation-history-attempt-row"
           >
             <td class="tw-py-1 tw-pl-6 tw-pr-4 tw-text-xs tw-text-muted" colspan="4">
-              <div class="tw-flex tw-flex-wrap tw-items-baseline tw-gap-x-4 tw-gap-y-1">
-                <div class="tw-min-w-0 tw-flex-1">
+              <div class="tw-flex tw-flex-wrap tw-items-start tw-gap-x-4 tw-gap-y-1">
+                <div class="tw-min-w-0 tw-flex-1 tw-truncate">
                   <span class="tw-font-medium">{{
                     attemptStatusLabelKey(attempt.status) | i18n
                   }}</span>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
@@ -21,7 +21,7 @@
     <tbody>
       @for (job of sortedJobs(); track job.id) {
         <!-- Job row -->
-        <tr class="tw-border-b tw-border-secondary-100">
+        <tr class="tw-border-b tw-border-secondary-100" data-testid="rotation-history-job-row">
           <td class="tw-py-2 tw-pr-4">{{ sourceLabelKey(job.source) | i18n }}</td>
           <td class="tw-py-2 tw-pr-4">
             <span bitBadge [variant]="jobStatusVariant(job.status)">
@@ -36,7 +36,10 @@
 
         <!-- Attempt rows (nested, indented) -->
         @for (attempt of job.attempts; track attempt.id) {
-          <tr class="tw-border-b tw-border-secondary-100 tw-bg-background-alt">
+          <tr
+            class="tw-border-b tw-border-secondary-100 tw-bg-background-alt"
+            data-testid="rotation-history-attempt-row"
+          >
             <td class="tw-py-1 tw-pl-6 tw-pr-4 tw-text-xs tw-text-muted" colspan="4">
               <div class="tw-flex tw-flex-wrap tw-items-baseline tw-gap-x-4 tw-gap-y-1">
                 <div class="tw-min-w-0 tw-flex-1">

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
@@ -37,37 +37,50 @@
         <!-- Attempt rows (nested, indented) -->
         @for (attempt of job.attempts; track attempt.id) {
           <tr class="tw-border-b tw-border-secondary-100 tw-bg-background-alt">
-            <td class="tw-py-1 tw-pl-6 tw-pr-4 tw-text-xs tw-text-muted" colspan="2">
-              <span class="tw-font-medium">{{ attemptStatusLabelKey(attempt.status) | i18n }}</span>
-              @if (attempt.failureReason) {
-                <span class="tw-ml-2 tw-truncate tw-text-danger" [title]="attempt.failureReason">
-                  — {{ attempt.failureReason }}
+            <td class="tw-py-1 tw-pl-6 tw-pr-4 tw-text-xs tw-text-muted" colspan="4">
+              <div class="tw-flex tw-flex-wrap tw-items-baseline tw-gap-x-4 tw-gap-y-1">
+                <div class="tw-min-w-0 tw-flex-1">
+                  <span class="tw-font-medium">{{
+                    attemptStatusLabelKey(attempt.status) | i18n
+                  }}</span>
+                  @if (attempt.failureReason) {
+                    <span
+                      class="tw-ml-2 tw-truncate tw-text-danger"
+                      [title]="attempt.failureReason"
+                    >
+                      — {{ attempt.failureReason }}
+                    </span>
+                  }
+                  @if (
+                    attempt.status === RotationAttemptStatus.Errored && attempt.syncState !== null
+                  ) {
+                    <span class="tw-ml-2 tw-text-muted">
+                      ({{ syncStateLabelKey(attempt.syncState) | i18n }})
+                    </span>
+                  }
+                  @if (
+                    attempt.status === RotationAttemptStatus.Rotated &&
+                    attempt.sessionTermination !== null &&
+                    attempt.sessionTermination !== SessionTerminationOutcome.NotRequested
+                  ) {
+                    <span class="tw-ml-2 tw-text-muted">
+                      — {{ sessionTerminationLabelKey(attempt.sessionTermination) | i18n }}
+                    </span>
+                  }
+                </div>
+                <span>
+                  <span class="tw-font-medium">{{ "pamRotationAttemptStarted" | i18n }}</span>
+                  {{ attempt.startedAt | date: "medium" }}
                 </span>
-              }
-              @if (attempt.status === RotationAttemptStatus.Errored && attempt.syncState !== null) {
-                <span class="tw-ml-2 tw-text-muted">
-                  ({{ syncStateLabelKey(attempt.syncState) | i18n }})
-                </span>
-              }
-              @if (
-                attempt.status === RotationAttemptStatus.Rotated &&
-                attempt.sessionTermination !== null &&
-                attempt.sessionTermination !== SessionTerminationOutcome.NotRequested
-              ) {
-                <span class="tw-ml-2 tw-text-muted">
-                  — {{ sessionTerminationLabelKey(attempt.sessionTermination) | i18n }}
-                </span>
-              }
-            </td>
-            <td class="tw-py-1 tw-pr-4 tw-text-xs tw-text-muted">
-              {{ attempt.startedAt | date: "medium" }}
-            </td>
-            <td class="tw-py-1 tw-text-xs tw-text-muted">
-              @if (attempt.endedAt) {
-                {{ attempt.endedAt | date: "medium" }}
-              } @else {
-                <span class="tw-italic">{{ "pamRotationAttemptInProgress" | i18n }}</span>
-              }
+                @if (attempt.endedAt) {
+                  <span>
+                    <span class="tw-font-medium">{{ "pamRotationAttemptEnded" | i18n }}</span>
+                    {{ attempt.endedAt | date: "medium" }}
+                  </span>
+                } @else {
+                  <span class="tw-italic">{{ "pamRotationAttemptInProgress" | i18n }}</span>
+                }
+              </div>
             </td>
           </tr>
         }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
@@ -157,10 +157,12 @@ describe("RotationHistoryComponent", () => {
 });
 
 describe("RotationHistoryComponent rendering", () => {
+  const i18nFake: Pick<I18nService, "t"> = { t: (id: string) => id };
+
   function render(jobs: RotationJob[]) {
     TestBed.configureTestingModule({
       imports: [RotationHistoryComponent],
-      providers: [{ provide: I18nService, useValue: { t: (key: string) => key } }],
+      providers: [{ provide: I18nService, useValue: i18nFake }],
     });
 
     const fixture = TestBed.createComponent(RotationHistoryComponent);
@@ -172,10 +174,12 @@ describe("RotationHistoryComponent rendering", () => {
   it("gives each attempt row a single cell spanning every column", () => {
     const fixture = render([rotationJob()]);
 
-    const attemptRows = fixture.debugElement.queryAll(By.css("tr.tw-bg-background-alt"));
+    const attemptRows = fixture.debugElement.queryAll(
+      By.css("[data-testid='rotation-history-attempt-row']"),
+    );
     expect(attemptRows).toHaveLength(1);
 
-    const cells = fixture.debugElement.queryAll(By.css("tr.tw-bg-background-alt td"));
+    const cells = attemptRows[0].queryAll(By.css("td"));
     expect(cells).toHaveLength(1);
     expect(cells[0].nativeElement.getAttribute("colspan")).toBe("4");
   });
@@ -202,7 +206,9 @@ describe("RotationHistoryComponent rendering", () => {
   it("leaves the job row filling the four headers, with the attempt count last", () => {
     const fixture = render([rotationJob()]);
 
-    const cells = fixture.debugElement.queryAll(By.css("tbody tr:not(.tw-bg-background-alt) td"));
+    const cells = fixture.debugElement.queryAll(
+      By.css("[data-testid='rotation-history-job-row'] td"),
+    );
     expect(cells).toHaveLength(4);
     expect(cells[3].nativeElement.textContent.trim()).toBe("1");
   });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
@@ -1,4 +1,7 @@
 import { TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 
 import type { RotationJob } from "../rotation";
 import {
@@ -8,7 +11,7 @@ import {
   RotationSyncState,
   SessionTerminationOutcome,
 } from "../rotation";
-import { jobId, rotationJob } from "../testing/rotation-builders";
+import { jobId, rotationAttempt, rotationJob } from "../testing/rotation-builders";
 
 import { RotationHistoryComponent } from "./rotation-history.component";
 
@@ -150,5 +153,76 @@ describe("RotationHistoryComponent", () => {
         "pamRotationAttemptStatusAbandoned",
       );
     });
+  });
+});
+
+describe("RotationHistoryComponent rendering", () => {
+  function render(jobs: RotationJob[]) {
+    TestBed.configureTestingModule({
+      imports: [RotationHistoryComponent],
+      providers: [{ provide: I18nService, useValue: { t: (key: string) => key } }],
+    });
+
+    const fixture = TestBed.createComponent(RotationHistoryComponent);
+    fixture.componentRef.setInput("jobs", jobs);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it("gives each attempt row a single cell spanning every column", () => {
+    const fixture = render([rotationJob()]);
+
+    const attemptRows = fixture.debugElement.queryAll(By.css("tr.tw-bg-background-alt"));
+    expect(attemptRows).toHaveLength(1);
+
+    const cells = fixture.debugElement.queryAll(By.css("tr.tw-bg-background-alt td"));
+    expect(cells).toHaveLength(1);
+    expect(cells[0].nativeElement.getAttribute("colspan")).toBe("4");
+  });
+
+  it("labels both timestamps of a finished attempt", () => {
+    const fixture = render([rotationJob()]);
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain("pamRotationAttemptStarted");
+    expect(text).toContain("pamRotationAttemptEnded");
+  });
+
+  it("shows in progress and no ended label while an attempt is running", () => {
+    const fixture = render([
+      rotationJob({ attempts: [rotationAttempt({ endedAt: undefined, status: "executing" })] }),
+    ]);
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain("pamRotationAttemptStarted");
+    expect(text).toContain("pamRotationAttemptInProgress");
+    expect(text).not.toContain("pamRotationAttemptEnded");
+  });
+
+  it("leaves the job row filling the four headers, with the attempt count last", () => {
+    const fixture = render([rotationJob()]);
+
+    const cells = fixture.debugElement.queryAll(By.css("tbody tr:not(.tw-bg-background-alt) td"));
+    expect(cells).toHaveLength(4);
+    expect(cells[3].nativeElement.textContent.trim()).toBe("1");
+  });
+
+  it("keeps the attempt status, failure reason and sync state in the row", () => {
+    const fixture = render([
+      rotationJob({
+        attempts: [
+          rotationAttempt({
+            status: "errored",
+            failureReason: "LDAP result code 53",
+            syncState: "indeterminate",
+          }),
+        ],
+      }),
+    ]);
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain("pamRotationAttemptStatusErrored");
+    expect(text).toContain("LDAP result code 53");
+    expect(text).toContain("pamRotationSyncStateIndeterminate");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
@@ -194,7 +194,11 @@ describe("RotationHistoryComponent rendering", () => {
 
   it("shows in progress and no ended label while an attempt is running", () => {
     const fixture = render([
-      rotationJob({ attempts: [rotationAttempt({ endedAt: undefined, status: "executing" })] }),
+      rotationJob({
+        attempts: [
+          rotationAttempt({ endedAt: undefined, status: RotationAttemptStatus.Executing }),
+        ],
+      }),
     ]);
 
     const text = fixture.nativeElement.textContent;
@@ -218,9 +222,9 @@ describe("RotationHistoryComponent rendering", () => {
       rotationJob({
         attempts: [
           rotationAttempt({
-            status: "errored",
+            status: RotationAttemptStatus.Errored,
             failureReason: "LDAP result code 53",
-            syncState: "indeterminate",
+            syncState: RotationSyncState.Indeterminate,
           }),
         ],
       }),


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review, part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

In `rotation-history.component.html`, each attempt row's `startedAt`/`endedAt` timestamps no longer sit under the job table's `Created`/`Attempts` headers.

- Attempt row now renders as a single `<td colspan="4">` instead of a status cell (`colspan="2"`) plus two bare timestamp cells, so it stops occupying the job row's column grid.
- Both timestamps get an inline `tw-font-medium` label (`pamRotationAttemptStarted` / `pamRotationAttemptEnded`) before the value; the unfinished-attempt case still falls back to `pamRotationAttemptInProgress`.
- Existing status, failure reason, sync state and session termination `@if` blocks moved into the row unchanged, wrapped in a `tw-flex tw-flex-wrap` container alongside the new timestamp spans.
- Added `data-testid` hooks on the job and attempt `<tr>` elements and five new rendering specs; no existing spec was changed.
- Two new `en` message keys added (`pamRotationAttemptStarted`, `pamRotationAttemptEnded`); nothing else in `messages.json` touched.

Stack: sits on the PR for `pam/rotux-connector-detail-manage-assignments`; `pam/rotux-failure-reason-plain-cause` sits on top of this one.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Daemons -> detail -> Recent activity

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-attempts-column-holds-timestamp.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-attempts-column-holds-timestamp.png" alt="after" width="460"> |

## Copy not yet approved

This PR adds user-facing wording the designer has not signed off on:

- `pamRotationAttemptStarted` = "Started" (proposed)
- `pamRotationAttemptEnded` = "Ended" (proposed)

## Known gaps

- `test:types` fails with 12 strict errors, but all are in files this ticket never touches (`rotation-config-row.ts`, `rotation-config-edit.component.ts`, `access-audit.component.spec.ts`, `story-fixtures.ts`, `access-rule-edit.component.spec.ts`, `target-system-edit.component.spec.ts`, `target-systems.service.spec.ts`) and predate this stack per `git log` on those paths. Not confirmed empirically against `pam/uat` (no checkout run).
- The unfinished-attempt (`In progress`, no `Ended` label) branch was not observed rendered in the browser; no seeded fixture has a null `endedAt`. It is source-verified in `rotation-history.component.html` only.
- A long `failureReason` now ellipsises the sync-state parenthetical that follows it, instead of both overflowing. No automated test covers the truncation fix.
- No UAT case file covers this rotation surface and no evidence screenshot exists on disk for this finding; reproduce steps were written from the routes and templates.
