### PR TITLE
Rotation failures surface a raw LDAP result code and nothing else

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19566,6 +19566,33 @@
   "pamRotationSessionTerminationUnknown": {
     "message": "Unknown"
   },
+  "pamRotationFailureCauseInsufficientRights": {
+    "message": "The access connector's account is not allowed to change this password. Grant it permission to reset the target account's password, then rotate again."
+  },
+  "pamRotationFailureCauseInvalidCredentials": {
+    "message": "The target system rejected the access connector's sign in. Check the credentials the connector uses for this target system, then rotate again."
+  },
+  "pamRotationFailureCausePasswordRejected": {
+    "message": "The target system rejected the new password. Check that this credential's password policy meets the target system's own password rules, then rotate again."
+  },
+  "pamRotationFailureCauseAccountNotFound": {
+    "message": "The target system could not find the account to rotate. Check the account identity on this managed credential, then rotate again."
+  },
+  "pamRotationFailureCauseDirectoryRefused": {
+    "message": "The target system refused to make the change. This commonly means the new password broke a password rule, or the connection to the target system was not encrypted."
+  },
+  "pamRotationFailureCauseTargetUnreachable": {
+    "message": "The access connector could not reach the target system. Check the target system's address and that the connector can reach it on the network, then rotate again."
+  },
+  "pamRotationFailureReportedDetail": {
+    "message": "Reported by the access connector: $REASON$",
+    "placeholders": {
+      "reason": {
+        "content": "$1",
+        "example": "target_rejected: LDAP result code 50"
+      }
+    }
+  },
   "pamAuditKindRotationConfigCreated": {
     "message": "Rotation config created"
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
@@ -39,19 +39,19 @@
             data-testid="rotation-history-attempt-row"
           >
             <td class="tw-py-1 tw-pl-6 tw-pr-4 tw-text-xs tw-text-muted" colspan="4">
+              @let failureCauseKey =
+                attempt.failureReason ? failureCauseLabelKey(attempt.failureReason) : null;
               <div class="tw-flex tw-flex-wrap tw-items-start tw-gap-x-4 tw-gap-y-1">
                 <div class="tw-min-w-0 tw-flex-1">
                   <span class="tw-font-medium">{{
                     attemptStatusLabelKey(attempt.status) | i18n
                   }}</span>
-                  @if (attempt.failureReason; as failureReason) {
-                    @if (failureCauseLabelKey(failureReason); as causeKey) {
-                      <span class="tw-ml-2 tw-text-danger">— {{ causeKey | i18n }}</span>
-                    } @else {
-                      <span class="tw-ml-2 tw-text-danger" [title]="failureReason">
-                        — {{ failureReason }}
-                      </span>
-                    }
+                  @if (failureCauseKey) {
+                    <span class="tw-ml-2 tw-text-danger">— {{ failureCauseKey | i18n }}</span>
+                  } @else if (attempt.failureReason; as failureReason) {
+                    <span class="tw-ml-2 tw-text-danger" [title]="failureReason">
+                      — {{ failureReason }}
+                    </span>
                   }
                   @if (
                     attempt.status === RotationAttemptStatus.Errored && attempt.syncState !== null
@@ -83,9 +83,9 @@
                   <span class="tw-italic">{{ "pamRotationAttemptInProgress" | i18n }}</span>
                 }
               </div>
-              @if (explainedFailureDetail(attempt.failureReason); as failureDetail) {
-                <span class="tw-mt-0.5 tw-block tw-text-muted" [title]="failureDetail">
-                  {{ "pamRotationFailureReportedDetail" | i18n: failureDetail }}
+              @if (failureCauseKey && attempt.failureReason; as failureReason) {
+                <span class="tw-mt-0.5 tw-block tw-text-muted" [title]="failureReason">
+                  {{ "pamRotationFailureReportedDetail" | i18n: failureReason }}
                 </span>
               }
             </td>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
@@ -49,9 +49,7 @@
                   @if (failureCauseKey) {
                     <span class="tw-ml-2 tw-text-danger">— {{ failureCauseKey | i18n }}</span>
                   } @else if (attempt.failureReason; as failureReason) {
-                    <span class="tw-ml-2 tw-text-danger" [title]="failureReason">
-                      — {{ failureReason }}
-                    </span>
+                    <span class="tw-ml-2 tw-text-danger">— {{ failureReason }}</span>
                   }
                   @if (
                     attempt.status === RotationAttemptStatus.Errored && attempt.syncState !== null
@@ -84,7 +82,7 @@
                 }
               </div>
               @if (failureCauseKey && attempt.failureReason; as failureReason) {
-                <span class="tw-mt-0.5 tw-block tw-text-muted" [title]="failureReason">
+                <span class="tw-mt-0.5 tw-block tw-text-muted">
                   {{ "pamRotationFailureReportedDetail" | i18n: failureReason }}
                 </span>
               }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
@@ -40,17 +40,18 @@
           >
             <td class="tw-py-1 tw-pl-6 tw-pr-4 tw-text-xs tw-text-muted" colspan="4">
               <div class="tw-flex tw-flex-wrap tw-items-start tw-gap-x-4 tw-gap-y-1">
-                <div class="tw-min-w-0 tw-flex-1 tw-truncate">
+                <div class="tw-min-w-0 tw-flex-1">
                   <span class="tw-font-medium">{{
                     attemptStatusLabelKey(attempt.status) | i18n
                   }}</span>
-                  @if (attempt.failureReason) {
-                    <span
-                      class="tw-ml-2 tw-truncate tw-text-danger"
-                      [title]="attempt.failureReason"
-                    >
-                      — {{ attempt.failureReason }}
-                    </span>
+                  @if (attempt.failureReason; as failureReason) {
+                    @if (failureCauseLabelKey(failureReason); as causeKey) {
+                      <span class="tw-ml-2 tw-text-danger">— {{ causeKey | i18n }}</span>
+                    } @else {
+                      <span class="tw-ml-2 tw-text-danger" [title]="failureReason">
+                        — {{ failureReason }}
+                      </span>
+                    }
                   }
                   @if (
                     attempt.status === RotationAttemptStatus.Errored && attempt.syncState !== null
@@ -82,6 +83,11 @@
                   <span class="tw-italic">{{ "pamRotationAttemptInProgress" | i18n }}</span>
                 }
               </div>
+              @if (explainedFailureDetail(attempt.failureReason); as failureDetail) {
+                <span class="tw-mt-0.5 tw-block tw-text-muted" [title]="failureDetail">
+                  {{ "pamRotationFailureReportedDetail" | i18n: failureDetail }}
+                </span>
+              }
             </td>
           </tr>
         }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
@@ -154,10 +154,59 @@ describe("RotationHistoryComponent", () => {
       );
     });
   });
+
+  describe("failureCauseLabelKey", () => {
+    it.each([
+      ["target_rejected: LDAP result code 19", "pamRotationFailureCausePasswordRejected"],
+      ["target_rejected: LDAP result code 32", "pamRotationFailureCauseAccountNotFound"],
+      ["target_rejected: LDAP result code 49", "pamRotationFailureCauseInvalidCredentials"],
+      ["target_rejected: LDAP result code 50", "pamRotationFailureCauseInsufficientRights"],
+      ["target_rejected: LDAP result code 53", "pamRotationFailureCauseDirectoryRefused"],
+      ["target_rejected: ldap error code 50", "pamRotationFailureCauseInsufficientRights"],
+      [
+        "target_unreachable: error kind: ConnectionRefused",
+        "pamRotationFailureCauseTargetUnreachable",
+      ],
+    ])("maps %s to %s", (failureReason, expected) => {
+      setup([]);
+      expect((component as any).failureCauseLabelKey(failureReason)).toBe(expected);
+    });
+
+    it.each([
+      ["target_rejected: LDAP result code 68"],
+      ["target unreachable"],
+      ["flaky target"],
+      ["target_rejected"],
+    ])("returns null for %s", (failureReason) => {
+      setup([]);
+      expect((component as any).failureCauseLabelKey(failureReason)).toBeNull();
+    });
+  });
+
+  describe("explainedFailureDetail", () => {
+    it("returns the recorded reason when an explanation replaced it", () => {
+      setup([]);
+      expect(
+        (component as any).explainedFailureDetail("target_rejected: LDAP result code 50"),
+      ).toBe("target_rejected: LDAP result code 50");
+    });
+
+    it("returns null for an unrecognised reason", () => {
+      setup([]);
+      expect((component as any).explainedFailureDetail("flaky target")).toBeNull();
+    });
+
+    it("returns null when no reason was recorded", () => {
+      setup([]);
+      expect((component as any).explainedFailureDetail(undefined)).toBeNull();
+    });
+  });
 });
 
 describe("RotationHistoryComponent rendering", () => {
-  const i18nFake: Pick<I18nService, "t"> = { t: (id: string) => id };
+  const i18nFake: Pick<I18nService, "t"> = {
+    t: (id: string, ...substitutions: (string | number)[]) => [id, ...substitutions].join(" "),
+  };
 
   function render(jobs: RotationJob[]) {
     TestBed.configureTestingModule({
@@ -234,5 +283,22 @@ describe("RotationHistoryComponent rendering", () => {
     expect(text).toContain("pamRotationAttemptStatusErrored");
     expect(text).toContain("LDAP result code 53");
     expect(text).toContain("pamRotationSyncStateIndeterminate");
+  });
+
+  it("explains a recognised failure and carries the recorded reason on its own line", () => {
+    const fixture = render([
+      rotationJob({
+        attempts: [
+          rotationAttempt({
+            status: RotationAttemptStatus.Errored,
+            failureReason: "target_rejected: LDAP result code 50",
+          }),
+        ],
+      }),
+    ]);
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain("pamRotationFailureCauseInsufficientRights");
+    expect(text).toContain("pamRotationFailureReportedDetail target_rejected: LDAP result code 50");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
@@ -182,25 +182,6 @@ describe("RotationHistoryComponent", () => {
       expect((component as any).failureCauseLabelKey(failureReason)).toBeNull();
     });
   });
-
-  describe("explainedFailureDetail", () => {
-    it("returns the recorded reason when an explanation replaced it", () => {
-      setup([]);
-      expect(
-        (component as any).explainedFailureDetail("target_rejected: LDAP result code 50"),
-      ).toBe("target_rejected: LDAP result code 50");
-    });
-
-    it("returns null for an unrecognised reason", () => {
-      setup([]);
-      expect((component as any).explainedFailureDetail("flaky target")).toBeNull();
-    });
-
-    it("returns null when no reason was recorded", () => {
-      setup([]);
-      expect((component as any).explainedFailureDetail(undefined)).toBeNull();
-    });
-  });
 });
 
 describe("RotationHistoryComponent rendering", () => {
@@ -300,5 +281,22 @@ describe("RotationHistoryComponent rendering", () => {
     const text = fixture.nativeElement.textContent;
     expect(text).toContain("pamRotationFailureCauseInsufficientRights");
     expect(text).toContain("pamRotationFailureReportedDetail target_rejected: LDAP result code 50");
+  });
+
+  it("shows an unrecognised failure reason alone, with no explanation line", () => {
+    const fixture = render([
+      rotationJob({
+        attempts: [
+          rotationAttempt({
+            status: RotationAttemptStatus.Errored,
+            failureReason: "flaky target",
+          }),
+        ],
+      }),
+    ]);
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain("flaky target");
+    expect(text).not.toContain("pamRotationFailureReportedDetail");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.ts
@@ -125,4 +125,46 @@ export class RotationHistoryComponent {
         return "pamRotationSessionTerminationUnknown";
     }
   }
+
+  /**
+   * The i18n key explaining a failure reason in plain language, or `null` when the reason is not
+   * one this screen recognises.
+   *
+   * The reason is `<connector token>` or `<connector token>: <detail>`, composed server-side by
+   * ReportRotationFailedRequestModel.ToFailureReason. Matching is deliberately narrow: an
+   * explanation that is wrong about why an access change failed is worse than no explanation, so
+   * anything unrecognised falls back to the raw string the attempt recorded.
+   */
+  protected failureCauseLabelKey(failureReason: string): string | null {
+    const ldapResultCode = /\bLDAP\s+(?:result\s+|error\s+)?code\s+(\d{1,3})\b/i.exec(
+      failureReason,
+    )?.[1];
+    switch (ldapResultCode) {
+      case "19":
+        return "pamRotationFailureCausePasswordRejected";
+      case "32":
+        return "pamRotationFailureCauseAccountNotFound";
+      case "49":
+        return "pamRotationFailureCauseInvalidCredentials";
+      case "50":
+        return "pamRotationFailureCauseInsufficientRights";
+      case "53":
+        return "pamRotationFailureCauseDirectoryRefused";
+    }
+
+    const [errorCode] = failureReason.split(":", 1);
+    if (errorCode.trim().toLowerCase() === "target_unreachable") {
+      return "pamRotationFailureCauseTargetUnreachable";
+    }
+
+    return null;
+  }
+
+  /** The recorded reason, to show as secondary detail — only when an explanation replaced it. */
+  protected explainedFailureDetail(failureReason: string | undefined): string | null {
+    if (!failureReason || this.failureCauseLabelKey(failureReason) === null) {
+      return null;
+    }
+    return failureReason;
+  }
 }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.ts
@@ -159,12 +159,4 @@ export class RotationHistoryComponent {
 
     return null;
   }
-
-  /** The recorded reason, to show as secondary detail — only when an explanation replaced it. */
-  protected explainedFailureDetail(failureReason: string | undefined): string | null {
-    if (!failureReason || this.failureCauseLabelKey(failureReason) === null) {
-      return null;
-    }
-    return failureReason;
-  }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- No tracked issue key for this ticket. -->

## 📔 Objective

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`.

Rotation attempt rows now show a plain-language explanation for five known LDAP result codes and the connector's target-unreachable error, with the raw reason kept underneath instead of being the row's only text.

- `failureCauseLabelKey()` matches LDAP result codes `19`, `32`, `49`, `50`, `53` (via a regex on `LDAP result code` / `LDAP error code`) and the `target_unreachable` token; anything else returns `null` and the row falls back to the raw reason exactly as it renders today.
- When a cause is recognised, the template swaps the raw string for the mapped sentence and adds a muted line below the row: `Reported by the access connector: <raw reason>`.
- Drops `tw-truncate` from the attempt row's left column and the reason span so both lines render in full, and removes the two `[title]` tooltips that duplicated the now-visible text.
- Adds 7 new `en` locale keys (six cause sentences plus `pamRotationFailureReportedDetail`); no existing message text changed.
- Adds spec coverage for the mapping table and for both the mapped and raw-only render paths.

Sits on `pam/rotux-attempt-rows-labelled-columns`; `pam/rotux-access-connector-terminology` sits on top of it.

## 📸 Screenshots

Captured at 1440x1024, before on `pam/uat` and after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Daemons -> detail -> Recent activity

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-raw-ldap-code-as-failure-reason.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-raw-ldap-code-as-failure-reason.png" alt="after" width="460"> |

### Copy not yet approved

The designer has not signed off on this wording. Treat it as proposed, not settled.

- `pamRotationFailureCauseInsufficientRights`: "The access connector's account is not allowed to change this password. Grant it permission to reset the target account's password, then rotate again."
- `pamRotationFailureCauseInvalidCredentials`: "The target system rejected the access connector's sign in. Check the credentials the connector uses for this target system, then rotate again."
- `pamRotationFailureCausePasswordRejected`: "The target system rejected the new password. Check that this credential's password policy meets the target system's own password rules, then rotate again."
- `pamRotationFailureCauseAccountNotFound`: "The target system could not find the account to rotate. Check the account identity on this managed credential, then rotate again."
- `pamRotationFailureCauseDirectoryRefused`: "The target system refused to make the change. This commonly means the new password broke a password rule, or the connection to the target system was not encrypted."
- `pamRotationFailureCauseTargetUnreachable`: "The access connector could not reach the target system. Check the target system's address and that the connector can reach it on the network, then rotate again."
- `pamRotationFailureReportedDetail`: "Reported by the access connector: $REASON$"

### Known gaps

- `test:types` (the strict tsc pass) fails with 12 errors across 7 files. All 7 files are byte-identical to `pam/uat` (verified per file), so this is a pre-existing failure on trunk, not caused or worsened by this change.
