### PR TITLE
Users are shown 'daemon' everywhere after the server renamed it to access connector

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19227,6 +19227,9 @@
   "pamAccessConnectorDeleted": {
     "message": "Access connector deleted."
   },
+  "pamAccessConnectorRegisterTitle": {
+    "message": "Register access connector"
+  },
   "pamAccessConnectorNamePlaceholder": {
     "message": "e.g. On-prem production server"
   },
@@ -19263,7 +19266,7 @@
   "pamAccessConnectorStatusDisabled": {
     "message": "Disabled"
   },
-  "pamAccessConnectorToken": {
+  "pamAccessConnectorTokenTitle": {
     "message": "Access connector token"
   },
   "pamAccessConnectorTokenWarningTitle": {
@@ -19271,6 +19274,9 @@
   },
   "pamAccessConnectorTokenWarningBody": {
     "message": "This token is shown only once and cannot be retrieved later. Copy it and deliver it to the access connector operator out of band, then paste it into the access connector configuration file. If the token is lost, delete this access connector and register a new one."
+  },
+  "pamAccessConnectorTokenLabel": {
+    "message": "Access connector token"
   },
   "pamAccessConnectorTokenHint": {
     "message": "This token will not be shown again."

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18769,8 +18769,8 @@
   "pamRotationTabTargetSystems": {
     "message": "Target systems"
   },
-  "pamRotationTabDaemons": {
-    "message": "Daemons"
+  "pamRotationTabAccessConnectors": {
+    "message": "Access connectors"
   },
   "pamRotationConfigCreateTitle": {
     "message": "Add managed credential"
@@ -18957,8 +18957,8 @@
   "pamTargetSystemTemplateEntraSummary": {
     "message": "Bitwarden automatically rotates a Microsoft Entra ID application secret."
   },
-  "pamTargetSystemTemplateCustomScriptSummary": {
-    "message": "Bitwarden automatically rotates the credential by running your script on a registered daemon."
+  "pamTargetSystemTemplateCustomScriptSummaryConnector": {
+    "message": "Bitwarden automatically rotates the credential by running your script on a registered access connector."
   },
   "pamTargetSystemNoResults": {
     "message": "No target systems match your search."
@@ -19074,8 +19074,8 @@
   "pamTargetSystemSupportsSessionTermination": {
     "message": "Supports session termination"
   },
-  "pamTargetSystemSupportsSessionTerminationHint": {
-    "message": "When enabled, the daemon will terminate active sessions after a credential is rotated."
+  "pamTargetSystemSupportsSessionTerminationHintConnector": {
+    "message": "When enabled, the access connector will terminate active sessions after a credential is rotated."
   },
   "pamTargetSystemSessionTerminationSupported": {
     "message": "Supported"
@@ -19095,14 +19095,14 @@
   "pamTargetSystemSetupGuidanceTitle": {
     "message": "Finish setting up rotation"
   },
-  "pamTargetSystemSetupGuidanceAutomaticDaemon": {
-    "message": "On the Daemons tab, register a rotation daemon (or reuse an existing one) and assign this target system to it — the daemon performs the rotations."
+  "pamTargetSystemSetupGuidanceAutomaticConnector": {
+    "message": "On the Access connectors tab, register an access connector (or reuse an existing one) and assign this target system to it. The access connector performs the rotations."
   },
   "pamTargetSystemSetupGuidanceAutomaticCredential": {
     "message": "On the Managed credentials tab, add a credential for this target system, then set the account to rotate and a schedule."
   },
-  "pamTargetSystemSetupGuidanceManual": {
-    "message": "On the Managed credentials tab, add a credential for this target system. There is no daemon to connect — you rotate the credential by hand and record each rotation there."
+  "pamTargetSystemSetupGuidanceManualConnector": {
+    "message": "On the Managed credentials tab, add a credential for this target system. There is no access connector to connect, so you rotate the credential by hand and record each rotation there."
   },
   "pamTargetSystemNotFound": {
     "message": "Target system not found."
@@ -19110,47 +19110,47 @@
   "pamTargetSystemDiscardTitle": {
     "message": "Discard target system"
   },
-  "pamDaemonSearch": {
-    "message": "Search daemons"
+  "pamAccessConnectorSearch": {
+    "message": "Search access connectors"
   },
-  "pamDaemonNew": {
-    "message": "New daemon"
+  "pamAccessConnectorNew": {
+    "message": "New access connector"
   },
-  "pamDaemonRegister": {
-    "message": "Register daemon"
+  "pamAccessConnectorRegister": {
+    "message": "Register access connector"
   },
-  "pamDaemonEmptyStateTitle": {
-    "message": "No daemons registered"
+  "pamAccessConnectorEmptyStateTitle": {
+    "message": "No access connectors registered"
   },
-  "pamDaemonEmptyStateDescription": {
-    "message": "Register a daemon to start rotating credentials."
+  "pamAccessConnectorEmptyStateDescription": {
+    "message": "Register an access connector to start rotating credentials."
   },
-  "pamDaemonConnection": {
+  "pamAccessConnectorConnection": {
     "message": "Connection"
   },
-  "pamDaemonAssignments": {
+  "pamAccessConnectorAssignments": {
     "message": "Assigned targets"
   },
-  "pamDaemonConnected": {
+  "pamAccessConnectorConnected": {
     "message": "Connected"
   },
-  "pamDaemonOffline": {
+  "pamAccessConnectorOffline": {
     "message": "Offline"
   },
-  "pamDaemonAssignTarget": {
+  "pamAccessConnectorAssignTarget": {
     "message": "Assign to target"
   },
   "pamDaemonAssignTargetDisabled": {
     "message": "Can't assign a target system while this connector is disabled. Enable it first."
   },
-  "pamDaemonAssignTargetTitle": {
+  "pamAccessConnectorAssignTargetTitle": {
     "message": "Assign target system"
   },
-  "pamDaemonAssignTargetLabel": {
+  "pamAccessConnectorAssignTargetLabel": {
     "message": "Target system"
   },
-  "pamDaemonAssignNoOptions": {
-    "message": "All active automatic target systems are already assigned to this daemon."
+  "pamAccessConnectorAssignNoOptions": {
+    "message": "All active automatic target systems are already assigned to this access connector."
   },
   "pamDaemonAssignNoTargetSystems": {
     "message": "There are no active automatic target systems to assign. Create one on the Target systems tab, or set an existing one to active."
@@ -19158,13 +19158,13 @@
   "pamDaemonAssignGoToTargetSystems": {
     "message": "Go to Target systems"
   },
-  "pamDaemonAssignConfirm": {
+  "pamAccessConnectorAssignConfirm": {
     "message": "Assign"
   },
-  "pamDaemonAssigned": {
+  "pamAccessConnectorAssigned": {
     "message": "Target system assigned."
   },
-  "pamDaemonUnassign": {
+  "pamAccessConnectorUnassign": {
     "message": "Remove $NAME$",
     "placeholders": {
       "name": {
@@ -19173,11 +19173,11 @@
       }
     }
   },
-  "pamDaemonUnassignConfirmTitle": {
+  "pamAccessConnectorUnassignConfirmTitle": {
     "message": "Remove assignment?"
   },
-  "pamDaemonUnassignConfirmContent": {
-    "message": "Remove $NAME$ from this daemon? Active rotation jobs claimed by this daemon will continue to completion.",
+  "pamAccessConnectorUnassignConfirmContent": {
+    "message": "Remove $NAME$ from this access connector? Active rotation jobs claimed by this access connector will continue to completion.",
     "placeholders": {
       "name": {
         "content": "$1",
@@ -19185,19 +19185,19 @@
       }
     }
   },
-  "pamDaemonUnassigned": {
+  "pamAccessConnectorUnassigned": {
     "message": "Target system removed."
   },
-  "pamDaemonDisable": {
+  "pamAccessConnectorDisable": {
     "message": "Disable"
   },
-  "pamDaemonEnable": {
+  "pamAccessConnectorEnable": {
     "message": "Enable"
   },
-  "pamDaemonDisableConfirmTitle": {
-    "message": "Disable daemon?"
+  "pamAccessConnectorDisableConfirmTitle": {
+    "message": "Disable access connector?"
   },
-  "pamDaemonDisableConfirmContent": {
+  "pamAccessConnectorDisableConfirmContent": {
     "message": "Disable $NAME$? It stops claiming new rotation jobs and any jobs it is currently running are released. You can re-enable it later.",
     "placeholders": {
       "name": {
@@ -19206,17 +19206,17 @@
       }
     }
   },
-  "pamDaemonDisabled": {
-    "message": "Daemon disabled."
+  "pamAccessConnectorDisabled": {
+    "message": "Access connector disabled."
   },
-  "pamDaemonEnabled": {
-    "message": "Daemon enabled."
+  "pamAccessConnectorEnabled": {
+    "message": "Access connector enabled."
   },
-  "pamDaemonDeleteConfirmTitle": {
-    "message": "Delete daemon?"
+  "pamAccessConnectorDeleteConfirmTitle": {
+    "message": "Delete access connector?"
   },
-  "pamDaemonDeleteConfirmContent": {
-    "message": "Deleting $NAME$ is permanent and invalidates its credentials. This daemon held the organization key in memory — if you suspect a compromise, rotate the organization key as a remediation. Running rotation jobs are released. Register a new daemon to resume rotation.",
+  "pamAccessConnectorDeleteConfirmContent": {
+    "message": "Deleting $NAME$ is permanent and invalidates its credentials. This access connector held the organization key in memory. If you suspect a compromise, rotate the organization key as a remediation. Running rotation jobs are released. Register a new access connector to resume rotation.",
     "placeholders": {
       "name": {
         "content": "$1",
@@ -19224,68 +19224,68 @@
       }
     }
   },
-  "pamDaemonDeleted": {
-    "message": "Daemon deleted."
+  "pamAccessConnectorDeleted": {
+    "message": "Access connector deleted."
   },
-  "pamDaemonRegisterTitle": {
-    "message": "Register daemon"
+  "pamAccessConnectorRegisterTitle": {
+    "message": "Register access connector"
   },
-  "pamDaemonNamePlaceholder": {
+  "pamAccessConnectorNamePlaceholder": {
     "message": "e.g. On-prem production server"
   },
-  "pamDaemonNameHint": {
-    "message": "A descriptive name to identify this daemon. Max 200 characters."
+  "pamAccessConnectorNameHint": {
+    "message": "A descriptive name to identify this access connector. Max 200 characters."
   },
-  "pamDaemonRegistered": {
-    "message": "Daemon registered."
+  "pamAccessConnectorRegistered": {
+    "message": "Access connector registered."
   },
-  "pamDaemonNoResults": {
-    "message": "No daemons match your search."
+  "pamAccessConnectorNoResults": {
+    "message": "No access connectors match your search."
   },
-  "pamDaemonDetailTitle": {
-    "message": "Daemon"
+  "pamAccessConnectorDetailTitle": {
+    "message": "Access connector"
   },
-  "pamDaemonNotFound": {
-    "message": "Daemon not found."
+  "pamAccessConnectorNotFound": {
+    "message": "Access connector not found."
   },
-  "pamDaemonDetailsHeading": {
+  "pamAccessConnectorDetailsHeading": {
     "message": "Details"
   },
-  "pamDaemonActivityHeading": {
+  "pamAccessConnectorActivityHeading": {
     "message": "Recent activity"
   },
-  "pamDaemonActivityEmpty": {
+  "pamAccessConnectorActivityEmpty": {
     "message": "No rotation activity yet."
   },
   "pamDaemonDetailAssignDisabledTooltip": {
     "message": "Target systems can only be assigned while the status is Enabled."
   },
-  "pamDaemonStatusEnabled": {
+  "pamAccessConnectorStatusEnabled": {
     "message": "Enabled"
   },
-  "pamDaemonStatusDisabled": {
+  "pamAccessConnectorStatusDisabled": {
     "message": "Disabled"
   },
-  "pamDaemonTokenTitle": {
-    "message": "Daemon token"
+  "pamAccessConnectorTokenTitle": {
+    "message": "Access connector token"
   },
-  "pamDaemonTokenWarningTitle": {
+  "pamAccessConnectorTokenWarningTitle": {
     "message": "Save this token now"
   },
-  "pamDaemonTokenWarningBody": {
-    "message": "This token is shown only once and cannot be retrieved later. Copy it and deliver it to the daemon operator out of band — paste it into the daemon configuration file. If the token is lost, delete this daemon and register a new one."
+  "pamAccessConnectorTokenWarningBody": {
+    "message": "This token is shown only once and cannot be retrieved later. Copy it and deliver it to the access connector operator out of band, then paste it into the access connector configuration file. If the token is lost, delete this access connector and register a new one."
   },
-  "pamDaemonTokenLabel": {
-    "message": "Daemon token"
+  "pamAccessConnectorTokenLabel": {
+    "message": "Access connector token"
   },
-  "pamDaemonTokenHint": {
+  "pamAccessConnectorTokenHint": {
     "message": "This token will not be shown again."
   },
-  "pamDaemonTokenCopy": {
+  "pamAccessConnectorTokenCopy": {
     "message": "Copy token"
   },
-  "pamDaemonTokenCopied": {
-    "message": "Daemon token copied."
+  "pamAccessConnectorTokenCopied": {
+    "message": "Access connector token copied."
   },
   "pamRotationConfigNew": {
     "message": "New managed credential"
@@ -19401,8 +19401,8 @@
   "pamRotationConfigRemoveManagedCredential": {
     "message": "Remove managed credential"
   },
-  "pamRotationConfigRemoveLockedContent": {
-    "message": "A rotation job is currently in progress. You can remove the rotation configuration once the daemon finishes it — or once it times out. Pausing only stops new jobs; it does not cancel the one already running."
+  "pamRotationConfigRemoveLockedContentConnector": {
+    "message": "A rotation job is currently in progress. You can remove the rotation configuration once the access connector finishes it, or once it times out. Pausing only stops new jobs; it does not cancel the one already running."
   },
   "pamRotationConfigCreateHeading": {
     "message": "Credential details"
@@ -19437,8 +19437,8 @@
   "pamRotationConfigAccountIdentity": {
     "message": "Account identity"
   },
-  "pamRotationConfigAccountIdentityHint": {
-    "message": "The account to rotate in the target system, e.g. a UPN, SQL login, or script argument. Passed to the daemon as-is."
+  "pamRotationConfigAccountIdentityHintConnector": {
+    "message": "The account to rotate in the target system, e.g. a UPN, SQL login, or script argument. Passed to the access connector as-is."
   },
   "pamRotationConfigTerminateSessions": {
     "message": "Terminate active sessions after rotation"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19227,9 +19227,6 @@
   "pamAccessConnectorDeleted": {
     "message": "Access connector deleted."
   },
-  "pamAccessConnectorRegisterTitle": {
-    "message": "Register access connector"
-  },
   "pamAccessConnectorNamePlaceholder": {
     "message": "e.g. On-prem production server"
   },
@@ -19266,7 +19263,7 @@
   "pamAccessConnectorStatusDisabled": {
     "message": "Disabled"
   },
-  "pamAccessConnectorTokenTitle": {
+  "pamAccessConnectorToken": {
     "message": "Access connector token"
   },
   "pamAccessConnectorTokenWarningTitle": {
@@ -19274,9 +19271,6 @@
   },
   "pamAccessConnectorTokenWarningBody": {
     "message": "This token is shown only once and cannot be retrieved later. Copy it and deliver it to the access connector operator out of band, then paste it into the access connector configuration file. If the token is lost, delete this access connector and register a new one."
-  },
-  "pamAccessConnectorTokenLabel": {
-    "message": "Access connector token"
   },
   "pamAccessConnectorTokenHint": {
     "message": "This token will not be shown again."

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" bit-dialog dialogSize="default">
   <ng-container bitDialogTitle>
-    {{ "pamDaemonAssignTargetTitle" | i18n }}
+    {{ "pamAccessConnectorAssignTargetTitle" | i18n }}
     <span class="tw-text-sm tw-normal-case tw-text-muted">{{ params.daemon.name }}</span>
   </ng-container>
 
@@ -16,10 +16,10 @@
         >{{ "pamDaemonAssignGoToTargetSystems" | i18n }}</a
       >
     } @else if (params.options.length === 0) {
-      <p class="tw-text-muted">{{ "pamDaemonAssignNoOptions" | i18n }}</p>
+      <p class="tw-text-muted">{{ "pamAccessConnectorAssignNoOptions" | i18n }}</p>
     } @else {
       <bit-form-field>
-        <bit-label>{{ "pamDaemonAssignTargetLabel" | i18n }}</bit-label>
+        <bit-label>{{ "pamAccessConnectorAssignTargetLabel" | i18n }}</bit-label>
         <bit-select formControlName="targetSystemId" id="assign-target-dialog_select_target">
           @for (system of params.options; track system.id) {
             <bit-option [value]="system.id" [label]="system.name"></bit-option>
@@ -38,7 +38,7 @@
         (click)="confirm()"
         id="assign-target-dialog_button_confirm"
       >
-        {{ "pamDaemonAssignConfirm" | i18n }}
+        {{ "pamAccessConnectorAssignConfirm" | i18n }}
       </button>
     }
     <button

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.spec.ts
@@ -76,7 +76,7 @@ describe("AssignTargetDialogComponent", () => {
   it("shows the all-assigned message when every eligible target is already assigned", async () => {
     await createComponent([]);
     const text = fixture.nativeElement.textContent as string;
-    expect(text).toContain("pamDaemonAssignNoOptions");
+    expect(text).toContain("pamAccessConnectorAssignNoOptions");
     expect(text).not.toContain("pamDaemonAssignNoTargetSystems");
   });
 
@@ -84,7 +84,7 @@ describe("AssignTargetDialogComponent", () => {
     await createComponent([], true);
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain("pamDaemonAssignNoTargetSystems");
-    expect(text).not.toContain("pamDaemonAssignNoOptions");
+    expect(text).not.toContain("pamAccessConnectorAssignNoOptions");
   });
 
   it("links to the Target systems tab when none exist", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -1,6 +1,6 @@
 <bit-header [title]="titleText()" icon="bwi-terminal">
   <bit-breadcrumbs slot="breadcrumbs">
-    <bit-breadcrumb [route]="['..']">{{ "pamRotationTabDaemons" | i18n }}</bit-breadcrumb>
+    <bit-breadcrumb [route]="['..']">{{ "pamRotationTabAccessConnectors" | i18n }}</bit-breadcrumb>
   </bit-breadcrumbs>
   @if (daemon()) {
     @if (enabled()) {
@@ -11,7 +11,7 @@
         [bitAction]="disable"
         id="daemon-detail_button_disable"
       >
-        {{ "pamDaemonDisable" | i18n }}
+        {{ "pamAccessConnectorDisable" | i18n }}
       </button>
     } @else {
       <button
@@ -21,7 +21,7 @@
         [bitAction]="enable"
         id="daemon-detail_button_enable"
       >
-        {{ "pamDaemonEnable" | i18n }}
+        {{ "pamAccessConnectorEnable" | i18n }}
       </button>
     }
     <button
@@ -43,33 +43,35 @@
     <!-- Details -->
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "pamDaemonDetailsHeading" | i18n }}</h2>
+        <h2 bitTypography="h5">{{ "pamAccessConnectorDetailsHeading" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <div class="tw-mb-4">
           <p bitTypography="helper" class="tw-mb-1 tw-font-semibold">{{ "status" | i18n }}</p>
           @if (d.connector.status === DaemonStatus.Enabled) {
-            <span bitBadge variant="success">{{ "pamDaemonStatusEnabled" | i18n }}</span>
+            <span bitBadge variant="success">{{ "pamAccessConnectorStatusEnabled" | i18n }}</span>
           } @else {
-            <span bitBadge variant="secondary">{{ "pamDaemonStatusDisabled" | i18n }}</span>
+            <span bitBadge variant="secondary">{{
+              "pamAccessConnectorStatusDisabled" | i18n
+            }}</span>
           }
         </div>
 
         <div class="tw-mb-4">
           <p bitTypography="helper" class="tw-mb-1 tw-font-semibold">
-            {{ "pamDaemonConnection" | i18n }}
+            {{ "pamAccessConnectorConnection" | i18n }}
           </p>
           @if (d.connector.isConnected) {
-            <span bitBadge variant="success">{{ "pamDaemonConnected" | i18n }}</span>
+            <span bitBadge variant="success">{{ "pamAccessConnectorConnected" | i18n }}</span>
           } @else {
-            <span bitBadge variant="secondary">{{ "pamDaemonOffline" | i18n }}</span>
+            <span bitBadge variant="secondary">{{ "pamAccessConnectorOffline" | i18n }}</span>
           }
         </div>
 
         <div>
           <div class="tw-mb-1 tw-flex tw-items-center tw-gap-3">
             <p bitTypography="helper" class="tw-m-0 tw-font-semibold">
-              {{ "pamDaemonAssignments" | i18n }}
+              {{ "pamAccessConnectorAssignments" | i18n }}
             </p>
             <button
               type="button"
@@ -82,7 +84,7 @@
               id="daemon-detail_button_assign"
               #assignButton
             >
-              {{ "pamDaemonAssignTarget" | i18n }}
+              {{ "pamAccessConnectorAssignTarget" | i18n }}
             </button>
           </div>
           @if (assignments().length === 0) {
@@ -97,7 +99,7 @@
                     bitIconButton="bwi-minus-circle"
                     size="small"
                     [disabled]="unassigning()"
-                    label="{{ 'pamDaemonUnassign' | i18n: assignment.name }}"
+                    label="{{ 'pamAccessConnectorUnassign' | i18n: assignment.name }}"
                     (click)="unassign(assignment)"
                     id="daemon-detail_button_unassign-{{ assignment.id }}"
                   ></button>
@@ -112,14 +114,14 @@
     <!-- Recent activity -->
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "pamDaemonActivityHeading" | i18n }}</h2>
+        <h2 bitTypography="h5">{{ "pamAccessConnectorActivityHeading" | i18n }}</h2>
       </bit-section-header>
       @if (d.jobs.length > 0) {
         <app-rotation-history [jobs]="d.jobs"></app-rotation-history>
       } @else {
         <bit-card>
           <p bitTypography="body2" class="tw-m-0 tw-text-muted">
-            {{ "pamDaemonActivityEmpty" | i18n }}
+            {{ "pamAccessConnectorActivityEmpty" | i18n }}
           </p>
         </bit-card>
       }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -263,7 +263,10 @@ export class DaemonDetailComponent {
     try {
       const confirmed = await this.dialogService.openSimpleDialog({
         title: { key: "pamAccessConnectorUnassignConfirmTitle" },
-        content: { key: "pamAccessConnectorUnassignConfirmContent", placeholders: [assignment.name] },
+        content: {
+          key: "pamAccessConnectorUnassignConfirmContent",
+          placeholders: [assignment.name],
+        },
         acceptButtonText: { key: "remove" },
         cancelButtonText: { key: "cancel" },
         type: "warning",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -157,9 +157,9 @@ export class DaemonDetailComponent {
       return;
     }
     const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonDisableConfirmTitle" },
-      content: { key: "pamDaemonDisableConfirmContent", placeholders: [connector.name] },
-      acceptButtonText: { key: "pamDaemonDisable" },
+      title: { key: "pamAccessConnectorDisableConfirmTitle" },
+      content: { key: "pamAccessConnectorDisableConfirmContent", placeholders: [connector.name] },
+      acceptButtonText: { key: "pamAccessConnectorDisable" },
       cancelButtonText: { key: "cancel" },
       type: "warning",
     });
@@ -171,7 +171,7 @@ export class DaemonDetailComponent {
       this.patchStatus(DaemonStatus.Disabled);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonDisabled"),
+        message: this.i18nService.t("pamAccessConnectorDisabled"),
       });
     } catch (e) {
       this.showError(e);
@@ -189,7 +189,7 @@ export class DaemonDetailComponent {
       this.patchStatus(DaemonStatus.Enabled);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonEnabled"),
+        message: this.i18nService.t("pamAccessConnectorEnabled"),
       });
     } catch (e) {
       this.showError(e);
@@ -203,8 +203,8 @@ export class DaemonDetailComponent {
       return;
     }
     const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonDeleteConfirmTitle" },
-      content: { key: "pamDaemonDeleteConfirmContent", placeholders: [connector.name] },
+      title: { key: "pamAccessConnectorDeleteConfirmTitle" },
+      content: { key: "pamAccessConnectorDeleteConfirmContent", placeholders: [connector.name] },
       acceptButtonText: { key: "delete" },
       cancelButtonText: { key: "cancel" },
       type: "danger",
@@ -216,7 +216,7 @@ export class DaemonDetailComponent {
       await this.rotationSdk.deleteConnector(this.organizationId, connector.id);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonDeleted"),
+        message: this.i18nService.t("pamAccessConnectorDeleted"),
       });
       await this.navigateToList();
     } catch (e) {
@@ -246,7 +246,7 @@ export class DaemonDetailComponent {
       this.patchAssignments((ids) => [...ids, targetSystemId]);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonAssigned"),
+        message: this.i18nService.t("pamAccessConnectorAssigned"),
       });
     } catch (e) {
       this.showError(e);
@@ -262,8 +262,8 @@ export class DaemonDetailComponent {
     this.unassigning.set(true);
     try {
       const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "pamDaemonUnassignConfirmTitle" },
-        content: { key: "pamDaemonUnassignConfirmContent", placeholders: [assignment.name] },
+        title: { key: "pamAccessConnectorUnassignConfirmTitle" },
+        content: { key: "pamAccessConnectorUnassignConfirmContent", placeholders: [assignment.name] },
         acceptButtonText: { key: "remove" },
         cancelButtonText: { key: "cancel" },
         type: "warning",
@@ -276,7 +276,7 @@ export class DaemonDetailComponent {
       this.assignButton()?.nativeElement.focus();
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonUnassigned"),
+        message: this.i18nService.t("pamAccessConnectorUnassigned"),
       });
     } catch (e) {
       this.showError(e);
@@ -306,7 +306,7 @@ export class DaemonDetailComponent {
     } catch {
       this.toastService.showToast({
         variant: "error",
-        message: this.i18nService.t("pamDaemonNotFound"),
+        message: this.i18nService.t("pamAccessConnectorNotFound"),
       });
       await this.navigateToList();
       return null;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" [bitSubmit]="submit" bit-dialog dialogSize="default">
   <ng-container bitDialogTitle>
-    {{ "pamAccessConnectorRegister" | i18n }}
+    {{ "pamAccessConnectorRegisterTitle" | i18n }}
   </ng-container>
 
   <div bitDialogContent>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" [bitSubmit]="submit" bit-dialog dialogSize="default">
   <ng-container bitDialogTitle>
-    {{ "pamAccessConnectorRegisterTitle" | i18n }}
+    {{ "pamAccessConnectorRegister" | i18n }}
   </ng-container>
 
   <div bitDialogContent>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" [bitSubmit]="submit" bit-dialog dialogSize="default">
   <ng-container bitDialogTitle>
-    {{ "pamDaemonRegisterTitle" | i18n }}
+    {{ "pamAccessConnectorRegisterTitle" | i18n }}
   </ng-container>
 
   <div bitDialogContent>
@@ -10,9 +10,9 @@
         bitInput
         formControlName="name"
         id="daemon-register-dialog_input_name"
-        [placeholder]="'pamDaemonNamePlaceholder' | i18n"
+        [placeholder]="'pamAccessConnectorNamePlaceholder' | i18n"
       />
-      <bit-hint>{{ "pamDaemonNameHint" | i18n }}</bit-hint>
+      <bit-hint>{{ "pamAccessConnectorNameHint" | i18n }}</bit-hint>
     </bit-form-field>
   </div>
 
@@ -24,7 +24,7 @@
       bitFormButton
       id="daemon-register-dialog_button_submit"
     >
-      {{ "pamDaemonRegister" | i18n }}
+      {{ "pamAccessConnectorRegister" | i18n }}
     </button>
     <button
       type="button"

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
@@ -1,5 +1,5 @@
 <bit-dialog
-  [title]="'pamAccessConnectorTokenTitle' | i18n"
+  [title]="'pamAccessConnectorToken' | i18n"
   [subtitle]="params.daemonName"
   dialogSize="large"
 >
@@ -9,7 +9,7 @@
     </bit-callout>
 
     <bit-form-field class="tw-mb-0">
-      <bit-label>{{ "pamAccessConnectorTokenLabel" | i18n }}</bit-label>
+      <bit-label>{{ "pamAccessConnectorToken" | i18n }}</bit-label>
       <input
         bitInput
         type="text"

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
@@ -1,15 +1,15 @@
 <bit-dialog
-  [title]="'pamDaemonTokenTitle' | i18n"
+  [title]="'pamAccessConnectorTokenTitle' | i18n"
   [subtitle]="params.daemonName"
   dialogSize="large"
 >
   <ng-container bitDialogContent>
-    <bit-callout type="warning" [title]="'pamDaemonTokenWarningTitle' | i18n">
-      {{ "pamDaemonTokenWarningBody" | i18n }}
+    <bit-callout type="warning" [title]="'pamAccessConnectorTokenWarningTitle' | i18n">
+      {{ "pamAccessConnectorTokenWarningBody" | i18n }}
     </bit-callout>
 
     <bit-form-field class="tw-mb-0">
-      <bit-label>{{ "pamDaemonTokenLabel" | i18n }}</bit-label>
+      <bit-label>{{ "pamAccessConnectorTokenLabel" | i18n }}</bit-label>
       <input
         bitInput
         type="text"
@@ -22,11 +22,11 @@
         type="button"
         bitIconButton="bwi-clone"
         bitSuffix
-        [label]="'pamDaemonTokenCopy' | i18n"
+        [label]="'pamAccessConnectorTokenCopy' | i18n"
         (click)="copyToken()"
         id="daemon-token-dialog_button_copy"
       ></button>
-      <bit-hint>{{ "pamDaemonTokenHint" | i18n }}</bit-hint>
+      <bit-hint>{{ "pamAccessConnectorTokenHint" | i18n }}</bit-hint>
     </bit-form-field>
   </ng-container>
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
@@ -1,5 +1,5 @@
 <bit-dialog
-  [title]="'pamAccessConnectorToken' | i18n"
+  [title]="'pamAccessConnectorTokenTitle' | i18n"
   [subtitle]="params.daemonName"
   dialogSize="large"
 >
@@ -9,7 +9,7 @@
     </bit-callout>
 
     <bit-form-field class="tw-mb-0">
-      <bit-label>{{ "pamAccessConnectorToken" | i18n }}</bit-label>
+      <bit-label>{{ "pamAccessConnectorTokenLabel" | i18n }}</bit-label>
       <input
         bitInput
         type="text"

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.ts
@@ -57,7 +57,7 @@ export class DaemonTokenDialogComponent {
     this.platformUtilsService.copyToClipboard(this.params.token);
     this.toastService.showToast({
       variant: "success",
-      message: this.i18nService.t("pamDaemonTokenCopied"),
+      message: this.i18nService.t("pamAccessConnectorTokenCopied"),
     });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -1,7 +1,7 @@
 <div class="tw-mb-4">
   <bit-search
     class="tw-max-w-md"
-    [placeholder]="'pamDaemonSearch' | i18n"
+    [placeholder]="'pamAccessConnectorSearch' | i18n"
     [formControl]="searchControl"
   ></bit-search>
 </div>
@@ -13,8 +13,8 @@
 } @else if (totalRows() === 0) {
   <bit-status-lockup>
     <bit-svg slot="graphic" [content]="noItemsIcon"></bit-svg>
-    <span slot="title">{{ "pamDaemonEmptyStateTitle" | i18n }}</span>
-    <span slot="description">{{ "pamDaemonEmptyStateDescription" | i18n }}</span>
+    <span slot="title">{{ "pamAccessConnectorEmptyStateTitle" | i18n }}</span>
+    <span slot="description">{{ "pamAccessConnectorEmptyStateDescription" | i18n }}</span>
     <button
       slot="button"
       type="button"
@@ -23,7 +23,7 @@
       [bitAction]="registerDaemon"
       id="daemons-tab_button_register-empty"
     >
-      {{ "pamDaemonNew" | i18n }}
+      {{ "pamAccessConnectorNew" | i18n }}
     </button>
   </bit-status-lockup>
 } @else {
@@ -32,8 +32,8 @@
       <tr>
         <th bitCell bitSortable="name">{{ "name" | i18n }}</th>
         <th bitCell>{{ "status" | i18n }}</th>
-        <th bitCell>{{ "pamDaemonConnection" | i18n }}</th>
-        <th bitCell>{{ "pamDaemonAssignments" | i18n }}</th>
+        <th bitCell>{{ "pamAccessConnectorConnection" | i18n }}</th>
+        <th bitCell>{{ "pamAccessConnectorAssignments" | i18n }}</th>
         <th bitCell class="tw-w-0"></th>
       </tr>
     </ng-container>
@@ -65,9 +65,9 @@
         <!-- Connection liveness -->
         <td bitCell>
           @if (r.isConnected) {
-            <span bitBadge variant="success">{{ "pamDaemonConnected" | i18n }}</span>
+            <span bitBadge variant="success">{{ "pamAccessConnectorConnected" | i18n }}</span>
           } @else {
-            <span bitBadge variant="secondary">{{ "pamDaemonOffline" | i18n }}</span>
+            <span bitBadge variant="secondary">{{ "pamAccessConnectorOffline" | i18n }}</span>
           }
         </td>
 
@@ -108,7 +108,7 @@
               id="daemons-tab_button_assign-{{ r.id }}"
             >
               <bit-icon name="bwi-plus-circle" class="tw-text-muted"></bit-icon>
-              {{ "pamDaemonAssignTarget" | i18n }}
+              {{ "pamAccessConnectorAssignTarget" | i18n }}
             </button>
             @if (r.daemon.assignedTargetSystemIds.length > 0) {
               @for (
@@ -123,19 +123,19 @@
                   (click)="unassign(r, assignmentId, r.assignmentNames[i])"
                 >
                   <bit-icon name="bwi-minus-circle" class="tw-text-muted"></bit-icon>
-                  {{ "pamDaemonUnassign" | i18n: r.assignmentNames[i] }}
+                  {{ "pamAccessConnectorUnassign" | i18n: r.assignmentNames[i] }}
                 </button>
               }
             }
             @if (r.enabled) {
               <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="disable(r)">
                 <bit-icon name="bwi-circle" class="tw-text-muted"></bit-icon>
-                {{ "pamDaemonDisable" | i18n }}
+                {{ "pamAccessConnectorDisable" | i18n }}
               </button>
             } @else {
               <button type="button" bitMenuItem [disabled]="isRowBusy(r.id)" (click)="enable(r)">
                 <bit-icon name="bwi-check-circle" class="tw-text-muted"></bit-icon>
-                {{ "pamDaemonEnable" | i18n }}
+                {{ "pamAccessConnectorEnable" | i18n }}
               </button>
             }
             <button
@@ -154,7 +154,7 @@
       @if (dataSource.filteredData.length === 0) {
         <tr bitRow>
           <td bitCell colspan="5" class="tw-py-6 tw-text-center tw-text-muted">
-            {{ "pamDaemonNoResults" | i18n }}
+            {{ "pamAccessConnectorNoResults" | i18n }}
           </td>
         </tr>
       }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -34,7 +34,7 @@ describe("DaemonsTabComponent", () => {
     return {
       id,
       name,
-      statusLabelKey: "pamDaemonStatusEnabled",
+      statusLabelKey: "pamAccessConnectorStatusEnabled",
       isConnected: true,
       assignmentNames: [],
       enabled: true,
@@ -480,7 +480,7 @@ describe("DaemonsTabComponent", () => {
       const el = fixture.nativeElement as HTMLElement;
       expect(el.querySelector("pam-rotation-load-error")).not.toBeNull();
       expect(el.textContent).toContain("pamRotationListLoadErrorTitle");
-      expect(el.textContent).not.toContain("pamDaemonEmptyStateTitle");
+      expect(el.textContent).not.toContain("pamAccessConnectorEmptyStateTitle");
     });
 
     it("retries both loads from the error state", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -154,7 +154,7 @@ export class DaemonsTabComponent {
       await this.daemonsService.registerCompleted(orgId);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonRegistered"),
+        message: this.i18nService.t("pamAccessConnectorRegistered"),
       });
     }
   };
@@ -187,7 +187,7 @@ export class DaemonsTabComponent {
         await this.daemonsService.assign(row.daemon, asUuid<TargetSystemId>(targetSystemId));
         this.toastService.showToast({
           variant: "success",
-          message: this.i18nService.t("pamDaemonAssigned"),
+          message: this.i18nService.t("pamAccessConnectorAssigned"),
         });
       } catch (e) {
         this.showError(e);
@@ -201,8 +201,8 @@ export class DaemonsTabComponent {
   ): Promise<void> =>
     this.busyRows.run(row.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "pamDaemonUnassignConfirmTitle" },
-        content: { key: "pamDaemonUnassignConfirmContent", placeholders: [targetName] },
+        title: { key: "pamAccessConnectorUnassignConfirmTitle" },
+        content: { key: "pamAccessConnectorUnassignConfirmContent", placeholders: [targetName] },
         acceptButtonText: { key: "remove" },
         cancelButtonText: { key: "cancel" },
         type: "warning",
@@ -214,7 +214,7 @@ export class DaemonsTabComponent {
         await this.daemonsService.unassign(row.daemon, asUuid<TargetSystemId>(targetSystemId));
         this.toastService.showToast({
           variant: "success",
-          message: this.i18nService.t("pamDaemonUnassigned"),
+          message: this.i18nService.t("pamAccessConnectorUnassigned"),
         });
       } catch (e) {
         this.showError(e);
@@ -224,9 +224,9 @@ export class DaemonsTabComponent {
   protected readonly disable = (row: DaemonRow): Promise<void> =>
     this.busyRows.run(row.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "pamDaemonDisableConfirmTitle" },
-        content: { key: "pamDaemonDisableConfirmContent", placeholders: [row.name] },
-        acceptButtonText: { key: "pamDaemonDisable" },
+        title: { key: "pamAccessConnectorDisableConfirmTitle" },
+        content: { key: "pamAccessConnectorDisableConfirmContent", placeholders: [row.name] },
+        acceptButtonText: { key: "pamAccessConnectorDisable" },
         cancelButtonText: { key: "cancel" },
         type: "warning",
       });
@@ -237,7 +237,7 @@ export class DaemonsTabComponent {
         await this.daemonsService.setEnabled(row.daemon, false);
         this.toastService.showToast({
           variant: "success",
-          message: this.i18nService.t("pamDaemonDisabled"),
+          message: this.i18nService.t("pamAccessConnectorDisabled"),
         });
       } catch (e) {
         this.showError(e);
@@ -250,7 +250,7 @@ export class DaemonsTabComponent {
         await this.daemonsService.setEnabled(row.daemon, true);
         this.toastService.showToast({
           variant: "success",
-          message: this.i18nService.t("pamDaemonEnabled"),
+          message: this.i18nService.t("pamAccessConnectorEnabled"),
         });
       } catch (e) {
         this.showError(e);
@@ -260,8 +260,8 @@ export class DaemonsTabComponent {
   protected readonly confirmDelete = (row: DaemonRow): Promise<void> =>
     this.busyRows.run(row.id, async () => {
       const confirmed = await this.dialogService.openSimpleDialog({
-        title: { key: "pamDaemonDeleteConfirmTitle" },
-        content: { key: "pamDaemonDeleteConfirmContent", placeholders: [row.name] },
+        title: { key: "pamAccessConnectorDeleteConfirmTitle" },
+        content: { key: "pamAccessConnectorDeleteConfirmContent", placeholders: [row.name] },
         acceptButtonText: { key: "delete" },
         cancelButtonText: { key: "cancel" },
         type: "danger",
@@ -273,7 +273,7 @@ export class DaemonsTabComponent {
         await this.daemonsService.delete(row.daemon);
         this.toastService.showToast({
           variant: "success",
-          message: this.i18nService.t("pamDaemonDeleted"),
+          message: this.i18nService.t("pamAccessConnectorDeleted"),
         });
       } catch (e) {
         this.showError(e);

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.spec.ts
@@ -151,18 +151,18 @@ describe("DaemonsService", () => {
       expect(rows[0].canAssign).toBe(false);
     });
 
-    it("uses pamDaemonStatusEnabled key for enabled daemons", async () => {
+    it("uses pamAccessConnectorStatusEnabled key for enabled connectors", async () => {
       rotationSdk.listConnectors.mockResolvedValue([makeDaemon({ status: DaemonStatus.Enabled })]);
       await service.load(orgId);
       const rows = await firstValue(service.rows$);
-      expect(rows[0].statusLabelKey).toBe("pamDaemonStatusEnabled");
+      expect(rows[0].statusLabelKey).toBe("pamAccessConnectorStatusEnabled");
     });
 
-    it("uses pamDaemonStatusDisabled key for disabled daemons", async () => {
+    it("uses pamAccessConnectorStatusDisabled key for disabled connectors", async () => {
       rotationSdk.listConnectors.mockResolvedValue([makeDaemon({ status: DaemonStatus.Disabled })]);
       await service.load(orgId);
       const rows = await firstValue(service.rows$);
-      expect(rows[0].statusLabelKey).toBe("pamDaemonStatusDisabled");
+      expect(rows[0].statusLabelKey).toBe("pamAccessConnectorStatusDisabled");
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
@@ -22,8 +22,7 @@ import { TargetSystemsService } from "../target-systems/target-systems.service";
 export type DaemonRow = {
   id: AccessConnectorId;
   name: string;
-  /** i18n key for the status badge label: pamAccessConnectorStatusEnabled | pamAccessConnectorStatusDisabled. */
-  statusLabelKey: string;
+  statusLabelKey: "pamAccessConnectorStatusEnabled" | "pamAccessConnectorStatusDisabled";
   isConnected: boolean;
   /** Target system names for the assignment badges, falling back to the raw ID when unresolved. */
   assignmentNames: string[];

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
@@ -22,7 +22,7 @@ import { TargetSystemsService } from "../target-systems/target-systems.service";
 export type DaemonRow = {
   id: AccessConnectorId;
   name: string;
-  /** i18n key for the status badge label: pamDaemonStatusEnabled | pamDaemonStatusDisabled. */
+  /** i18n key for the status badge label: pamAccessConnectorStatusEnabled | pamAccessConnectorStatusDisabled. */
   statusLabelKey: string;
   isConnected: boolean;
   /** Target system names for the assignment badges, falling back to the raw ID when unresolved. */
@@ -240,8 +240,8 @@ export class DaemonsService {
       name: daemon.name,
       statusLabelKey:
         daemon.status === DaemonStatus.Enabled
-          ? "pamDaemonStatusEnabled"
-          : "pamDaemonStatusDisabled",
+          ? "pamAccessConnectorStatusEnabled"
+          : "pamAccessConnectorStatusDisabled",
       isConnected: daemon.isConnected,
       assignmentNames: daemon.assignedTargetSystemIds.map(
         (id) => systemById.get(id)?.name ?? String(id),

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
@@ -48,7 +48,7 @@
             id="rotation-config-edit_input_account-identity"
             formControlName="accountIdentity"
           />
-          <bit-hint>{{ "pamRotationConfigAccountIdentityHint" | i18n }}</bit-hint>
+          <bit-hint>{{ "pamRotationConfigAccountIdentityHintConnector" | i18n }}</bit-hint>
         </bit-form-field>
 
         <bit-form-control>
@@ -195,7 +195,7 @@
                   id="rotation-config-edit_input_account-identity-edit"
                   formControlName="accountIdentity"
                 />
-                <bit-hint>{{ "pamRotationConfigAccountIdentityHint" | i18n }}</bit-hint>
+                <bit-hint>{{ "pamRotationConfigAccountIdentityHintConnector" | i18n }}</bit-hint>
               </bit-form-field>
 
               <bit-form-control disableMargin>
@@ -252,7 +252,7 @@
           </p>
           @if (detail.config.hasActiveJob) {
             <bit-callout type="info" class="tw-mb-3">
-              {{ "pamRotationConfigRemoveLockedContent" | i18n }}
+              {{ "pamRotationConfigRemoveLockedContentConnector" | i18n }}
             </bit-callout>
           }
           <button

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.html
@@ -9,7 +9,7 @@
           [bitAction]="registerDaemon"
           id="rotation-shell_button_new-daemon"
         >
-          {{ "pamDaemonNew" | i18n }}
+          {{ "pamAccessConnectorNew" | i18n }}
         </button>
       }
     }
@@ -41,7 +41,7 @@
     }
   }
   <bit-tab-nav-bar slot="tabs" [label]="'pamRotationTitle' | i18n">
-    <bit-tab-link route="daemons">{{ "pamRotationTabDaemons" | i18n }}</bit-tab-link>
+    <bit-tab-link route="daemons">{{ "pamRotationTabAccessConnectors" | i18n }}</bit-tab-link>
     <bit-tab-link route="target-systems">{{ "pamRotationTabTargetSystems" | i18n }}</bit-tab-link>
     <bit-tab-link route="managed-credentials" [berryValue]="awaitingManualCount()">{{
       "pamRotationTabManagedCredentials" | i18n

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
@@ -93,7 +93,7 @@ describe("RotationShellComponent", () => {
       (fixture.nativeElement as HTMLElement).querySelectorAll("bit-tab-link"),
     ).map((el) => el.textContent?.trim());
     expect(labels).toEqual([
-      "pamRotationTabDaemons",
+      "pamRotationTabAccessConnectors",
       "pamRotationTabTargetSystems",
       "pamRotationTabManagedCredentials",
     ]);

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.ts
@@ -112,7 +112,7 @@ export class RotationShellComponent {
       await this.daemonsService.registerCompleted(orgId);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonRegistered"),
+        message: this.i18nService.t("pamAccessConnectorRegistered"),
       });
     }
   };

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.routes.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.routes.ts
@@ -55,7 +55,7 @@ export const rotationRoutes: Routes = [
   {
     path: "daemons/:daemonId",
     component: DaemonDetailComponent,
-    data: { titleId: "pamDaemonDetailTitle" },
+    data: { titleId: "pamAccessConnectorDetailTitle" },
   },
   {
     path: "",
@@ -66,7 +66,7 @@ export const rotationRoutes: Routes = [
       {
         path: "daemons",
         component: DaemonsTabComponent,
-        data: { titleId: "pamRotationTabDaemons" },
+        data: { titleId: "pamRotationTabAccessConnectors" },
       },
       {
         path: "target-systems",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
@@ -159,11 +159,9 @@ export const QuartzSchedulePreset = Object.freeze({
 export type QuartzSchedulePreset = SdkQuartzSchedulePreset;
 
 /**
- * The UI's name for {@link AccessConnectorStatus}.
- *
- * The server, the SDK and every user-facing string say *access connector*. The alias survives
- * because this feature's identifiers are named `Daemon*` (`DaemonRow`, `DaemonsService`, the
- * `daemons/` directory and route segment), and the status type reads alongside them.
+ * {@link AccessConnectorStatus} under this feature's local `Daemon*` naming (`DaemonRow`,
+ * `DaemonsService`, the `daemons/` directory and route segment). Only those identifiers still say
+ * daemon; every user-facing string says *access connector*.
  */
 export const DaemonStatus = AccessConnectorStatus;
 export type DaemonStatus = AccessConnectorStatus;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
@@ -161,9 +161,9 @@ export type QuartzSchedulePreset = SdkQuartzSchedulePreset;
 /**
  * The UI's name for {@link AccessConnectorStatus}.
  *
- * The server and the SDK say *access connector*; this admin surface says *daemon*, as does every
- * `pamDaemon*` i18n key and the standalone agent that consumes a registration token. Aliasing
- * rather than renaming keeps that user-facing vocabulary intact without introducing a second type.
+ * The server, the SDK and every user-facing string say *access connector*. The alias survives
+ * because this feature's identifiers are named `Daemon*` (`DaemonRow`, `DaemonsService`, the
+ * `daemons/` directory and route segment), and the status type reads alongside them.
  */
 export const DaemonStatus = AccessConnectorStatus;
 export type DaemonStatus = AccessConnectorStatus;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
@@ -160,8 +160,8 @@ export type QuartzSchedulePreset = SdkQuartzSchedulePreset;
 
 /**
  * {@link AccessConnectorStatus} under this feature's local `Daemon*` naming (`DaemonRow`,
- * `DaemonsService`, the `daemons/` directory and route segment). Only those identifiers still say
- * daemon; every user-facing string says *access connector*.
+ * `DaemonsService`, the `daemons/` directory and route segment). The alias lets the status type
+ * read alongside them without introducing a second type.
  */
 export const DaemonStatus = AccessConnectorStatus;
 export type DaemonStatus = AccessConnectorStatus;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
@@ -112,7 +112,9 @@
               id="target-system-edit_checkbox_session-termination"
             />
             <bit-label>{{ "pamTargetSystemSupportsSessionTermination" | i18n }}</bit-label>
-            <bit-hint>{{ "pamTargetSystemSupportsSessionTerminationHint" | i18n }}</bit-hint>
+            <bit-hint>{{
+              "pamTargetSystemSupportsSessionTerminationHintConnector" | i18n
+            }}</bit-hint>
           </bit-form-control>
 
           @if (showTerminationWarning()) {
@@ -222,11 +224,11 @@
       <bit-callout type="info" [title]="'pamTargetSystemSetupGuidanceTitle' | i18n">
         @if (existing()?.method === TargetSystemMethod.Automatic) {
           <ol class="tw-mb-0 tw-ps-4">
-            <li>{{ "pamTargetSystemSetupGuidanceAutomaticDaemon" | i18n }}</li>
+            <li>{{ "pamTargetSystemSetupGuidanceAutomaticConnector" | i18n }}</li>
             <li>{{ "pamTargetSystemSetupGuidanceAutomaticCredential" | i18n }}</li>
           </ol>
         } @else {
-          <p class="tw-mb-0">{{ "pamTargetSystemSetupGuidanceManual" | i18n }}</p>
+          <p class="tw-mb-0">{{ "pamTargetSystemSetupGuidanceManualConnector" | i18n }}</p>
         }
       </bit-callout>
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-empty-state.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-empty-state.component.ts
@@ -40,7 +40,7 @@ const TEMPLATES: TargetSystemTemplate[] = [
     key: "custom-script",
     icon: "bwi-terminal",
     titleKey: "pamTargetSystemKindCustomScript",
-    summaryKey: "pamTargetSystemTemplateCustomScriptSummary",
+    summaryKey: "pamTargetSystemTemplateCustomScriptSummaryConnector",
   },
 ];
 


### PR DESCRIPTION
## 🎟️ Tracking

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/uat`.

## 📔 Objective

Renames every user-facing "daemon" string in PAM Rotation to "access connector," leaving identifiers, routes, and audit-log keys untouched.

- 54 i18n keys renamed (`pamDaemon*` to `pamAccessConnector*`) across 21 files, each added at the deleted key's position and repointed at every call site; `en` is the only locale carrying them.
- The 8 `pamAuditKind*` keys are deliberately excluded; audit-log rows still render "daemon".
- No identifier, directory, route segment, or feature flag renamed (`daemons/`, `DaemonRow`, `DaemonsService`, `/pam/rotation/daemons` all untouched).
- The `DaemonStatus` doc comment in `rotation.ts` is rewritten because it no longer holds once no `pamDaemon*` key exists.
- Includes a follow-up commit restoring two keys a simplify pass had collapsed (`pamAccessConnectorTokenTitle` / `pamAccessConnectorTokenLabel`) and re-adding the missing `pamAccessConnectorRegisterTitle` key.

Sits on `pam/rotux-failure-reason-plain-cause`; it is the top of the stack.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/uat`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation (all surfaces)

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/before-uat-rotux-daemon-terminology-user-facing.png" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/f2b8ead0a28f5bb5590362c60049e4eb/raw/after-uat-rotux-daemon-terminology-user-facing.png" alt="after" width="460"> |

## Copy not yet approved

This PR introduces user-facing wording the designer has not signed off on. Treat every string below as proposed, not settled:

- `pamAccessConnectorSearch`: "Search access connectors"
- `pamAccessConnectorNew`: "New access connector"
- `pamAccessConnectorRegister`: "Register access connector"
- `pamAccessConnectorEmptyStateTitle`: "No access connectors registered"
- `pamAccessConnectorEmptyStateDescription`: "Register an access connector to start rotating credentials."
- `pamAccessConnectorAssignNoOptions`: "All active automatic target systems are already assigned to this access connector."
- `pamAccessConnectorUnassignConfirmContent`: "Remove $NAME$ from this access connector? Active rotation jobs claimed by this access connector will continue to completion."
- `pamAccessConnectorDisableConfirmTitle`: "Disable access connector?"
- `pamAccessConnectorDisabled`: "Access connector disabled."
- `pamAccessConnectorEnabled`: "Access connector enabled."
- `pamAccessConnectorDeleteConfirmTitle`: "Delete access connector?"
- `pamAccessConnectorDeleteConfirmContent`: "Deleting $NAME$ is permanent and invalidates its credentials. This access connector held the organization key in memory. If you suspect a compromise, rotate the organization key as a remediation. Running rotation jobs are released. Register a new access connector to resume rotation."
- `pamAccessConnectorDeleted`: "Access connector deleted."
- `pamAccessConnectorRegisterTitle`: "Register access connector"
- `pamAccessConnectorNameHint`: "A descriptive name to identify this access connector. Max 200 characters."
- `pamAccessConnectorRegistered`: "Access connector registered."
- `pamAccessConnectorNoResults`: "No access connectors match your search."
- `pamAccessConnectorDetailTitle`: "Access connector"
- `pamAccessConnectorNotFound`: "Access connector not found."
- `pamAccessConnectorTokenTitle`: "Access connector token"
- `pamAccessConnectorTokenWarningBody`: "This token is shown only once and cannot be retrieved later. Copy it and deliver it to the access connector operator out of band, then paste it into the access connector configuration file. If the token is lost, delete this access connector and register a new one."
- `pamAccessConnectorTokenLabel`: "Access connector token"
- `pamAccessConnectorTokenCopied`: "Access connector token copied."
- `pamRotationTabAccessConnectors`: "Access connectors"
- `pamTargetSystemTemplateCustomScriptSummaryConnector`: "Bitwarden automatically rotates the credential by running your script on a registered access connector."
- `pamTargetSystemSupportsSessionTerminationHintConnector`: "When enabled, the access connector will terminate active sessions after a credential is rotated."
- `pamTargetSystemSetupGuidanceAutomaticConnector`: "On the Access connectors tab, register an access connector (or reuse an existing one) and assign this target system to it. The access connector performs the rotations."
- `pamTargetSystemSetupGuidanceManualConnector`: "On the Managed credentials tab, add a credential for this target system. There is no access connector to connect, so you rotate the credential by hand and record each rotation there."
- `pamRotationConfigRemoveLockedContentConnector`: "A rotation job is currently in progress. You can remove the rotation configuration once the access connector finishes it, or once it times out. Pausing only stops new jobs; it does not cancel the one already running."
- `pamRotationConfigAccountIdentityHintConnector`: "The account to rotate in the target system, e.g. a UPN, SQL login, or script argument. Passed to the access connector as-is."

## Known gaps

- Type check: 12 strict-mode errors exist in the repo, but every erroring file is byte-identical to `pam/uat` and none is in this diff. This is strongly evidenced as pre-existing rather than proven; a base-branch build was not run in this read-only stage to confirm. CI on the eventual PR will still show red unless the stack fixes it elsewhere.
- One unrelated test suite (`access-rules-sdk.service.spec.ts`, not in this diff) died to a jest worker SIGSEGV in the full run; it passes cleanly on its own with `--runInBand`. Treated as infrastructure flake, not a defect.
- The zero-connector empty state (`pamAccessConnectorEmptyStateTitle` / `pamAccessConnectorEmptyStateDescription`) was not rendered-verified: no reachable environment had zero registered connectors. Both keys carry the required copy in `en/messages.json`.
- The 8 `pamAuditKindDaemon*` keys and one "Rotation offered to daemon" message are pre-existing, outside this diff, and still render "daemon" in the audit log after this change. The locale immutability rule means they cannot be edited in place; retiring them needs new key ids in a follow-up.
- Tab order: the rendered tab bar shows Access connectors as the first tab, not the third as originally specified. This is the recorded decision `rotux-tab-order-vs-setup-order` (`rotation.routes.ts:54-71` reordered), not a defect in this PR; the label itself is correct.
