### PR TITLE
[PM-43062] [NonOffical] Organization invite broken with sso login for existing user

### DIFF
--- a/apps/web/src/app/auth/guards/deep-link/deep-link.guard.ts
+++ b/apps/web/src/app/auth/guards/deep-link/deep-link.guard.ts
@@ -90,7 +90,11 @@ export function deepLinkGuard(): CanActivateFn {
      * SSO users would be navigated to the "lock" component loop if we persisted the "lock" url.
      */
 
-    if (lowerCaseUrl.includes("/login-initiated") || lowerCaseUrl.includes("/lock")) {
+    if (
+      lowerCaseUrl.includes("/login-initiated") ||
+      lowerCaseUrl.includes("/lock") ||
+      lowerCaseUrl.includes("/sso")
+    ) {
       return false;
     }
 


### PR DESCRIPTION
First of all I encountered the issue with a client based on `web-v2026.8.1` and Vaultwarden.
I'm unsure if the issue is possible with the official client since the user needs to already exists and log using SSO while accepting to join an Organization.

I'm unable to test using an official Bitwarden instance, so I'm unsure if the issue is present in an official setup.
I apologize if it's not the case.

With the new release I observed that the `/#sso?code...` url from the sso redirection is now [set](https://github.com/bitwarden/clients/blob/web-v2026.8.1/apps/web/src/app/core/router.service.ts#L88) as the previousUrl before the call to the `deepLinkGuard` and the user prompt to unlock the vault.

Since the url is considered Valid it's [persisted](https://github.com/bitwarden/clients/blob/web-v2026.8.1/apps/web/src/app/auth/guards/deep-link/deep-link.guard.ts#L55) and overwrite the invitation url previously saved preventing accepting the invitation.