### PR TITLE
[PM-43064] Look up fill assist targeting rules with frame URL instead of tab URL

### DIFF
--- a/apps/browser/src/background/runtime.background.spec.ts
+++ b/apps/browser/src/background/runtime.background.spec.ts
@@ -1,6 +1,7 @@
 import { mock, MockProxy } from "jest-mock-extended";
 
 import { ExtensionCommand } from "@bitwarden/common/autofill/constants";
+import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 
@@ -113,5 +114,134 @@ describe("RuntimeBackground collectPageDetailsResponse routing", () => {
 
     expect(autofillOrchestrator.autofillActiveTabFromCommand).not.toHaveBeenCalled();
     expect(autofillOrchestrator.autofillActiveTabForCipherType).not.toHaveBeenCalled();
+  });
+});
+
+describe("RuntimeBackground getUrlAutofillTargetingRules", () => {
+  const committedUrl = "https://example.test/entry";
+  const routedUrl = "https://example.test/logged-in/step-one";
+
+  let runtimeBackground: RuntimeBackground;
+  let mainBackground: MockProxy<MainBackground>;
+  let domainSettingsService: MockProxy<DomainSettingsService>;
+
+  const message = { command: "getUrlAutofillTargetingRules" };
+
+  /** Stands in for the frame lookup `BrowserApi.getFrameDetails` performs. */
+  const mockFrameLookup = (url: string | undefined) => {
+    (chrome.webNavigation.getFrame as unknown as jest.Mock).mockImplementation(
+      (_details, callback) => callback(url == null ? undefined : { url }),
+    );
+  };
+
+  beforeEach(() => {
+    (chrome.runtime as any).onInstalled = { addListener: jest.fn() };
+
+    domainSettingsService = mock<DomainSettingsService>();
+    mainBackground = mock<MainBackground>();
+    (mainBackground as any).domainSettingsService = domainSettingsService;
+
+    runtimeBackground = new RuntimeBackground(
+      mainBackground,
+      mock<AutofillService>(),
+      mock<BrowserPlatformUtilsService>(),
+      undefined as any,
+      undefined as any,
+      undefined as any,
+      mock<LogService>(),
+      undefined as any,
+      undefined as any,
+      undefined as any,
+      undefined as any,
+      undefined as any,
+      undefined as any,
+      undefined as any,
+      undefined as any,
+      mock<AutofillOrchestrator>(),
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("matches rules against the frame's live URL rather than the URL it was committed at", async () => {
+    mockFrameLookup(routedUrl);
+    const sender = {
+      frameId: 0,
+      // `sender.url` reports the last cross-document navigation, so a same-document route
+      // change leaves it pinned to the entry URL.
+      url: committedUrl,
+      tab: createChromeTabMock({ id: 1, url: routedUrl }),
+    } as chrome.runtime.MessageSender;
+
+    await runtimeBackground.processMessageWithSender(message, sender);
+
+    expect(domainSettingsService.getTargetingRulesForUrl).toHaveBeenCalledWith(routedUrl);
+  });
+
+  it("matches a sub-frame against its own URL, not the tab's", async () => {
+    const subFrameUrl = "https://widget.example.test/form";
+    mockFrameLookup(subFrameUrl);
+    const sender = {
+      frameId: 7,
+      url: subFrameUrl,
+      tab: createChromeTabMock({ id: 1, url: routedUrl }),
+    } as chrome.runtime.MessageSender;
+
+    await runtimeBackground.processMessageWithSender(message, sender);
+
+    expect(domainSettingsService.getTargetingRulesForUrl).toHaveBeenCalledWith(subFrameUrl);
+  });
+
+  it("falls back to the tab URL for a top-level frame when the frame lookup resolves nothing", async () => {
+    mockFrameLookup(undefined);
+    const sender = {
+      frameId: 0,
+      url: committedUrl,
+      tab: createChromeTabMock({ id: 1, url: routedUrl }),
+    } as chrome.runtime.MessageSender;
+
+    await runtimeBackground.processMessageWithSender(message, sender);
+
+    expect(domainSettingsService.getTargetingRulesForUrl).toHaveBeenCalledWith(routedUrl);
+  });
+
+  it("falls back to the sender URL for a sub-frame when the frame lookup resolves nothing", async () => {
+    const subFrameUrl = "https://widget.example.test/form";
+    mockFrameLookup(undefined);
+    const sender = {
+      frameId: 7,
+      url: subFrameUrl,
+      tab: createChromeTabMock({ id: 1, url: routedUrl }),
+    } as chrome.runtime.MessageSender;
+
+    await runtimeBackground.processMessageWithSender(message, sender);
+
+    expect(domainSettingsService.getTargetingRulesForUrl).toHaveBeenCalledWith(subFrameUrl);
+  });
+
+  it("falls back to the sender URL when there is no tab to look a frame up in", async () => {
+    const sender = { frameId: undefined, url: committedUrl } as chrome.runtime.MessageSender;
+
+    await runtimeBackground.processMessageWithSender(message, sender);
+
+    expect(chrome.webNavigation.getFrame).not.toHaveBeenCalled();
+    expect(domainSettingsService.getTargetingRulesForUrl).toHaveBeenCalledWith(committedUrl);
+  });
+
+  it("returns the resolved rules to the caller", async () => {
+    const rules = [{ category: "account-login", fields: {} }] as any;
+    mockFrameLookup(routedUrl);
+    domainSettingsService.getTargetingRulesForUrl.mockResolvedValue(rules);
+    const sender = {
+      frameId: 0,
+      url: committedUrl,
+      tab: createChromeTabMock({ id: 1, url: routedUrl }),
+    } as chrome.runtime.MessageSender;
+
+    const result = await runtimeBackground.processMessageWithSender(message, sender);
+
+    expect(result).toBe(rules);
   });
 });

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -221,10 +221,7 @@ export default class RuntimeBackground {
         return result;
       }
       case "getUrlAutofillTargetingRules": {
-        // Because content scripts are injected into all _frames_, we give precedence
-        // to targeting rules matching by frame URI (`sender.url`) over tab URI, to avoid
-        // selector collision with coincidentally-matching in-frame structures.
-        const senderURL = sender.url ?? sender.tab?.url;
+        const senderURL = await this.resolveSenderFrameUrl(sender);
         const targetingRulesForUrl =
           await this.main.domainSettingsService.getTargetingRulesForUrl(senderURL);
 
@@ -264,6 +261,42 @@ export default class RuntimeBackground {
         break;
       }
     }
+  }
+
+  /** Resolves the URL currently loaded in the frame a message came from. */
+  private async resolveSenderFrameUrl(
+    sender: chrome.runtime.MessageSender,
+  ): Promise<string | undefined> {
+    const tabId = sender.tab?.id;
+    const frameId = sender.frameId;
+
+    if (tabId != null && frameId != null) {
+      /**
+       * Because content scripts are injected into all _frames_, frame URI takes precedence over tab URI
+       * to avoid selector collision with coincidentally-matching in-frame structures. `sender.url` is
+       * not a usable source for that: it reports the frame's last _cross-document_ navigation, so a
+       * same-document navigation (`history.pushState` / `replaceState`) leaves it pinned to the URL the
+       * document was committed at. Single-page apps that route after load would otherwise be matched
+       * against their entry URL for the life of the document.
+       *
+       * `webNavigation` tracks same-document navigations, so the frame lookup reports the live URL. The
+       * fallbacks cover a frame the lookup cannot resolve: the tab URI for a top-level frame (also
+       * same-document aware), and `sender.url` as a last resort.
+       */
+      const frameUrl = await BrowserApi.getFrameDetails({ tabId, frameId })
+        .then((frame) => frame?.url)
+        .catch((): undefined => undefined);
+
+      if (frameUrl) {
+        return frameUrl;
+      }
+    }
+
+    if (frameId === 0 && sender.tab?.url) {
+      return sender.tab.url;
+    }
+
+    return sender.url ?? sender.tab?.url;
   }
 
   private async handleSetBitwardenAsDefaultPasswordManager(

--- a/apps/browser/src/background/runtime.background.ts
+++ b/apps/browser/src/background/runtime.background.ts
@@ -271,18 +271,10 @@ export default class RuntimeBackground {
     const frameId = sender.frameId;
 
     if (tabId != null && frameId != null) {
-      /**
-       * Because content scripts are injected into all _frames_, frame URI takes precedence over tab URI
-       * to avoid selector collision with coincidentally-matching in-frame structures. `sender.url` is
-       * not a usable source for that: it reports the frame's last _cross-document_ navigation, so a
-       * same-document navigation (`history.pushState` / `replaceState`) leaves it pinned to the URL the
-       * document was committed at. Single-page apps that route after load would otherwise be matched
-       * against their entry URL for the life of the document.
-       *
-       * `webNavigation` tracks same-document navigations, so the frame lookup reports the live URL. The
-       * fallbacks cover a frame the lookup cannot resolve: the tab URI for a top-level frame (also
-       * same-document aware), and `sender.url` as a last resort.
-       */
+      // `frame.url` takes precedence over `tab.url` to minimize selector
+      // collisions between frames with similar in-frame markup. `frame.url`
+      // takes precedence over `sender.url` because the sender's value is pinned
+      // to the frame URI when the port was opened.
       const frameUrl = await BrowserApi.getFrameDetails({ tabId, frameId })
         .then((frame) => frame?.url)
         .catch((): undefined => undefined);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-43064](https://bitwarden.atlassian.net/browse/PM-43064)

## 📔 Objective

In cases of same-document navigation, the targeting rules retrieved for Fill Assist functionality use stale tab url references. These changes use the frame url in the rules lookup instead.

example: `https://banking.easybank.de/logintransaction/firstlevel`

Note: there are other places where we should switch to using frame urls instead of tab urls; will address in followup work.

[PM-43064]: https://bitwarden.atlassian.net/browse/PM-43064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ