### PR TITLE
Connector detail omits a required assign-dialog param, so the stack tip fails tsc

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
@@ -146,6 +146,64 @@ describe("DaemonDetailComponent", () => {
     expect(config.data.options.map((s) => s.id)).toEqual([sysId("ts-2")]);
   });
 
+  it("flags that the org has no active automatic target system", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon({ assignedTargetSystemIds: [] }));
+    rotationSdk.listTargetSystems.mockResolvedValue([]);
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(undefined) } as never);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
+    await comp.assignTarget();
+
+    const config = dialog.open.mock.calls[0][1] as unknown as {
+      data: { options: TargetSystem[]; noActiveAutomaticSystems: boolean };
+    };
+    expect(config.data.options).toEqual([]);
+    expect(config.data.noActiveAutomaticSystems).toBe(true);
+  });
+
+  it("does not flag when the only active system is already assigned to this daemon", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem()]);
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(undefined) } as never);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
+    await comp.assignTarget();
+
+    const config = dialog.open.mock.calls[0][1] as unknown as {
+      data: { options: TargetSystem[]; noActiveAutomaticSystems: boolean };
+    };
+    expect(config.data.options).toEqual([]);
+    expect(config.data.noActiveAutomaticSystems).toBe(false);
+  });
+
+  it("surfaces the error instead of opening the dialog when the target-systems load failed", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+    rotationSdk.listTargetSystems.mockRejectedValue(new Error("boom"));
+    const dialog = mock<DialogService>();
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    const toast = TestBed.inject(ToastService);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
+    await comp.assignTarget();
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(rotationSdk.assignTarget).not.toHaveBeenCalled();
+    expect(toast.showToast).toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
+  });
+
   it("does not open the assign dialog while the daemon is disabled", async () => {
     rotationSdk.getConnector.mockResolvedValue(makeDaemon({ status: DaemonStatus.Disabled }));
     rotationSdk.listTargetSystems.mockResolvedValue([makeSystem(), makeOtherSystem()]);

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
@@ -18,6 +18,7 @@ import {
   targetSystem,
 } from "../testing/rotation-builders";
 
+import type { AssignTargetDialogParams } from "./assign-target-dialog.component";
 import { DaemonAssignment, DaemonDetailComponent } from "./daemon-detail.component";
 
 const i18nFake: Pick<I18nService, "t" | "translate"> = {
@@ -146,62 +147,57 @@ describe("DaemonDetailComponent", () => {
     expect(config.data.options.map((s) => s.id)).toEqual([sysId("ts-2")]);
   });
 
-  it("flags that the org has no active automatic target system", async () => {
-    rotationSdk.getConnector.mockResolvedValue(makeDaemon({ assignedTargetSystemIds: [] }));
-    rotationSdk.listTargetSystems.mockResolvedValue([]);
-    const dialog = mock<DialogService>();
-    dialog.open.mockReturnValue({ closed: of(undefined) } as never);
-    await setup(rotationSdk, connectorId("daemon-1"), dialog);
-    fixture = TestBed.createComponent(DaemonDetailComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
+  describe("assignTarget", () => {
+    let dialog: ReturnType<typeof mock<DialogService>>;
 
-    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
-    await comp.assignTarget();
+    async function openAssign(): Promise<void> {
+      dialog = mock<DialogService>();
+      dialog.open.mockReturnValue({ closed: of(undefined) } as never);
+      await setup(rotationSdk, connectorId("daemon-1"), dialog);
+      fixture = TestBed.createComponent(DaemonDetailComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-    const config = dialog.open.mock.calls[0][1] as unknown as {
-      data: { options: TargetSystem[]; noActiveAutomaticSystems: boolean };
-    };
-    expect(config.data.options).toEqual([]);
-    expect(config.data.noActiveAutomaticSystems).toBe(true);
-  });
+      const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
+      await comp.assignTarget();
+    }
 
-  it("does not flag when the only active system is already assigned to this daemon", async () => {
-    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
-    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem()]);
-    const dialog = mock<DialogService>();
-    dialog.open.mockReturnValue({ closed: of(undefined) } as never);
-    await setup(rotationSdk, connectorId("daemon-1"), dialog);
-    fixture = TestBed.createComponent(DaemonDetailComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
+    function dialogData(): AssignTargetDialogParams {
+      return (dialog.open.mock.calls[0][1] as unknown as { data: AssignTargetDialogParams }).data;
+    }
 
-    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
-    await comp.assignTarget();
+    it("flags that the org has no active automatic target system", async () => {
+      rotationSdk.getConnector.mockResolvedValue(makeDaemon({ assignedTargetSystemIds: [] }));
+      rotationSdk.listTargetSystems.mockResolvedValue([]);
 
-    const config = dialog.open.mock.calls[0][1] as unknown as {
-      data: { options: TargetSystem[]; noActiveAutomaticSystems: boolean };
-    };
-    expect(config.data.options).toEqual([]);
-    expect(config.data.noActiveAutomaticSystems).toBe(false);
-  });
+      await openAssign();
 
-  it("surfaces the error instead of opening the dialog when the target-systems load failed", async () => {
-    rotationSdk.getConnector.mockResolvedValue(makeDaemon());
-    rotationSdk.listTargetSystems.mockRejectedValue(new Error("boom"));
-    const dialog = mock<DialogService>();
-    await setup(rotationSdk, connectorId("daemon-1"), dialog);
-    const toast = TestBed.inject(ToastService);
-    fixture = TestBed.createComponent(DaemonDetailComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
+      expect(dialogData().options).toEqual([]);
+      expect(dialogData().noActiveAutomaticSystems).toBe(true);
+    });
 
-    const comp = fixture.componentInstance as unknown as { assignTarget: () => Promise<void> };
-    await comp.assignTarget();
+    it("does not flag when the only active system is already assigned to this daemon", async () => {
+      rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+      rotationSdk.listTargetSystems.mockResolvedValue([makeSystem()]);
 
-    expect(dialog.open).not.toHaveBeenCalled();
-    expect(rotationSdk.assignTarget).not.toHaveBeenCalled();
-    expect(toast.showToast).toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
+      await openAssign();
+
+      expect(dialogData().options).toEqual([]);
+      expect(dialogData().noActiveAutomaticSystems).toBe(false);
+    });
+
+    it("surfaces the error instead of opening the dialog when the target-systems load failed", async () => {
+      rotationSdk.getConnector.mockResolvedValue(makeDaemon());
+      rotationSdk.listTargetSystems.mockRejectedValue(new Error("boom"));
+
+      await openAssign();
+
+      expect(dialog.open).not.toHaveBeenCalled();
+      expect(rotationSdk.assignTarget).not.toHaveBeenCalled();
+      expect(TestBed.inject(ToastService).showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "error" }),
+      );
+    });
   });
 
   it("does not open the assign dialog while the daemon is disabled", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -123,7 +123,7 @@ export class DaemonDetailComponent {
   );
 
   private readonly targetSystemsLoadError = toSignal(this.targetSystemsService.loadError$, {
-    initialValue: null as unknown | null,
+    initialValue: null,
   });
 
   /**
@@ -228,17 +228,18 @@ export class DaemonDetailComponent {
     }
   };
 
-  /** Assign an active automatic target system to this daemon. */
+  /**
+   * Assign an active automatic target system to this daemon.
+   *
+   * A failed target-systems load leaves the shared list empty, which is indistinguishable from an
+   * org that genuinely has none — so the failure is surfaced rather than letting the dialog assert
+   * the org has no active automatic target system.
+   */
   protected readonly assignTarget = async (): Promise<void> => {
     const connector = this.connector();
     if (connector == null || !this.enabled()) {
       return;
     }
-    /**
-     * A failed target-systems load leaves the list empty, which is indistinguishable from an org
-     * that genuinely has none — so the failure is surfaced rather than letting the dialog assert
-     * the org has no active automatic target system.
-     */
     const targetSystemsError = this.targetSystemsLoadError();
     if (targetSystemsError) {
       this.showError(targetSystemsError);

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -122,6 +122,10 @@ export class DaemonDetailComponent {
     { initialValue: [] as TargetSystem[] },
   );
 
+  private readonly targetSystemsLoadError = toSignal(this.targetSystemsService.loadError$, {
+    initialValue: null as unknown | null,
+  });
+
   /**
    * Holds every remove button, not just the clicked one: `bitIconButton` aria-disables rather than
    * natively disabling, so without this a second click stacks a second confirmation dialog over the
@@ -230,11 +234,23 @@ export class DaemonDetailComponent {
     if (connector == null || !this.enabled()) {
       return;
     }
+    /**
+     * A failed target-systems load leaves the list empty, which is indistinguishable from an org
+     * that genuinely has none — so the failure is surfaced rather than letting the dialog assert
+     * the org has no active automatic target system.
+     */
+    const targetSystemsError = this.targetSystemsLoadError();
+    if (targetSystemsError) {
+      this.showError(targetSystemsError);
+      return;
+    }
+
+    const activeSystems = this.activeAutomaticSystems();
     const assigned = new Set(connector.assignedTargetSystemIds);
-    const options = this.activeAutomaticSystems().filter((s) => !assigned.has(s.id));
+    const options = activeSystems.filter((s) => !assigned.has(s.id));
 
     const ref = AssignTargetDialogComponent.open(this.dialogService, {
-      data: { daemon: connector, options },
+      data: { daemon: connector, options, noActiveAutomaticSystems: activeSystems.length === 0 },
     });
     const selected = await ref.closed.toPromise();
     if (!selected) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

From the PAM UAT review, part of a stack of per-ticket fixes rooted on `pam/rotux-access-connector-terminology`.

Passes the `AssignTargetDialogComponent`'s required `noActiveAutomaticSystems` param from `daemon-detail.component.ts` so the assembled stack no longer fails `tsc` with `TS2741`.

- Computes `noActiveAutomaticSystems: activeSystems.length === 0` when calling `AssignTargetDialogComponent.open`.
- Adds a `targetSystemsLoadError` signal (from `targetSystemsService.loadError$`) and short-circuits `assignTarget()` with an error toast when the target-systems load failed, instead of treating the failure as "zero active systems".
- Adds three tests in `daemon-detail.component.spec.ts`: flag true (no active systems), flag false (only active system already assigned), and the load-error path.
- Only `daemon-detail.component.ts` and `daemon-detail.component.spec.ts` change; no template or i18n changes.

Sits on `pam/rotux-access-connector-terminology` (bottom of the stack); `pam/rotux2-connector-detail-action-placement` sits on top of it.

### Known gaps

- The assembled stack tip still fails `tsc` after this fix, but for 12 errors unrelated to this ticket's two files (pre-existing null/undefined and fixture-typing issues elsewhere, plus one apparent trunk-drift import of a `LockService` that `@bitwarden/auth/common` no longer exports). This ticket's own fix does land: `daemon-detail` no longer appears in the error list.
- That "pre-existing on base" conclusion is from diff and import analysis only; `tsc` was not run against the base branch itself to confirm empirically, since doing so would have required checking out or worktree-adding the base.

## 📸 Screenshots

Captured at 1440x1024. Before on `pam/rotux-access-connector-terminology`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Access connectors -> detail

| Before | After |
|---|---|
| <img src="" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/7fd6ec6d34c0f905643681d517ca6a3c/raw/after-uat-rotux2-stack-tip-assign-dialog-param.png" alt="after" width="460"> |
