### PR TITLE
Disable and Delete sit in the page header instead of the established footer position

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -2,38 +2,6 @@
   <bit-breadcrumbs slot="breadcrumbs">
     <bit-breadcrumb [route]="['..']">{{ "pamRotationTabAccessConnectors" | i18n }}</bit-breadcrumb>
   </bit-breadcrumbs>
-  @if (daemon()) {
-    @if (enabled()) {
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        [bitAction]="disable"
-        id="daemon-detail_button_disable"
-      >
-        {{ "pamAccessConnectorDisable" | i18n }}
-      </button>
-    } @else {
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        [bitAction]="enable"
-        id="daemon-detail_button_enable"
-      >
-        {{ "pamAccessConnectorEnable" | i18n }}
-      </button>
-    }
-    <button
-      type="button"
-      bitButton
-      buttonType="danger"
-      [bitAction]="deleteDaemon"
-      id="daemon-detail_button_delete"
-    >
-      {{ "delete" | i18n }}
-    </button>
-  }
 </bit-header>
 
 @if (loading()) {
@@ -126,5 +94,38 @@
         </bit-card>
       }
     </bit-section>
+    <div class="tw-flex tw-items-center tw-gap-2">
+      @if (enabled()) {
+        <button
+          type="button"
+          bitButton
+          buttonType="secondary"
+          [bitAction]="disable"
+          id="daemon-detail_button_disable"
+        >
+          {{ "pamAccessConnectorDisable" | i18n }}
+        </button>
+      } @else {
+        <button
+          type="button"
+          bitButton
+          buttonType="secondary"
+          [bitAction]="enable"
+          id="daemon-detail_button_enable"
+        >
+          {{ "pamAccessConnectorEnable" | i18n }}
+        </button>
+      }
+      <button
+        type="button"
+        bitButton
+        buttonType="danger"
+        [bitAction]="deleteDaemon"
+        class="tw-ms-auto"
+        id="daemon-detail_button_delete"
+      >
+        {{ "delete" | i18n }}
+      </button>
+    </div>
   </div>
 }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
@@ -46,6 +46,24 @@ function makeOtherSystem(): TargetSystem {
   return targetSystem({ id: sysId("ts-2"), name: "Prod MSSQL" });
 }
 
+function daemonProviders(
+  rotationSdk: ReturnType<typeof mock<RotationSdkService>>,
+  daemonId = connectorId("daemon-1"),
+  dialogService: ReturnType<typeof mock<DialogService>> = mock<DialogService>(),
+) {
+  return [
+    provideRouter([]),
+    { provide: RotationSdkService, useValue: rotationSdk },
+    { provide: I18nService, useValue: i18nFake },
+    { provide: ToastService, useValue: mock<ToastService>() },
+    { provide: DialogService, useValue: dialogService },
+    {
+      provide: ActivatedRoute,
+      useValue: { snapshot: { params: { organizationId: ORGANIZATION_ID, daemonId } } },
+    },
+  ];
+}
+
 async function setup(
   rotationSdk: ReturnType<typeof mock<RotationSdkService>>,
   daemonId = connectorId("daemon-1"),
@@ -54,17 +72,7 @@ async function setup(
   TestBed.overrideComponent(DaemonDetailComponent, { set: { template: "", imports: [] } });
   await TestBed.configureTestingModule({
     imports: [DaemonDetailComponent],
-    providers: [
-      provideRouter([]),
-      { provide: RotationSdkService, useValue: rotationSdk },
-      { provide: I18nService, useValue: i18nFake },
-      { provide: ToastService, useValue: mock<ToastService>() },
-      { provide: DialogService, useValue: dialogService },
-      {
-        provide: ActivatedRoute,
-        useValue: { snapshot: { params: { organizationId: ORGANIZATION_ID, daemonId } } },
-      },
-    ],
+    providers: daemonProviders(rotationSdk, daemonId, dialogService),
   }).compileComponents();
 }
 
@@ -368,38 +376,14 @@ describe("DaemonDetailComponent", () => {
   });
 });
 
-// JSDOM has no ResizeObserver; bit-breadcrumbs renders through bitOverflowList, which constructs one.
-class ResizeObserverStub {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-(global as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
-
-// Mounts the real template (no override) so where the action row sits in the DOM is asserted
-// against what renders — the one thing a template-stubbed spec cannot see.
-describe("DaemonDetailComponent — action row (rendered)", () => {
+describe("DaemonDetailComponent action row (rendered)", () => {
   async function render(daemon: AccessConnectorDetail): Promise<HTMLElement> {
     const rotationSdk = mock<RotationSdkService>();
     rotationSdk.getConnector.mockResolvedValue(daemon);
     rotationSdk.listTargetSystems.mockResolvedValue([makeSystem()]);
     await TestBed.configureTestingModule({
       imports: [DaemonDetailComponent, NoopAnimationsModule],
-      providers: [
-        provideRouter([]),
-        { provide: RotationSdkService, useValue: rotationSdk },
-        { provide: I18nService, useValue: i18nFake },
-        { provide: ToastService, useValue: mock<ToastService>() },
-        { provide: DialogService, useValue: mock<DialogService>() },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: {
-              params: { organizationId: ORGANIZATION_ID, daemonId: connectorId("daemon-1") },
-            },
-          },
-        },
-      ],
+      providers: daemonProviders(rotationSdk),
     }).compileComponents();
     const fixture: ComponentFixture<DaemonDetailComponent> =
       TestBed.createComponent(DaemonDetailComponent);
@@ -407,6 +391,10 @@ describe("DaemonDetailComponent — action row (rendered)", () => {
     await fixture.whenStable();
     fixture.detectChanges();
     return fixture.nativeElement as HTMLElement;
+  }
+
+  function actionRow(el: HTMLElement): HTMLElement {
+    return el.querySelector(".tw-max-w-4xl")?.lastElementChild as HTMLElement;
   }
 
   it("leaves the page header with its title and breadcrumbs only", async () => {
@@ -419,27 +407,21 @@ describe("DaemonDetailComponent — action row (rendered)", () => {
     expect(header.querySelector("#daemon-detail_button_delete")).toBeNull();
   });
 
-  it("puts Disable and Delete in one row at the foot of the page content", async () => {
+  it("puts Disable and Delete in one row at the foot of the page content, Delete pushed to the end", async () => {
     const el = await render(makeDaemon());
 
-    const row = el.querySelector(".tw-max-w-4xl")?.lastElementChild as HTMLElement;
+    const row = actionRow(el);
     expect(Array.from(row.querySelectorAll("button")).map((b) => b.id)).toEqual([
       "daemon-detail_button_disable",
       "daemon-detail_button_delete",
     ]);
-  });
-
-  it("right-aligns Delete so it reads last", async () => {
-    const el = await render(makeDaemon());
-
-    const del = el.querySelector("#daemon-detail_button_delete") as HTMLElement;
-    expect(del.className).toContain("tw-ms-auto");
+    expect(row.querySelector("#daemon-detail_button_delete")?.className).toContain("tw-ms-auto");
   });
 
   it("offers Enable in the same row when the connector is disabled", async () => {
     const el = await render(makeDaemon({ status: DaemonStatus.Disabled }));
 
-    const row = el.querySelector(".tw-max-w-4xl")?.lastElementChild as HTMLElement;
+    const row = actionRow(el);
     expect(row.querySelector("#daemon-detail_button_enable")).toBeTruthy();
     expect(row.querySelector("#daemon-detail_button_disable")).toBeNull();
   });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
 import { of } from "rxjs";
@@ -364,5 +365,82 @@ describe("DaemonDetailComponent", () => {
 
     expect(nav).toHaveBeenCalled();
     expect(toast.showToast).toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
+  });
+});
+
+// JSDOM has no ResizeObserver; bit-breadcrumbs renders through bitOverflowList, which constructs one.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+
+// Mounts the real template (no override) so where the action row sits in the DOM is asserted
+// against what renders — the one thing a template-stubbed spec cannot see.
+describe("DaemonDetailComponent — action row (rendered)", () => {
+  async function render(daemon: AccessConnectorDetail): Promise<HTMLElement> {
+    const rotationSdk = mock<RotationSdkService>();
+    rotationSdk.getConnector.mockResolvedValue(daemon);
+    rotationSdk.listTargetSystems.mockResolvedValue([makeSystem()]);
+    await TestBed.configureTestingModule({
+      imports: [DaemonDetailComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        { provide: RotationSdkService, useValue: rotationSdk },
+        { provide: I18nService, useValue: i18nFake },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              params: { organizationId: ORGANIZATION_ID, daemonId: connectorId("daemon-1") },
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+    const fixture: ComponentFixture<DaemonDetailComponent> =
+      TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it("leaves the page header with its title and breadcrumbs only", async () => {
+    const el = await render(makeDaemon());
+
+    const header = el.querySelector("bit-header") as HTMLElement;
+    expect(header).toBeTruthy();
+    expect(header.querySelector("#daemon-detail_button_disable")).toBeNull();
+    expect(header.querySelector("#daemon-detail_button_enable")).toBeNull();
+    expect(header.querySelector("#daemon-detail_button_delete")).toBeNull();
+  });
+
+  it("puts Disable and Delete in one row at the foot of the page content", async () => {
+    const el = await render(makeDaemon());
+
+    const row = el.querySelector(".tw-max-w-4xl")?.lastElementChild as HTMLElement;
+    expect(Array.from(row.querySelectorAll("button")).map((b) => b.id)).toEqual([
+      "daemon-detail_button_disable",
+      "daemon-detail_button_delete",
+    ]);
+  });
+
+  it("right-aligns Delete so it reads last", async () => {
+    const el = await render(makeDaemon());
+
+    const del = el.querySelector("#daemon-detail_button_delete") as HTMLElement;
+    expect(del.className).toContain("tw-ms-auto");
+  });
+
+  it("offers Enable in the same row when the connector is disabled", async () => {
+    const el = await render(makeDaemon({ status: DaemonStatus.Disabled }));
+
+    const row = el.querySelector(".tw-max-w-4xl")?.lastElementChild as HTMLElement;
+    expect(row.querySelector("#daemon-detail_button_enable")).toBeTruthy();
+    expect(row.querySelector("#daemon-detail_button_disable")).toBeNull();
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -147,7 +147,6 @@ export class DaemonDetailComponent {
 
   protected readonly titleText = computed(() => this.connector()?.name ?? "");
 
-  /** True when the daemon is enabled; drives Disable vs Enable in the header. */
   protected readonly enabled = computed(() => this.connector()?.status === DaemonStatus.Enabled);
 
   constructor() {


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

From the PAM UAT review, part of a stack of per-ticket fixes rooted on `pam/rotux-access-connector-terminology`.

Moves the connector detail page's Disable/Enable and Delete buttons out of `<bit-header>` and into a footer row at the bottom of the page content, matching the placement pattern used elsewhere (for example `access-rule-edit.component.html`).

- `daemon-detail.component.html`: `bit-header` now closes on title and breadcrumbs only, same shape as `target-system-edit.component.html`.
- The same two buttons (`disable`/`enable`, `delete`) are re-added verbatim as the last child of the `tw-max-w-4xl` content div, in a `tw-flex tw-items-center tw-gap-2` row with `tw-ms-auto` on Delete.
- No i18n changes: `pamAccessConnectorDisable`, `pamAccessConnectorEnable` and `delete` are existing strings, moved unchanged.
- `daemon-detail.component.ts`: one deleted doc comment above the `enabled` computed that described the old header placement, now stale.
- `daemon-detail.component.spec.ts`: a new rendered `describe` appended at the end of the file, asserting the header holds no action buttons and the footer row holds the buttons in the expected order with `tw-ms-auto` on Delete.

Sits on `pam/rotux2-assign-dialog-no-active-systems-param`; `pam/rotux2-rotation-failure-cause-once-per-job` sits on top of this one.

### Known gaps

- No before screenshot: there is no UAT case file or evidence capture for this PAM Rotation surface (`findings.json` has zero `rotux2` entries), so the route and repro steps were reconstructed from `rotation.routes.ts` and `pam-org-nav-slot.component.html`.
- `types` check fails on the stack (12 `typescript-strict-plugin` errors), but all 12 are in files this ticket does not touch and are byte-identical to the base branch and to trunk: pre-existing, not introduced here.

## 📸 Screenshots

Captured at 1440x1024, before on `pam/rotux-access-connector-terminology`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Access connectors -> detail

| Before | After |
|---|---|
| <img src="" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/7fd6ec6d34c0f905643681d517ca6a3c/raw/after-uat-rotux2-connector-detail-action-placement.png" alt="after" width="460"> |
