### PR TITLE
A failed rotation repeats the same plain-cause sentence once per attempt

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.html
@@ -20,6 +20,7 @@
     </thead>
     <tbody>
       @for (job of sortedJobs(); track job.id) {
+        @let jobCauseKey = jobFailureCauseLabelKey(job);
         <tr class="tw-border-b tw-border-secondary-100" data-testid="rotation-history-job-row">
           <td class="tw-py-2 tw-pr-4">{{ sourceLabelKey(job.source) | i18n }}</td>
           <td class="tw-py-2 tw-pr-4">
@@ -32,6 +33,16 @@
           </td>
           <td class="tw-py-2 tw-text-muted">{{ job.attempts.length }}</td>
         </tr>
+
+        @if (jobCauseKey) {
+          <tr class="tw-bg-background-alt" data-testid="rotation-history-job-cause-row">
+            <td class="tw-py-2 tw-pl-6 tw-pr-4" colspan="4">
+              <bit-callout type="danger" class="[&_aside]:!tw-mb-0">{{
+                jobCauseKey | i18n
+              }}</bit-callout>
+            </td>
+          </tr>
+        }
 
         @for (attempt of job.attempts; track attempt.id) {
           <tr
@@ -47,7 +58,9 @@
                     attemptStatusLabelKey(attempt.status) | i18n
                   }}</span>
                   @if (failureCauseKey) {
-                    <span class="tw-ml-2 tw-text-danger">— {{ failureCauseKey | i18n }}</span>
+                    @if (!jobCauseKey) {
+                      <span class="tw-ml-2 tw-text-danger">— {{ failureCauseKey | i18n }}</span>
+                    }
                   } @else if (attempt.failureReason; as failureReason) {
                     <span class="tw-ml-2 tw-text-danger">— {{ failureReason }}</span>
                   }
@@ -82,7 +95,7 @@
                 }
               </div>
               @if (failureCauseKey && attempt.failureReason; as failureReason) {
-                <span class="tw-mt-0.5 tw-block tw-text-muted">
+                <span class="tw-mt-0.5 tw-block tw-text-muted tw-font-mono">
                   {{ "pamRotationFailureReportedDetail" | i18n: failureReason }}
                 </span>
               }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
@@ -195,6 +195,7 @@ describe("RotationHistoryComponent", () => {
     it("returns the shared key when every attempt failed the same recognised way", () => {
       setup([]);
       const job = makeJob({
+        status: RotationJobStatus.Failed,
         attempts: [
           failedAttempt("7", "target_rejected: LDAP result code 50"),
           failedAttempt("8", "target_rejected: LDAP result code 50"),
@@ -210,6 +211,7 @@ describe("RotationHistoryComponent", () => {
     it("returns null when the attempts resolve to two different causes", () => {
       setup([]);
       const job = makeJob({
+        status: RotationJobStatus.Failed,
         attempts: [
           failedAttempt("7", "target_rejected: LDAP result code 50"),
           failedAttempt("8", "target_unreachable: error kind: ConnectionRefused"),
@@ -222,6 +224,7 @@ describe("RotationHistoryComponent", () => {
     it("skips an unrecognised attempt rather than letting it disqualify the job", () => {
       setup([]);
       const job = makeJob({
+        status: RotationJobStatus.Failed,
         attempts: [
           failedAttempt("7", "target_rejected: LDAP result code 50"),
           failedAttempt("8", "flaky target"),
@@ -235,14 +238,54 @@ describe("RotationHistoryComponent", () => {
 
     it("returns null when no attempt failed", () => {
       setup([]);
-      expect((component as any).jobFailureCauseLabelKey(makeJob())).toBeNull();
+      expect(
+        (component as any).jobFailureCauseLabelKey(makeJob({ status: RotationJobStatus.Failed })),
+      ).toBeNull();
     });
 
     it("returns null when the only failure is unrecognised", () => {
       setup([]);
-      const job = makeJob({ attempts: [failedAttempt("7", "flaky target")] });
+      const job = makeJob({
+        status: RotationJobStatus.Failed,
+        attempts: [failedAttempt("7", "flaky target")],
+      });
 
       expect((component as any).jobFailureCauseLabelKey(job)).toBeNull();
+    });
+
+    it("returns null for a job that retried and succeeded", () => {
+      setup([]);
+      const job = makeJob({
+        status: RotationJobStatus.Succeeded,
+        attempts: [
+          failedAttempt("7", "target_rejected: LDAP result code 53"),
+          rotationAttempt({ id: attemptId("8"), status: RotationAttemptStatus.Rotated }),
+        ],
+      });
+
+      expect((component as any).jobFailureCauseLabelKey(job)).toBeNull();
+    });
+
+    it("returns null for a job that is still pending", () => {
+      setup([]);
+      const job = makeJob({
+        status: RotationJobStatus.Pending,
+        attempts: [failedAttempt("7", "target_rejected: LDAP result code 53")],
+      });
+
+      expect((component as any).jobFailureCauseLabelKey(job)).toBeNull();
+    });
+
+    it("returns the shared key for a timed-out job", () => {
+      setup([]);
+      const job = makeJob({
+        status: RotationJobStatus.TimedOut,
+        attempts: [failedAttempt("7", "target_rejected: LDAP result code 53")],
+      });
+
+      expect((component as any).jobFailureCauseLabelKey(job)).toBe(
+        "pamRotationFailureCauseDirectoryRefused",
+      );
     });
   });
 });
@@ -366,6 +409,7 @@ describe("RotationHistoryComponent rendering", () => {
   it("states one shared cause once for the job instead of once per attempt row", () => {
     const fixture = render([
       rotationJob({
+        status: RotationJobStatus.Failed,
         attempts: [
           failedAttempt("7", "target_rejected: LDAP result code 50"),
           failedAttempt("8", "target_rejected: LDAP result code 50"),
@@ -390,7 +434,10 @@ describe("RotationHistoryComponent rendering", () => {
 
   it("spans the cause row across all four columns", () => {
     const fixture = render([
-      rotationJob({ attempts: [failedAttempt("7", "target_rejected: LDAP result code 50")] }),
+      rotationJob({
+        status: RotationJobStatus.Failed,
+        attempts: [failedAttempt("7", "target_rejected: LDAP result code 50")],
+      }),
     ]);
 
     const cells = fixture.debugElement.queryAll(
@@ -404,6 +451,7 @@ describe("RotationHistoryComponent rendering", () => {
   it("keeps a cause on every attempt row when the job failed in two different ways", () => {
     const fixture = render([
       rotationJob({
+        status: RotationJobStatus.Failed,
         attempts: [
           failedAttempt("7", "target_rejected: LDAP result code 50"),
           failedAttempt("8", "target_unreachable: error kind: ConnectionRefused"),
@@ -421,6 +469,7 @@ describe("RotationHistoryComponent rendering", () => {
   it("keeps an unrecognised reason on its own row beside the job-level cause", () => {
     const fixture = render([
       rotationJob({
+        status: RotationJobStatus.Failed,
         attempts: [
           failedAttempt("7", "target_rejected: LDAP result code 50"),
           failedAttempt("8", "target_rejected: LDAP result code 50"),
@@ -431,5 +480,26 @@ describe("RotationHistoryComponent rendering", () => {
 
     expect(fixture.debugElement.queryAll(By.css("bit-callout"))).toHaveLength(1);
     expect(fixture.nativeElement.textContent).toContain("flaky target");
+  });
+
+  it("states no job-level cause for a job that retried and succeeded", () => {
+    const fixture = render([
+      rotationJob({
+        status: RotationJobStatus.Succeeded,
+        attempts: [
+          failedAttempt("7", "target_rejected: LDAP result code 53"),
+          rotationAttempt({ id: attemptId("8"), status: RotationAttemptStatus.Rotated }),
+        ],
+      }),
+    ]);
+
+    expect(fixture.debugElement.queryAll(By.css("bit-callout"))).toHaveLength(0);
+    expect(
+      fixture.debugElement.queryAll(By.css("[data-testid='rotation-history-job-cause-row']")),
+    ).toHaveLength(0);
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain("pamRotationJobStatusSucceeded");
+    expect(text.match(/pamRotationFailureCauseDirectoryRefused/g)).toHaveLength(1);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
@@ -2,9 +2,8 @@ import { TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 
-import type { RotationAttempt, RotationAttemptId, RotationJob } from "../rotation";
+import type { RotationAttempt, RotationJob } from "../rotation";
 import {
   RotationAttemptStatus,
   RotationJobStatus,
@@ -12,16 +11,12 @@ import {
   RotationSyncState,
   SessionTerminationOutcome,
 } from "../rotation";
-import { id, jobId, rotationAttempt, rotationJob } from "../testing/rotation-builders";
+import { attemptId, jobId, rotationAttempt, rotationJob } from "../testing/rotation-builders";
 
 import { RotationHistoryComponent } from "./rotation-history.component";
 
 function makeJob(overrides: Partial<RotationJob> = {}): RotationJob {
   return rotationJob(overrides);
-}
-
-function attemptId(label: string): RotationAttemptId {
-  return asUuid<RotationAttemptId>(id(label));
 }
 
 function failedAttempt(label: string, failureReason: string): RotationAttempt {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.spec.ts
@@ -2,8 +2,9 @@ import { TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { asUuid } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 
-import type { RotationJob } from "../rotation";
+import type { RotationAttempt, RotationAttemptId, RotationJob } from "../rotation";
 import {
   RotationAttemptStatus,
   RotationJobStatus,
@@ -11,12 +12,24 @@ import {
   RotationSyncState,
   SessionTerminationOutcome,
 } from "../rotation";
-import { jobId, rotationAttempt, rotationJob } from "../testing/rotation-builders";
+import { id, jobId, rotationAttempt, rotationJob } from "../testing/rotation-builders";
 
 import { RotationHistoryComponent } from "./rotation-history.component";
 
 function makeJob(overrides: Partial<RotationJob> = {}): RotationJob {
   return rotationJob(overrides);
+}
+
+function attemptId(label: string): RotationAttemptId {
+  return asUuid<RotationAttemptId>(id(label));
+}
+
+function failedAttempt(label: string, failureReason: string): RotationAttempt {
+  return rotationAttempt({
+    id: attemptId(label),
+    status: RotationAttemptStatus.Errored,
+    failureReason,
+  });
 }
 
 describe("RotationHistoryComponent", () => {
@@ -182,6 +195,61 @@ describe("RotationHistoryComponent", () => {
       expect((component as any).failureCauseLabelKey(failureReason)).toBeNull();
     });
   });
+
+  describe("jobFailureCauseLabelKey", () => {
+    it("returns the shared key when every attempt failed the same recognised way", () => {
+      setup([]);
+      const job = makeJob({
+        attempts: [
+          failedAttempt("7", "target_rejected: LDAP result code 50"),
+          failedAttempt("8", "target_rejected: LDAP result code 50"),
+          failedAttempt("9", "target_rejected: ldap error code 50"),
+        ],
+      });
+
+      expect((component as any).jobFailureCauseLabelKey(job)).toBe(
+        "pamRotationFailureCauseInsufficientRights",
+      );
+    });
+
+    it("returns null when the attempts resolve to two different causes", () => {
+      setup([]);
+      const job = makeJob({
+        attempts: [
+          failedAttempt("7", "target_rejected: LDAP result code 50"),
+          failedAttempt("8", "target_unreachable: error kind: ConnectionRefused"),
+        ],
+      });
+
+      expect((component as any).jobFailureCauseLabelKey(job)).toBeNull();
+    });
+
+    it("skips an unrecognised attempt rather than letting it disqualify the job", () => {
+      setup([]);
+      const job = makeJob({
+        attempts: [
+          failedAttempt("7", "target_rejected: LDAP result code 50"),
+          failedAttempt("8", "flaky target"),
+        ],
+      });
+
+      expect((component as any).jobFailureCauseLabelKey(job)).toBe(
+        "pamRotationFailureCauseInsufficientRights",
+      );
+    });
+
+    it("returns null when no attempt failed", () => {
+      setup([]);
+      expect((component as any).jobFailureCauseLabelKey(makeJob())).toBeNull();
+    });
+
+    it("returns null when the only failure is unrecognised", () => {
+      setup([]);
+      const job = makeJob({ attempts: [failedAttempt("7", "flaky target")] });
+
+      expect((component as any).jobFailureCauseLabelKey(job)).toBeNull();
+    });
+  });
 });
 
 describe("RotationHistoryComponent rendering", () => {
@@ -298,5 +366,75 @@ describe("RotationHistoryComponent rendering", () => {
     const text = fixture.nativeElement.textContent;
     expect(text).toContain("flaky target");
     expect(text).not.toContain("pamRotationFailureReportedDetail");
+  });
+
+  it("states one shared cause once for the job instead of once per attempt row", () => {
+    const fixture = render([
+      rotationJob({
+        attempts: [
+          failedAttempt("7", "target_rejected: LDAP result code 50"),
+          failedAttempt("8", "target_rejected: LDAP result code 50"),
+          failedAttempt("9", "target_rejected: LDAP result code 50"),
+        ],
+      }),
+    ]);
+
+    expect(fixture.debugElement.queryAll(By.css("bit-callout"))).toHaveLength(1);
+
+    const text = fixture.nativeElement.textContent;
+    expect(text.match(/pamRotationFailureCauseInsufficientRights/g)).toHaveLength(1);
+
+    const attemptRows = fixture.debugElement.queryAll(
+      By.css("[data-testid='rotation-history-attempt-row']"),
+    );
+    expect(attemptRows).toHaveLength(3);
+    attemptRows.forEach((row) =>
+      expect(row.nativeElement.textContent).toContain("pamRotationFailureReportedDetail"),
+    );
+  });
+
+  it("spans the cause row across all four columns", () => {
+    const fixture = render([
+      rotationJob({ attempts: [failedAttempt("7", "target_rejected: LDAP result code 50")] }),
+    ]);
+
+    const cells = fixture.debugElement.queryAll(
+      By.css("[data-testid='rotation-history-job-cause-row'] td"),
+    );
+    expect(cells).toHaveLength(1);
+    expect(cells[0].nativeElement.getAttribute("colspan")).toBe("4");
+    expect(cells[0].query(By.css("bit-callout"))).not.toBeNull();
+  });
+
+  it("keeps a cause on every attempt row when the job failed in two different ways", () => {
+    const fixture = render([
+      rotationJob({
+        attempts: [
+          failedAttempt("7", "target_rejected: LDAP result code 50"),
+          failedAttempt("8", "target_unreachable: error kind: ConnectionRefused"),
+        ],
+      }),
+    ]);
+
+    expect(fixture.debugElement.queryAll(By.css("bit-callout"))).toHaveLength(0);
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain("pamRotationFailureCauseInsufficientRights");
+    expect(text).toContain("pamRotationFailureCauseTargetUnreachable");
+  });
+
+  it("keeps an unrecognised reason on its own row beside the job-level cause", () => {
+    const fixture = render([
+      rotationJob({
+        attempts: [
+          failedAttempt("7", "target_rejected: LDAP result code 50"),
+          failedAttempt("8", "target_rejected: LDAP result code 50"),
+          failedAttempt("9", "flaky target"),
+        ],
+      }),
+    ]);
+
+    expect(fixture.debugElement.queryAll(By.css("bit-callout"))).toHaveLength(1);
+    expect(fixture.nativeElement.textContent).toContain("flaky target");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
 
-import { BadgeModule, BadgeVariant, TableModule } from "@bitwarden/components";
+import { BadgeModule, BadgeVariant, CalloutModule, TableModule } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import {
@@ -23,7 +23,7 @@ import {
   selector: "app-rotation-history",
   templateUrl: "./rotation-history.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, BadgeModule, TableModule, I18nPipe],
+  imports: [CommonModule, BadgeModule, CalloutModule, TableModule, I18nPipe],
 })
 export class RotationHistoryComponent {
   readonly jobs = input.required<RotationJob[]>();
@@ -158,5 +158,33 @@ export class RotationHistoryComponent {
     }
 
     return null;
+  }
+
+  /**
+   * The one plain-cause key that explains a whole job, or `null` when the job's attempts do not
+   * agree on one.
+   *
+   * `failureReason` is per-attempt and `RotationJob` has no failure field, so a job-level cause is a
+   * derivation, not data. It is only safe to state once when every attempt this screen *recognises*
+   * resolves to the same key: a job whose first attempt could not reach the target and whose retry
+   * the directory refused failed two ways, and claiming one cause for it would misdescribe why an
+   * access change failed. Attempts whose reason is unrecognised are skipped rather than
+   * disqualifying - they keep their own raw reason on their own row.
+   */
+  protected jobFailureCauseLabelKey(job: RotationJob): string | null {
+    let shared: string | null = null;
+
+    for (const attempt of job.attempts) {
+      const key = attempt.failureReason ? this.failureCauseLabelKey(attempt.failureReason) : null;
+      if (key === null) {
+        continue;
+      }
+      if (shared !== null && shared !== key) {
+        return null;
+      }
+      shared = key;
+    }
+
+    return shared;
   }
 }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-history.component.ts
@@ -170,8 +170,16 @@ export class RotationHistoryComponent {
    * the directory refused failed two ways, and claiming one cause for it would misdescribe why an
    * access change failed. Attempts whose reason is unrecognised are skipped rather than
    * disqualifying - they keep their own raw reason on their own row.
+   *
+   * A job that is still running, or that retried and succeeded, carries errored attempts too, so
+   * the job's own status gates the derivation: only a job that finished failed has a cause to
+   * state.
    */
   protected jobFailureCauseLabelKey(job: RotationJob): string | null {
+    if (job.status !== RotationJobStatus.Failed && job.status !== RotationJobStatus.TimedOut) {
+      return null;
+    }
+
     let shared: string | null = null;
 
     for (const attempt of job.attempts) {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/testing/rotation-builders.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/testing/rotation-builders.ts
@@ -217,3 +217,8 @@ export function configId(label: string): RotationConfigId {
 export function jobId(label: string): RotationJobId {
   return asUuid<RotationJobId>(id(label));
 }
+
+/** A branded {@link RotationAttemptId} from a label. */
+export function attemptId(label: string): RotationAttemptId {
+  return asUuid<RotationAttemptId>(id(label));
+}


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

This comes from the PAM UAT review and is part of a stack of per-ticket fixes rooted on `pam/rotux-access-connector-terminology`.

Collapses a rotation job's repeated per-attempt failure-cause sentence into a single callout shown once for the job, and only when the job actually finished failed.

- Adds `jobFailureCauseLabelKey()` to `RotationHistoryComponent`, returning a shared cause key only when `job.status` is `Failed` or `TimedOut` and every attempt's recognised cause agrees; otherwise `null`.
- Template inserts one `tr`/`td colspan="4"` row with `bit-callout type="danger"` between the job row and its attempts when a shared cause exists.
- Suppresses the inline per-attempt cause span only for attempts whose own cause matches the shared key; an attempt with an unrecognised reason still shows its reason inline.
- Adds `tw-font-mono` to the `pamRotationFailureReportedDetail` line.
- Adds an `attemptId()` test-id builder to `rotation-builders.ts` and 207 lines of new spec coverage, including a retried-and-succeeded job and a still-pending job.

Sits on `pam/rotux2-connector-detail-action-placement`; it is the top of this stack.

## 📸 Screenshots

Captured at 1440x1024: before on `pam/rotux-access-connector-terminology`, after on the assembled stack tip.

### Admin Console -> PAM -> Rotation -> Access connectors -> detail, and Managed credentials -> history

| Before | After |
|---|---|
| <img src="" alt="before" width="460"> | <img src="https://gist.githubusercontent.com/maxkpower/7fd6ec6d34c0f905643681d517ca6a3c/raw/after-uat-rotux2-rotation-failure-explained-once.png" alt="after" width="460"> |

## Known gaps

- No `before` screenshot exists for this finding (empty cell above); the `after` shot is the only capture available, so the visual comparison rests on the after image plus the JSDOM assertions in `rotation-history.component.spec.ts`.
- The mixed-cause case (a job whose attempts fail two different recognised ways, so no callout appears and each attempt keeps its own cause) has no database fixture to verify live: every multi-attempt job in the QA data shares one failure reason. That path is covered only by unit tests, not manual verification.
- `attemptId()` was added to `rotation-builders.ts`, a file outside the three-file surface this ticket was originally scoped to touch. It is test-only (a single new branded-id helper, no existing builder changed) and does not overlap the neighbouring ticket's surface, but it is the one path a stack rebase could conflict on.
- `tsc --strict` reports 12 pre-existing errors across 7 PAM files unrelated to this diff; none are in a file this ticket or the stack beneath it touches.
