### PR TITLE
[PM-43080] feat: add SSO-only login option for self-hosted environments

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -38,6 +38,9 @@
   "useSingleSignOn": {
     "message": "Use single sign-on"
   },
+  "onlyAllowSingleSignOn": {
+    "message": "Only allow single sign-on"
+  },
   "yourOrganizationRequiresSingleSignOn": {
     "message": "Your organization requires single sign-on."
   },

--- a/apps/browser/src/admin-console/types/group-policy-environment.ts
+++ b/apps/browser/src/admin-console/types/group-policy-environment.ts
@@ -6,4 +6,5 @@ export type GroupPolicyEnvironment = {
   icons?: string;
   notifications?: string;
   events?: string;
+  ssoOnly?: boolean;
 };

--- a/apps/browser/src/managed_schema.json
+++ b/apps/browser/src/managed_schema.json
@@ -13,7 +13,11 @@
         "identity": { "type": "string" },
         "icons": { "type": "string" },
         "notifications": { "type": "string" },
-        "events": { "type": "string" }
+        "events": { "type": "string" },
+        "ssoOnly": {
+          "type": "boolean",
+          "description": "When true, the login screen for this environment offers only single sign-on"
+        }
       }
     }
   }

--- a/apps/browser/src/platform/services/browser-environment.service.ts
+++ b/apps/browser/src/platform/services/browser-environment.service.ts
@@ -79,5 +79,8 @@ export class BrowserEnvironmentService extends DefaultEnvironmentService {
       notifications: env.notifications,
       events: env.events,
     });
+    // setEnvironment replaces the whole state, so apply the SSO-only flag after it. Coerce
+    // defensively: a boolean schema value arrives as `true`, but a registry DWORD may surface as 1.
+    await this.setSsoOnly(env.ssoOnly === true || (env.ssoOnly as unknown) === 1);
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -1515,6 +1515,9 @@
   "useSingleSignOn": {
     "message": "Use single sign-on"
   },
+  "onlyAllowSingleSignOn": {
+    "message": "Only allow single sign-on"
+  },
   "yourOrganizationRequiresSingleSignOn": {
     "message": "Your organization requires single sign-on."
   },

--- a/libs/angular/src/auth/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.html
+++ b/libs/angular/src/auth/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.html
@@ -94,6 +94,16 @@
       </bit-form-field>
     </ng-container>
 
+    <bit-form-control class="tw-mt-3">
+      <input
+        id="self_hosted_env_settings_form_input_sso_only"
+        type="checkbox"
+        formControlName="ssoOnly"
+        bitCheckbox
+      />
+      <bit-label>{{ "onlyAllowSingleSignOn" | i18n }}</bit-label>
+    </bit-form-control>
+
     <span
       *ngIf="showErrorSummary"
       class="tw-block tw-text-danger tw-mt-2"

--- a/libs/angular/src/auth/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.ts
+++ b/libs/angular/src/auth/self-hosted-env-config-dialog/self-hosted-env-config-dialog.component.ts
@@ -21,6 +21,7 @@ import {
   DialogRef,
   AsyncActionsModule,
   ButtonModule,
+  CheckboxModule,
   DialogModule,
   DialogService,
   FormFieldModule,
@@ -100,6 +101,7 @@ function onlyHttpsValidator(): ValidatorFn {
     ReactiveFormsModule,
     FormFieldModule,
     AsyncActionsModule,
+    CheckboxModule,
   ],
 })
 export class SelfHostedEnvConfigDialogComponent implements OnInit, OnDestroy {
@@ -127,6 +129,7 @@ export class SelfHostedEnvConfigDialogComponent implements OnInit, OnDestroy {
       iconsUrl: ["", [onlyHttpsValidator()]],
       notificationsUrl: ["", [onlyHttpsValidator()]],
       sendUrl: ["", [onlyHttpsValidator()]],
+      ssoOnly: [false],
     },
     { validators: selfHostedEnvSettingsFormValidator() },
   );
@@ -196,6 +199,13 @@ export class SelfHostedEnvConfigDialogComponent implements OnInit, OnDestroy {
           });
         },
       });
+
+    // Populate the SSO-only toggle from its own stream, which is stored alongside the environment.
+    this.environmentService.ssoOnly$
+      .pipe(take(1), takeUntil(this.destroy$))
+      .subscribe((ssoOnly) => {
+        this.formGroup.patchValue({ ssoOnly });
+      });
   }
   submit = async () => {
     this.formGroup.markAllAsTouched();
@@ -215,6 +225,10 @@ export class SelfHostedEnvConfigDialogComponent implements OnInit, OnDestroy {
       notifications: this.notificationsUrl.value,
       send: this.sendUrl.value,
     });
+
+    // Order matters: setEnvironment writes the fresh self-hosted state (clearing any prior flag),
+    // then setSsoOnly merges the toggle onto it.
+    await this.environmentService.setSsoOnly(this.formGroup.value.ssoOnly ?? false);
 
     await this.dialogRef.close(true);
   };

--- a/libs/auth/src/angular/login/login.component.html
+++ b/libs/auth/src/angular/login/login.component.html
@@ -11,7 +11,7 @@
         appAutofocus
         data-testid="login-email-input"
         (input)="onEmailInput($event)"
-        (keyup.enter)="ssoRequired ? handleSsoClick() : continuePressed()"
+        (keyup.enter)="ssoRequired || ssoOnly ? handleSsoClick() : continuePressed()"
       />
     </bit-form-field>
 
@@ -30,6 +30,7 @@
     <div class="tw-grid tw-gap-3">
       <!-- Continue button -->
       <button
+        *ngIf="!ssoOnly"
         type="button"
         bitButton
         block
@@ -43,10 +44,10 @@
         {{ "continue" | i18n }}
       </button>
 
-      <div class="tw-text-center">{{ "or" | i18n }}</div>
+      <div *ngIf="!ssoOnly" class="tw-text-center">{{ "or" | i18n }}</div>
 
       <!-- Button to Login with Passkey -->
-      <ng-container *ngIf="isLoginWithPasskeySupported()">
+      <ng-container *ngIf="!ssoOnly && isLoginWithPasskeySupported()">
         <button
           type="button"
           bitButton
@@ -68,7 +69,7 @@
         type="button"
         bitButton
         block
-        [buttonType]="ssoRequired ? 'primary' : 'secondary'"
+        [buttonType]="ssoRequired || ssoOnly ? 'primary' : 'secondary'"
         data-testid="login-sso-button"
         (click)="handleSsoClick()"
       >

--- a/libs/auth/src/angular/login/login.component.ts
+++ b/libs/auth/src/angular/login/login.component.ts
@@ -106,6 +106,13 @@ export class LoginComponent implements OnInit, OnDestroy {
   loginUiState: LoginUiState = LoginUiState.EMAIL_ENTRY;
   ssoRequired = false;
 
+  /**
+   * When true, the email-entry screen offers only single sign-on: Continue, Log in with passkey,
+   * and the "or" divider are hidden, and the email field's Enter key routes to SSO. Derived from the
+   * environment's `ssoOnly` flag (set via the self-hosted config dialog or pre-configured by MDM).
+   */
+  protected ssoOnly = false;
+
   formGroup = this.formBuilder.group(
     {
       email: ["", [Validators.required, Validators.email]],
@@ -233,6 +240,9 @@ export class LoginComponent implements OnInit, OnDestroy {
     // (if it was found in query params or was the remembered email)
     await this.initSsoRequiredTracking();
 
+    // Derive the "SSO only" login-screen state from the environment's ssoOnly flag.
+    this.initSsoOnlyTracking();
+
     // Listen for region/environment changes after initialization.
     // If the user switches region while on the password entry screen, we need to clear
     // any stale authentication errors from the previous region and refresh the prelogin
@@ -321,6 +331,20 @@ export class LoginComponent implements OnInit, OnDestroy {
         this.ssoRequired = emailValue
           ? ssoRequiredCache.some((e) => e.email === emailValue && e.webVaultUrl === webVaultUrl)
           : false;
+      });
+  }
+
+  /**
+   * Collapses the email-entry screen to single sign-on only when the self-hosted environment's
+   * `ssoOnly` flag is set. The flag is a property of the environment, so it can be set either by
+   * the self-hosted config dialog or pre-configured by MDM (which seeds the environment on install).
+   * On Extension/Desktop the environment can change without a page reload, so this stays subscribed.
+   */
+  private initSsoOnlyTracking(): void {
+    this.environmentService.ssoOnly$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((ssoOnly) => {
+        this.ssoOnly = ssoOnly;
       });
   }
 

--- a/libs/common/src/platform/abstractions/environment.service.ts
+++ b/libs/common/src/platform/abstractions/environment.service.ts
@@ -111,6 +111,13 @@ export abstract class EnvironmentService {
   abstract cloudWebVaultUrl$: Observable<string>;
 
   /**
+   * Whether the self-hosted environment has opted in to offering only single sign-on on the login
+   * screen. Stored alongside the global environment state, so it is readable before login and is
+   * reset whenever the environment region changes.
+   */
+  abstract ssoOnly$: Observable<boolean>;
+
+  /**
    * Retrieve all the available regions for environment selectors.
    *
    * This currently relies on compile time provided constants, and will not change at runtime.
@@ -123,6 +130,12 @@ export abstract class EnvironmentService {
    * Set the global environment.
    */
   abstract setEnvironment(region: Region, urls?: Urls): Promise<Urls>;
+
+  /**
+   * Set the self-hosted "only allow single sign-on" flag, merging it onto the current global
+   * environment state. Call after {@link setEnvironment} so the flag lands on the fresh state.
+   */
+  abstract setSsoOnly(ssoOnly: boolean): Promise<void>;
 
   /**
    * Seed the environment state for a given user based on the global environment.

--- a/libs/common/src/platform/services/default-environment.service.spec.ts
+++ b/libs/common/src/platform/services/default-environment.service.spec.ts
@@ -488,6 +488,48 @@ describe("EnvironmentService", () => {
     });
   });
 
+  describe("ssoOnly$", () => {
+    it("emits false when the flag is absent from global state", async () => {
+      setGlobalData(Region.SelfHosted, new EnvironmentUrls());
+
+      expect(await firstValueFrom(sut.ssoOnly$)).toBe(false);
+    });
+
+    it("emits the stored value when the flag is set in global state", async () => {
+      stateProvider.global.getFake(GLOBAL_ENVIRONMENT_KEY).stateSubject.next({
+        region: Region.SelfHosted,
+        urls: new EnvironmentUrls(),
+        ssoOnly: true,
+      });
+
+      expect(await firstValueFrom(sut.ssoOnly$)).toBe(true);
+    });
+  });
+
+  describe("setSsoOnly", () => {
+    it("persists the flag so it is observable on ssoOnly$", async () => {
+      setGlobalData(Region.SelfHosted, new EnvironmentUrls());
+
+      await sut.setSsoOnly(true);
+      await awaitAsync();
+
+      expect(await firstValueFrom(sut.ssoOnly$)).toBe(true);
+    });
+
+    it("clears the flag when the region is later switched to a cloud region", async () => {
+      setGlobalData(Region.SelfHosted, new EnvironmentUrls());
+      await sut.setSsoOnly(true);
+      await awaitAsync();
+      expect(await firstValueFrom(sut.ssoOnly$)).toBe(true);
+
+      // setEnvironment replaces the whole global state, so the flag does not survive a region change
+      await sut.setEnvironment(Region.US);
+      await awaitAsync();
+
+      expect(await firstValueFrom(sut.ssoOnly$)).toBe(false);
+    });
+  });
+
   describe("cloudWebVaultUrl$", () => {
     it("no extra initialization, returns US vault", async () => {
       expect(await firstValueFrom(sut.cloudWebVaultUrl$)).toBe("https://vault.bitwarden.com");

--- a/libs/common/src/platform/services/default-environment.service.ts
+++ b/libs/common/src/platform/services/default-environment.service.ts
@@ -38,6 +38,7 @@ export class EnvironmentUrls {
 class EnvironmentState {
   region: Region;
   urls: EnvironmentUrls;
+  ssoOnly?: boolean;
 
   static fromJSON(obj: Jsonify<EnvironmentState>): EnvironmentState {
     return Object.assign(new EnvironmentState(), obj);
@@ -153,6 +154,7 @@ export class DefaultEnvironmentService implements EnvironmentService {
   environment$: Observable<Environment>;
   globalEnvironment$: Observable<Environment>;
   cloudWebVaultUrl$: Observable<string>;
+  ssoOnly$: Observable<boolean>;
 
   constructor(
     private stateProvider: StateProvider,
@@ -170,6 +172,11 @@ export class DefaultEnvironmentService implements EnvironmentService {
     this.globalEnvironment$ = this.stateProvider
       .getGlobal(GLOBAL_ENVIRONMENT_KEY)
       .state$.pipe(map((state) => this.buildEnvironment(state?.region, state?.urls)));
+
+    this.ssoOnly$ = this.globalState.state$.pipe(
+      map((state) => state?.ssoOnly ?? false),
+      distinctUntilChanged(),
+    );
 
     // The current environment emitted by environment$ can come from two sources: the "global" environment,
     // which represents the environment used by the application before a user authenticates, and the "user" environment,
@@ -278,6 +285,15 @@ export class DefaultEnvironmentService implements EnvironmentService {
 
       return urls;
     }
+  }
+
+  async setSsoOnly(ssoOnly: boolean): Promise<void> {
+    // Merge onto the existing global state rather than replacing it, so region/urls are preserved.
+    // setEnvironment replaces the whole state, so this flag is intentionally reset on region change.
+    await this.globalState.update((state) => ({
+      ...state,
+      ssoOnly,
+    }));
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

Not tracking, but this is a feature our organization really really wants for our users.

## 📔 Objective
If you self-host Bitwarden and force everyone through SSO, the login screen still shows stuff people can't actually use — the **Continue** button (email + master password) and **Log in with passkey**. 

This adds an opt-in flag, `ssoOnly`, that strips the login screen down to just single sign-on for those setups.

Flip it on and the screen hides:
-  **Continue**,
-  **Log in with passkey**, and the "or" line.
- makes **Use single sign-on** the main button
- makes Enter in the email field go straight to SSO. 

Under the hood, `ssoOnly` just lives on the environment (`EnvironmentState.ssoOnly`, read via `EnvironmentService.ssoOnly$` /
`setSsoOnly`), so there's one place that holds the truth and the shared login screen just watches it. Two ways to turn it on, both writing that same spot:

- **The self-hosted setup dialog** — a new "Only allow single sign-on"
  checkbox.
- **MDM / managed storage** — set `environment.ssoOnly`, and it gets applied
  to the environment when the extension installs, right alongside the managed
  server URL (browser only for now).

Side note:
- only adds `ssoOnly$` / `setSsoOnly` to `EnvironmentService` in `libs/common`. CLI/web/browser inherit the default implementation, so no CLI change.
- the dialog is self-hosted-only and switching to a cloud region clears the flag. Cloud login is multi-tenant and intentionally unaffected.
- matching the existing managed base-URL behaviour (a policy pushed to an already-installed extension won't apply retroactively).
- the dialog path works on desktop via the shared component, but desktop has no managed-environment seed yet.
- the server's domain-claim + Require-SSO policy still enforces routing.

## 📸 Screenshots
Without checkmark:

<img width="477" height="591" alt="{85717593-33DA-44BD-A7D8-0973C6955F93}" src="https://github.com/user-attachments/assets/44ae69cc-1aaf-474a-b3f9-d1002356221b" />
<img width="477" height="596" alt="{FC4C2FCD-22CA-4D03-9CB6-A9D8F9621642}" src="https://github.com/user-attachments/assets/a85540e5-ae55-417f-9a77-aa6e07e5e272" />

---

With checkmark:

<img width="476" height="591" alt="{398295DF-256A-4EFE-A027-425CB8DD166E}" src="https://github.com/user-attachments/assets/d08fe251-a25c-4640-9eba-111ebdae1c0b" />
<img width="478" height="590" alt="{29778439-C4EC-44B1-9A72-0D6C8944541B}" src="https://github.com/user-attachments/assets/708b82de-d360-443d-becc-bff568e09c41" />