### PR TITLE
fix(pam): move the access-rules toolbar filters onto bit-filter-menu

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -391,10 +391,9 @@ export class AccessAuditComponent implements OnInit {
     return candidates;
   }
 
-  /** A multi-select chip's selection, or null for no selection, which matches every row. */
-  private selectedValues(chip: FilterControl | undefined): string[] | null {
-    const selected = selectedFilterStrings(chip?.value());
-    return selected.length > 0 ? selected : null;
+  /** A multi-select chip's selection; empty when the chip narrows nothing. */
+  private selectedValues(chip: FilterControl | undefined): string[] {
+    return selectedFilterStrings(chip?.value());
   }
 
   /** The single-select time-period chip's selection, whose value is a scalar rather than a list. */
@@ -412,16 +411,16 @@ export class AccessAuditComponent implements OnInit {
    */
   private readonly filter = computed<AuditTrailFilter>(() => {
     const { from, to } = this.range();
-    const actors = this.selectedValues(this.actorChip()) ?? [];
-    const items = this.selectedValues(this.itemChip()) ?? [];
+    const actors = this.selectedValues(this.actorChip());
+    const items = this.selectedValues(this.itemChip());
     const rules = this.ruleItemIds();
     return {
       start: from ?? undefined,
       end: to ?? undefined,
-      kinds: (this.selectedValues(this.kindChip()) ?? []) as AccessAuditEventKind[],
+      kinds: this.selectedValues(this.kindChip()) as AccessAuditEventKind[],
       actorIds: actors.filter((value) => value !== AUTOMATED_ACTOR),
       includeAutomatedActor: actors.includes(AUTOMATED_ACTOR),
-      requesterIds: this.selectedValues(this.requesterChip()) ?? [],
+      requesterIds: this.selectedValues(this.requesterChip()),
       cipherIds: items.filter((value) => !rules.has(value)),
       ruleIds: items.filter((value) => rules.has(value)),
     };

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -391,7 +391,6 @@ export class AccessAuditComponent implements OnInit {
     return candidates;
   }
 
-  /** A multi-select chip's selection; empty when the chip narrows nothing. */
   private selectedValues(chip: FilterControl | undefined): string[] {
     return selectedFilterStrings(chip?.value());
   }

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.ts
@@ -50,6 +50,7 @@ import {
 import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import { AccessNameResolverService } from "../access-requests/access-name-resolver.service";
+import { selectedFilterStrings } from "../helpers/selected-filter-strings";
 
 import {
   AUDIT_TIME_PERIOD_LABEL_KEYS,
@@ -392,11 +393,7 @@ export class AccessAuditComponent implements OnInit {
 
   /** A multi-select chip's selection, or null for no selection, which matches every row. */
   private selectedValues(chip: FilterControl | undefined): string[] | null {
-    const value = chip?.value();
-    if (!Array.isArray(value)) {
-      return null;
-    }
-    const selected = value.filter((entry): entry is string => typeof entry === "string");
+    const selected = selectedFilterStrings(chip?.value());
     return selected.length > 0 ? selected : null;
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.html
@@ -51,18 +51,26 @@
         [placeholder]="'pamSearchRules' | i18n"
         formControlName="search"
       />
-      <bit-chip-filter
+      <bit-filter-menu
+        #statusFilter
+        key="status"
         [placeholderText]="'status' | i18n"
-        placeholderIcon="bwi-filter"
-        [options]="statusOptions"
-        formControlName="status"
-      />
-      <bit-chip-filter
+        [unsetLabel]="'all' | i18n"
+      >
+        @for (option of statusOptions; track option.value) {
+          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+        }
+      </bit-filter-menu>
+      <bit-filter-menu
+        #collectionFilter
+        key="collection"
         [placeholderText]="'pamAccessRuleCollectionsColumn' | i18n"
-        placeholderIcon="bwi-collection-shared"
-        [options]="collectionOptions()"
-        formControlName="collection"
-      />
+        multiple
+      >
+        @for (option of collectionOptions(); track option.value) {
+          <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+        }
+      </bit-filter-menu>
     </div>
 
     <div class="tw-overflow-x-auto">

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
@@ -1,11 +1,14 @@
+import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, provideRouter, Router } from "@angular/router";
 import { of } from "rxjs";
 
 import { CollectionAdminService } from "@bitwarden/admin-console/common";
+import { CollectionAdminView } from "@bitwarden/common/admin-console/models/collections";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { DialogService, FilterControl, ToastService } from "@bitwarden/components";
+import { HeaderModule } from "@bitwarden/web-vault/app/layouts/header/header.module";
 
 import { accessRuleDeactivateConfirmOptions, AccessRuleSdkService, AccessRuleView } from "..";
 
@@ -513,5 +516,160 @@ describe("AccessRulesComponent — bulk deactivate confirmation", () => {
 
     expect(openSimpleDialog).not.toHaveBeenCalled();
     expect(updateAccessRule).toHaveBeenCalled();
+  });
+});
+
+/**
+ * The toolbar chips own their own selection rather than a form control, so these render the real
+ * template — the blanked template every other block here uses would leave the `viewChild`s unset.
+ */
+describe("AccessRulesComponent — toolbar filters", () => {
+  let fixture: ComponentFixture<AccessRulesComponent>;
+
+  const collection = (id: string, name: string) => ({ id, name }) as unknown as CollectionAdminView;
+
+  /**
+   * {@link rule} with collections on it, which the base helper leaves empty. Cast through
+   * `unknown` for the same reason `rule` is: the SDK brands `collections` as `CollectionId[]`.
+   */
+  const ruleIn = (id: string, name: string, collections: string[], enabled = true) =>
+    ({ ...rule(id, name, enabled), collections }) as unknown as AccessRuleView;
+
+  const setupToolbar = async (rules: AccessRuleView[], collections: CollectionAdminView[] = []) => {
+    TestBed.configureTestingModule({
+      imports: [AccessRulesComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { params: of({ organizationId: "org-1" }) } },
+        {
+          provide: AccessRuleSdkService,
+          useValue: { listAccessRules: jest.fn().mockResolvedValue(rules) },
+        },
+        { provide: ToastService, useValue: { showToast: jest.fn() } },
+        { provide: I18nService, useValue: i18nFake },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+        {
+          provide: CollectionAdminService,
+          useValue: { collectionAdminViews$: () => of(collections) },
+        },
+      ],
+    });
+
+    // The header pulls in the whole org/account shell; the chips under test don't need it.
+    TestBed.overrideComponent(AccessRulesComponent, {
+      remove: { imports: [HeaderModule] },
+      add: { schemas: [NO_ERRORS_SCHEMA] },
+    });
+    TestBed.overrideProvider(DialogService, { useValue: { openSimpleDialog: jest.fn() } });
+
+    fixture = TestBed.createComponent(AccessRulesComponent);
+    for (let i = 0; i < 3; i++) {
+      fixture.detectChanges();
+      await fixture.whenStable();
+    }
+  };
+
+  /** A chip reached through the `FilterControl` contract, the way the component reads it. */
+  const chip = (name: "statusFilter" | "collectionFilter"): FilterControl => {
+    const chips = fixture.componentInstance as unknown as Record<
+      string,
+      () => FilterControl | undefined
+    >;
+    const control = chips[name]();
+    if (control == null) {
+      throw new Error(`the ${name} chip did not render`);
+    }
+    return control;
+  };
+
+  const select = (name: "statusFilter" | "collectionFilter", value: unknown) => {
+    chip(name).setValue(value);
+    fixture.detectChanges();
+  };
+
+  /** The rule names left in the table, in data-source order. */
+  const visible = () =>
+    (fixture.componentInstance["dataSource"].filteredData ?? []).map((r) => r.name);
+
+  it("declares an option per collection, sorted by name", async () => {
+    await setupToolbar(
+      [ruleIn("rule-1", "VPN", ["col-2"])],
+      [collection("col-1", "Servers"), collection("col-2", "Databases")],
+    );
+
+    expect(fixture.componentInstance["collectionOptions"]()).toEqual([
+      { label: "Databases", value: "col-2" },
+      { label: "Servers", value: "col-1" },
+    ]);
+  });
+
+  it("narrows the table to the status selected on the chip", async () => {
+    await setupToolbar([rule("rule-1", "VPN", true), rule("rule-2", "SSH", false)]);
+
+    select("statusFilter", "enabled");
+    expect(visible()).toEqual(["VPN"]);
+
+    select("statusFilter", "disabled");
+    expect(visible()).toEqual(["SSH"]);
+  });
+
+  it("widens within the collections chip — a rule matches any of the selected collections", async () => {
+    await setupToolbar(
+      [
+        ruleIn("rule-1", "VPN", ["col-1"]),
+        ruleIn("rule-2", "SSH", ["col-2"]),
+        ruleIn("rule-3", "RDP", ["col-3"]),
+      ],
+      [collection("col-1", "Servers"), collection("col-2", "Databases")],
+    );
+
+    select("collectionFilter", ["col-1"]);
+    expect(visible()).toEqual(["VPN"]);
+
+    select("collectionFilter", ["col-1", "col-2"]);
+    expect(visible()).toEqual(["VPN", "SSH"]);
+  });
+
+  it("stops narrowing when the last collection is cleared from the chip", async () => {
+    await setupToolbar(
+      [ruleIn("rule-1", "VPN", ["col-1"]), ruleIn("rule-2", "SSH", ["col-2"])],
+      [collection("col-1", "Servers")],
+    );
+
+    select("collectionFilter", ["col-1"]);
+    expect(visible()).toEqual(["VPN"]);
+
+    select("collectionFilter", []);
+    expect(visible()).toEqual(["VPN", "SSH"]);
+  });
+
+  it("narrows across the two chips at once", async () => {
+    await setupToolbar(
+      [
+        ruleIn("rule-1", "VPN", ["col-1"], true),
+        ruleIn("rule-2", "SSH", ["col-1"], false),
+        ruleIn("rule-3", "RDP", ["col-2"], true),
+      ],
+      [collection("col-1", "Servers"), collection("col-2", "Databases")],
+    );
+
+    select("statusFilter", "enabled");
+    select("collectionFilter", ["col-1"]);
+
+    expect(visible()).toEqual(["VPN"]);
+  });
+
+  it("narrows on the search box alongside the chips", async () => {
+    await setupToolbar(
+      [ruleIn("rule-1", "VPN access", ["col-1"]), ruleIn("rule-2", "VPN backup", ["col-2"])],
+      [collection("col-1", "Servers"), collection("col-2", "Databases")],
+    );
+
+    fixture.componentInstance["filterForm"].controls.search.setValue("backup");
+    fixture.detectChanges();
+    expect(visible()).toEqual(["VPN backup"]);
+
+    select("collectionFilter", ["col-1"]);
+    expect(visible()).toEqual([]);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
@@ -520,8 +520,8 @@ describe("AccessRulesComponent — bulk deactivate confirmation", () => {
 });
 
 /**
- * The toolbar chips own their own selection rather than a form control, so these render the real
- * template — the blanked template every other block here uses would leave the `viewChild`s unset.
+ * These render the real template: the chips own their selection, and the blanked template the
+ * other blocks use would leave the `viewChild`s unset.
  */
 describe("AccessRulesComponent — toolbar filters", () => {
   let fixture: ComponentFixture<AccessRulesComponent>;
@@ -529,8 +529,8 @@ describe("AccessRulesComponent — toolbar filters", () => {
   const collection = (id: string, name: string) => ({ id, name }) as unknown as CollectionAdminView;
 
   /**
-   * {@link rule} with collections on it, which the base helper leaves empty. Cast through
-   * `unknown` for the same reason `rule` is: the SDK brands `collections` as `CollectionId[]`.
+   * {@link rule} with collections on it. Cast through `unknown` for the same reason `rule` is:
+   * the SDK brands `collections` as `CollectionId[]`.
    */
   const ruleIn = (id: string, name: string, collections: string[], enabled = true) =>
     ({ ...rule(id, name, enabled), collections }) as unknown as AccessRuleView;

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.spec.ts
@@ -571,11 +571,7 @@ describe("AccessRulesComponent — toolbar filters", () => {
 
   /** A chip reached through the `FilterControl` contract, the way the component reads it. */
   const chip = (name: "statusFilter" | "collectionFilter"): FilterControl => {
-    const chips = fixture.componentInstance as unknown as Record<
-      string,
-      () => FilterControl | undefined
-    >;
-    const control = chips[name]();
+    const control = fixture.componentInstance[name]();
     if (control == null) {
       throw new Error(`the ${name} chip did not render`);
     }

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
@@ -24,6 +24,8 @@ import {
   ButtonModule,
   CheckboxModule,
   DialogService,
+  FILTER_CONTROL,
+  FilterControl,
   FilterMenuComponent,
   FilterOptionComponent,
   IconButtonModule,
@@ -126,7 +128,7 @@ export class AccessRulesComponent {
   // --- Toolbar filters ---
   // Only `search` is a reactive-form control: `bit-filter-menu` isn't a
   // `ControlValueAccessor`, so the status/collection chips below own their own
-  // selection and are read directly off their view-child refs in `filterInputs`.
+  // selection and are read through the `FilterControl` contract in `filterInputs`.
   protected readonly filterForm = new FormGroup({
     search: new FormControl("", { nonNullable: true }),
   });
@@ -136,16 +138,21 @@ export class AccessRulesComponent {
     { requireSync: true },
   );
 
-  private readonly statusFilter = viewChild<FilterMenuComponent>("statusFilter");
-  private readonly collectionFilter = viewChild<FilterMenuComponent>("collectionFilter");
+  private readonly statusFilter = viewChild("statusFilter", { read: FILTER_CONTROL });
+  private readonly collectionFilter = viewChild("collectionFilter", { read: FILTER_CONTROL });
+
+  /** A multi-select chip's selection, filtered down to the strings it's actually made of. */
+  private selectedValues(chip: FilterControl | undefined): string[] {
+    const value = chip?.value();
+    return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+  }
 
   private readonly filterInputs = computed(() => {
-    const status = this.statusFilter()?.value() as AccessRuleStatusFilter | undefined;
-    const collections = this.collectionFilter()?.value();
+    const status = this.statusFilter()?.value();
     return {
       text: this.searchTerm().trim().toLowerCase(),
-      status: status ?? null,
-      collectionIds: Array.isArray(collections) ? (collections as string[]) : [],
+      status: (typeof status === "string" ? status : null) as AccessRuleStatusFilter | null,
+      collectionIds: this.selectedValues(this.collectionFilter()),
     };
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
@@ -1,6 +1,13 @@
 import { SelectionModel } from "@angular/cdk/collections";
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  viewChild,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -16,9 +23,9 @@ import {
   BulkActionsBarComponent,
   ButtonModule,
   CheckboxModule,
-  ChipFilterComponent,
-  ChipFilterOption,
   DialogService,
+  FilterMenuComponent,
+  FilterOptionComponent,
   IconButtonModule,
   IconModule,
   LinkModule,
@@ -70,7 +77,8 @@ import { ApprovalMethodPipe } from "./approval-method.pipe";
     BulkActionsBarComponent,
     ButtonModule,
     CheckboxModule,
-    ChipFilterComponent,
+    FilterMenuComponent,
+    FilterOptionComponent,
     HeaderModule,
     IconButtonModule,
     IconModule,
@@ -116,36 +124,39 @@ export class AccessRulesComponent {
   });
 
   // --- Toolbar filters ---
+  // Only `search` is a reactive-form control: `bit-filter-menu` isn't a
+  // `ControlValueAccessor`, so the status/collection chips below own their own
+  // selection and are read directly off their view-child refs in `filterInputs`.
   protected readonly filterForm = new FormGroup({
     search: new FormControl("", { nonNullable: true }),
-    status: new FormControl<AccessRuleStatusFilter | null>(null),
-    collection: new FormControl<string | null>(null),
   });
 
-  private readonly filterInputs = toSignal(
-    this.filterForm.valueChanges.pipe(
-      startWith(null),
-      map(() => this.filterForm.getRawValue()),
-    ),
+  private readonly searchTerm = toSignal(
+    this.filterForm.controls.search.valueChanges.pipe(startWith("")),
     { requireSync: true },
   );
 
-  protected readonly statusOptions: ChipFilterOption<AccessRuleStatusFilter>[] = [
-    {
-      label: this.i18nService.t("pamAccessRuleActive"),
-      value: "enabled",
-      icon: "bwi-check-circle",
-    },
-    {
-      label: this.i18nService.t("pamAccessRuleInactive"),
-      value: "disabled",
-      icon: "bwi-subtract-circle",
-    },
+  private readonly statusFilter = viewChild<FilterMenuComponent>("statusFilter");
+  private readonly collectionFilter = viewChild<FilterMenuComponent>("collectionFilter");
+
+  private readonly filterInputs = computed(() => {
+    const status = this.statusFilter()?.value() as AccessRuleStatusFilter | undefined;
+    const collections = this.collectionFilter()?.value();
+    return {
+      text: this.searchTerm().trim().toLowerCase(),
+      status: status ?? null,
+      collectionIds: Array.isArray(collections) ? (collections as string[]) : [],
+    };
+  });
+
+  protected readonly statusOptions: { label: string; value: AccessRuleStatusFilter }[] = [
+    { label: this.i18nService.t("pamAccessRuleActive"), value: "enabled" },
+    { label: this.i18nService.t("pamAccessRuleInactive"), value: "disabled" },
   ];
 
-  protected readonly collectionOptions = computed<ChipFilterOption<string>[]>(() =>
+  protected readonly collectionOptions = computed<{ label: string; value: string }[]>(() =>
     this.collections()
-      .map((c) => ({ label: c.name, value: c.id, icon: "bwi-collection-shared" as const }))
+      .map((c) => ({ label: c.name, value: c.id }))
       .sort((a, b) => a.label.localeCompare(b.label)),
   );
 
@@ -184,14 +195,13 @@ export class AccessRulesComponent {
 
     // Recompute the combined filter whenever any toolbar control changes.
     effect(() => {
-      const { search, status, collection } = this.filterInputs();
-      const text = search.trim().toLowerCase();
+      const { text, status, collectionIds } = this.filterInputs();
       this.dataSource.filter = (rule) => {
-        const collectionIds = rule.collections.map(uuidAsString);
+        const ruleCollectionIds = rule.collections.map(uuidAsString);
         return accessRuleMatchesFilter(
-          { name: rule.name, enabled: rule.enabled, collections: collectionIds },
-          resolveCollectionNames(collectionIds, this.collections()),
-          { text, status, collectionId: collection },
+          { name: rule.name, enabled: rule.enabled, collections: ruleCollectionIds },
+          resolveCollectionNames(ruleCollectionIds, this.collections()),
+          { text, status, collectionIds },
         );
       };
     });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
@@ -126,9 +126,8 @@ export class AccessRulesComponent {
   });
 
   // --- Toolbar filters ---
-  // Only `search` is a reactive-form control: `bit-filter-menu` isn't a
-  // `ControlValueAccessor`, so the status/collection chips below own their own
-  // selection and are read through the `FilterControl` contract in `filterInputs`.
+  // `bit-filter-menu` isn't a `ControlValueAccessor`, so only `search` is a form control; the
+  // status/collection chips own their selection and are read through the `FilterControl` contract.
   protected readonly filterForm = new FormGroup({
     search: new FormControl("", { nonNullable: true }),
   });

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rules.component.ts
@@ -25,7 +25,6 @@ import {
   CheckboxModule,
   DialogService,
   FILTER_CONTROL,
-  FilterControl,
   FilterMenuComponent,
   FilterOptionComponent,
   IconButtonModule,
@@ -55,6 +54,7 @@ import {
   copyRuleName,
   resolveCollectionNames,
   rulesChangingEnabled,
+  selectedFilterStrings,
 } from "..";
 import { DurationLongPipe } from "../date/duration-long.pipe";
 import { RelativeTimePipe } from "../date/relative-time.pipe";
@@ -141,18 +141,12 @@ export class AccessRulesComponent {
   private readonly statusFilter = viewChild("statusFilter", { read: FILTER_CONTROL });
   private readonly collectionFilter = viewChild("collectionFilter", { read: FILTER_CONTROL });
 
-  /** A multi-select chip's selection, filtered down to the strings it's actually made of. */
-  private selectedValues(chip: FilterControl | undefined): string[] {
-    const value = chip?.value();
-    return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
-  }
-
   private readonly filterInputs = computed(() => {
     const status = this.statusFilter()?.value();
     return {
       text: this.searchTerm().trim().toLowerCase(),
       status: (typeof status === "string" ? status : null) as AccessRuleStatusFilter | null,
-      collectionIds: this.selectedValues(this.collectionFilter()),
+      collectionIds: selectedFilterStrings(this.collectionFilter()?.value()),
     };
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-table.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-table.spec.ts
@@ -11,7 +11,7 @@ describe("accessRuleMatchesFilter", () => {
   const filter = (overrides: Partial<AccessRuleFilter> = {}): AccessRuleFilter => ({
     text: "",
     status: null,
-    collectionId: null,
+    collectionIds: [],
     ...overrides,
   });
 
@@ -39,16 +39,33 @@ describe("accessRuleMatchesFilter", () => {
       accessRuleMatchesFilter(
         rule({ collections: ["col-1"] }),
         [],
-        filter({ collectionId: "col-2" }),
+        filter({ collectionIds: ["col-2"] }),
       ),
     ).toBe(false);
     expect(
       accessRuleMatchesFilter(
         rule({ collections: ["col-2"] }),
         [],
-        filter({ collectionId: "col-2" }),
+        filter({ collectionIds: ["col-2"] }),
       ),
     ).toBe(true);
+  });
+
+  it("matches a rule carrying any of several selected collections", () => {
+    expect(
+      accessRuleMatchesFilter(
+        rule({ collections: ["col-3"] }),
+        [],
+        filter({ collectionIds: ["col-2", "col-3"] }),
+      ),
+    ).toBe(true);
+    expect(
+      accessRuleMatchesFilter(
+        rule({ collections: ["col-1"] }),
+        [],
+        filter({ collectionIds: ["col-2", "col-3"] }),
+      ),
+    ).toBe(false);
   });
 
   it("matches search text against the rule name", () => {

--- a/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-table.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/access-rule-table.ts
@@ -6,7 +6,8 @@ export type AccessRuleFilter = {
   /** Lower-cased, trimmed text matched against the rule name + collection names. */
   text: string;
   status: AccessRuleStatusFilter | null;
-  collectionId: string | null;
+  /** A rule matches if it carries any of these; empty means no collection filtering. */
+  collectionIds: string[];
 };
 
 /**
@@ -32,7 +33,10 @@ export function accessRuleMatchesFilter(
   if (filter.status === "disabled" && rule.enabled) {
     return false;
   }
-  if (filter.collectionId != null && !rule.collections.includes(filter.collectionId)) {
+  if (
+    filter.collectionIds.length > 0 &&
+    !filter.collectionIds.some((id) => rule.collections.includes(id))
+  ) {
     return false;
   }
   if (filter.text.length > 0) {

--- a/bitwarden_license/bit-web/src/app/pam/helpers/selected-filter-strings.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/selected-filter-strings.spec.ts
@@ -1,0 +1,27 @@
+import { selectedFilterStrings } from "./selected-filter-strings";
+
+describe("selectedFilterStrings", () => {
+  it("returns a string array unchanged", () => {
+    expect(selectedFilterStrings(["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("drops non-string members of the array", () => {
+    expect(selectedFilterStrings(["a", 1, null, "b", undefined])).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty array for an empty array", () => {
+    expect(selectedFilterStrings([])).toEqual([]);
+  });
+
+  it("returns an empty array for a single string, since a chip's value is never a bare scalar", () => {
+    expect(selectedFilterStrings("a")).toEqual([]);
+  });
+
+  it("returns an empty array for undefined", () => {
+    expect(selectedFilterStrings(undefined)).toEqual([]);
+  });
+
+  it("returns an empty array for null", () => {
+    expect(selectedFilterStrings(null)).toEqual([]);
+  });
+});

--- a/bitwarden_license/bit-web/src/app/pam/helpers/selected-filter-strings.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/selected-filter-strings.spec.ts
@@ -13,15 +13,10 @@ describe("selectedFilterStrings", () => {
     expect(selectedFilterStrings([])).toEqual([]);
   });
 
-  it("returns an empty array for a single string, since a chip's value is never a bare scalar", () => {
+  it("returns an empty array for anything that isn't an array", () => {
+    // A chip's value is never a bare scalar, so there is nothing to unwrap.
     expect(selectedFilterStrings("a")).toEqual([]);
-  });
-
-  it("returns an empty array for undefined", () => {
     expect(selectedFilterStrings(undefined)).toEqual([]);
-  });
-
-  it("returns an empty array for null", () => {
     expect(selectedFilterStrings(null)).toEqual([]);
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/helpers/selected-filter-strings.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/selected-filter-strings.ts
@@ -1,12 +1,9 @@
 /**
- * A multi-select chip's raw value, narrowed down to the strings it's actually made of.
+ * A multi-select chip's raw value, narrowed to the strings it's made of.
  *
- * Takes `unknown` rather than a `FilterControl` — a chip's `value()` is untyped until read
- * through that contract, and this stays pure and Angular-free so it can be shared by every
- * caller reading one. A non-array value, `undefined`/`null`, and non-string members all
- * resolve to `[]` rather than throwing; a caller that needs "no selection" to mean something
- * other than an empty array (e.g. `null`, to match every row) wraps this rather than
- * re-filtering the value itself.
+ * Takes `unknown` rather than a `FilterControl`: a chip's `value()` is untyped until read
+ * through that contract, and staying Angular-free lets every caller reading one share this.
+ * Anything that isn't an array of strings resolves to `[]` rather than throwing.
  */
 export function selectedFilterStrings(value: unknown): string[] {
   return Array.isArray(value)

--- a/bitwarden_license/bit-web/src/app/pam/helpers/selected-filter-strings.ts
+++ b/bitwarden_license/bit-web/src/app/pam/helpers/selected-filter-strings.ts
@@ -1,0 +1,15 @@
+/**
+ * A multi-select chip's raw value, narrowed down to the strings it's actually made of.
+ *
+ * Takes `unknown` rather than a `FilterControl` — a chip's `value()` is untyped until read
+ * through that contract, and this stays pure and Angular-free so it can be shared by every
+ * caller reading one. A non-array value, `undefined`/`null`, and non-string members all
+ * resolve to `[]` rather than throwing; a caller that needs "no selection" to mean something
+ * other than an empty array (e.g. `null`, to match every row) wraps this rather than
+ * re-filtering the value itself.
+ */
+export function selectedFilterStrings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}

--- a/bitwarden_license/bit-web/src/app/pam/index.ts
+++ b/bitwarden_license/bit-web/src/app/pam/index.ts
@@ -113,3 +113,4 @@ export type { RequestAccessErrorOutcome } from "./helpers/request-access-error";
 export { accessRuleErrorMessageKey, classifyAccessRuleError } from "./helpers/access-rule-error";
 export type { AccessRuleErrorField, AccessRuleErrorOutcome } from "./helpers/access-rule-error";
 export { activateAccessErrorMessageKey } from "./helpers/activate-access-error";
+export { selectedFilterStrings } from "./helpers/selected-filter-strings";


### PR DESCRIPTION
Design review 2026-09-04: the collections filter should use the component library's filter component. `bit-chip-filter` is deprecated in favour of `bit-filter-menu`, so both toolbar chips move. Collections becomes multi-select; the predicate changes from equality to "any of". No copy changes.