### PR TITLE
fix(pam): name the org nav group Privileged Controls and place it under Access Intelligence

### DIFF
--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.html
+++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.html
@@ -10,6 +10,7 @@
         route="access-intelligence"
       ></bit-nav-item>
     }
+    <app-pam-org-nav-slot [organization]="organization" />
 
     @if (canShowVaultTab(organization)) {
       <bit-nav-item
@@ -83,7 +84,6 @@
       route="integrations"
       *ngIf="integrationPageEnabled$ | async"
     ></bit-nav-item>
-    <app-pam-org-nav-slot [organization]="organization" />
     <bit-nav-group
       icon="bwi-cog"
       [text]="'settings' | i18n"

--- a/apps/web/src/app/dirt/event-logs/components/organization-events/events.component.ts
+++ b/apps/web/src/app/dirt/event-logs/components/organization-events/events.component.ts
@@ -60,7 +60,7 @@ const EVENT_SYSTEM_USER_TO_TRANSLATION: Record<EventSystemUser, string> = {
   [EventSystemUser.DomainVerification]: "domainVerification",
   [EventSystemUser.PublicApi]: "publicApi",
   [EventSystemUser.BitwardenPortal]: "system",
-  [EventSystemUser.Pam]: "pam",
+  [EventSystemUser.Pam]: "privilegedControls",
 };
 
 @Component({

--- a/apps/web/src/app/pam/org-nav-slot/pam-org-nav-slot.component.html
+++ b/apps/web/src/app/pam/org-nav-slot/pam-org-nav-slot.component.html
@@ -1,5 +1,5 @@
 @if (showPam()) {
-  <bit-nav-group icon="bwi-lock-encrypted" [text]="'pam' | i18n" route="pam">
+  <bit-nav-group icon="bwi-lock-encrypted" [text]="'privilegedControls' | i18n" route="pam">
     @if (showAccessRules()) {
       <bit-nav-item [text]="'pamAccessRules' | i18n" route="pam/access-rules" />
     }

--- a/apps/web/src/app/pam/org-nav-slot/pam-org-nav-slot.component.spec.ts
+++ b/apps/web/src/app/pam/org-nav-slot/pam-org-nav-slot.component.spec.ts
@@ -36,7 +36,7 @@ describe("PamOrgNavSlotComponent", () => {
         {
           provide: I18nService,
           useValue: new I18nMockService({
-            pam: "Privileged access",
+            privilegedControls: "Privileged Controls",
             pamAccessRules: "Access rules",
             pamAuditLog: "Audit log",
             pamRotationNav: "Rotation",

--- a/apps/web/src/app/pam/org-nav-slot/pam-org-nav-slot.component.stories.ts
+++ b/apps/web/src/app/pam/org-nav-slot/pam-org-nav-slot.component.stories.ts
@@ -1,0 +1,73 @@
+import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+import { of } from "rxjs";
+
+import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { I18nMockService, NavigationModule } from "@bitwarden/components";
+
+import { PamOrgNavSlotComponent } from "./pam-org-nav-slot.component";
+
+function organization(canManageAccessRules: boolean, canAccessEventLogs: boolean): Organization {
+  return { canManageAccessRules, canAccessEventLogs } as Organization;
+}
+
+function nav(options: { rotationEnabled?: boolean } = {}) {
+  const { rotationEnabled = false } = options;
+  return moduleMetadata({
+    imports: [PamOrgNavSlotComponent, NavigationModule],
+    providers: [
+      {
+        provide: ConfigService,
+        useValue: {
+          getFeatureFlag$: (flag: FeatureFlag) =>
+            of(flag === FeatureFlag.PamRotation ? rotationEnabled : true),
+        },
+      },
+      {
+        provide: I18nService,
+        useFactory: () =>
+          new I18nMockService({
+            privilegedControls: "Privileged Controls",
+            pamAccessRules: "Access rules",
+            pamAuditLog: "Audit log",
+            pamRotationNav: "Rotation",
+          }),
+      },
+    ],
+  });
+}
+
+export default {
+  title: "Web/PAM/Org Nav Slot",
+  component: PamOrgNavSlotComponent,
+  render: (args) => ({
+    props: args,
+    template: `
+      <bit-side-nav>
+        <app-pam-org-nav-slot [organization]="organization" />
+      </bit-side-nav>
+    `,
+  }),
+} as Meta<PamOrgNavSlotComponent>;
+
+type Story = StoryObj<PamOrgNavSlotComponent>;
+
+/** Both permissions granted, rotation off — the shipped shape of the group today. */
+export const Default: Story = {
+  decorators: [nav()],
+  args: { organization: organization(true, true) },
+};
+
+/** Rotation's own flag on top of the other two, adding the third item. */
+export const WithRotation: Story = {
+  decorators: [nav({ rotationEnabled: true })],
+  args: { organization: organization(true, true) },
+};
+
+/** No event-log permission — Audit log drops out, leaving Access rules alone. */
+export const AccessRulesOnly: Story = {
+  decorators: [nav()],
+  args: { organization: organization(true, false) },
+};

--- a/apps/web/src/app/pam/org-nav-slot/pam-org-nav-slot.component.stories.ts
+++ b/apps/web/src/app/pam/org-nav-slot/pam-org-nav-slot.component.stories.ts
@@ -1,39 +1,63 @@
-import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+import { ChangeDetectionStrategy, Component } from "@angular/core";
+import { RouterModule, Routes, provideRouter, withHashLocation } from "@angular/router";
+import { Decorator, Meta, StoryObj, applicationConfig, moduleMetadata } from "@storybook/angular";
 import { of } from "rxjs";
 
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { I18nMockService, NavigationModule } from "@bitwarden/components";
+import {
+  I18nMockService,
+  LayoutComponent,
+  NavigationModule,
+  StorybookGlobalStateProvider,
+} from "@bitwarden/components";
+// eslint-disable-next-line no-restricted-imports
+import { positionFixedWrapperDecorator } from "@bitwarden/components/src/stories/storybook-decorators";
+import { GlobalStateProvider } from "@bitwarden/state";
 
 import { PamOrgNavSlotComponent } from "./pam-org-nav-slot.component";
+
+@Component({
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class StoryContentComponent {}
+
+const routes: Routes = [
+  {
+    path: "pam",
+    children: [
+      { path: "access-rules", component: StoryContentComponent },
+      { path: "audit", component: StoryContentComponent },
+      { path: "rotation", component: StoryContentComponent },
+    ],
+  },
+];
+
+/** Renders the story at `url`; hash routing keeps Storybook's own query string intact. */
+const atUrl =
+  (url: string): Decorator =>
+  (storyFn, context) => {
+    window.location.hash = url;
+    return storyFn(context);
+  };
 
 function organization(canManageAccessRules: boolean, canAccessEventLogs: boolean): Organization {
   return { canManageAccessRules, canAccessEventLogs } as Organization;
 }
 
-function nav(options: { rotationEnabled?: boolean } = {}) {
+function featureFlags(options: { rotationEnabled?: boolean } = {}) {
   const { rotationEnabled = false } = options;
   return moduleMetadata({
-    imports: [PamOrgNavSlotComponent, NavigationModule],
     providers: [
       {
         provide: ConfigService,
         useValue: {
           getFeatureFlag$: (flag: FeatureFlag) =>
-            of(flag === FeatureFlag.PamRotation ? rotationEnabled : true),
+            of(flag === FeatureFlag.Pam || (rotationEnabled && flag === FeatureFlag.PamRotation)),
         },
-      },
-      {
-        provide: I18nService,
-        useFactory: () =>
-          new I18nMockService({
-            privilegedControls: "Privileged Controls",
-            pamAccessRules: "Access rules",
-            pamAuditLog: "Audit log",
-            pamRotationNav: "Rotation",
-          }),
       },
     ],
   });
@@ -42,12 +66,51 @@ function nav(options: { rotationEnabled?: boolean } = {}) {
 export default {
   title: "Web/PAM/Org Nav Slot",
   component: PamOrgNavSlotComponent,
+  decorators: [
+    atUrl("/pam/access-rules"),
+    positionFixedWrapperDecorator(),
+    moduleMetadata({
+      imports: [PamOrgNavSlotComponent, NavigationModule, LayoutComponent, RouterModule],
+      providers: [
+        {
+          provide: I18nService,
+          useFactory: () =>
+            new I18nMockService({
+              privilegedControls: "Privileged Controls",
+              pamAccessRules: "Access rules",
+              pamAuditLog: "Audit log",
+              pamRotationNav: "Rotation",
+              submenu: "submenu",
+              toggleCollapse: "toggle collapse",
+              toggleSideNavigation: "Toggle side navigation",
+              resizeSideNavigation: "Resize side navigation",
+              sideNavigation: "Side navigation",
+              skipToContent: "Skip to content",
+              skipLink: "Skip link",
+              loading: "Loading",
+            }),
+        },
+      ],
+    }),
+    applicationConfig({
+      providers: [
+        provideRouter(routes, withHashLocation()),
+        {
+          provide: GlobalStateProvider,
+          useClass: StorybookGlobalStateProvider,
+        },
+      ],
+    }),
+  ],
   render: (args) => ({
     props: args,
     template: `
-      <bit-side-nav>
-        <app-pam-org-nav-slot [organization]="organization" />
-      </bit-side-nav>
+      <bit-layout>
+        <bit-side-nav>
+          <app-pam-org-nav-slot [organization]="organization" />
+        </bit-side-nav>
+        <router-outlet></router-outlet>
+      </bit-layout>
     `,
   }),
 } as Meta<PamOrgNavSlotComponent>;
@@ -56,18 +119,18 @@ type Story = StoryObj<PamOrgNavSlotComponent>;
 
 /** Both permissions granted, rotation off — the shipped shape of the group today. */
 export const Default: Story = {
-  decorators: [nav()],
+  decorators: [featureFlags()],
   args: { organization: organization(true, true) },
 };
 
 /** Rotation's own flag on top of the other two, adding the third item. */
 export const WithRotation: Story = {
-  decorators: [nav({ rotationEnabled: true })],
+  decorators: [featureFlags({ rotationEnabled: true })],
   args: { organization: organization(true, true) },
 };
 
 /** No event-log permission — Audit log drops out, leaving Access rules alone. */
 export const AccessRulesOnly: Story = {
-  decorators: [nav()],
+  decorators: [featureFlags()],
   args: { organization: organization(true, false) },
 };

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -17330,9 +17330,6 @@
   "copy": {
     "message": "Copy"
   },
-  "pam": {
-    "message": "PAM"
-  },
   "pamAccessRules": {
     "message": "Access rules"
   },


### PR DESCRIPTION
Design review 2026-09-04. Repoints the nav label at the existing `privilegedControls` key and deletes the orphaned `pam` key; moves the slot to directly beneath Access Intelligence. The icon was already correct as of e0019c2b18.