### PR TITLE
fix(pam): keep the access-rule edit breadcrumb trail on one line

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -277,7 +277,10 @@ describe("AccessAuditComponent", () => {
    * `bit-filter-menu` owns its own selection — there is no form control to set — and the chips only
    * exist once the ready branch has rendered.
    */
-  const selectFilter = (chip: "kind" | "actor" | "requester" | "timePeriod", value: unknown) => {
+  const selectFilter = (
+    chip: "kind" | "actor" | "requester" | "item" | "timePeriod",
+    value: unknown,
+  ) => {
     fixture.detectChanges();
     component()[`${chip}Chip`]().setValue(value);
     fixture.detectChanges();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -865,7 +865,7 @@ describe("HistoryTabComponent", () => {
     });
 
     it("names the item by id in the confirm when the cipher is not in the approver's vault", async () => {
-      const unnamed = { ...unstartedApproval, cipherName: null };
+      const unnamed = { ...unstartedApproval, cipherName: null as string | null };
       managedRows$.next([unnamed]);
       create();
       showManaged();

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.html
@@ -1,14 +1,19 @@
 <bit-header [title]="titleText()">
-  <div slot="breadcrumbs" class="tw-flex tw-items-baseline">
-    <bit-breadcrumbs showTrailingArrow>
-      <bit-breadcrumb [route]="['..']">{{ "pamAccessRules" | i18n }}</bit-breadcrumb>
-    </bit-breadcrumbs>
+  <div slot="breadcrumbs" class="tw-flex tw-items-baseline tw-min-w-0">
+    <!-- `bit-breadcrumbs`' host carries `tw-w-full`, sized against its own containing block; this
+         wrapper gives it one shaped to its content instead of the whole row, so the static crumb
+         below stays in flow next to it rather than being pushed to the row's far edge. -->
+    <div class="tw-min-w-0">
+      <bit-breadcrumbs showTrailingArrow>
+        <bit-breadcrumb [route]="['..']">{{ "pamAccessRules" | i18n }}</bit-breadcrumb>
+      </bit-breadcrumbs>
+    </div>
     <!-- A route-less bit-breadcrumb falls back to a focusable button that does nothing and never
          gets aria-current; a static span carries the current-page semantics without that trap. -->
     <span
       bitTypography="h3"
       aria-current="page"
-      class="tw-inline-block !tw-m-0 !tw-text-fg-heading"
+      class="tw-inline-block tw-shrink-0 tw-whitespace-nowrap !tw-m-0 !tw-text-fg-heading"
       >{{ pageTypeKey | i18n }}</span
     >
   </div>

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -192,6 +192,26 @@ describe("AccessRuleEditComponent — page furniture", () => {
       '[slot="breadcrumbs"] > [aria-current="page"]',
     );
     expect(pageTypeCrumb.textContent.trim()).toBe("pamAccessRuleEditTitle");
+
+    // `bit-breadcrumbs`' host carries `tw-w-full`, which otherwise resolves against the whole
+    // breadcrumbs row and pushes the page-type crumb to the row's far edge, squeezed to a wrap.
+    // Wrapping it gives that `tw-w-full` a shrink-to-content container instead, so both crumbs
+    // stay on one line.
+    const breadcrumbsSlot = fixture.nativeElement.querySelector(
+      '[slot="breadcrumbs"]',
+    ) as HTMLElement;
+    const breadcrumbsEl = breadcrumbsSlot.querySelector("bit-breadcrumbs") as HTMLElement;
+    expect(breadcrumbsEl.parentElement).not.toBe(breadcrumbsSlot);
+    expect(breadcrumbsEl.parentElement?.classList.contains("tw-min-w-0")).toBe(true);
+    // Reserved so it can never be squeezed back into a wrap by a long rule name or a narrow trail.
+    expect(pageTypeCrumb.classList.contains("tw-shrink-0")).toBe(true);
+    expect(pageTypeCrumb.classList.contains("tw-whitespace-nowrap")).toBe(true);
+
+    // The rule's name stays the page's real `<h1>`; the page-type crumb above is a static span,
+    // never a routed `bit-breadcrumb` that VFO1 could promote into a second heading.
+    const headings = fixture.nativeElement.querySelectorAll("h1");
+    expect(headings).toHaveLength(1);
+    expect(headings[0].textContent).toContain("Production database access");
   });
 
   it("shows the create-page crumb and heading in create mode", async () => {
@@ -211,8 +231,9 @@ describe("AccessRuleEditComponent — page furniture", () => {
     );
     expect(pageTypeCrumb.textContent.trim()).toBe("pamAccessRuleCreateTitle");
 
-    const heading = fixture.nativeElement.querySelector("h1");
-    expect(heading.textContent).toContain("pamAccessRuleCreateTitle");
+    const headings = fixture.nativeElement.querySelectorAll("h1");
+    expect(headings).toHaveLength(1);
+    expect(headings[0].textContent).toContain("pamAccessRuleCreateTitle");
   });
 
   it("badges the saved rule as on, inside the heading", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-rules/access-rule-edit/access-rule-edit.component.spec.ts
@@ -164,6 +164,12 @@ describe("AccessRuleEditComponent — page furniture", () => {
     return fixture;
   };
 
+  const singleHeading = (fixture: ComponentFixture<AccessRuleEditComponent>): HTMLElement => {
+    const headings = fixture.nativeElement.querySelectorAll("h1");
+    expect(headings).toHaveLength(1);
+    return headings[0];
+  };
+
   it("shows the rule's name as the heading, with the list and edit-page crumbs", async () => {
     const fixture = await render(
       { params: { accessRuleId: "11111111-1111-1111-1111-111111111111" } },
@@ -209,9 +215,7 @@ describe("AccessRuleEditComponent — page furniture", () => {
 
     // The rule's name stays the page's real `<h1>`; the page-type crumb above is a static span,
     // never a routed `bit-breadcrumb` that VFO1 could promote into a second heading.
-    const headings = fixture.nativeElement.querySelectorAll("h1");
-    expect(headings).toHaveLength(1);
-    expect(headings[0].textContent).toContain("Production database access");
+    expect(singleHeading(fixture).textContent).toContain("Production database access");
   });
 
   it("shows the create-page crumb and heading in create mode", async () => {
@@ -231,9 +235,7 @@ describe("AccessRuleEditComponent — page furniture", () => {
     );
     expect(pageTypeCrumb.textContent.trim()).toBe("pamAccessRuleCreateTitle");
 
-    const headings = fixture.nativeElement.querySelectorAll("h1");
-    expect(headings).toHaveLength(1);
-    expect(headings[0].textContent).toContain("pamAccessRuleCreateTitle");
+    expect(singleHeading(fixture).textContent).toContain("pamAccessRuleCreateTitle");
   });
 
   it("badges the saved rule as on, inside the heading", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/testing/story-fixtures.ts
+++ b/bitwarden_license/bit-web/src/app/pam/testing/story-fixtures.ts
@@ -1,11 +1,12 @@
 import { provideZonelessChangeDetection } from "@angular/core";
 import { of } from "rxjs";
 
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/key-management/vault-timeout";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LockService } from "@bitwarden/unlock";
 import { ProductSwitcherService } from "@bitwarden/web-vault/app/layouts/product-switcher/shared/product-switcher.service";
 
 import type {


### PR DESCRIPTION
Design review 2026-09-04: "the breadcrumbs are broken". `bit-breadcrumbs` sets `tw-w-full` on its host, so the sibling crumb was pushed to the far edge and squeezed to its min-content width.

The last crumb is deliberately not a `bit-breadcrumb`: under VFO1 an active crumb is promoted to the page `<h1>`, which would replace the rule name.