### PR TITLE
feat(pam): add status, target system and collection filters to managed credentials

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19180,8 +19180,8 @@
   "pamRotationConfigSetUpTargetSystem": {
     "message": "Set up a target system"
   },
-  "pamRotationConfigNoResults": {
-    "message": "No results match your search."
+  "pamRotationConfigNoResultsFiltered": {
+    "message": "No managed credentials match your filters."
   },
   "pamRotationConfigColumnCredential": {
     "message": "Credential"

--- a/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-audit/access-audit.component.spec.ts
@@ -277,7 +277,10 @@ describe("AccessAuditComponent", () => {
    * Selects a chip's option through the `FilterControl` contract; `bit-filter-menu` owns its own
    * selection rather than a form control.
    */
-  const selectFilter = (chip: "kind" | "actor" | "requester" | "timePeriod", value: unknown) => {
+  const selectFilter = (
+    chip: "kind" | "actor" | "requester" | "item" | "timePeriod",
+    value: unknown,
+  ) => {
     fixture.detectChanges();
     component()[`${chip}Chip`]().setValue(value);
     fixture.detectChanges();

--- a/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/access-requests/history-tab.component.spec.ts
@@ -844,7 +844,7 @@ describe("HistoryTabComponent", () => {
     });
 
     it("names the item by id in the confirm when the cipher is not in the approver's vault", async () => {
-      const unnamed = { ...unstartedApproval, cipherName: null };
+      const unnamed = { ...unstartedApproval, cipherName: null as string | null };
       managedRows$.next([unnamed]);
       create();
       showManaged();

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -33,12 +33,47 @@
     </button>
   </bit-status-lockup>
 } @else {
-  <div class="tw-mb-4">
+  <div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-center tw-gap-3">
     <bit-search
-      class="tw-max-w-md"
+      class="tw-grow tw-max-w-md"
       [placeholder]="'pamRotationConfigSearch' | i18n"
       [formControl]="searchControl"
     ></bit-search>
+    <bit-filter-menu
+      #statusFilter
+      key="status"
+      [placeholderText]="'status' | i18n"
+      [unsetLabel]="'all' | i18n"
+    >
+      <bit-filter-option [value]="'pamRotationConfigStatusActive'">
+        {{ "pamRotationConfigStatusActive" | i18n }}
+      </bit-filter-option>
+      <bit-filter-option [value]="'pamRotationConfigStatusPaused'">
+        {{ "pamRotationConfigStatusPaused" | i18n }}
+      </bit-filter-option>
+    </bit-filter-menu>
+    <bit-filter-menu
+      #targetSystemFilter
+      key="targetSystem"
+      [placeholderText]="'pamRotationConfigColumnTargetSystem' | i18n"
+      [unsetLabel]="'all' | i18n"
+    >
+      @for (name of targetSystemNames(); track name) {
+        <bit-filter-option [value]="name">{{ name }}</bit-filter-option>
+      }
+    </bit-filter-menu>
+    @if (collectionOptions().length > 0) {
+      <bit-filter-menu
+        #collectionFilter
+        key="collection"
+        [placeholderText]="'pamCollectionFilter' | i18n"
+        [unsetLabel]="'all' | i18n"
+      >
+        @for (option of collectionOptions(); track option.id) {
+          <bit-filter-option [value]="option.id">{{ option.name }}</bit-filter-option>
+        }
+      </bit-filter-menu>
+    }
   </div>
 
   <bit-table [dataSource]="dataSource">

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.html
@@ -58,8 +58,8 @@
       [placeholderText]="'pamRotationConfigColumnTargetSystem' | i18n"
       [unsetLabel]="'all' | i18n"
     >
-      @for (name of targetSystemNames(); track name) {
-        <bit-filter-option [value]="name">{{ name }}</bit-filter-option>
+      @for (option of targetSystemOptions(); track option.id) {
+        <bit-filter-option [value]="option.id">{{ option.name }}</bit-filter-option>
       }
     </bit-filter-menu>
     @if (collectionOptions().length > 0) {
@@ -241,7 +241,7 @@
       @if (noResults()) {
         <tr bitRow>
           <td bitCell colspan="8" class="tw-py-6 tw-text-center tw-text-muted">
-            {{ "pamRotationConfigNoResults" | i18n }}
+            {{ "pamRotationConfigNoResultsFiltered" | i18n }}
           </td>
         </tr>
       }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -1,14 +1,23 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { ActivatedRoute, provideRouter, Router } from "@angular/router";
 import { BehaviorSubject, of } from "rxjs";
 
+import { CollectionAdminService } from "@bitwarden/admin-console/common";
+import { CollectionAdminView } from "@bitwarden/common/admin-console/models/collections";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { asUuid, uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { DialogService, FilterMenuComponent, ToastService } from "@bitwarden/components";
+import type { CipherId } from "@bitwarden/sdk-internal";
 
+import { OrgCiphersService } from "../org-ciphers.service";
 import type { RotationConfig } from "../rotation";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 import {
   ORGANIZATION_ID,
+  id,
   rotationConfigDescription,
   rotationConfig,
 } from "../testing/rotation-builders";
@@ -32,6 +41,13 @@ function makeRow(
     "My Cipher",
     description,
   );
+}
+
+function makeCipher(cipherId: CipherId, collectionIds: string[] = []): CipherView {
+  const cipher = new CipherView();
+  cipher.id = uuidAsString(cipherId);
+  cipher.collectionIds = collectionIds;
+  return cipher;
 }
 
 function makeConfigsServiceStub(rows: RotationConfigRow[] = [makeRow()]) {
@@ -77,6 +93,21 @@ describe("ManagedCredentialsTabComponent", () => {
         { provide: ActivatedRoute, useValue: { params: of({ organizationId: ORGANIZATION_ID }) } },
         { provide: RotationConfigsService, useValue: configsService },
         { provide: TargetSystemsService, useValue: targetSystemsService },
+        {
+          provide: OrgCiphersService,
+          useValue: {
+            ciphers$: new BehaviorSubject([]),
+            load: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: CollectionAdminService,
+          useValue: { collectionAdminViews$: () => of([]) },
+        },
+        {
+          provide: AccountService,
+          useValue: { activeAccount$: of({ id: "user-1" }) },
+        },
         { provide: ToastService, useValue: toastService },
         { provide: DialogService, useValue: dialogService },
         { provide: I18nService, useValue: i18nFake },
@@ -218,6 +249,145 @@ describe("ManagedCredentialsTabComponent", () => {
       expect(toastService.showToast).toHaveBeenCalledWith(
         expect.objectContaining({ variant: "success" }),
       );
+    });
+  });
+
+  describe("toolbar filters", () => {
+    const cipherA = asUuid<CipherId>(id("cipher-a"));
+    const cipherB = asUuid<CipherId>(id("cipher-b"));
+    const cipherC = asUuid<CipherId>(id("cipher-c"));
+
+    const rowA = makeRow({
+      cipherId: cipherA,
+      targetSystemName: "Prod Entra",
+      enabled: true,
+    });
+    const rowB = makeRow({
+      cipherId: cipherB,
+      targetSystemName: "Staging AD",
+      enabled: false,
+    });
+    const rowC = makeRow({
+      cipherId: cipherC,
+      targetSystemName: "Prod Entra",
+      enabled: true,
+    });
+
+    function setupWithData(
+      rows: RotationConfigRow[],
+      ciphers: CipherView[],
+      collections: CollectionAdminView[] = [],
+    ) {
+      configsService = makeConfigsServiceStub(rows);
+      targetSystemsService = {
+        systems$: new BehaviorSubject<unknown[]>([{ id: "ts-1" }]),
+        load: jest.fn().mockResolvedValue(undefined),
+      };
+      toastService = { showToast: jest.fn() };
+      dialogService = { openSimpleDialog: jest.fn().mockResolvedValue(true) };
+
+      TestBed.configureTestingModule({
+        imports: [ManagedCredentialsTabComponent],
+        providers: [
+          provideRouter([]),
+          {
+            provide: ActivatedRoute,
+            useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
+          },
+          { provide: RotationConfigsService, useValue: configsService },
+          { provide: TargetSystemsService, useValue: targetSystemsService },
+          {
+            provide: OrgCiphersService,
+            useValue: {
+              ciphers$: new BehaviorSubject(ciphers),
+              load: jest.fn().mockResolvedValue(undefined),
+            },
+          },
+          {
+            provide: CollectionAdminService,
+            useValue: { collectionAdminViews$: () => of(collections) },
+          },
+          { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+          { provide: ToastService, useValue: toastService },
+          { provide: DialogService, useValue: dialogService },
+          { provide: I18nService, useValue: i18nFake },
+        ],
+      });
+
+      fixture = TestBed.createComponent(ManagedCredentialsTabComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    }
+
+    function chip(key: string): FilterMenuComponent {
+      return fixture.debugElement.query(By.css(`bit-filter-menu[key="${key}"]`)).componentInstance;
+    }
+
+    it("derives target-system options from the loaded rows, sorted by name", () => {
+      setupWithData([rowA, rowB, rowC], []);
+      expect(component.targetSystemNames()).toEqual(["Prod Entra", "Staging AD"]);
+    });
+
+    it("derives collection options from the rows' ciphers, not every org collection", async () => {
+      setupWithData(
+        [rowA, rowB],
+        [makeCipher(cipherA, ["col-1"]), makeCipher(cipherB, ["col-2"])],
+        [
+          { id: "col-1", name: "Engineering" } as CollectionAdminView,
+          { id: "col-2", name: "Finance" } as CollectionAdminView,
+          { id: "col-3", name: "Unreferenced" } as CollectionAdminView,
+        ],
+      );
+      await fixture.whenStable();
+      expect(component.collectionOptions()).toEqual([
+        { id: "col-1", name: "Engineering" },
+        { id: "col-2", name: "Finance" },
+      ]);
+    });
+
+    it("does not render the collection chip when no row's cipher carries a collection", () => {
+      setupWithData([rowA], [makeCipher(cipherA, [])]);
+      expect(fixture.debugElement.query(By.css('bit-filter-menu[key="collection"]'))).toBeNull();
+    });
+
+    it("narrows rows to the selected status", () => {
+      setupWithData([rowA, rowB, rowC], []);
+      chip("status").toggle("pamRotationConfigStatusPaused");
+      fixture.detectChanges();
+      expect(component.processedRows()).toHaveLength(1);
+      expect(component.processedRows()[0].config.cipherId).toBe(cipherB);
+    });
+
+    it("narrows rows to the selected target system", () => {
+      setupWithData([rowA, rowB, rowC], []);
+      chip("targetSystem").toggle("Staging AD");
+      fixture.detectChanges();
+      expect(component.processedRows()).toHaveLength(1);
+      expect(component.processedRows()[0].config.cipherId).toBe(cipherB);
+    });
+
+    it("narrows rows to the selected collection", () => {
+      setupWithData(
+        [rowA, rowB, rowC],
+        [makeCipher(cipherA, ["col-1"]), makeCipher(cipherB, ["col-2"])],
+        [
+          { id: "col-1", name: "Engineering" } as CollectionAdminView,
+          { id: "col-2", name: "Finance" } as CollectionAdminView,
+        ],
+      );
+      chip("collection").toggle("col-1");
+      fixture.detectChanges();
+      expect(component.processedRows()).toHaveLength(1);
+      expect(component.processedRows()[0].config.cipherId).toBe(cipherA);
+    });
+
+    it("ANDs the chips with each other and with the search text", () => {
+      setupWithData([rowA, rowB, rowC], []);
+      component.searchControl.setValue("prod");
+      chip("status").toggle("pamRotationConfigStatusActive");
+      fixture.detectChanges();
+      const ids = component.processedRows().map((r: RotationConfigRow) => r.config.cipherId);
+      expect(ids.sort()).toEqual([cipherA, cipherC].sort());
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -20,6 +20,7 @@ import {
   id,
   rotationConfigDescription,
   rotationConfig,
+  sysId,
 } from "../testing/rotation-builders";
 
 import { ManagedCredentialsTabComponent } from "./managed-credentials-tab.component";
@@ -268,16 +269,19 @@ describe("ManagedCredentialsTabComponent", () => {
 
     const rowA = makeRow({
       cipherId: cipherA,
+      targetSystemId: sysId("1"),
       targetSystemName: "Prod Entra",
       enabled: true,
     });
     const rowB = makeRow({
       cipherId: cipherB,
+      targetSystemId: sysId("2"),
       targetSystemName: "Staging AD",
       enabled: false,
     });
     const rowC = makeRow({
       cipherId: cipherC,
+      targetSystemId: sysId("1"),
       targetSystemName: "Prod Entra",
       enabled: true,
     });
@@ -323,7 +327,24 @@ describe("ManagedCredentialsTabComponent", () => {
 
     it("derives target-system options from the loaded rows, sorted by name", () => {
       setupWithData([rowA, rowB, rowC], []);
-      expect(component.targetSystemNames()).toEqual(["Prod Entra", "Staging AD"]);
+      expect(component.targetSystemOptions()).toEqual([
+        { id: sysId("1"), name: "Prod Entra" },
+        { id: sysId("2"), name: "Staging AD" },
+      ]);
+    });
+
+    it("keys target-system options by id, so two systems sharing a name stay distinct", () => {
+      const rowSameNameOtherSystem = makeRow({
+        cipherId: cipherC,
+        targetSystemId: sysId("2"),
+        targetSystemName: "Prod Entra",
+        enabled: true,
+      });
+      setupWithData([rowA, rowSameNameOtherSystem], []);
+      expect(component.targetSystemOptions()).toEqual([
+        { id: sysId("1"), name: "Prod Entra" },
+        { id: sysId("2"), name: "Prod Entra" },
+      ]);
     });
 
     it("derives collection options from the rows' ciphers, not every org collection", async () => {
@@ -358,7 +379,7 @@ describe("ManagedCredentialsTabComponent", () => {
 
     it("narrows rows to the selected target system", () => {
       setupWithData([rowA, rowB, rowC], []);
-      chip("targetSystem").toggle("Staging AD");
+      chip("targetSystem").toggle(sysId("2"));
       fixture.detectChanges();
       expect(component.processedRows()).toHaveLength(1);
       expect(component.processedRows()[0].config.cipherId).toBe(cipherB);
@@ -367,7 +388,11 @@ describe("ManagedCredentialsTabComponent", () => {
     it("narrows rows to the selected collection", () => {
       setupWithData(
         [rowA, rowB, rowC],
-        [makeCipher(cipherA, ["col-1"]), makeCipher(cipherB, ["col-2"])],
+        [
+          makeCipher(cipherA, ["col-1"]),
+          makeCipher(cipherB, ["col-2"]),
+          makeCipher(cipherC, ["col-2"]),
+        ],
         [
           { id: "col-1", name: "Engineering" } as CollectionAdminView,
           { id: "col-2", name: "Finance" } as CollectionAdminView,
@@ -379,6 +404,20 @@ describe("ManagedCredentialsTabComponent", () => {
       expect(component.processedRows()[0].config.cipherId).toBe(cipherA);
     });
 
+    it("does not exclude a row from the collection filter when its cipher never loaded", () => {
+      // cipherC is absent from the loaded ciphers: a viewer without canEditAllCiphers only
+      // gets ciphers OrgCiphersService assigned them, so rowC's collections are unknown, not empty.
+      setupWithData(
+        [rowA, rowC],
+        [makeCipher(cipherA, ["col-1"])],
+        [{ id: "col-1", name: "Engineering" } as CollectionAdminView],
+      );
+      chip("collection").toggle("col-1");
+      fixture.detectChanges();
+      const ids = component.processedRows().map((r: RotationConfigRow) => r.config.cipherId);
+      expect(ids.sort()).toEqual([cipherA, cipherC].sort());
+    });
+
     it("ANDs the chips with each other and with the search text", () => {
       setupWithData([rowA, rowB, rowC], []);
       component.searchControl.setValue("prod");
@@ -386,6 +425,13 @@ describe("ManagedCredentialsTabComponent", () => {
       fixture.detectChanges();
       const ids = component.processedRows().map((r: RotationConfigRow) => r.config.cipherId);
       expect(ids.sort()).toEqual([cipherA, cipherC].sort());
+    });
+
+    it("shows the generic no-results message when chip filters alone empty the table", () => {
+      setupWithData([rowA], []);
+      chip("status").toggle("pamRotationConfigStatusPaused");
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain("pamRotationConfigNoResultsFiltered");
     });
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.spec.ts
@@ -65,6 +65,29 @@ function makeConfigsServiceStub(rows: RotationConfigRow[] = [makeRow()]) {
   };
 }
 
+function makeCipherCollectionProviders(
+  ciphers: CipherView[] = [],
+  collections: CollectionAdminView[] = [],
+) {
+  return [
+    {
+      provide: OrgCiphersService,
+      useValue: {
+        ciphers$: new BehaviorSubject(ciphers),
+        load: jest.fn().mockResolvedValue(undefined),
+      },
+    },
+    {
+      provide: CollectionAdminService,
+      useValue: { collectionAdminViews$: () => of(collections) },
+    },
+    {
+      provide: AccountService,
+      useValue: { activeAccount$: of({ id: "user-1" }) },
+    },
+  ];
+}
+
 describe("ManagedCredentialsTabComponent", () => {
   let fixture: ComponentFixture<ManagedCredentialsTabComponent>;
   let component: any;
@@ -93,21 +116,7 @@ describe("ManagedCredentialsTabComponent", () => {
         { provide: ActivatedRoute, useValue: { params: of({ organizationId: ORGANIZATION_ID }) } },
         { provide: RotationConfigsService, useValue: configsService },
         { provide: TargetSystemsService, useValue: targetSystemsService },
-        {
-          provide: OrgCiphersService,
-          useValue: {
-            ciphers$: new BehaviorSubject([]),
-            load: jest.fn().mockResolvedValue(undefined),
-          },
-        },
-        {
-          provide: CollectionAdminService,
-          useValue: { collectionAdminViews$: () => of([]) },
-        },
-        {
-          provide: AccountService,
-          useValue: { activeAccount$: of({ id: "user-1" }) },
-        },
+        ...makeCipherCollectionProviders(),
         { provide: ToastService, useValue: toastService },
         { provide: DialogService, useValue: dialogService },
         { provide: I18nService, useValue: i18nFake },
@@ -296,18 +305,7 @@ describe("ManagedCredentialsTabComponent", () => {
           },
           { provide: RotationConfigsService, useValue: configsService },
           { provide: TargetSystemsService, useValue: targetSystemsService },
-          {
-            provide: OrgCiphersService,
-            useValue: {
-              ciphers$: new BehaviorSubject(ciphers),
-              load: jest.fn().mockResolvedValue(undefined),
-            },
-          },
-          {
-            provide: CollectionAdminService,
-            useValue: { collectionAdminViews$: () => of(collections) },
-          },
-          { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+          ...makeCipherCollectionProviders(ciphers, collections),
           { provide: ToastService, useValue: toastService },
           { provide: DialogService, useValue: dialogService },
           { provide: I18nService, useValue: i18nFake },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.stories.ts
@@ -147,6 +147,7 @@ export default {
               status: "Status",
               all: "All",
               options: "Options",
+              search: "Search",
               pamCollectionFilter: "Collection",
               pamNoTargetSystemsYetTitle: "No target systems yet",
               pamRotationConfigColumnCredential: "Credential",
@@ -163,7 +164,7 @@ export default {
               pamRotationConfigInProgress: "Rotation in progress",
               pamRotationConfigManualDue: "Manual rotation due",
               pamRotationConfigNew: "New managed credential",
-              pamRotationConfigNoResults: "No results match your search.",
+              pamRotationConfigNoResultsFiltered: "No managed credentials match your filters.",
               pamRotationConfigNoTargetSystems:
                 "Set up a target system before you can rotate credentials. A target system defines where a credential lives and how Bitwarden rotates it.",
               pamRotationConfigPause: "Pause",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.stories.ts
@@ -1,0 +1,206 @@
+import { importProvidersFrom } from "@angular/core";
+import { ActivatedRoute, RouterModule } from "@angular/router";
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+import { of } from "rxjs";
+
+import { CollectionAdminService } from "@bitwarden/admin-console/common";
+import { CollectionAdminView } from "@bitwarden/common/admin-console/models/collections";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { asUuid, uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { DialogService, I18nMockService, ToastService } from "@bitwarden/components";
+import type { CipherId } from "@bitwarden/sdk-internal";
+
+import { OrgCiphersService } from "../org-ciphers.service";
+import { TargetSystemsService } from "../target-systems/target-systems.service";
+import {
+  id,
+  sysId,
+  rotationConfig,
+  rotationConfigActions,
+  rotationConfigDescription,
+} from "../testing/rotation-builders";
+
+import { ManagedCredentialsTabComponent } from "./managed-credentials-tab.component";
+import { buildRotationConfigRow, RotationConfigRow } from "./rotation-config-row";
+import { RotationConfigsService } from "./rotation-configs.service";
+
+const CIPHER_PROD = asUuid<CipherId>(id("cipher-prod-db"));
+const CIPHER_STAGING = asUuid<CipherId>(id("cipher-staging-admin"));
+const CIPHER_CI = asUuid<CipherId>(id("cipher-ci-token"));
+
+function cipher(cipherId: CipherId, name: string, collectionIds: string[]): CipherView {
+  const c = new CipherView();
+  c.id = uuidAsString(cipherId);
+  c.name = name;
+  c.collectionIds = collectionIds;
+  return c;
+}
+
+const CIPHERS: CipherView[] = [
+  cipher(CIPHER_PROD, "Prod DB service account", ["col-1"]),
+  cipher(CIPHER_STAGING, "Staging admin login", ["col-2"]),
+  cipher(CIPHER_CI, "CI pipeline token", ["col-1", "col-2"]),
+];
+
+const COLLECTIONS: CollectionAdminView[] = [
+  { id: "col-1", name: "Production" } as CollectionAdminView,
+  { id: "col-2", name: "Engineering" } as CollectionAdminView,
+];
+
+const ROWS: RotationConfigRow[] = [
+  buildRotationConfigRow(
+    rotationConfig({
+      cipherId: CIPHER_PROD,
+      targetSystemId: sysId("1"),
+      targetSystemName: "Prod Entra",
+      enabled: true,
+    }),
+    undefined,
+    "Prod DB service account",
+    rotationConfigDescription(),
+  ),
+  buildRotationConfigRow(
+    rotationConfig({
+      cipherId: CIPHER_STAGING,
+      targetSystemId: sysId("2"),
+      targetSystemName: "Staging AD",
+      enabled: false,
+      awaitingManualRotation: true,
+    }),
+    undefined,
+    "Staging admin login",
+    rotationConfigDescription({
+      actions: rotationConfigActions({
+        canRotateNow: false,
+        canRecordManual: true,
+        canPause: false,
+        canResume: true,
+      }),
+    }),
+  ),
+  buildRotationConfigRow(
+    rotationConfig({
+      cipherId: CIPHER_CI,
+      targetSystemId: sysId("1"),
+      targetSystemName: "Prod Entra",
+      enabled: true,
+      hasActiveJob: true,
+    }),
+    undefined,
+    "CI pipeline token",
+    rotationConfigDescription(),
+  ),
+];
+
+function rotationServices(rows: RotationConfigRow[]) {
+  return moduleMetadata({
+    providers: [
+      {
+        provide: RotationConfigsService,
+        useValue: {
+          loading$: of(false),
+          rows$: of(rows),
+          configs$: of(rows.map((r) => r.config)),
+          awaitingManualCount$: of(rows.filter((r) => r.awaitingManualRotation).length),
+          load: () => Promise.resolve(),
+          pause: () => Promise.resolve(),
+          resume: () => Promise.resolve(),
+          rotateNow: () => Promise.resolve(),
+          recordManual: () => Promise.resolve(),
+          delete: () => Promise.resolve(),
+        },
+      },
+      {
+        provide: OrgCiphersService,
+        useValue: { ciphers$: of(rows.length > 0 ? CIPHERS : []), load: () => Promise.resolve() },
+      },
+      {
+        provide: TargetSystemsService,
+        useValue: {
+          systems$: of([{ id: sysId("1") }, { id: sysId("2") }]),
+          load: () => Promise.resolve(),
+        },
+      },
+    ],
+  });
+}
+
+export default {
+  title: "Web/PAM/Rotation/Managed Credentials Tab",
+  component: ManagedCredentialsTabComponent,
+  decorators: [
+    applicationConfig({
+      providers: [
+        importProvidersFrom(RouterModule.forRoot([])),
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ organizationId: "org-1" }) },
+        },
+        {
+          provide: I18nService,
+          useFactory: () =>
+            new I18nMockService({
+              delete: "Delete",
+              edit: "Edit",
+              status: "Status",
+              all: "All",
+              options: "Options",
+              pamCollectionFilter: "Collection",
+              pamNoTargetSystemsYetTitle: "No target systems yet",
+              pamRotationConfigColumnCredential: "Credential",
+              pamRotationConfigColumnLastRotation: "Last rotation",
+              pamRotationConfigColumnNextRotation: "Next rotation",
+              pamRotationConfigColumnRotateOnAccessEnd: "Rotate on access end",
+              pamRotationConfigColumnSchedule: "Schedule",
+              pamRotationConfigColumnTargetSystem: "Target system",
+              pamRotationConfigDeleteLockedTitle:
+                "Can't remove while a rotation is in progress. It clears when the current job finishes or times out.",
+              pamRotationConfigEmptyState: "No managed credentials configured",
+              pamRotationConfigEmptyStateDescription:
+                "Add a managed credential to start rotating it automatically.",
+              pamRotationConfigInProgress: "Rotation in progress",
+              pamRotationConfigManualDue: "Manual rotation due",
+              pamRotationConfigNew: "New managed credential",
+              pamRotationConfigNoResults: "No results match your search.",
+              pamRotationConfigNoTargetSystems:
+                "Set up a target system before you can rotate credentials. A target system defines where a credential lives and how Bitwarden rotates it.",
+              pamRotationConfigPause: "Pause",
+              pamRotationConfigRecordManual: "Record manual rotation",
+              pamRotationConfigResume: "Resume",
+              pamRotationConfigRotateNow: "Rotate now",
+              pamRotationConfigRotateNowDisabledTitle:
+                "Cannot rotate now — the rotation is disabled, paused, or already in progress.",
+              pamRotationConfigSearch: "Search managed credentials",
+              pamRotationConfigSetUpTargetSystem: "Set up a target system",
+              pamRotationConfigStatusActive: "Active",
+              pamRotationConfigStatusPaused: "Paused",
+            }),
+        },
+        { provide: AccountService, useValue: { activeAccount$: of({ id: "user-1" }) } },
+        {
+          provide: CollectionAdminService,
+          useValue: { collectionAdminViews$: () => of(COLLECTIONS) },
+        },
+        { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
+        { provide: ToastService, useValue: { showToast: () => {} } },
+      ],
+    }),
+  ],
+} as Meta<ManagedCredentialsTabComponent>;
+
+type Story = StoryObj<ManagedCredentialsTabComponent>;
+
+/**
+ * Two target systems and both statuses, so the Status and Target system chips each narrow the
+ * table; the Collection chip resolves its options from the rows' ciphers.
+ */
+export const Default: Story = {
+  decorators: [rotationServices(ROWS)],
+};
+
+/** Target systems exist, but no managed credential has been configured yet. */
+export const Empty: Story = {
+  decorators: [rotationServices([])],
+};

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
@@ -1,18 +1,34 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+  viewChild,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import { map } from "rxjs";
+import { firstValueFrom, map } from "rxjs";
 
+import { CollectionAdminService } from "@bitwarden/admin-console/common";
 import { NoResults } from "@bitwarden/assets/svg";
+import { CollectionAdminView } from "@bitwarden/common/admin-console/models/collections";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { ErrorResponse } from "@bitwarden/common/models/response/error.response";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { asUuid, uuidAsString } from "@bitwarden/common/platform/abstractions/sdk/sdk.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
+import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import {
   BadgeModule,
   ButtonModule,
   DialogService,
+  FilterMenuComponent,
+  FilterMenuModule,
   IconButtonModule,
   IconModule,
   MenuModule,
@@ -25,8 +41,10 @@ import {
   ToastService,
   TooltipDirective,
 } from "@bitwarden/components";
+import type { CipherId } from "@bitwarden/sdk-internal";
 import { I18nPipe } from "@bitwarden/ui-common";
 
+import { OrgCiphersService } from "../org-ciphers.service";
 import { TargetSystemMethod, TargetSystem } from "../rotation";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 
@@ -49,6 +67,7 @@ import { RotationConfigsService } from "./rotation-configs.service";
     ReactiveFormsModule,
     BadgeModule,
     ButtonModule,
+    FilterMenuModule,
     IconButtonModule,
     IconModule,
     MenuModule,
@@ -68,6 +87,9 @@ export class ManagedCredentialsTabComponent {
   private readonly router = inject(Router);
   private readonly configsService = inject(RotationConfigsService);
   private readonly targetSystemsService = inject(TargetSystemsService);
+  private readonly orgCiphersService = inject(OrgCiphersService);
+  private readonly collectionAdminService = inject(CollectionAdminService);
+  private readonly accountService = inject(AccountService);
   private readonly dialogService = inject(DialogService);
   private readonly toastService = inject(ToastService);
   private readonly i18nService = inject(I18nService);
@@ -100,12 +122,63 @@ export class ManagedCredentialsTabComponent {
   /** Expose for template. */
   protected readonly TargetSystemMethod = TargetSystemMethod;
 
+  /** Status/target-system/collection toolbar chips; read directly rather than via a form control. */
+  private readonly statusFilterChip = viewChild<FilterMenuComponent>("statusFilter");
+  private readonly targetSystemFilterChip = viewChild<FilterMenuComponent>("targetSystemFilter");
+  private readonly collectionFilterChip = viewChild<FilterMenuComponent>("collectionFilter");
+
+  /** Distinct target system names present in the currently-loaded rows, sorted for the chip. */
+  protected readonly targetSystemNames = computed(() =>
+    [...new Set(this.rows().map((r) => r.targetSystemName))].sort((a, b) => a.localeCompare(b)),
+  );
+
+  private readonly ciphers = toSignal(this.orgCiphersService.ciphers$, {
+    initialValue: [] as CipherView[],
+  });
+
+  /** Each cipher's collection ids, keyed by its id, for resolving a row's collections via `cipherId`. */
+  private readonly cipherCollectionIdsById = computed(() => {
+    const map = new Map<CipherId, string[]>();
+    for (const cipher of this.ciphers()) {
+      map.set(asUuid<CipherId>(cipher.id), cipher.collectionIds);
+    }
+    return map;
+  });
+
+  /**
+   * The org's collections, for resolving the ids above to names. Loaded directly here rather than
+   * through a page-scoped service, since `CollectionAdminService` is already provided at the app
+   * root (see `apps/web/src/app/core/core.module.ts`) and `access-rules.component.ts` reads it the
+   * same way.
+   */
+  private readonly collections = signal<CollectionAdminView[]>([]);
+
+  /**
+   * Collection filter options: only the collections actually reachable from a visible row's
+   * cipher, not every collection in the org — an option nothing on this page matches is noise, not
+   * a filter.
+   */
+  protected readonly collectionOptions = computed(() => {
+    const nameById = new Map(this.collections().map((c) => [uuidAsString(c.id), c.name]));
+    const collectionIdsByCipher = this.cipherCollectionIdsById();
+    const present = new Set<string>();
+    for (const row of this.rows()) {
+      for (const collectionId of collectionIdsByCipher.get(row.config.cipherId) ?? []) {
+        present.add(collectionId);
+      }
+    }
+    return [...present]
+      .map((id) => ({ id, name: nameById.get(id) ?? id }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
+
   constructor() {
     effect(() => {
       const organizationId = this.organizationId();
       void this.configsService.load(organizationId);
       // Also loads target systems so the empty state can tell if one must be set up first.
       void this.targetSystemsService.load(organizationId);
+      void this.loadCollections(organizationId);
     });
 
     effect(() => {
@@ -114,11 +187,42 @@ export class ManagedCredentialsTabComponent {
 
     effect(() => {
       const text = this.searchText().trim().toLowerCase();
-      this.dataSource.filter = (row) =>
-        text === "" ||
-        row.cipherName.toLowerCase().includes(text) ||
-        row.targetSystemName.toLowerCase().includes(text);
+      const status = this.statusFilterChip()?.value() as string | null | undefined;
+      const targetSystemName = this.targetSystemFilterChip()?.value() as string | null | undefined;
+      const collectionId = this.collectionFilterChip()?.value() as string | null | undefined;
+      const collectionIdsByCipher = this.cipherCollectionIdsById();
+
+      this.dataSource.filter = (row) => {
+        if (
+          text !== "" &&
+          !row.cipherName.toLowerCase().includes(text) &&
+          !row.targetSystemName.toLowerCase().includes(text)
+        ) {
+          return false;
+        }
+        if (status != null && row.statusLabelKey !== status) {
+          return false;
+        }
+        if (targetSystemName != null && row.targetSystemName !== targetSystemName) {
+          return false;
+        }
+        if (
+          collectionId != null &&
+          !(collectionIdsByCipher.get(row.config.cipherId) ?? []).includes(collectionId)
+        ) {
+          return false;
+        }
+        return true;
+      };
     });
+  }
+
+  private async loadCollections(organizationId: OrganizationId): Promise<void> {
+    const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
+    const collections = await firstValueFrom(
+      this.collectionAdminService.collectionAdminViews$(organizationId, userId),
+    );
+    this.collections.set(collections);
   }
 
   protected readonly processedRows = toSignal(this.dataSource.connect(), {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
@@ -45,7 +45,7 @@ import type { CipherId } from "@bitwarden/sdk-internal";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { OrgCiphersService } from "../org-ciphers.service";
-import { TargetSystemMethod, TargetSystem } from "../rotation";
+import { TargetSystemMethod, TargetSystem, TargetSystemId } from "../rotation";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 
 import { RotationConfigRow } from "./rotation-config-row";
@@ -129,10 +129,22 @@ export class ManagedCredentialsTabComponent {
   });
   private readonly collectionFilterChip = viewChild("collectionFilter", { read: FILTER_CONTROL });
 
-  /** Distinct target system names present in the currently-loaded rows, sorted for the chip. */
-  protected readonly targetSystemNames = computed(() =>
-    [...new Set(this.rows().map((r) => r.targetSystemName))].sort((a, b) => a.localeCompare(b)),
-  );
+  /**
+   * Distinct target systems present in the currently-loaded rows, keyed by id and sorted by name
+   * for the chip. Keyed by id rather than name: target system names carry no uniqueness
+   * constraint (`target-system-edit.component.ts` validates only required + maxLength), so two
+   * systems sharing a name would otherwise collapse into one chip option that matched rows
+   * against either.
+   */
+  protected readonly targetSystemOptions = computed(() => {
+    const nameById = new Map<TargetSystemId, string>();
+    for (const row of this.rows()) {
+      nameById.set(row.config.targetSystemId, row.targetSystemName);
+    }
+    return [...nameById.entries()]
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
 
   private readonly ciphers = toSignal(this.orgCiphersService.ciphers$, {
     initialValue: [] as CipherView[],
@@ -150,8 +162,8 @@ export class ManagedCredentialsTabComponent {
   /**
    * The org's collections, for resolving the ids above to names. Loaded directly here rather than
    * through a page-scoped service, since `CollectionAdminService` is already provided at the app
-   * root (see `apps/web/src/app/core/core.module.ts`) and `access-rules.component.ts` reads it the
-   * same way.
+   * root (see `apps/web/src/app/core/core.module.ts`) and `services/access-rules.service.ts` reads
+   * it the same way.
    */
   private readonly collections = signal<CollectionAdminView[]>([]);
 
@@ -164,7 +176,7 @@ export class ManagedCredentialsTabComponent {
     const nameById = new Map(this.collections().map((c) => [uuidAsString(c.id), c.name]));
     const present = new Set<string>();
     for (const row of this.rows()) {
-      for (const collectionId of this.cipherCollectionIds(row)) {
+      for (const collectionId of this.cipherCollectionIds(row) ?? []) {
         present.add(collectionId);
       }
     }
@@ -173,9 +185,17 @@ export class ManagedCredentialsTabComponent {
       .sort((a, b) => a.name.localeCompare(b.name));
   });
 
-  /** `row`'s cipher's collection ids, via {@link cipherCollectionIdsById}. */
-  private cipherCollectionIds(row: RotationConfigRow): string[] {
-    return this.cipherCollectionIdsById().get(row.config.cipherId) ?? [];
+  /**
+   * `row`'s cipher's collection ids, via {@link cipherCollectionIdsById}, or `undefined` when the
+   * cipher never loaded — a viewer without `canEditAllCiphers` only gets ciphers assigned to them
+   * from `OrgCiphersService`, so a row outside that set is not "in no collection", it is unknown.
+   * Callers must not treat the two the same: `collectionOptions` folds `undefined` into no
+   * contribution (fine, it only builds a menu from what's visible), but the collection filter
+   * below must not read it as "excluded", or a credential the viewer cannot decrypt would drop out
+   * of every collection selection with no sign that it was ever considered.
+   */
+  private cipherCollectionIds(row: RotationConfigRow): string[] | undefined {
+    return this.cipherCollectionIdsById().get(row.config.cipherId);
   }
 
   constructor() {
@@ -194,7 +214,8 @@ export class ManagedCredentialsTabComponent {
     effect(() => {
       const text = this.searchText().trim().toLowerCase();
       const status = this.statusFilterChip()?.value() as string | null | undefined;
-      const targetSystemName = this.targetSystemFilterChip()?.value() as string | null | undefined;
+      const targetSystemId = this.targetSystemFilterChip()?.value() as
+        TargetSystemId | null | undefined;
       const collectionId = this.collectionFilterChip()?.value() as string | null | undefined;
 
       this.dataSource.filter = (row) => {
@@ -208,10 +229,15 @@ export class ManagedCredentialsTabComponent {
         if (status != null && row.statusLabelKey !== status) {
           return false;
         }
-        if (targetSystemName != null && row.targetSystemName !== targetSystemName) {
+        if (targetSystemId != null && row.config.targetSystemId !== targetSystemId) {
           return false;
         }
-        if (collectionId != null && !this.cipherCollectionIds(row).includes(collectionId)) {
+        const rowCollectionIds = this.cipherCollectionIds(row);
+        if (
+          collectionId != null &&
+          rowCollectionIds !== undefined &&
+          !rowCollectionIds.includes(collectionId)
+        ) {
           return false;
         }
         return true;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/managed-credentials-tab.component.ts
@@ -27,7 +27,7 @@ import {
   BadgeModule,
   ButtonModule,
   DialogService,
-  FilterMenuComponent,
+  FILTER_CONTROL,
   FilterMenuModule,
   IconButtonModule,
   IconModule,
@@ -123,9 +123,11 @@ export class ManagedCredentialsTabComponent {
   protected readonly TargetSystemMethod = TargetSystemMethod;
 
   /** Status/target-system/collection toolbar chips; read directly rather than via a form control. */
-  private readonly statusFilterChip = viewChild<FilterMenuComponent>("statusFilter");
-  private readonly targetSystemFilterChip = viewChild<FilterMenuComponent>("targetSystemFilter");
-  private readonly collectionFilterChip = viewChild<FilterMenuComponent>("collectionFilter");
+  private readonly statusFilterChip = viewChild("statusFilter", { read: FILTER_CONTROL });
+  private readonly targetSystemFilterChip = viewChild("targetSystemFilter", {
+    read: FILTER_CONTROL,
+  });
+  private readonly collectionFilterChip = viewChild("collectionFilter", { read: FILTER_CONTROL });
 
   /** Distinct target system names present in the currently-loaded rows, sorted for the chip. */
   protected readonly targetSystemNames = computed(() =>
@@ -160,10 +162,9 @@ export class ManagedCredentialsTabComponent {
    */
   protected readonly collectionOptions = computed(() => {
     const nameById = new Map(this.collections().map((c) => [uuidAsString(c.id), c.name]));
-    const collectionIdsByCipher = this.cipherCollectionIdsById();
     const present = new Set<string>();
     for (const row of this.rows()) {
-      for (const collectionId of collectionIdsByCipher.get(row.config.cipherId) ?? []) {
+      for (const collectionId of this.cipherCollectionIds(row)) {
         present.add(collectionId);
       }
     }
@@ -171,6 +172,11 @@ export class ManagedCredentialsTabComponent {
       .map((id) => ({ id, name: nameById.get(id) ?? id }))
       .sort((a, b) => a.name.localeCompare(b.name));
   });
+
+  /** `row`'s cipher's collection ids, via {@link cipherCollectionIdsById}. */
+  private cipherCollectionIds(row: RotationConfigRow): string[] {
+    return this.cipherCollectionIdsById().get(row.config.cipherId) ?? [];
+  }
 
   constructor() {
     effect(() => {
@@ -190,7 +196,6 @@ export class ManagedCredentialsTabComponent {
       const status = this.statusFilterChip()?.value() as string | null | undefined;
       const targetSystemName = this.targetSystemFilterChip()?.value() as string | null | undefined;
       const collectionId = this.collectionFilterChip()?.value() as string | null | undefined;
-      const collectionIdsByCipher = this.cipherCollectionIdsById();
 
       this.dataSource.filter = (row) => {
         if (
@@ -206,10 +211,7 @@ export class ManagedCredentialsTabComponent {
         if (targetSystemName != null && row.targetSystemName !== targetSystemName) {
           return false;
         }
-        if (
-          collectionId != null &&
-          !(collectionIdsByCipher.get(row.config.cipherId) ?? []).includes(collectionId)
-        ) {
+        if (collectionId != null && !this.cipherCollectionIds(row).includes(collectionId)) {
           return false;
         }
         return true;

--- a/bitwarden_license/bit-web/src/app/pam/testing/story-fixtures.ts
+++ b/bitwarden_license/bit-web/src/app/pam/testing/story-fixtures.ts
@@ -1,11 +1,12 @@
 import { provideZonelessChangeDetection } from "@angular/core";
 import { of } from "rxjs";
 
-import { LockService, LogoutService } from "@bitwarden/auth/common";
+import { LogoutService } from "@bitwarden/auth/common";
 import { VaultTimeoutSettingsService } from "@bitwarden/common/key-management/vault-timeout";
 import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
+import { LockService } from "@bitwarden/unlock";
 import { ProductSwitcherService } from "@bitwarden/web-vault/app/layouts/product-switcher/shared/product-switcher.service";
 
 import type {


### PR DESCRIPTION
Design review 2026-09-04, with a mockup: a width-capped search plus filter chips, same concept as the other PAM pages.

The existing `tw-max-w-md` on the search was inert: `bit-search` sets no host display class, so as a block child it is an inline box and `max-width` does not apply. Making the row a flex container is what activates the cap. Adds the rotation module's first Storybook stories.