### PR TITLE
fix(pam): rename the rotation daemons surface to access connectors

### DIFF
--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -18769,8 +18769,8 @@
   "pamRotationTabTargetSystems": {
     "message": "Target systems"
   },
-  "pamRotationTabDaemons": {
-    "message": "Daemons"
+  "pamRotationTabAccessConnectors": {
+    "message": "Access connectors"
   },
   "pamRotationConfigCreateTitle": {
     "message": "Add managed credential"
@@ -18856,8 +18856,8 @@
   "pamTargetSystemTemplateEntraSummary": {
     "message": "Bitwarden automatically rotates a Microsoft Entra ID application secret."
   },
-  "pamTargetSystemTemplateCustomScriptSummary": {
-    "message": "Bitwarden automatically rotates the credential by running your script on a registered daemon."
+  "pamTargetSystemTemplateCustomScriptConnectorSummary": {
+    "message": "Bitwarden automatically rotates the credential by running your script on a registered access connector."
   },
   "pamTargetSystemNoResults": {
     "message": "No target systems match your search."
@@ -18964,8 +18964,8 @@
   "pamTargetSystemSupportsSessionTermination": {
     "message": "Supports session termination"
   },
-  "pamTargetSystemSupportsSessionTerminationHint": {
-    "message": "When enabled, the daemon will terminate active sessions after a credential is rotated."
+  "pamTargetSystemSupportsSessionTerminationConnectorHint": {
+    "message": "When enabled, the access connector will terminate active sessions after a credential is rotated."
   },
   "pamTargetSystemSessionTerminationSupported": {
     "message": "Supported"
@@ -18985,64 +18985,64 @@
   "pamTargetSystemSetupGuidanceTitle": {
     "message": "Finish setting up rotation"
   },
-  "pamTargetSystemSetupGuidanceAutomaticDaemon": {
-    "message": "On the Daemons tab, register a rotation daemon (or reuse an existing one) and assign this target system to it — the daemon performs the rotations."
+  "pamTargetSystemSetupGuidanceAutomaticAccessConnector": {
+    "message": "On the Access connectors tab, register an access connector (or reuse an existing one) and assign this target system to it — the access connector performs the rotations."
   },
   "pamTargetSystemSetupGuidanceAutomaticCredential": {
     "message": "On the Managed credentials tab, add a credential for this target system, then set the account to rotate and a schedule."
   },
-  "pamTargetSystemSetupGuidanceManual": {
-    "message": "On the Managed credentials tab, add a credential for this target system. There is no daemon to connect — you rotate the credential by hand and record each rotation there."
+  "pamTargetSystemSetupGuidanceManualConnector": {
+    "message": "On the Managed credentials tab, add a credential for this target system. There is no access connector to connect — you rotate the credential by hand and record each rotation there."
   },
   "pamTargetSystemNotFound": {
     "message": "Target system not found."
   },
-  "pamDaemonSearch": {
-    "message": "Search daemons"
+  "pamAccessConnectorSearch": {
+    "message": "Search access connectors"
   },
-  "pamDaemonNew": {
-    "message": "New daemon"
+  "pamAccessConnectorNew": {
+    "message": "New access connector"
   },
-  "pamDaemonRegister": {
-    "message": "Register daemon"
+  "pamAccessConnectorRegister": {
+    "message": "Register access connector"
   },
-  "pamDaemonEmptyStateTitle": {
-    "message": "No daemons registered"
+  "pamAccessConnectorEmptyStateTitle": {
+    "message": "No access connectors registered"
   },
-  "pamDaemonEmptyStateDescription": {
-    "message": "Register a daemon to start rotating credentials."
+  "pamAccessConnectorEmptyStateDescription": {
+    "message": "Register an access connector to start rotating credentials."
   },
-  "pamDaemonConnection": {
+  "pamAccessConnectorConnection": {
     "message": "Connection"
   },
-  "pamDaemonAssignments": {
+  "pamAccessConnectorAssignments": {
     "message": "Assigned targets"
   },
-  "pamDaemonConnected": {
+  "pamAccessConnectorConnected": {
     "message": "Connected"
   },
-  "pamDaemonOffline": {
+  "pamAccessConnectorOffline": {
     "message": "Offline"
   },
-  "pamDaemonAssignTarget": {
+  "pamAccessConnectorAssignTarget": {
     "message": "Assign to target"
   },
-  "pamDaemonAssignTargetTitle": {
+  "pamAccessConnectorAssignTargetTitle": {
     "message": "Assign target system"
   },
-  "pamDaemonAssignTargetLabel": {
+  "pamAccessConnectorAssignTargetLabel": {
     "message": "Target system"
   },
-  "pamDaemonAssignNoOptions": {
-    "message": "All active automatic target systems are already assigned to this daemon."
+  "pamAccessConnectorAssignNoOptions": {
+    "message": "All active automatic target systems are already assigned to this access connector."
   },
-  "pamDaemonAssignConfirm": {
+  "pamAccessConnectorAssignConfirm": {
     "message": "Assign"
   },
-  "pamDaemonAssigned": {
+  "pamAccessConnectorAssigned": {
     "message": "Target system assigned."
   },
-  "pamDaemonUnassign": {
+  "pamAccessConnectorUnassign": {
     "message": "Remove $NAME$",
     "placeholders": {
       "name": {
@@ -19051,11 +19051,11 @@
       }
     }
   },
-  "pamDaemonUnassignConfirmTitle": {
+  "pamAccessConnectorUnassignConfirmTitle": {
     "message": "Remove assignment?"
   },
-  "pamDaemonUnassignConfirmContent": {
-    "message": "Remove $NAME$ from this daemon? Active rotation jobs claimed by this daemon will continue to completion.",
+  "pamAccessConnectorUnassignConfirmContent": {
+    "message": "Remove $NAME$ from this access connector? Active rotation jobs claimed by this access connector will continue to completion.",
     "placeholders": {
       "name": {
         "content": "$1",
@@ -19063,19 +19063,19 @@
       }
     }
   },
-  "pamDaemonUnassigned": {
+  "pamAccessConnectorUnassigned": {
     "message": "Target system removed."
   },
-  "pamDaemonDisable": {
+  "pamAccessConnectorDisable": {
     "message": "Disable"
   },
-  "pamDaemonEnable": {
+  "pamAccessConnectorEnable": {
     "message": "Enable"
   },
-  "pamDaemonDisableConfirmTitle": {
-    "message": "Disable daemon?"
+  "pamAccessConnectorDisableConfirmTitle": {
+    "message": "Disable access connector?"
   },
-  "pamDaemonDisableConfirmContent": {
+  "pamAccessConnectorDisableConfirmContent": {
     "message": "Disable $NAME$? It stops claiming new rotation jobs and any jobs it is currently running are released. You can re-enable it later.",
     "placeholders": {
       "name": {
@@ -19084,17 +19084,17 @@
       }
     }
   },
-  "pamDaemonDisabled": {
-    "message": "Daemon disabled."
+  "pamAccessConnectorDisabled": {
+    "message": "Access connector disabled."
   },
-  "pamDaemonEnabled": {
-    "message": "Daemon enabled."
+  "pamAccessConnectorEnabled": {
+    "message": "Access connector enabled."
   },
-  "pamDaemonDeleteConfirmTitle": {
-    "message": "Delete daemon?"
+  "pamAccessConnectorDeleteConfirmTitle": {
+    "message": "Delete access connector?"
   },
-  "pamDaemonDeleteConfirmContent": {
-    "message": "Deleting $NAME$ is permanent and invalidates its credentials. This daemon held the organization key in memory — if you suspect a compromise, rotate the organization key as a remediation. Running rotation jobs are released. Register a new daemon to resume rotation.",
+  "pamAccessConnectorDeleteConfirmContent": {
+    "message": "Deleting $NAME$ is permanent and invalidates its credentials. This access connector held the organization key in memory — if you suspect a compromise, rotate the organization key as a remediation. Running rotation jobs are released. Register a new access connector to resume rotation.",
     "placeholders": {
       "name": {
         "content": "$1",
@@ -19102,65 +19102,65 @@
       }
     }
   },
-  "pamDaemonDeleted": {
-    "message": "Daemon deleted."
+  "pamAccessConnectorDeleted": {
+    "message": "Access connector deleted."
   },
-  "pamDaemonRegisterTitle": {
-    "message": "Register daemon"
+  "pamAccessConnectorRegisterTitle": {
+    "message": "Register access connector"
   },
-  "pamDaemonNamePlaceholder": {
+  "pamAccessConnectorNamePlaceholder": {
     "message": "e.g. On-prem production server"
   },
-  "pamDaemonNameHint": {
-    "message": "A descriptive name to identify this daemon. Max 200 characters."
+  "pamAccessConnectorNameHint": {
+    "message": "A descriptive name to identify this access connector. Max 200 characters."
   },
-  "pamDaemonRegistered": {
-    "message": "Daemon registered."
+  "pamAccessConnectorRegistered": {
+    "message": "Access connector registered."
   },
-  "pamDaemonNoResults": {
-    "message": "No daemons match your search."
+  "pamAccessConnectorNoResults": {
+    "message": "No access connectors match your search."
   },
-  "pamDaemonDetailTitle": {
-    "message": "Daemon"
+  "pamAccessConnectorDetailTitle": {
+    "message": "Access connector"
   },
-  "pamDaemonNotFound": {
-    "message": "Daemon not found."
+  "pamAccessConnectorNotFound": {
+    "message": "Access connector not found."
   },
-  "pamDaemonDetailsHeading": {
+  "pamAccessConnectorDetailsHeading": {
     "message": "Details"
   },
-  "pamDaemonActivityHeading": {
+  "pamAccessConnectorActivityHeading": {
     "message": "Recent activity"
   },
-  "pamDaemonActivityEmpty": {
+  "pamAccessConnectorActivityEmpty": {
     "message": "No rotation activity yet."
   },
-  "pamDaemonStatusEnabled": {
+  "pamAccessConnectorStatusEnabled": {
     "message": "Enabled"
   },
-  "pamDaemonStatusDisabled": {
+  "pamAccessConnectorStatusDisabled": {
     "message": "Disabled"
   },
-  "pamDaemonTokenTitle": {
-    "message": "Daemon token"
+  "pamAccessConnectorTokenTitle": {
+    "message": "Access connector token"
   },
-  "pamDaemonTokenWarningTitle": {
+  "pamAccessConnectorTokenWarningTitle": {
     "message": "Save this token now"
   },
-  "pamDaemonTokenWarningBody": {
-    "message": "This token is shown only once and cannot be retrieved later. Copy it and deliver it to the daemon operator out of band — paste it into the daemon configuration file. If the token is lost, delete this daemon and register a new one."
+  "pamAccessConnectorTokenWarningBody": {
+    "message": "This token is shown only once and cannot be retrieved later. Copy it and deliver it to the daemon operator out of band — paste it into the daemon configuration file. If the token is lost, delete this access connector and register a new one."
   },
-  "pamDaemonTokenLabel": {
-    "message": "Daemon token"
+  "pamAccessConnectorTokenLabel": {
+    "message": "Access connector token"
   },
-  "pamDaemonTokenHint": {
+  "pamAccessConnectorTokenHint": {
     "message": "This token will not be shown again."
   },
-  "pamDaemonTokenCopy": {
+  "pamAccessConnectorTokenCopy": {
     "message": "Copy token"
   },
-  "pamDaemonTokenCopied": {
-    "message": "Daemon token copied."
+  "pamAccessConnectorTokenCopied": {
+    "message": "Access connector token copied."
   },
   "pamRotationConfigNew": {
     "message": "New managed credential"
@@ -19273,8 +19273,8 @@
   "pamRotationConfigRemove": {
     "message": "Remove rotation configuration"
   },
-  "pamRotationConfigRemoveLockedContent": {
-    "message": "A rotation job is currently in progress. You can remove the rotation configuration once the daemon finishes it — or once it times out. Pausing only stops new jobs; it does not cancel the one already running."
+  "pamRotationConfigRemoveLockedConnectorContent": {
+    "message": "A rotation job is currently in progress. You can remove the rotation configuration once the access connector finishes it — or once it times out. Pausing only stops new jobs; it does not cancel the one already running."
   },
   "pamRotationConfigCreateHeading": {
     "message": "Credential details"
@@ -19309,8 +19309,8 @@
   "pamRotationConfigAccountIdentity": {
     "message": "Account identity"
   },
-  "pamRotationConfigAccountIdentityHint": {
-    "message": "The account to rotate in the target system, e.g. a UPN, SQL login, or script argument. Passed to the daemon as-is."
+  "pamRotationConfigAccountIdentityConnectorHint": {
+    "message": "The account to rotate in the target system, e.g. a UPN, SQL login, or script argument. Passed to the access connector as-is."
   },
   "pamRotationConfigTerminateSessions": {
     "message": "Terminate active sessions after rotation"

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -19147,8 +19147,8 @@
   "pamAccessConnectorTokenWarningTitle": {
     "message": "Save this token now"
   },
-  "pamAccessConnectorTokenWarningBody": {
-    "message": "This token is shown only once and cannot be retrieved later. Copy it and deliver it to the daemon operator out of band — paste it into the daemon configuration file. If the token is lost, delete this access connector and register a new one."
+  "pamAccessConnectorTokenDaemonWarningBody": {
+    "message": "This token is shown only once and cannot be retrieved later. Copy it and deliver it out of band to the operator of the rotation daemon that will use this access connector — paste it into the daemon's configuration file. If the token is lost, delete this access connector and register a new one."
   },
   "pamAccessConnectorTokenLabel": {
     "message": "Access connector token"

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.html
@@ -1,15 +1,15 @@
 <form [formGroup]="form" bit-dialog dialogSize="default">
   <ng-container bitDialogTitle>
-    {{ "pamDaemonAssignTargetTitle" | i18n }}
+    {{ "pamAccessConnectorAssignTargetTitle" | i18n }}
     <span class="tw-text-sm tw-normal-case tw-text-muted">{{ params.daemon.name }}</span>
   </ng-container>
 
   <div bitDialogContent>
     @if (params.options.length === 0) {
-      <p class="tw-text-muted">{{ "pamDaemonAssignNoOptions" | i18n }}</p>
+      <p class="tw-text-muted">{{ "pamAccessConnectorAssignNoOptions" | i18n }}</p>
     } @else {
       <bit-form-field>
-        <bit-label>{{ "pamDaemonAssignTargetLabel" | i18n }}</bit-label>
+        <bit-label>{{ "pamAccessConnectorAssignTargetLabel" | i18n }}</bit-label>
         <bit-select formControlName="targetSystemId" id="assign-target-dialog_select_target">
           @for (system of params.options; track system.id) {
             <bit-option [value]="system.id" [label]="system.name"></bit-option>
@@ -28,7 +28,7 @@
         (click)="confirm()"
         id="assign-target-dialog_button_confirm"
       >
-        {{ "pamDaemonAssignConfirm" | i18n }}
+        {{ "pamAccessConnectorAssignConfirm" | i18n }}
       </button>
     }
     <button

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/assign-target-dialog.component.spec.ts
@@ -64,7 +64,7 @@ describe("AssignTargetDialogComponent", () => {
   it("shows an empty-options message when there are no options", async () => {
     await createComponent([]);
     const html = fixture.nativeElement.textContent as string;
-    expect(html).toContain("pamDaemonAssignNoOptions");
+    expect(html).toContain("pamAccessConnectorAssignNoOptions");
   });
 
   it("closes with undefined on cancel", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -1,6 +1,6 @@
 <bit-header [title]="titleText()" icon="bwi-terminal">
   <bit-breadcrumbs slot="breadcrumbs">
-    <bit-breadcrumb [route]="['..']">{{ "pamRotationTabDaemons" | i18n }}</bit-breadcrumb>
+    <bit-breadcrumb [route]="['..']">{{ "pamRotationTabAccessConnectors" | i18n }}</bit-breadcrumb>
   </bit-breadcrumbs>
   @if (daemon()) {
     @if (enabled()) {
@@ -11,7 +11,7 @@
         [bitAction]="disable"
         id="daemon-detail_button_disable"
       >
-        {{ "pamDaemonDisable" | i18n }}
+        {{ "pamAccessConnectorDisable" | i18n }}
       </button>
     } @else {
       <button
@@ -21,7 +21,7 @@
         [bitAction]="enable"
         id="daemon-detail_button_enable"
       >
-        {{ "pamDaemonEnable" | i18n }}
+        {{ "pamAccessConnectorEnable" | i18n }}
       </button>
     }
     <button
@@ -43,32 +43,34 @@
     <!-- Details -->
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "pamDaemonDetailsHeading" | i18n }}</h2>
+        <h2 bitTypography="h5">{{ "pamAccessConnectorDetailsHeading" | i18n }}</h2>
       </bit-section-header>
       <bit-card>
         <div class="tw-mb-4">
           <p bitTypography="helper" class="tw-mb-1 tw-font-semibold">{{ "status" | i18n }}</p>
           @if (d.connector.status === DaemonStatus.Enabled) {
-            <span bitBadge variant="success">{{ "pamDaemonStatusEnabled" | i18n }}</span>
+            <span bitBadge variant="success">{{ "pamAccessConnectorStatusEnabled" | i18n }}</span>
           } @else {
-            <span bitBadge variant="secondary">{{ "pamDaemonStatusDisabled" | i18n }}</span>
+            <span bitBadge variant="secondary">{{
+              "pamAccessConnectorStatusDisabled" | i18n
+            }}</span>
           }
         </div>
 
         <div class="tw-mb-4">
           <p bitTypography="helper" class="tw-mb-1 tw-font-semibold">
-            {{ "pamDaemonConnection" | i18n }}
+            {{ "pamAccessConnectorConnection" | i18n }}
           </p>
           @if (d.connector.isConnected) {
-            <span bitBadge variant="success">{{ "pamDaemonConnected" | i18n }}</span>
+            <span bitBadge variant="success">{{ "pamAccessConnectorConnected" | i18n }}</span>
           } @else {
-            <span bitBadge variant="secondary">{{ "pamDaemonOffline" | i18n }}</span>
+            <span bitBadge variant="secondary">{{ "pamAccessConnectorOffline" | i18n }}</span>
           }
         </div>
 
         <div>
           <p bitTypography="helper" class="tw-mb-1 tw-font-semibold">
-            {{ "pamDaemonAssignments" | i18n }}
+            {{ "pamAccessConnectorAssignments" | i18n }}
           </p>
           @if (assignmentNames().length === 0) {
             <span class="tw-text-muted">&mdash;</span>
@@ -86,14 +88,14 @@
     <!-- Recent activity -->
     <bit-section>
       <bit-section-header>
-        <h2 bitTypography="h5">{{ "pamDaemonActivityHeading" | i18n }}</h2>
+        <h2 bitTypography="h5">{{ "pamAccessConnectorActivityHeading" | i18n }}</h2>
       </bit-section-header>
       @if (d.jobs.length > 0) {
         <app-rotation-history [jobs]="d.jobs"></app-rotation-history>
       } @else {
         <bit-card>
           <p bitTypography="body2" class="tw-m-0 tw-text-muted">
-            {{ "pamDaemonActivityEmpty" | i18n }}
+            {{ "pamAccessConnectorActivityEmpty" | i18n }}
           </p>
         </bit-card>
       }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -109,9 +109,9 @@ export class DaemonDetailComponent {
       return;
     }
     const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonDisableConfirmTitle" },
-      content: { key: "pamDaemonDisableConfirmContent", placeholders: [connector.name] },
-      acceptButtonText: { key: "pamDaemonDisable" },
+      title: { key: "pamAccessConnectorDisableConfirmTitle" },
+      content: { key: "pamAccessConnectorDisableConfirmContent", placeholders: [connector.name] },
+      acceptButtonText: { key: "pamAccessConnectorDisable" },
       cancelButtonText: { key: "cancel" },
       type: "warning",
     });
@@ -123,7 +123,7 @@ export class DaemonDetailComponent {
       this.patchStatus(DaemonStatus.Disabled);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonDisabled"),
+        message: this.i18nService.t("pamAccessConnectorDisabled"),
       });
     } catch (e) {
       this.showError(e);
@@ -141,7 +141,7 @@ export class DaemonDetailComponent {
       this.patchStatus(DaemonStatus.Enabled);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonEnabled"),
+        message: this.i18nService.t("pamAccessConnectorEnabled"),
       });
     } catch (e) {
       this.showError(e);
@@ -155,8 +155,8 @@ export class DaemonDetailComponent {
       return;
     }
     const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonDeleteConfirmTitle" },
-      content: { key: "pamDaemonDeleteConfirmContent", placeholders: [connector.name] },
+      title: { key: "pamAccessConnectorDeleteConfirmTitle" },
+      content: { key: "pamAccessConnectorDeleteConfirmContent", placeholders: [connector.name] },
       acceptButtonText: { key: "delete" },
       cancelButtonText: { key: "cancel" },
       type: "danger",
@@ -168,7 +168,7 @@ export class DaemonDetailComponent {
       await this.rotationSdk.deleteConnector(this.organizationId, connector.id);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonDeleted"),
+        message: this.i18nService.t("pamAccessConnectorDeleted"),
       });
       await this.navigateToList();
     } catch (e) {
@@ -197,7 +197,7 @@ export class DaemonDetailComponent {
     } catch {
       this.toastService.showToast({
         variant: "error",
-        message: this.i18nService.t("pamDaemonNotFound"),
+        message: this.i18nService.t("pamAccessConnectorNotFound"),
       });
       await this.navigateToList();
       return null;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-register-dialog.component.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" [bitSubmit]="submit" bit-dialog dialogSize="default">
   <ng-container bitDialogTitle>
-    {{ "pamDaemonRegisterTitle" | i18n }}
+    {{ "pamAccessConnectorRegisterTitle" | i18n }}
   </ng-container>
 
   <div bitDialogContent>
@@ -10,9 +10,9 @@
         bitInput
         formControlName="name"
         id="daemon-register-dialog_input_name"
-        [placeholder]="'pamDaemonNamePlaceholder' | i18n"
+        [placeholder]="'pamAccessConnectorNamePlaceholder' | i18n"
       />
-      <bit-hint>{{ "pamDaemonNameHint" | i18n }}</bit-hint>
+      <bit-hint>{{ "pamAccessConnectorNameHint" | i18n }}</bit-hint>
     </bit-form-field>
   </div>
 
@@ -24,7 +24,7 @@
       bitFormButton
       id="daemon-register-dialog_button_submit"
     >
-      {{ "pamDaemonRegister" | i18n }}
+      {{ "pamAccessConnectorRegister" | i18n }}
     </button>
     <button
       type="button"

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
@@ -5,7 +5,7 @@
 >
   <ng-container bitDialogContent>
     <bit-callout type="warning" [title]="'pamAccessConnectorTokenWarningTitle' | i18n">
-      {{ "pamAccessConnectorTokenWarningBody" | i18n }}
+      {{ "pamAccessConnectorTokenDaemonWarningBody" | i18n }}
     </bit-callout>
 
     <bit-form-field class="tw-mb-0">

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.html
@@ -1,15 +1,15 @@
 <bit-dialog
-  [title]="'pamDaemonTokenTitle' | i18n"
+  [title]="'pamAccessConnectorTokenTitle' | i18n"
   [subtitle]="params.daemonName"
   dialogSize="large"
 >
   <ng-container bitDialogContent>
-    <bit-callout type="warning" [title]="'pamDaemonTokenWarningTitle' | i18n">
-      {{ "pamDaemonTokenWarningBody" | i18n }}
+    <bit-callout type="warning" [title]="'pamAccessConnectorTokenWarningTitle' | i18n">
+      {{ "pamAccessConnectorTokenWarningBody" | i18n }}
     </bit-callout>
 
     <bit-form-field class="tw-mb-0">
-      <bit-label>{{ "pamDaemonTokenLabel" | i18n }}</bit-label>
+      <bit-label>{{ "pamAccessConnectorTokenLabel" | i18n }}</bit-label>
       <input
         bitInput
         type="text"
@@ -22,11 +22,11 @@
         type="button"
         bitIconButton="bwi-clone"
         bitSuffix
-        [label]="'pamDaemonTokenCopy' | i18n"
+        [label]="'pamAccessConnectorTokenCopy' | i18n"
         (click)="copyToken()"
         id="daemon-token-dialog_button_copy"
       ></button>
-      <bit-hint>{{ "pamDaemonTokenHint" | i18n }}</bit-hint>
+      <bit-hint>{{ "pamAccessConnectorTokenHint" | i18n }}</bit-hint>
     </bit-form-field>
   </ng-container>
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-token-dialog.component.ts
@@ -54,7 +54,7 @@ export class DaemonTokenDialogComponent {
     this.platformUtilsService.copyToClipboard(this.params.token);
     this.toastService.showToast({
       variant: "success",
-      message: this.i18nService.t("pamDaemonTokenCopied"),
+      message: this.i18nService.t("pamAccessConnectorTokenCopied"),
     });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -1,7 +1,7 @@
 <div class="tw-mb-4">
   <bit-search
     class="tw-max-w-md"
-    [placeholder]="'pamDaemonSearch' | i18n"
+    [placeholder]="'pamAccessConnectorSearch' | i18n"
     [formControl]="searchControl"
   ></bit-search>
 </div>
@@ -11,8 +11,8 @@
 } @else if (totalRows() === 0) {
   <bit-status-lockup>
     <bit-svg slot="graphic" [content]="noItemsIcon"></bit-svg>
-    <span slot="title">{{ "pamDaemonEmptyStateTitle" | i18n }}</span>
-    <span slot="description">{{ "pamDaemonEmptyStateDescription" | i18n }}</span>
+    <span slot="title">{{ "pamAccessConnectorEmptyStateTitle" | i18n }}</span>
+    <span slot="description">{{ "pamAccessConnectorEmptyStateDescription" | i18n }}</span>
     <button
       slot="button"
       type="button"
@@ -21,7 +21,7 @@
       [bitAction]="registerDaemon"
       id="daemons-tab_button_register-empty"
     >
-      {{ "pamDaemonNew" | i18n }}
+      {{ "pamAccessConnectorNew" | i18n }}
     </button>
   </bit-status-lockup>
 } @else {
@@ -30,8 +30,8 @@
       <tr>
         <th bitCell bitSortable="name">{{ "name" | i18n }}</th>
         <th bitCell>{{ "status" | i18n }}</th>
-        <th bitCell>{{ "pamDaemonConnection" | i18n }}</th>
-        <th bitCell>{{ "pamDaemonAssignments" | i18n }}</th>
+        <th bitCell>{{ "pamAccessConnectorConnection" | i18n }}</th>
+        <th bitCell>{{ "pamAccessConnectorAssignments" | i18n }}</th>
         <th bitCell class="tw-w-0"></th>
       </tr>
     </ng-container>
@@ -63,9 +63,9 @@
         <!-- Connection liveness -->
         <td bitCell>
           @if (r.isConnected) {
-            <span bitBadge variant="success">{{ "pamDaemonConnected" | i18n }}</span>
+            <span bitBadge variant="success">{{ "pamAccessConnectorConnected" | i18n }}</span>
           } @else {
-            <span bitBadge variant="secondary">{{ "pamDaemonOffline" | i18n }}</span>
+            <span bitBadge variant="secondary">{{ "pamAccessConnectorOffline" | i18n }}</span>
           }
         </td>
 
@@ -98,7 +98,7 @@
             @if (r.canAssign) {
               <button type="button" bitMenuItem (click)="openAssignDialog(r)">
                 <bit-icon name="bwi-plus-circle" class="tw-text-muted"></bit-icon>
-                {{ "pamDaemonAssignTarget" | i18n }}
+                {{ "pamAccessConnectorAssignTarget" | i18n }}
               </button>
             }
             @if (r.daemon.assignedTargetSystemIds.length > 0) {
@@ -113,19 +113,19 @@
                   (click)="unassign(r.daemon, assignmentId, r.assignmentNames[i])"
                 >
                   <bit-icon name="bwi-minus-circle" class="tw-text-muted"></bit-icon>
-                  {{ "pamDaemonUnassign" | i18n: r.assignmentNames[i] }}
+                  {{ "pamAccessConnectorUnassign" | i18n: r.assignmentNames[i] }}
                 </button>
               }
             }
             @if (r.enabled) {
               <button type="button" bitMenuItem (click)="disable(r)">
                 <bit-icon name="bwi-circle" class="tw-text-muted"></bit-icon>
-                {{ "pamDaemonDisable" | i18n }}
+                {{ "pamAccessConnectorDisable" | i18n }}
               </button>
             } @else {
               <button type="button" bitMenuItem (click)="enable(r)">
                 <bit-icon name="bwi-check-circle" class="tw-text-muted"></bit-icon>
-                {{ "pamDaemonEnable" | i18n }}
+                {{ "pamAccessConnectorEnable" | i18n }}
               </button>
             }
             <button type="button" bitMenuItem (click)="confirmDelete(r)">
@@ -139,7 +139,7 @@
       @if (dataSource.filteredData.length === 0) {
         <tr bitRow>
           <td bitCell colspan="5" class="tw-py-6 tw-text-center tw-text-muted">
-            {{ "pamDaemonNoResults" | i18n }}
+            {{ "pamAccessConnectorNoResults" | i18n }}
           </td>
         </tr>
       }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -28,7 +28,7 @@ describe("DaemonsTabComponent", () => {
     return {
       id: connectorId("daemon-1"),
       name: "Test Daemon",
-      statusLabelKey: "pamDaemonStatusEnabled",
+      statusLabelKey: "pamAccessConnectorStatusEnabled",
       isConnected: true,
       assignmentNames: [],
       enabled: true,
@@ -108,7 +108,7 @@ describe("DaemonsTabComponent", () => {
     await component.openDetail(row);
 
     expect(navigateSpy).toHaveBeenCalledWith(
-      ["..", "daemons", connectorId("daemon-9")],
+      ["..", "access-connectors", connectorId("daemon-9")],
       expect.objectContaining({ relativeTo: expect.anything() }),
     );
   });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.stories.ts
@@ -1,0 +1,129 @@
+import { importProvidersFrom } from "@angular/core";
+import { ActivatedRoute, RouterModule } from "@angular/router";
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+import { of } from "rxjs";
+
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { DialogService, I18nMockService, ToastService } from "@bitwarden/components";
+
+import { AccessConnector, TargetSystem } from "../rotation";
+import { TargetSystemsService } from "../target-systems/target-systems.service";
+import { ORGANIZATION_ID, accessConnector, connectorId, sysId } from "../testing/rotation-builders";
+
+import { DaemonsTabComponent } from "./daemons-tab.component";
+import { DaemonRow, DaemonsService } from "./daemons.service";
+
+function row(daemon: AccessConnector, assignmentNames: string[] = []): DaemonRow {
+  return {
+    id: daemon.id,
+    name: daemon.name,
+    statusLabelKey:
+      daemon.status === "enabled"
+        ? "pamAccessConnectorStatusEnabled"
+        : "pamAccessConnectorStatusDisabled",
+    isConnected: daemon.isConnected,
+    assignmentNames,
+    enabled: daemon.status === "enabled",
+    canAssign: daemon.status === "enabled",
+    daemon,
+  };
+}
+
+const CONNECTOR_PROD = accessConnector({
+  id: connectorId("connector-prod"),
+  name: "Prod on-prem connector",
+  assignedTargetSystemIds: [sysId("1")],
+});
+
+const CONNECTOR_STAGING = accessConnector({
+  id: connectorId("connector-staging"),
+  name: "Staging connector",
+  status: "disabled",
+  isConnected: false,
+});
+
+const ROWS: DaemonRow[] = [row(CONNECTOR_PROD, ["Prod Entra"]), row(CONNECTOR_STAGING, [])];
+
+function rotationServices(rows: DaemonRow[]) {
+  return moduleMetadata({
+    providers: [
+      {
+        provide: DaemonsService,
+        useValue: {
+          loading$: of(false),
+          rows$: of(rows),
+          daemons$: of(rows.map((r) => r.daemon)),
+          load: () => Promise.resolve(),
+          registerCompleted: () => Promise.resolve(),
+          assign: () => Promise.resolve(),
+          unassign: () => Promise.resolve(),
+          setEnabled: () => Promise.resolve(),
+          delete: () => Promise.resolve(),
+        },
+      },
+      {
+        provide: TargetSystemsService,
+        useValue: {
+          activeAutomaticSystems$: of([{ id: sysId("1") }] as TargetSystem[]),
+          load: () => Promise.resolve(),
+        },
+      },
+    ],
+  });
+}
+
+export default {
+  title: "Web/PAM/Rotation/Access Connectors Tab",
+  component: DaemonsTabComponent,
+  decorators: [
+    applicationConfig({
+      providers: [
+        importProvidersFrom(RouterModule.forRoot([])),
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
+        },
+        {
+          provide: I18nService,
+          useFactory: () =>
+            new I18nMockService({
+              delete: "Delete",
+              name: "Name",
+              status: "Status",
+              options: "Options",
+              pamAccessConnectorSearch: "Search access connectors",
+              pamAccessConnectorEmptyStateTitle: "No access connectors registered",
+              pamAccessConnectorEmptyStateDescription:
+                "Register an access connector to start rotating credentials.",
+              pamAccessConnectorNew: "New access connector",
+              pamAccessConnectorConnection: "Connection",
+              pamAccessConnectorAssignments: "Assigned targets",
+              pamAccessConnectorConnected: "Connected",
+              pamAccessConnectorOffline: "Offline",
+              pamAccessConnectorAssignTarget: "Assign to target",
+              pamAccessConnectorUnassign: "Remove __$1__",
+              pamAccessConnectorDisable: "Disable",
+              pamAccessConnectorEnable: "Enable",
+              pamAccessConnectorNoResults: "No access connectors match your search.",
+              pamAccessConnectorStatusEnabled: "Enabled",
+              pamAccessConnectorStatusDisabled: "Disabled",
+            }),
+        },
+        { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
+        { provide: ToastService, useValue: { showToast: () => {} } },
+      ],
+    }),
+  ],
+} as Meta<DaemonsTabComponent>;
+
+type Story = StoryObj<DaemonsTabComponent>;
+
+/** One connected/enabled connector with an assignment, and one disabled/offline connector. */
+export const Default: Story = {
+  decorators: [rotationServices(ROWS)],
+};
+
+/** No access connectors have been registered yet. */
+export const Empty: Story = {
+  decorators: [rotationServices([])],
+};

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -109,12 +109,12 @@ export class DaemonsTabComponent {
 
   protected readonly totalRows = computed(() => this.rows().length);
 
-  /** Navigate to the daemon detail page (sibling of the shell). */
+  /** Navigate to the access-connector detail page (sibling of the shell). */
   protected readonly openDetail = (row: DaemonRow): Promise<boolean> =>
-    this.router.navigate(["..", "daemons", row.id], { relativeTo: this.route });
+    this.router.navigate(["..", "access-connectors", row.id], { relativeTo: this.route });
 
   /**
-   * Open the daemon registration dialog and refresh the shared list on success.
+   * Open the access-connector registration dialog and refresh the shared list on success.
    * Owned by the empty state; the shell's header button covers the non-empty list.
    */
   protected readonly registerDaemon = async (): Promise<void> => {
@@ -127,7 +127,7 @@ export class DaemonsTabComponent {
       await this.daemonsService.registerCompleted(orgId);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonRegistered"),
+        message: this.i18nService.t("pamAccessConnectorRegistered"),
       });
     }
   };
@@ -147,7 +147,7 @@ export class DaemonsTabComponent {
       await this.daemonsService.assign(row.daemon, asUuid<TargetSystemId>(targetSystemId));
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonAssigned"),
+        message: this.i18nService.t("pamAccessConnectorAssigned"),
       });
     } catch (e) {
       this.showError(e);
@@ -160,8 +160,8 @@ export class DaemonsTabComponent {
     targetName: string,
   ): Promise<void> => {
     const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonUnassignConfirmTitle" },
-      content: { key: "pamDaemonUnassignConfirmContent", placeholders: [targetName] },
+      title: { key: "pamAccessConnectorUnassignConfirmTitle" },
+      content: { key: "pamAccessConnectorUnassignConfirmContent", placeholders: [targetName] },
       acceptButtonText: { key: "remove" },
       cancelButtonText: { key: "cancel" },
       type: "warning",
@@ -173,7 +173,7 @@ export class DaemonsTabComponent {
       await this.daemonsService.unassign(daemon, asUuid<TargetSystemId>(targetSystemId));
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonUnassigned"),
+        message: this.i18nService.t("pamAccessConnectorUnassigned"),
       });
     } catch (e) {
       this.showError(e);
@@ -182,9 +182,9 @@ export class DaemonsTabComponent {
 
   protected readonly disable = async (row: DaemonRow): Promise<void> => {
     const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonDisableConfirmTitle" },
-      content: { key: "pamDaemonDisableConfirmContent", placeholders: [row.name] },
-      acceptButtonText: { key: "pamDaemonDisable" },
+      title: { key: "pamAccessConnectorDisableConfirmTitle" },
+      content: { key: "pamAccessConnectorDisableConfirmContent", placeholders: [row.name] },
+      acceptButtonText: { key: "pamAccessConnectorDisable" },
       cancelButtonText: { key: "cancel" },
       type: "warning",
     });
@@ -195,7 +195,7 @@ export class DaemonsTabComponent {
       await this.daemonsService.setEnabled(row.daemon, false);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonDisabled"),
+        message: this.i18nService.t("pamAccessConnectorDisabled"),
       });
     } catch (e) {
       this.showError(e);
@@ -207,7 +207,7 @@ export class DaemonsTabComponent {
       await this.daemonsService.setEnabled(row.daemon, true);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonEnabled"),
+        message: this.i18nService.t("pamAccessConnectorEnabled"),
       });
     } catch (e) {
       this.showError(e);
@@ -216,8 +216,8 @@ export class DaemonsTabComponent {
 
   protected readonly confirmDelete = async (row: DaemonRow): Promise<void> => {
     const confirmed = await this.dialogService.openSimpleDialog({
-      title: { key: "pamDaemonDeleteConfirmTitle" },
-      content: { key: "pamDaemonDeleteConfirmContent", placeholders: [row.name] },
+      title: { key: "pamAccessConnectorDeleteConfirmTitle" },
+      content: { key: "pamAccessConnectorDeleteConfirmContent", placeholders: [row.name] },
       acceptButtonText: { key: "delete" },
       cancelButtonText: { key: "cancel" },
       type: "danger",
@@ -229,7 +229,7 @@ export class DaemonsTabComponent {
       await this.daemonsService.delete(row.daemon);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonDeleted"),
+        message: this.i18nService.t("pamAccessConnectorDeleted"),
       });
     } catch (e) {
       this.showError(e);

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.spec.ts
@@ -119,18 +119,18 @@ describe("DaemonsService", () => {
       expect(rows[0].canAssign).toBe(false);
     });
 
-    it("uses pamDaemonStatusEnabled key for enabled daemons", async () => {
+    it("uses pamAccessConnectorStatusEnabled key for enabled daemons", async () => {
       rotationSdk.listConnectors.mockResolvedValue([makeDaemon({ status: DaemonStatus.Enabled })]);
       await service.load(orgId);
       const rows = await firstValue(service.rows$);
-      expect(rows[0].statusLabelKey).toBe("pamDaemonStatusEnabled");
+      expect(rows[0].statusLabelKey).toBe("pamAccessConnectorStatusEnabled");
     });
 
-    it("uses pamDaemonStatusDisabled key for disabled daemons", async () => {
+    it("uses pamAccessConnectorStatusDisabled key for disabled daemons", async () => {
       rotationSdk.listConnectors.mockResolvedValue([makeDaemon({ status: DaemonStatus.Disabled })]);
       await service.load(orgId);
       const rows = await firstValue(service.rows$);
-      expect(rows[0].statusLabelKey).toBe("pamDaemonStatusDisabled");
+      expect(rows[0].statusLabelKey).toBe("pamAccessConnectorStatusDisabled");
     });
   });
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons.service.ts
@@ -22,7 +22,7 @@ import { TargetSystemsService } from "../target-systems/target-systems.service";
 export type DaemonRow = {
   id: AccessConnectorId;
   name: string;
-  /** i18n key for the status badge label: pamDaemonStatusEnabled | pamDaemonStatusDisabled. */
+  /** i18n key for the status badge label: pamAccessConnectorStatusEnabled | pamAccessConnectorStatusDisabled. */
   statusLabelKey: string;
   isConnected: boolean;
   /** Target system names for the assignment badges, falling back to the raw ID when unresolved. */
@@ -220,8 +220,8 @@ export class DaemonsService {
       name: daemon.name,
       statusLabelKey:
         daemon.status === DaemonStatus.Enabled
-          ? "pamDaemonStatusEnabled"
-          : "pamDaemonStatusDisabled",
+          ? "pamAccessConnectorStatusEnabled"
+          : "pamAccessConnectorStatusDisabled",
       isConnected: daemon.isConnected,
       assignmentNames: daemon.assignedTargetSystemIds.map(
         (id) => systemById.get(id)?.name ?? String(id),

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
@@ -48,7 +48,7 @@
             id="rotation-config-edit_input_account-identity"
             formControlName="accountIdentity"
           />
-          <bit-hint>{{ "pamRotationConfigAccountIdentityHint" | i18n }}</bit-hint>
+          <bit-hint>{{ "pamRotationConfigAccountIdentityConnectorHint" | i18n }}</bit-hint>
         </bit-form-field>
 
         <bit-form-control>
@@ -195,7 +195,7 @@
                   id="rotation-config-edit_input_account-identity-edit"
                   formControlName="accountIdentity"
                 />
-                <bit-hint>{{ "pamRotationConfigAccountIdentityHint" | i18n }}</bit-hint>
+                <bit-hint>{{ "pamRotationConfigAccountIdentityConnectorHint" | i18n }}</bit-hint>
               </bit-form-field>
 
               <bit-form-control disableMargin>
@@ -252,7 +252,7 @@
           </p>
           @if (detail.config.hasActiveJob) {
             <bit-callout type="info" class="tw-mb-3">
-              {{ "pamRotationConfigRemoveLockedContent" | i18n }}
+              {{ "pamRotationConfigRemoveLockedConnectorContent" | i18n }}
             </bit-callout>
           }
           <button

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.html
@@ -26,16 +26,16 @@
         </button>
       }
     }
-    @case ("daemons") {
+    @case ("access-connectors") {
       @if (hasDaemons()) {
         <button
           type="button"
           bitButton
           buttonType="primary"
           [bitAction]="registerDaemon"
-          id="rotation-shell_button_new-daemon"
+          id="rotation-shell_button_new-access-connector"
         >
-          {{ "pamDaemonNew" | i18n }}
+          {{ "pamAccessConnectorNew" | i18n }}
         </button>
       }
     }
@@ -45,7 +45,9 @@
       "pamRotationTabManagedCredentials" | i18n
     }}</bit-tab-link>
     <bit-tab-link route="target-systems">{{ "pamRotationTabTargetSystems" | i18n }}</bit-tab-link>
-    <bit-tab-link route="daemons">{{ "pamRotationTabDaemons" | i18n }}</bit-tab-link>
+    <bit-tab-link route="access-connectors">{{
+      "pamRotationTabAccessConnectors" | i18n
+    }}</bit-tab-link>
   </bit-tab-nav-bar>
 </app-header>
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.spec.ts
@@ -91,7 +91,7 @@ describe("RotationShellComponent", () => {
     const text = (fixture.nativeElement as HTMLElement).textContent ?? "";
     expect(text).toContain("pamRotationTabManagedCredentials");
     expect(text).toContain("pamRotationTabTargetSystems");
-    expect(text).toContain("pamRotationTabDaemons");
+    expect(text).toContain("pamRotationTabAccessConnectors");
   });
 
   it("calls load on RotationConfigsService with the organization id on init", async () => {
@@ -212,7 +212,7 @@ describe("RotationShellComponent (real router)", () => {
             { path: "", pathMatch: "full", redirectTo: "target-systems" },
             { path: "managed-credentials", component: StubComponent },
             { path: "target-systems", component: StubComponent },
-            { path: "daemons", component: StubComponent },
+            { path: "access-connectors", component: StubComponent },
           ],
         },
       ],
@@ -260,10 +260,10 @@ describe("RotationShellComponent (real router)", () => {
 
   it("reports the active tab from the child route", async () => {
     const shell = (await harness.navigateByUrl(
-      "/rotation/daemons",
+      "/rotation/access-connectors",
       RotationShellComponent,
     )) as unknown as { activeTab: () => string | null };
-    expect(shell.activeTab()).toBe("daemons");
+    expect(shell.activeTab()).toBe("access-connectors");
   });
 
   it("navigates from the shell to the sibling create page", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-shell.component.ts
@@ -23,7 +23,7 @@ import { TargetSystemsService } from "./target-systems/target-systems.service";
 
 /**
  * Rotation feature shell: renders the page header and the three routed tabs (Managed
- * credentials / Target systems / Daemons); page-scoped services stay shared across tab
+ * credentials / Target systems / Access connectors); page-scoped services stay shared across tab
  * navigation since the shell stays mounted.
  *
  * The header hosts the active tab's primary create action, driven by the active child route, so
@@ -54,7 +54,7 @@ export class RotationShellComponent {
     { requireSync: true },
   );
 
-  /** The path of the active child route ("target-systems" / "daemons" / ...), driving the header button. */
+  /** The path of the active child route ("target-systems" / "access-connectors" / ...), driving the header button. */
   protected readonly activeTab = toSignal(
     this.router.events.pipe(
       filter((e) => e instanceof NavigationEnd),
@@ -80,7 +80,7 @@ export class RotationShellComponent {
   });
   protected readonly hasConfigs = computed(() => this.configs().length > 0);
 
-  /** Whether any daemons exist; hides the "New daemon" header button, since the empty state owns that action. */
+  /** Whether any access connectors exist; hides the "New access connector" header button, since the empty state owns that action. */
   private readonly daemons = toSignal(this.daemonsService.daemons$, {
     initialValue: [] as AccessConnector[],
   });
@@ -101,7 +101,7 @@ export class RotationShellComponent {
   protected readonly createTargetSystem = (): Promise<boolean> =>
     this.router.navigate(["target-systems", "new"], { relativeTo: this.route });
 
-  /** Open the daemon registration dialog and refresh the shared list on success. */
+  /** Open the access-connector registration dialog and refresh the shared list on success. */
   protected readonly registerDaemon = async (): Promise<void> => {
     const orgId = this.organizationId();
     const ref = DaemonRegisterDialogComponent.open(this.dialogService, {
@@ -112,7 +112,7 @@ export class RotationShellComponent {
       await this.daemonsService.registerCompleted(orgId);
       this.toastService.showToast({
         variant: "success",
-        message: this.i18nService.t("pamDaemonRegistered"),
+        message: this.i18nService.t("pamAccessConnectorRegistered"),
       });
     }
   };

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.routes.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.routes.ts
@@ -43,9 +43,9 @@ export const rotationRoutes: Routes = [
     data: { titleId: "pamTargetSystemEditTitle" },
   },
   {
-    path: "daemons/:daemonId",
+    path: "access-connectors/:daemonId",
     component: DaemonDetailComponent,
-    data: { titleId: "pamDaemonDetailTitle" },
+    data: { titleId: "pamAccessConnectorDetailTitle" },
   },
   {
     path: "",
@@ -64,9 +64,9 @@ export const rotationRoutes: Routes = [
         data: { titleId: "pamRotationTabTargetSystems" },
       },
       {
-        path: "daemons",
+        path: "access-connectors",
         component: DaemonsTabComponent,
-        data: { titleId: "pamRotationTabDaemons" },
+        data: { titleId: "pamRotationTabAccessConnectors" },
       },
     ],
   },

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
@@ -165,8 +165,7 @@ export type QuartzSchedulePreset = SdkQuartzSchedulePreset;
  * The server, the SDK, and now the admin UI's own copy all say *access connector* — only this
  * module's code identifiers (`DaemonStatus`, `DaemonsService`, the `daemons/` directory) and the
  * standalone agent that consumes a registration token still say *daemon*. Aliasing rather than
- * renaming keeps that identifier rename out of this diff without introducing a second type; see
- * DECISIONS.md for why.
+ * renaming keeps that identifier rename out of this diff without introducing a second type.
  */
 export const DaemonStatus = AccessConnectorStatus;
 export type DaemonStatus = AccessConnectorStatus;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation.ts
@@ -8,7 +8,8 @@
  *
  * Note the vocabulary shift: what this module called a *rotation daemon* the server calls an
  * *access connector*; the standalone agent consuming a registration token is still the rotation
- * daemon.
+ * daemon. This file's identifiers (`DaemonStatus`, `DaemonsService`, the `daemons/` directory) are
+ * untouched pending a follow-up rename.
  */
 import type {
   AccessConnectorStatus as SdkAccessConnectorStatus,
@@ -161,9 +162,11 @@ export type QuartzSchedulePreset = SdkQuartzSchedulePreset;
 /**
  * The UI's name for {@link AccessConnectorStatus}.
  *
- * The server and the SDK say *access connector*; this admin surface says *daemon*, as does every
- * `pamDaemon*` i18n key and the standalone agent that consumes a registration token. Aliasing
- * rather than renaming keeps that user-facing vocabulary intact without introducing a second type.
+ * The server, the SDK, and now the admin UI's own copy all say *access connector* — only this
+ * module's code identifiers (`DaemonStatus`, `DaemonsService`, the `daemons/` directory) and the
+ * standalone agent that consumes a registration token still say *daemon*. Aliasing rather than
+ * renaming keeps that identifier rename out of this diff without introducing a second type; see
+ * DECISIONS.md for why.
  */
 export const DaemonStatus = AccessConnectorStatus;
 export type DaemonStatus = AccessConnectorStatus;

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
@@ -106,7 +106,9 @@
               id="target-system-edit_checkbox_session-termination"
             />
             <bit-label>{{ "pamTargetSystemSupportsSessionTermination" | i18n }}</bit-label>
-            <bit-hint>{{ "pamTargetSystemSupportsSessionTerminationHint" | i18n }}</bit-hint>
+            <bit-hint>{{
+              "pamTargetSystemSupportsSessionTerminationConnectorHint" | i18n
+            }}</bit-hint>
           </bit-form-control>
 
           @if (showTerminationWarning()) {
@@ -210,15 +212,15 @@
   } @else {
 
     <div class="tw-max-w-4xl">
-      <!-- Setup guidance: how to connect this target system to a daemon + add a credential -->
+      <!-- Setup guidance: how to connect this target system to an access connector + add a credential -->
       <bit-callout type="info" [title]="'pamTargetSystemSetupGuidanceTitle' | i18n">
         @if (existing()?.method === TargetSystemMethod.Automatic) {
           <ol class="tw-mb-0 tw-ps-4">
-            <li>{{ "pamTargetSystemSetupGuidanceAutomaticDaemon" | i18n }}</li>
+            <li>{{ "pamTargetSystemSetupGuidanceAutomaticAccessConnector" | i18n }}</li>
             <li>{{ "pamTargetSystemSetupGuidanceAutomaticCredential" | i18n }}</li>
           </ol>
         } @else {
-          <p class="tw-mb-0">{{ "pamTargetSystemSetupGuidanceManual" | i18n }}</p>
+          <p class="tw-mb-0">{{ "pamTargetSystemSetupGuidanceManualConnector" | i18n }}</p>
         }
       </bit-callout>
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-empty-state.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-empty-state.component.ts
@@ -40,7 +40,7 @@ const TEMPLATES: TargetSystemTemplate[] = [
     key: "custom-script",
     icon: "bwi-terminal",
     titleKey: "pamTargetSystemKindCustomScript",
-    summaryKey: "pamTargetSystemTemplateCustomScriptSummary",
+    summaryKey: "pamTargetSystemTemplateCustomScriptConnectorSummary",
   },
 ];
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/testing/rotation-builders.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/testing/rotation-builders.ts
@@ -94,7 +94,7 @@ export function accessConnector(overrides: Partial<AccessConnector> = {}): Acces
   return {
     id: ACCESS_CONNECTOR_ID,
     organizationId: ORGANIZATION_ID,
-    name: "Rotation daemon 1",
+    name: "Access connector 1",
     status: "enabled" as AccessConnectorStatus,
     isConnected: true,
     lastHeartbeatAt: TIMESTAMP,


### PR DESCRIPTION
Design review 2026-09-04: "the daemon tab should be access connectors". The SDK already agrees, re-exporting `AccessConnectorStatus`.

The harvested frames call it "Rotation connectors"; the review is later and direct, so it wins. Route renamed too, safe because the feature is unreleased and flag gated. Files, classes and DB tables still say daemon deliberately: a mechanical identifier rename would bury the reviewable part of this diff.