### PR TITLE
fix(pam): give the rotation sub-pages a readable breadcrumb trail

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -1,7 +1,24 @@
 <bit-header [title]="titleText()" icon="bwi-terminal">
-  <bit-breadcrumbs slot="breadcrumbs">
-    <bit-breadcrumb [route]="['..']">{{ "pamRotationTabAccessConnectors" | i18n }}</bit-breadcrumb>
-  </bit-breadcrumbs>
+  <div slot="breadcrumbs" class="tw-flex tw-items-baseline tw-min-w-0">
+    <!-- `bit-breadcrumbs`' host carries `tw-w-full`, sized against its own containing block; this
+         wrapper gives it one shaped to its content instead of the whole row, so the static crumb
+         below stays in flow next to it rather than being pushed to the row's far edge. -->
+    <div class="tw-min-w-0">
+      <bit-breadcrumbs showTrailingArrow>
+        <bit-breadcrumb [route]="['..']">{{
+          "pamRotationTabAccessConnectors" | i18n
+        }}</bit-breadcrumb>
+      </bit-breadcrumbs>
+    </div>
+    <!-- A route-less bit-breadcrumb falls back to a focusable button that does nothing and never
+         gets aria-current; a static span carries the current-page semantics without that trap. -->
+    <span
+      bitTypography="h3"
+      aria-current="page"
+      class="tw-inline-block tw-shrink-0 tw-whitespace-nowrap !tw-m-0 !tw-text-fg-heading"
+      >{{ titleText() }}</span
+    >
+  </div>
   @if (daemon()) {
     @if (enabled()) {
       <button

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -3,7 +3,7 @@
     <!-- `bit-breadcrumbs`' host carries `tw-w-full`, sized against its own containing block; this
          wrapper gives it one shaped to its content instead of the whole row, so the static crumb
          below stays in flow next to it rather than being pushed to the row's far edge. -->
-    <div class="tw-min-w-0">
+    <div class="tw-min-w-0 tw-shrink-0">
       <bit-breadcrumbs showTrailingArrow>
         <bit-breadcrumb [route]="['..']">{{
           "pamRotationTabAccessConnectors" | i18n
@@ -11,11 +11,13 @@
       </bit-breadcrumbs>
     </div>
     <!-- A route-less bit-breadcrumb falls back to a focusable button that does nothing and never
-         gets aria-current; a static span carries the current-page semantics without that trap. -->
+         gets aria-current; a static span carries the current-page semantics without that trap.
+         `titleText()` here is the connector's own name (up to 200 chars, see
+         daemon-register-dialog.component.ts), so it must truncate rather than hold a fixed width. -->
     <span
       bitTypography="h3"
       aria-current="page"
-      class="tw-inline-block tw-shrink-0 tw-whitespace-nowrap !tw-m-0 !tw-text-fg-heading"
+      class="tw-inline-block tw-min-w-0 tw-truncate !tw-m-0 !tw-text-fg-heading"
       >{{ titleText() }}</span
     >
   </div>

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.stories.ts
@@ -1,0 +1,89 @@
+import { importProvidersFrom } from "@angular/core";
+import { provideRouter, RouterOutlet, Routes, withHashLocation } from "@angular/router";
+import {
+  applicationConfig,
+  componentWrapperDecorator,
+  Decorator,
+  Meta,
+  moduleMetadata,
+  StoryObj,
+} from "@storybook/angular";
+
+import { DialogService, ToastService } from "@bitwarden/components";
+import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
+
+import { RotationSdkService } from "../rotation-sdk.service";
+import {
+  accessConnector,
+  accessConnectorDetail,
+  ORGANIZATION_ID,
+  targetSystem,
+} from "../testing/rotation-builders";
+
+import { DaemonDetailComponent } from "./daemon-detail.component";
+
+const SAMPLE_DETAIL = accessConnectorDetail({
+  connector: accessConnector({ name: "Prod on-prem connector" }),
+});
+
+const rotationSdk: Partial<RotationSdkService> = {
+  listTargetSystems: () => Promise.resolve([targetSystem()]),
+  getConnector: () => Promise.resolve(SAMPLE_DETAIL),
+  enableConnector: () => Promise.resolve(),
+  disableConnector: () => Promise.resolve(),
+  deleteConnector: () => Promise.resolve(),
+};
+
+/**
+ * Mirrors `rotation.routes.ts` (minus its guards) so the page reads `organizationId` /
+ * `daemonId` from real route params. A stubbed `ActivatedRoute` can't resolve the page's
+ * `['..']` breadcrumb, which then falls back to the current URL and renders as the active page
+ * instead of a link back to the tab.
+ */
+const routes: Routes = [
+  {
+    path: "organizations/:organizationId/pam/rotation",
+    children: [
+      { path: "access-connectors", children: [] },
+      { path: "access-connectors/:daemonId", component: DaemonDetailComponent },
+    ],
+  },
+];
+
+/** Renders the story at `url`; hash routing keeps Storybook's own query string intact. */
+const atUrl =
+  (url: string): Decorator =>
+  (storyFn, context) => {
+    window.location.hash = url;
+    return storyFn(context);
+  };
+
+export default {
+  title: "Web/PAM/Rotation/Access Connector Detail",
+  component: DaemonDetailComponent,
+  render: () => ({ template: `<router-outlet></router-outlet>` }),
+  decorators: [
+    componentWrapperDecorator((story) => `<div class="tw-p-6">${story}</div>`),
+    moduleMetadata({ imports: [RouterOutlet] }),
+    applicationConfig({
+      providers: [
+        importProvidersFrom(PreloadedEnglishI18nModule),
+        provideRouter(routes, withHashLocation()),
+        { provide: RotationSdkService, useValue: rotationSdk },
+        { provide: ToastService, useValue: { showToast: () => {} } },
+        { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
+      ],
+    }),
+  ],
+} as Meta<DaemonDetailComponent>;
+
+type Story = StoryObj<DaemonDetailComponent>;
+
+/** The breadcrumb trail reads "Access connectors > Prod on-prem connector" — the connector's own name. */
+export const Default: Story = {
+  decorators: [
+    atUrl(
+      `/organizations/${ORGANIZATION_ID}/pam/rotation/access-connectors/${SAMPLE_DETAIL.connector.id}`,
+    ),
+  ],
+};

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.stories.ts
@@ -15,6 +15,7 @@ import { RotationSdkService } from "../rotation-sdk.service";
 import {
   accessConnector,
   accessConnectorDetail,
+  connectorId,
   ORGANIZATION_ID,
   targetSystem,
 } from "../testing/rotation-builders";
@@ -26,9 +27,20 @@ const SAMPLE_DETAIL = accessConnectorDetail({
   connector: accessConnector({ name: "Prod on-prem connector" }),
 });
 
+const LONG_NAME_DETAIL = accessConnectorDetail({
+  connector: accessConnector({
+    id: connectorId("long-name"),
+    name: "AWS us-east-1 Production On-Prem Access Connector Primary",
+  }),
+});
+
+const CONNECTORS_BY_ID = new Map(
+  [SAMPLE_DETAIL, LONG_NAME_DETAIL].map((detail) => [detail.connector.id, detail]),
+);
+
 const rotationSdk: Partial<RotationSdkService> = {
   listTargetSystems: () => Promise.resolve([targetSystem()]),
-  getConnector: () => Promise.resolve(SAMPLE_DETAIL),
+  getConnector: (_organizationId, id) => Promise.resolve(CONNECTORS_BY_ID.get(id) ?? SAMPLE_DETAIL),
   enableConnector: () => Promise.resolve(),
   disableConnector: () => Promise.resolve(),
   deleteConnector: () => Promise.resolve(),
@@ -76,6 +88,15 @@ export const Default: Story = {
   decorators: [
     atUrl(
       `/organizations/${ORGANIZATION_ID}/pam/rotation/access-connectors/${SAMPLE_DETAIL.connector.id}`,
+    ),
+  ],
+};
+
+/** A realistic long connector name, to check the breadcrumb truncates rather than crowding the header buttons. */
+export const LongName: Story = {
+  decorators: [
+    atUrl(
+      `/organizations/${ORGANIZATION_ID}/pam/rotation/access-connectors/${LONG_NAME_DETAIL.connector.id}`,
     ),
   ],
 };

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.stories.ts
@@ -3,7 +3,6 @@ import { provideRouter, RouterOutlet, Routes, withHashLocation } from "@angular/
 import {
   applicationConfig,
   componentWrapperDecorator,
-  Decorator,
   Meta,
   moduleMetadata,
   StoryObj,
@@ -19,6 +18,7 @@ import {
   ORGANIZATION_ID,
   targetSystem,
 } from "../testing/rotation-builders";
+import { atUrl } from "../testing/story-helpers";
 
 import { DaemonDetailComponent } from "./daemon-detail.component";
 
@@ -49,14 +49,6 @@ const routes: Routes = [
     ],
   },
 ];
-
-/** Renders the story at `url`; hash routing keeps Storybook's own query string intact. */
-const atUrl =
-  (url: string): Decorator =>
-  (storyFn, context) => {
-    window.location.hash = url;
-    return storyFn(context);
-  };
 
 export default {
   title: "Web/PAM/Rotation/Access Connector Detail",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.html
@@ -1,9 +1,24 @@
 <bit-header [title]="titleText()" icon="bwi-key">
-  <bit-breadcrumbs slot="breadcrumbs">
-    <bit-breadcrumb [route]="['..']">{{
-      "pamRotationTabManagedCredentials" | i18n
-    }}</bit-breadcrumb>
-  </bit-breadcrumbs>
+  <div slot="breadcrumbs" class="tw-flex tw-items-baseline tw-min-w-0">
+    <!-- `bit-breadcrumbs`' host carries `tw-w-full`, sized against its own containing block; this
+         wrapper gives it one shaped to its content instead of the whole row, so the static crumb
+         below stays in flow next to it rather than being pushed to the row's far edge. -->
+    <div class="tw-min-w-0">
+      <bit-breadcrumbs showTrailingArrow>
+        <bit-breadcrumb [route]="['..']">{{
+          "pamRotationTabManagedCredentials" | i18n
+        }}</bit-breadcrumb>
+      </bit-breadcrumbs>
+    </div>
+    <!-- A route-less bit-breadcrumb falls back to a focusable button that does nothing and never
+         gets aria-current; a static span carries the current-page semantics without that trap. -->
+    <span
+      bitTypography="h3"
+      aria-current="page"
+      class="tw-inline-block tw-shrink-0 tw-whitespace-nowrap !tw-m-0 !tw-text-fg-heading"
+      >{{ titleText() }}</span
+    >
+  </div>
 </bit-header>
 
 @if (loading()) {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.stories.ts
@@ -1,0 +1,90 @@
+import { importProvidersFrom } from "@angular/core";
+import { provideRouter, RouterOutlet, Routes, withHashLocation } from "@angular/router";
+import {
+  applicationConfig,
+  componentWrapperDecorator,
+  Decorator,
+  Meta,
+  moduleMetadata,
+  StoryObj,
+} from "@storybook/angular";
+
+import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { DialogService, ToastService } from "@bitwarden/components";
+import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
+
+import { RotationSdkService } from "../rotation-sdk.service";
+import { ORGANIZATION_ID, rotationConfigDetail, targetSystem } from "../testing/rotation-builders";
+
+import { RotationConfigEditComponent } from "./rotation-config-edit.component";
+
+const SAMPLE_DETAIL = rotationConfigDetail();
+
+const rotationSdk: Partial<RotationSdkService> = {
+  listTargetSystems: () => Promise.resolve([targetSystem()]),
+  getConfig: () => Promise.resolve(SAMPLE_DETAIL),
+  updateConfig: () => Promise.resolve(SAMPLE_DETAIL),
+  deleteConfig: () => Promise.resolve(),
+};
+
+/**
+ * Mirrors `rotation.routes.ts` (minus its guards) so the page reads `organizationId` /
+ * `configId` from real route params. A stubbed `ActivatedRoute` can't resolve the page's
+ * `['..']` breadcrumb, which then falls back to the current URL and renders as the active page
+ * instead of a link back to the tab.
+ */
+const routes: Routes = [
+  {
+    path: "organizations/:organizationId/pam/rotation",
+    children: [
+      { path: "managed-credentials", children: [] },
+      { path: "managed-credentials/new", component: RotationConfigEditComponent },
+      { path: "managed-credentials/:configId", component: RotationConfigEditComponent },
+    ],
+  },
+];
+
+/** Renders the story at `url`; hash routing keeps Storybook's own query string intact. */
+const atUrl =
+  (url: string): Decorator =>
+  (storyFn, context) => {
+    window.location.hash = url;
+    return storyFn(context);
+  };
+
+export default {
+  title: "Web/PAM/Rotation/Config Edit",
+  component: RotationConfigEditComponent,
+  render: () => ({ template: `<router-outlet></router-outlet>` }),
+  decorators: [
+    componentWrapperDecorator((story) => `<div class="tw-p-6">${story}</div>`),
+    moduleMetadata({ imports: [RouterOutlet] }),
+    applicationConfig({
+      providers: [
+        importProvidersFrom(PreloadedEnglishI18nModule),
+        provideRouter(routes, withHashLocation()),
+        { provide: RotationSdkService, useValue: rotationSdk },
+        { provide: ToastService, useValue: { showToast: () => {} } },
+        { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
+        // Only reached through `OrgCiphersService.load()`, which the edit path never calls;
+        // present so its constructor's `inject()`s resolve.
+        { provide: AccountService, useValue: {} as Partial<AccountService> },
+        { provide: OrganizationService, useValue: {} as Partial<OrganizationService> },
+        { provide: CipherService, useValue: {} as Partial<CipherService> },
+      ],
+    }),
+  ],
+} as Meta<RotationConfigEditComponent>;
+
+type Story = StoryObj<RotationConfigEditComponent>;
+
+/** Edit mode: the breadcrumb trail reads "Managed credentials > Edit managed credential". */
+export const Edit: Story = {
+  decorators: [
+    atUrl(
+      `/organizations/${ORGANIZATION_ID}/pam/rotation/managed-credentials/${SAMPLE_DETAIL.config.id}`,
+    ),
+  ],
+};

--- a/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/managed-credentials/rotation-config-edit.component.stories.ts
@@ -3,7 +3,6 @@ import { provideRouter, RouterOutlet, Routes, withHashLocation } from "@angular/
 import {
   applicationConfig,
   componentWrapperDecorator,
-  Decorator,
   Meta,
   moduleMetadata,
   StoryObj,
@@ -17,6 +16,7 @@ import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests"
 
 import { RotationSdkService } from "../rotation-sdk.service";
 import { ORGANIZATION_ID, rotationConfigDetail, targetSystem } from "../testing/rotation-builders";
+import { atUrl } from "../testing/story-helpers";
 
 import { RotationConfigEditComponent } from "./rotation-config-edit.component";
 
@@ -45,14 +45,6 @@ const routes: Routes = [
     ],
   },
 ];
-
-/** Renders the story at `url`; hash routing keeps Storybook's own query string intact. */
-const atUrl =
-  (url: string): Decorator =>
-  (storyFn, context) => {
-    window.location.hash = url;
-    return storyFn(context);
-  };
 
 export default {
   title: "Web/PAM/Rotation/Config Edit",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.html
@@ -1,7 +1,22 @@
 <bit-header [title]="titleText()" icon="bwi-desktop">
-  <bit-breadcrumbs slot="breadcrumbs">
-    <bit-breadcrumb [route]="['..']">{{ "pamRotationTabTargetSystems" | i18n }}</bit-breadcrumb>
-  </bit-breadcrumbs>
+  <div slot="breadcrumbs" class="tw-flex tw-items-baseline tw-min-w-0">
+    <!-- `bit-breadcrumbs`' host carries `tw-w-full`, sized against its own containing block; this
+         wrapper gives it one shaped to its content instead of the whole row, so the static crumb
+         below stays in flow next to it rather than being pushed to the row's far edge. -->
+    <div class="tw-min-w-0">
+      <bit-breadcrumbs showTrailingArrow>
+        <bit-breadcrumb [route]="['..']">{{ "pamRotationTabTargetSystems" | i18n }}</bit-breadcrumb>
+      </bit-breadcrumbs>
+    </div>
+    <!-- A route-less bit-breadcrumb falls back to a focusable button that does nothing and never
+         gets aria-current; a static span carries the current-page semantics without that trap. -->
+    <span
+      bitTypography="h3"
+      aria-current="page"
+      class="tw-inline-block tw-shrink-0 tw-whitespace-nowrap !tw-m-0 !tw-text-fg-heading"
+      >{{ titleText() }}</span
+    >
+  </div>
 </bit-header>
 
 <!-- Shared password-policy card for both create and edit modes; its controls are self-gating. -->

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.stories.ts
@@ -1,0 +1,80 @@
+import { importProvidersFrom } from "@angular/core";
+import { provideRouter, RouterOutlet, Routes, withHashLocation } from "@angular/router";
+import {
+  applicationConfig,
+  componentWrapperDecorator,
+  Decorator,
+  Meta,
+  moduleMetadata,
+  StoryObj,
+} from "@storybook/angular";
+
+import { DialogService, ToastService } from "@bitwarden/components";
+import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
+
+import { RotationSdkService } from "../rotation-sdk.service";
+import { ORGANIZATION_ID, targetSystem } from "../testing/rotation-builders";
+
+import { TargetSystemEditComponent } from "./target-system-edit.component";
+
+const SAMPLE_SYSTEM = targetSystem({ name: "Prod Entra" });
+
+const rotationSdk: Partial<RotationSdkService> = {
+  listTargetSystems: () => Promise.resolve([SAMPLE_SYSTEM]),
+  updateTargetSystem: () => Promise.resolve(),
+  enableTargetSystem: () => Promise.resolve(),
+  disableTargetSystem: () => Promise.resolve(),
+};
+
+/**
+ * Mirrors `rotation.routes.ts` (minus its guards) so the page reads `organizationId` /
+ * `targetSystemId` from real route params. A stubbed `ActivatedRoute` can't resolve the page's
+ * `['..']` breadcrumb, which then falls back to the current URL and renders as the active page
+ * instead of a link back to the tab.
+ */
+const routes: Routes = [
+  {
+    path: "organizations/:organizationId/pam/rotation",
+    children: [
+      { path: "target-systems", children: [] },
+      { path: "target-systems/new", component: TargetSystemEditComponent },
+      { path: "target-systems/:targetSystemId", component: TargetSystemEditComponent },
+    ],
+  },
+];
+
+/** Renders the story at `url`; hash routing keeps Storybook's own query string intact. */
+const atUrl =
+  (url: string): Decorator =>
+  (storyFn, context) => {
+    window.location.hash = url;
+    return storyFn(context);
+  };
+
+export default {
+  title: "Web/PAM/Rotation/Target System Edit",
+  component: TargetSystemEditComponent,
+  render: () => ({ template: `<router-outlet></router-outlet>` }),
+  decorators: [
+    componentWrapperDecorator((story) => `<div class="tw-p-6">${story}</div>`),
+    moduleMetadata({ imports: [RouterOutlet] }),
+    applicationConfig({
+      providers: [
+        importProvidersFrom(PreloadedEnglishI18nModule),
+        provideRouter(routes, withHashLocation()),
+        { provide: RotationSdkService, useValue: rotationSdk },
+        { provide: ToastService, useValue: { showToast: () => {} } },
+        { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
+      ],
+    }),
+  ],
+} as Meta<TargetSystemEditComponent>;
+
+type Story = StoryObj<TargetSystemEditComponent>;
+
+/** Edit mode: the breadcrumb trail reads "Target systems > Edit target system". */
+export const Edit: Story = {
+  decorators: [
+    atUrl(`/organizations/${ORGANIZATION_ID}/pam/rotation/target-systems/${SAMPLE_SYSTEM.id}`),
+  ],
+};

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-system-edit.component.stories.ts
@@ -3,7 +3,6 @@ import { provideRouter, RouterOutlet, Routes, withHashLocation } from "@angular/
 import {
   applicationConfig,
   componentWrapperDecorator,
-  Decorator,
   Meta,
   moduleMetadata,
   StoryObj,
@@ -14,6 +13,7 @@ import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests"
 
 import { RotationSdkService } from "../rotation-sdk.service";
 import { ORGANIZATION_ID, targetSystem } from "../testing/rotation-builders";
+import { atUrl } from "../testing/story-helpers";
 
 import { TargetSystemEditComponent } from "./target-system-edit.component";
 
@@ -42,14 +42,6 @@ const routes: Routes = [
     ],
   },
 ];
-
-/** Renders the story at `url`; hash routing keeps Storybook's own query string intact. */
-const atUrl =
-  (url: string): Decorator =>
-  (storyFn, context) => {
-    window.location.hash = url;
-    return storyFn(context);
-  };
 
 export default {
   title: "Web/PAM/Rotation/Target System Edit",

--- a/bitwarden_license/bit-web/src/app/pam/rotation/testing/story-helpers.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/testing/story-helpers.ts
@@ -1,0 +1,9 @@
+import { Decorator } from "@storybook/angular";
+
+/** Renders the story at `url`; hash routing keeps Storybook's own query string intact. */
+export const atUrl =
+  (url: string): Decorator =>
+  (storyFn, context) => {
+    window.location.hash = url;
+    return storyFn(context);
+  };


### PR DESCRIPTION
Design review 2026-09-04: "it's not clear to me that these are breadcrumbs at all". A one-item trail with no separator reads as a caption. Same construction as the access-rule edit page, including not promoting the last crumb to the page heading.