### PR TITLE
fix(pam): rework the access connector detail page layout and empty states

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.html
@@ -21,38 +21,23 @@
       >{{ titleText() }}</span
     >
   </div>
-  @if (daemon()) {
-    @if (enabled()) {
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        [bitAction]="disable"
-        id="daemon-detail_button_disable"
+  <!-- Sits inside the h1 next to the name, mirroring access-rule-edit.component.html's status
+       badge; the sr-only label keeps the bare "Enabled"/"Disabled" from reading as part of the
+       connector's title. -->
+  <span slot="title-suffix" class="tw-flex tw-h-full tw-items-center">
+    @if (daemon()) {
+      <span class="tw-sr-only">{{ "status" | i18n }}:</span>
+      <span
+        bitBadge
+        [variant]="enabled() ? 'success' : 'secondary'"
+        id="daemon-detail_badge_status"
+        >{{
+          (enabled() ? "pamAccessConnectorStatusEnabled" : "pamAccessConnectorStatusDisabled")
+            | i18n
+        }}</span
       >
-        {{ "pamAccessConnectorDisable" | i18n }}
-      </button>
-    } @else {
-      <button
-        type="button"
-        bitButton
-        buttonType="secondary"
-        [bitAction]="enable"
-        id="daemon-detail_button_enable"
-      >
-        {{ "pamAccessConnectorEnable" | i18n }}
-      </button>
     }
-    <button
-      type="button"
-      bitButton
-      buttonType="danger"
-      [bitAction]="deleteDaemon"
-      id="daemon-detail_button_delete"
-    >
-      {{ "delete" | i18n }}
-    </button>
-  }
+  </span>
 </bit-header>
 
 @if (loading()) {
@@ -76,7 +61,7 @@
           }
         </div>
 
-        <div class="tw-mb-4">
+        <div>
           <p bitTypography="helper" class="tw-mb-1 tw-font-semibold">
             {{ "pamAccessConnectorConnection" | i18n }}
           </p>
@@ -86,21 +71,36 @@
             <span bitBadge variant="secondary">{{ "pamAccessConnectorOffline" | i18n }}</span>
           }
         </div>
+      </bit-card>
+    </bit-section>
 
-        <div>
-          <p bitTypography="helper" class="tw-mb-1 tw-font-semibold">
-            {{ "pamAccessConnectorAssignments" | i18n }}
-          </p>
-          @if (assignmentNames().length === 0) {
-            <span class="tw-text-muted">&mdash;</span>
-          } @else {
-            <div class="tw-flex tw-flex-wrap tw-gap-1">
-              @for (name of assignmentNames(); track $index) {
-                <span bitBadge variant="subtle">{{ name }}</span>
-              }
-            </div>
-          }
-        </div>
+    <!-- Assigned targets -->
+    <bit-section>
+      <bit-section-header>
+        <h2 bitTypography="h5">{{ "pamAccessConnectorAssignments" | i18n }}</h2>
+        @if (enabled()) {
+          <button
+            slot="end"
+            type="button"
+            bitButton
+            buttonType="secondary"
+            [bitAction]="openAssignDialog"
+            id="daemon-detail_button_assign-target"
+          >
+            {{ "pamAccessConnectorAssignTargets" | i18n }}
+          </button>
+        }
+      </bit-section-header>
+      <bit-card>
+        @if (assignmentNames().length === 0) {
+          <span class="tw-text-muted">&mdash;</span>
+        } @else {
+          <div class="tw-flex tw-flex-wrap tw-gap-1">
+            @for (name of assignmentNames(); track $index) {
+              <span bitBadge variant="subtle">{{ name }}</span>
+            }
+          </div>
+        }
       </bit-card>
     </bit-section>
 
@@ -119,5 +119,42 @@
         </bit-card>
       }
     </bit-section>
+
+    <p bitTypography="body2" class="tw-text-muted">
+      {{ "pamAccessConnectorDeleteConfirmContent" | i18n: d.connector.name }}
+    </p>
+    <div class="tw-flex tw-items-center tw-gap-2">
+      @if (enabled()) {
+        <button
+          type="button"
+          bitButton
+          buttonType="secondary"
+          [bitAction]="disable"
+          id="daemon-detail_button_disable"
+        >
+          {{ "pamAccessConnectorDisable" | i18n }}
+        </button>
+      } @else {
+        <button
+          type="button"
+          bitButton
+          buttonType="secondary"
+          [bitAction]="enable"
+          id="daemon-detail_button_enable"
+        >
+          {{ "pamAccessConnectorEnable" | i18n }}
+        </button>
+      }
+      <button
+        type="button"
+        bitButton
+        buttonType="danger"
+        [bitAction]="deleteDaemon"
+        class="tw-ms-auto"
+        id="daemon-detail_button_delete"
+      >
+        {{ "delete" | i18n }}
+      </button>
+    </div>
   </div>
 }

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
+import { of } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { DialogService, ToastService } from "@bitwarden/components";
@@ -136,6 +137,66 @@ describe("DaemonDetailComponent", () => {
       connectorId("daemon-1"),
     );
     expect(nav).toHaveBeenCalled();
+  });
+
+  it("assigns the selected target system, patches assignments, and shows a success toast", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon({ assignedTargetSystemIds: [] }));
+    rotationSdk.assignTarget.mockResolvedValue(undefined);
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(sysId("ts-1")) } as any);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as {
+      openAssignDialog: () => Promise<void>;
+      assignmentNames: () => string[];
+    };
+    await comp.openAssignDialog();
+
+    expect(rotationSdk.assignTarget).toHaveBeenCalledWith(
+      ORGANIZATION_ID,
+      connectorId("daemon-1"),
+      sysId("ts-1"),
+    );
+    expect(comp.assignmentNames()).toEqual(["Prod Entra"]);
+    expect(TestBed.inject(ToastService).showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "success" }),
+    );
+  });
+
+  it("does not assign anything when the assign dialog is dismissed", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon({ assignedTargetSystemIds: [] }));
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(undefined) } as any);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as { openAssignDialog: () => Promise<void> };
+    await comp.openAssignDialog();
+
+    expect(rotationSdk.assignTarget).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast when assignTarget rejects", async () => {
+    rotationSdk.getConnector.mockResolvedValue(makeDaemon({ assignedTargetSystemIds: [] }));
+    rotationSdk.assignTarget.mockRejectedValue(new Error("boom"));
+    const dialog = mock<DialogService>();
+    dialog.open.mockReturnValue({ closed: of(sysId("ts-1")) } as any);
+    await setup(rotationSdk, connectorId("daemon-1"), dialog);
+    fixture = TestBed.createComponent(DaemonDetailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const comp = fixture.componentInstance as unknown as { openAssignDialog: () => Promise<void> };
+    await comp.openAssignDialog();
+
+    expect(TestBed.inject(ToastService).showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "error" }),
+    );
   });
 
   it("toasts and navigates back when the daemon is not found", async () => {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.stories.ts
@@ -11,12 +11,16 @@ import {
 import { DialogService, ToastService } from "@bitwarden/components";
 import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
 
+import { AccessConnectorStatus } from "../rotation";
 import { RotationSdkService } from "../rotation-sdk.service";
 import {
   accessConnector,
   accessConnectorDetail,
   connectorId,
+  jobId,
   ORGANIZATION_ID,
+  rotationJob,
+  sysId,
   targetSystem,
 } from "../testing/rotation-builders";
 import { atUrl } from "../testing/story-helpers";
@@ -34,16 +38,47 @@ const LONG_NAME_DETAIL = accessConnectorDetail({
   }),
 });
 
+const OFFLINE_DETAIL = accessConnectorDetail({
+  connector: accessConnector({
+    id: connectorId("offline"),
+    name: "Offline connector",
+    isConnected: false,
+  }),
+});
+
+const DISABLED_DETAIL = accessConnectorDetail({
+  connector: accessConnector({
+    id: connectorId("disabled"),
+    name: "Disabled connector",
+    status: AccessConnectorStatus.Disabled,
+  }),
+});
+
+const TARGET_SYSTEM_A = targetSystem({ id: sysId("a"), name: "Prod Entra" });
+const TARGET_SYSTEM_B = targetSystem({ id: sysId("b"), name: "Staging Postgres" });
+
+const POPULATED_DETAIL = accessConnectorDetail({
+  connector: accessConnector({
+    id: connectorId("populated"),
+    name: "Populated connector",
+    assignedTargetSystemIds: [TARGET_SYSTEM_A.id, TARGET_SYSTEM_B.id],
+  }),
+  jobs: [rotationJob(), rotationJob({ id: jobId("job-2"), status: "failed" })],
+});
+
 const CONNECTORS_BY_ID = new Map(
-  [SAMPLE_DETAIL, LONG_NAME_DETAIL].map((detail) => [detail.connector.id, detail]),
+  [SAMPLE_DETAIL, LONG_NAME_DETAIL, OFFLINE_DETAIL, DISABLED_DETAIL, POPULATED_DETAIL].map(
+    (detail) => [detail.connector.id, detail],
+  ),
 );
 
 const rotationSdk: Partial<RotationSdkService> = {
-  listTargetSystems: () => Promise.resolve([targetSystem()]),
+  listTargetSystems: () => Promise.resolve([TARGET_SYSTEM_A, TARGET_SYSTEM_B]),
   getConnector: (_organizationId, id) => Promise.resolve(CONNECTORS_BY_ID.get(id) ?? SAMPLE_DETAIL),
   enableConnector: () => Promise.resolve(),
   disableConnector: () => Promise.resolve(),
   deleteConnector: () => Promise.resolve(),
+  assignTarget: () => Promise.resolve(),
 };
 
 /**
@@ -83,7 +118,11 @@ export default {
 
 type Story = StoryObj<DaemonDetailComponent>;
 
-/** The breadcrumb trail reads "Access connectors > Prod on-prem connector" — the connector's own name. */
+/**
+ * The breadcrumb trail reads "Access connectors > Prod on-prem connector" — the connector's own
+ * name. Also doubles as the no-assignments AND no-activity empty-state pair, since both are the
+ * builder's defaults.
+ */
 export const Default: Story = {
   decorators: [
     atUrl(
@@ -92,11 +131,38 @@ export const Default: Story = {
   ],
 };
 
-/** A realistic long connector name, to check the breadcrumb truncates rather than crowding the header buttons. */
+/** A realistic long connector name, to check the breadcrumb truncates rather than crowding the title-suffix status badge. */
 export const LongName: Story = {
   decorators: [
     atUrl(
       `/organizations/${ORGANIZATION_ID}/pam/rotation/access-connectors/${LONG_NAME_DETAIL.connector.id}`,
+    ),
+  ],
+};
+
+/** Offline connector: the Connection field's badge reads "Offline". */
+export const Offline: Story = {
+  decorators: [
+    atUrl(
+      `/organizations/${ORGANIZATION_ID}/pam/rotation/access-connectors/${OFFLINE_DETAIL.connector.id}`,
+    ),
+  ],
+};
+
+/** Disabled connector: both status badges read "Disabled", the bottom row shows Enable, and the Assign-targets button is hidden. */
+export const Disabled: Story = {
+  decorators: [
+    atUrl(
+      `/organizations/${ORGANIZATION_ID}/pam/rotation/access-connectors/${DISABLED_DETAIL.connector.id}`,
+    ),
+  ],
+};
+
+/** Two assigned targets and two rotation jobs: the uncapped badge list and app-rotation-history both render real rows. */
+export const Populated: Story = {
+  decorators: [
+    atUrl(
+      `/organizations/${ORGANIZATION_ID}/pam/rotation/access-connectors/${POPULATED_DETAIL.connector.id}`,
     ),
   ],
 };

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -107,7 +107,7 @@ export class DaemonDetailComponent {
   });
 
   /** Active+automatic systems not already assigned to this connector — mirrors the tab's `openAssignDialog` filter (`daemons-tab.component.ts`). */
-  protected readonly assignableSystems = computed(() => {
+  private readonly assignableSystems = computed(() => {
     const connector = this.connector();
     if (connector == null) {
       return [];

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemon-detail.component.ts
@@ -25,9 +25,17 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { RotationHistoryComponent } from "../managed-credentials/rotation-history.component";
-import { AccessConnectorDetail, AccessConnectorId, DaemonStatus } from "../rotation";
+import {
+  AccessConnectorDetail,
+  AccessConnectorId,
+  DaemonStatus,
+  TargetSystem,
+  TargetSystemId,
+} from "../rotation";
 import { RotationSdkService } from "../rotation-sdk.service";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
+
+import { AssignTargetDialogComponent } from "./assign-target-dialog.component";
 
 /**
  * Routed detail page for a single rotation daemon — a sibling of the rotation shell, matching
@@ -80,6 +88,11 @@ export class DaemonDetailComponent {
     initialValue: new Map(),
   });
 
+  private readonly activeAutomaticSystems = toSignal(
+    this.targetSystemsService.activeAutomaticSystems$,
+    { initialValue: [] as TargetSystem[] },
+  );
+
   /** The connector itself; the detail's other half is its recent job history. */
   private readonly connector = computed(() => this.daemon()?.connector ?? null);
 
@@ -91,6 +104,16 @@ export class DaemonDetailComponent {
     }
     const map = this.systemById();
     return connector.assignedTargetSystemIds.map((id) => map.get(id)?.name ?? id);
+  });
+
+  /** Active+automatic systems not already assigned to this connector — mirrors the tab's `openAssignDialog` filter (`daemons-tab.component.ts`). */
+  protected readonly assignableSystems = computed(() => {
+    const connector = this.connector();
+    if (connector == null) {
+      return [];
+    }
+    const assigned = new Set(connector.assignedTargetSystemIds);
+    return this.activeAutomaticSystems().filter((s) => !assigned.has(s.id));
   });
 
   protected readonly titleText = computed(() => this.connector()?.name ?? "");
@@ -176,6 +199,36 @@ export class DaemonDetailComponent {
     }
   };
 
+  /**
+   * Assign a target system to this connector. Uses `RotationSdkService.assignTarget` directly
+   * rather than `DaemonsService` — that service is tab-scoped and owns a full list this page
+   * doesn't have; patches the local `daemon` signal the same way {@link patchStatus} does.
+   */
+  protected readonly openAssignDialog = async (): Promise<void> => {
+    const connector = this.connector();
+    if (connector == null) {
+      return;
+    }
+    const ref = AssignTargetDialogComponent.open(this.dialogService, {
+      data: { daemon: connector, options: this.assignableSystems() },
+    });
+    const targetSystemId = await ref.closed.toPromise();
+    if (!targetSystemId) {
+      return;
+    }
+    try {
+      const id = asUuid<TargetSystemId>(targetSystemId);
+      await this.rotationSdk.assignTarget(this.organizationId, connector.id, id);
+      this.patchAssignment(id);
+      this.toastService.showToast({
+        variant: "success",
+        message: this.i18nService.t("pamAccessConnectorAssigned"),
+      });
+    } catch (e) {
+      this.showError(e);
+    }
+  };
+
   private async initialize(): Promise<void> {
     try {
       const [daemon] = await Promise.all([
@@ -215,6 +268,21 @@ export class DaemonDetailComponent {
       return;
     }
     this.daemon.set({ ...daemon, connector: { ...daemon.connector, status } });
+  }
+
+  /** Patch the loaded daemon's assignments locally, mirroring {@link patchStatus}. */
+  private patchAssignment(targetSystemId: TargetSystemId): void {
+    const daemon = this.daemon();
+    if (daemon == null) {
+      return;
+    }
+    this.daemon.set({
+      ...daemon,
+      connector: {
+        ...daemon.connector,
+        assignedTargetSystemIds: [...daemon.connector.assignedTargetSystemIds, targetSystemId],
+      },
+    });
   }
 
   private showError(e: unknown): void {


### PR DESCRIPTION
Design review 2026-09-04: "clean this one up, nicer empty states, the button placement is super odd". No frame exists for this page, so the structure was settled by a design brief first rather than invented mid-build. Worth a designer's eye before this leaves draft.