### PR TITLE
fix(pam): space the rotation settings card controls

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/rotation-schedule-input.component.html
@@ -1,4 +1,4 @@
-<bit-form-field disableMargin>
+<bit-form-field>
   <bit-label>{{ "pamRotationScheduleLabel" | i18n }}</bit-label>
   <bit-select
     id="rotation-schedule-input_select_preset"


### PR DESCRIPTION
Design review 2026-09-04: "the spacing here is odd". The schedule field and the checkbox after it both set `disableMargin`, which is for the last control in a card, so they sat flush. The shared schedule input is used by the create form too.