### PR TITLE
feat(pam): add filter chips to the target systems and access connectors tabs

### DIFF
--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.html
@@ -1,9 +1,33 @@
-<div class="tw-mb-4">
+<div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-center tw-gap-3">
   <bit-search
-    class="tw-max-w-md"
+    class="tw-grow tw-max-w-md"
     [placeholder]="'pamAccessConnectorSearch' | i18n"
     [formControl]="searchControl"
   ></bit-search>
+  @if (statusOptions().length > 0) {
+    <bit-filter-menu
+      #statusFilter
+      key="status"
+      [placeholderText]="'status' | i18n"
+      [unsetLabel]="'all' | i18n"
+    >
+      @for (option of statusOptions(); track option.value) {
+        <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+      }
+    </bit-filter-menu>
+  }
+  @if (connectionOptions().length > 0) {
+    <bit-filter-menu
+      #connectionFilter
+      key="connection"
+      [placeholderText]="'pamAccessConnectorConnection' | i18n"
+      [unsetLabel]="'all' | i18n"
+    >
+      @for (option of connectionOptions(); track option.value) {
+        <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+      }
+    </bit-filter-menu>
+  }
 </div>
 
 @if (loading()) {

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.spec.ts
@@ -1,14 +1,16 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { DialogService, FilterMenuComponent, ToastService } from "@bitwarden/components";
 
-import type { AccessConnector, TargetSystemId, TargetSystem } from "../rotation";
+import type { AccessConnector, AccessConnectorId, TargetSystemId, TargetSystem } from "../rotation";
+import { DaemonStatus } from "../rotation";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
-import { ORGANIZATION_ID, connectorId, sysId } from "../testing/rotation-builders";
+import { ORGANIZATION_ID, accessConnector, connectorId, sysId } from "../testing/rotation-builders";
 
 import { DaemonsTabComponent } from "./daemons-tab.component";
 import { DaemonsService, DaemonRow } from "./daemons.service";
@@ -209,5 +211,173 @@ describe("DaemonsTabComponent", () => {
     await component.unassign(daemon, sysId("ts-1"), "Prod");
 
     expect(daemonsService.unassign).toHaveBeenCalledWith(daemon, sysId("ts-1"));
+  });
+});
+
+describe("DaemonsTabComponent toolbar filters", () => {
+  /** The component's protected surface, as these tests read it. */
+  type FiltersComp = {
+    dataSource: { filteredData?: DaemonRow[] };
+    searchControl: { setValue: (value: string) => void };
+    statusOptions: () => { value: string; label: string }[];
+    connectionOptions: () => { value: boolean; label: string }[];
+  };
+
+  let fixture: ComponentFixture<DaemonsTabComponent>;
+  let component: FiltersComp;
+
+  function makeRow(overrides: {
+    id: AccessConnectorId;
+    name: string;
+    enabled: boolean;
+    isConnected: boolean;
+  }): DaemonRow {
+    const { id, name, enabled, isConnected } = overrides;
+    return {
+      id,
+      name,
+      statusLabelKey: enabled
+        ? "pamAccessConnectorStatusEnabled"
+        : "pamAccessConnectorStatusDisabled",
+      isConnected,
+      assignmentNames: [],
+      enabled,
+      canAssign: enabled,
+      daemon: accessConnector({
+        id,
+        name,
+        status: enabled ? DaemonStatus.Enabled : DaemonStatus.Disabled,
+        isConnected,
+      }),
+    };
+  }
+
+  const enabledConnected = makeRow({
+    id: connectorId("c-1"),
+    name: "Prod on-prem",
+    enabled: true,
+    isConnected: true,
+  });
+  const enabledOffline = makeRow({
+    id: connectorId("c-2"),
+    name: "Prod backup",
+    enabled: true,
+    isConnected: false,
+  });
+  const disabledOffline = makeRow({
+    id: connectorId("c-3"),
+    name: "Staging",
+    enabled: false,
+    isConnected: false,
+  });
+
+  /** Renders the real template, unlike the suite above — the chips are what's under test. */
+  function setup(rows: DaemonRow[]) {
+    TestBed.configureTestingModule({
+      imports: [DaemonsTabComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: DaemonsService,
+          useValue: {
+            loading$: new BehaviorSubject<boolean>(false),
+            rows$: new BehaviorSubject<DaemonRow[]>(rows),
+            load: jest.fn().mockResolvedValue(undefined),
+            registerCompleted: jest.fn().mockResolvedValue(undefined),
+            assign: jest.fn().mockResolvedValue(undefined),
+            unassign: jest.fn().mockResolvedValue(undefined),
+            setEnabled: jest.fn().mockResolvedValue(undefined),
+            delete: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: TargetSystemsService,
+          useValue: {
+            activeAutomaticSystems$: of([] as TargetSystem[]),
+            load: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        { provide: I18nService, useValue: { t: (key: string) => key } },
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(DaemonsTabComponent);
+    component = fixture.componentInstance as unknown as FiltersComp;
+    fixture.detectChanges();
+  }
+
+  function chip(key: string): FilterMenuComponent {
+    return fixture.debugElement.query(By.css(`bit-filter-menu[key="${key}"]`)).componentInstance;
+  }
+
+  function visibleIds(): string[] {
+    return (component.dataSource.filteredData ?? []).map((row) => row.id as string).sort();
+  }
+
+  it("caps the search by making it a flex item, not a block child", () => {
+    setup([enabledConnected]);
+    const search = fixture.debugElement.query(By.css("bit-search"));
+    expect(search.nativeElement.className).toContain("tw-grow");
+    expect(search.nativeElement.className).toContain("tw-max-w-md");
+    expect(search.nativeElement.parentElement.className).toContain("tw-flex");
+  });
+
+  it("derives the status options from the loaded rows, sorted by label", () => {
+    setup([enabledConnected, enabledOffline, disabledOffline]);
+    expect(component.statusOptions()).toEqual([
+      { value: "pamAccessConnectorStatusDisabled", label: "pamAccessConnectorStatusDisabled" },
+      { value: "pamAccessConnectorStatusEnabled", label: "pamAccessConnectorStatusEnabled" },
+    ]);
+  });
+
+  it("derives the connection options from the rows' liveness flag", () => {
+    setup([enabledConnected, enabledOffline, disabledOffline]);
+    expect(component.connectionOptions()).toEqual([
+      { value: true, label: "pamAccessConnectorConnected" },
+      { value: false, label: "pamAccessConnectorOffline" },
+    ]);
+  });
+
+  it("leaves the chips out of the toolbar when no connectors are registered", () => {
+    setup([]);
+    expect(fixture.debugElement.query(By.css("bit-search"))).not.toBeNull();
+    expect(fixture.debugElement.query(By.css("bit-filter-menu"))).toBeNull();
+  });
+
+  it("narrows rows to the selected status", () => {
+    setup([enabledConnected, enabledOffline, disabledOffline]);
+    chip("status").toggle("pamAccessConnectorStatusDisabled");
+    fixture.detectChanges();
+    expect(visibleIds()).toEqual([connectorId("c-3") as string]);
+  });
+
+  it("narrows rows to the offline side of the connection chip, where the value is false", () => {
+    setup([enabledConnected, enabledOffline, disabledOffline]);
+    chip("connection").toggle(false);
+    fixture.detectChanges();
+    expect(visibleIds()).toEqual(
+      [connectorId("c-2") as string, connectorId("c-3") as string].sort(),
+    );
+  });
+
+  it("ANDs the chips with each other and with the search text", () => {
+    setup([enabledConnected, enabledOffline, disabledOffline]);
+    component.searchControl.setValue("prod");
+    chip("connection").toggle(false);
+    fixture.detectChanges();
+    expect(visibleIds()).toEqual([connectorId("c-2") as string]);
+  });
+
+  it("shows the no-results row when the chips alone empty the table", () => {
+    setup([enabledConnected]);
+    chip("connection").toggle(false);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain("pamAccessConnectorNoResults");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.stories.ts
@@ -35,6 +35,12 @@ const CONNECTOR_PROD = accessConnector({
   assignedTargetSystemIds: [sysId("1")],
 });
 
+const CONNECTOR_EU = accessConnector({
+  id: connectorId("connector-eu"),
+  name: "EU region connector",
+  isConnected: false,
+});
+
 const CONNECTOR_STAGING = accessConnector({
   id: connectorId("connector-staging"),
   name: "Staging connector",
@@ -42,7 +48,11 @@ const CONNECTOR_STAGING = accessConnector({
   isConnected: false,
 });
 
-const ROWS: DaemonRow[] = [row(CONNECTOR_PROD, ["Prod Entra"]), row(CONNECTOR_STAGING, [])];
+const ROWS: DaemonRow[] = [
+  row(CONNECTOR_PROD, ["Prod Entra"]),
+  row(CONNECTOR_EU, ["Prod Entra", "Reporting SQL"]),
+  row(CONNECTOR_STAGING, []),
+];
 
 function rotationServices(rows: DaemonRow[]) {
   return moduleMetadata({
@@ -90,7 +100,9 @@ export default {
               delete: "Delete",
               name: "Name",
               status: "Status",
+              all: "All",
               options: "Options",
+              removeItem: "Remove __$1__",
               pamAccessConnectorSearch: "Search access connectors",
               pamAccessConnectorEmptyStateTitle: "No access connectors registered",
               pamAccessConnectorEmptyStateDescription:
@@ -120,7 +132,10 @@ export default {
 
 type Story = StoryObj<DaemonsTabComponent>;
 
-/** One connected/enabled connector with an assignment, and one disabled/offline connector. */
+/**
+ * Both statuses and both connection states, so the Status and Connection chips each narrow the
+ * table — including an enabled connector that is offline, which only one of them excludes.
+ */
 export const Default: Story = {
   decorators: [rotationServices(ROWS)],
 };

--- a/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/daemons/daemons-tab.component.ts
@@ -1,5 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, computed, effect, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  viewChild,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -15,6 +22,8 @@ import {
   BadgeModule,
   ButtonModule,
   DialogService,
+  FILTER_CONTROL,
+  FilterMenuModule,
   IconButtonModule,
   IconModule,
   LinkModule,
@@ -29,6 +38,7 @@ import {
 } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
+import { filterOptions } from "../filter-options";
 import { AccessConnector, DaemonStatus, TargetSystemId, TargetSystem } from "../rotation";
 import { TargetSystemsService } from "../target-systems/target-systems.service";
 
@@ -46,6 +56,7 @@ import { DaemonRow, DaemonsService } from "./daemons.service";
     AsyncActionsModule,
     BadgeModule,
     ButtonModule,
+    FilterMenuModule,
     IconButtonModule,
     IconModule,
     LinkModule,
@@ -83,6 +94,36 @@ export class DaemonsTabComponent {
   protected readonly searchControl = new FormControl("", { nonNullable: true });
   private readonly searchText = toSignal(this.searchControl.valueChanges, { initialValue: "" });
 
+  /** Status/connection toolbar chips; read directly rather than via a form control. */
+  private readonly statusFilterChip = viewChild("statusFilter", { read: FILTER_CONTROL });
+  private readonly connectionFilterChip = viewChild("connectionFilter", { read: FILTER_CONTROL });
+
+  protected readonly statusOptions = computed(() =>
+    filterOptions(
+      this.rows().map(
+        (row) => [row.statusLabelKey, this.i18nService.t(row.statusLabelKey)] as const,
+      ),
+    ),
+  );
+
+  /**
+   * Connection options carry the row's `isConnected` as their value, so "Offline" selects `false`.
+   * The filter below must therefore test the chip against `null`, not for truthiness.
+   */
+  protected readonly connectionOptions = computed(() =>
+    filterOptions(
+      this.rows().map(
+        (row) =>
+          [
+            row.isConnected,
+            this.i18nService.t(
+              row.isConnected ? "pamAccessConnectorConnected" : "pamAccessConnectorOffline",
+            ),
+          ] as const,
+      ),
+    ),
+  );
+
   private readonly organizationId = toSignal(
     this.route.params.pipe(map((p) => p["organizationId"] as OrganizationId)),
     { requireSync: true },
@@ -103,7 +144,21 @@ export class DaemonsTabComponent {
 
     effect(() => {
       const text = this.searchText().trim().toLowerCase();
-      this.dataSource.filter = (row) => !text || row.name.toLowerCase().includes(text);
+      const status = this.statusFilterChip()?.value() as string | null | undefined;
+      const connected = this.connectionFilterChip()?.value() as boolean | null | undefined;
+
+      this.dataSource.filter = (row) => {
+        if (text !== "" && !row.name.toLowerCase().includes(text)) {
+          return false;
+        }
+        if (status != null && row.statusLabelKey !== status) {
+          return false;
+        }
+        if (connected != null && row.isConnected !== connected) {
+          return false;
+        }
+        return true;
+      };
     });
   }
 

--- a/bitwarden_license/bit-web/src/app/pam/rotation/filter-options.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/filter-options.ts
@@ -1,0 +1,14 @@
+/** A `bit-filter-option`'s binding: the row-model value it selects for, and its display label. */
+export type FilterOption<T> = { value: T; label: string };
+
+/**
+ * The distinct options in a set of `[value, label]` pairs, sorted by label.
+ *
+ * Callers pass one pair per row on screen, so an option that would match nothing never reaches the
+ * menu. The labels are already translated, so the ordering follows the active locale.
+ */
+export function filterOptions<T>(pairs: readonly (readonly [T, string])[]): FilterOption<T>[] {
+  return [...new Map(pairs)]
+    .map(([value, label]) => ({ value, label }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.html
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.html
@@ -1,11 +1,47 @@
 @if (!loading()) {
   @if (dataSource.data.length > 0 || searchControl.value) {
-    <div class="tw-mb-4">
+    <div class="tw-mb-4 tw-flex tw-flex-wrap tw-items-center tw-gap-3">
       <bit-search
-        class="tw-max-w-md"
+        class="tw-grow tw-max-w-md"
         [placeholder]="'pamTargetSystemSearch' | i18n"
         [formControl]="searchControl"
       ></bit-search>
+      @if (methodOptions().length > 0) {
+        <bit-filter-menu
+          #methodFilter
+          key="method"
+          [placeholderText]="'pamTargetSystemMethodColumn' | i18n"
+          [unsetLabel]="'all' | i18n"
+        >
+          @for (option of methodOptions(); track option.value) {
+            <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+          }
+        </bit-filter-menu>
+      }
+      @if (kindOptions().length > 0) {
+        <bit-filter-menu
+          #kindFilter
+          key="kind"
+          [placeholderText]="'pamTargetSystemKindColumn' | i18n"
+          [unsetLabel]="'all' | i18n"
+        >
+          @for (option of kindOptions(); track option.value) {
+            <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+          }
+        </bit-filter-menu>
+      }
+      @if (statusOptions().length > 0) {
+        <bit-filter-menu
+          #statusFilter
+          key="status"
+          [placeholderText]="'status' | i18n"
+          [unsetLabel]="'all' | i18n"
+        >
+          @for (option of statusOptions(); track option.value) {
+            <bit-filter-option [value]="option.value">{{ option.label }}</bit-filter-option>
+          }
+        </bit-filter-menu>
+      }
     </div>
 
     <bit-table [dataSource]="dataSource">

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.spec.ts
@@ -1,12 +1,13 @@
 import { ComponentFixture, TestBed, fakeAsync, tick, flushMicrotasks } from "@angular/core/testing";
 import { ReactiveFormsModule } from "@angular/forms";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { ActivatedRoute, Router, provideRouter } from "@angular/router";
 import { mock } from "jest-mock-extended";
 import { BehaviorSubject, of } from "rxjs";
 
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
-import { DialogService, ToastService } from "@bitwarden/components";
+import { DialogService, FilterMenuComponent, ToastService } from "@bitwarden/components";
 
 import { DaemonsService } from "../daemons/daemons.service";
 import { DaemonStatus, type AccessConnector, type TargetSystem } from "../rotation";
@@ -371,5 +372,163 @@ describe("TargetSystemsTabComponent", () => {
         }),
       );
     }));
+  });
+});
+
+describe("TargetSystemsTabComponent toolbar filters", () => {
+  /** The component's protected surface, as these tests read it. */
+  type FiltersComp = {
+    dataSource: { filteredData?: TargetSystemRow[] };
+    searchControl: { setValue: (value: string) => void };
+    methodOptions: () => { value: string; label: string }[];
+    kindOptions: () => { value: string; label: string }[];
+    statusOptions: () => { value: string; label: string }[];
+  };
+
+  let fixture: ComponentFixture<TargetSystemsTabComponent>;
+  let component: FiltersComp;
+
+  const entraActive = makeSystem({
+    id: sysId("1"),
+    name: "Prod Entra",
+    method: TargetSystemMethod.Automatic,
+    kind: TargetSystemKind.Entra,
+    status: TargetSystemStatus.Active,
+  });
+  const mssqlDisabled = makeSystem({
+    id: sysId("2"),
+    name: "Prod SQL reporting",
+    method: TargetSystemMethod.Automatic,
+    kind: TargetSystemKind.Mssql,
+    status: TargetSystemStatus.Disabled,
+  });
+  const manualActive = makeSystem({
+    id: sysId("3"),
+    name: "Mainframe payroll",
+    method: TargetSystemMethod.Manual,
+    kind: null,
+    status: TargetSystemStatus.Active,
+  });
+
+  /** Renders the real template, unlike the suite above — the chips are what's under test. */
+  function setup(systems: TargetSystem[]) {
+    TestBed.configureTestingModule({
+      imports: [TargetSystemsTabComponent, ReactiveFormsModule, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        {
+          provide: TargetSystemsService,
+          useValue: {
+            loading$: new BehaviorSubject<boolean>(false),
+            systems$: new BehaviorSubject<TargetSystem[]>(systems),
+            systemById$: new BehaviorSubject(new Map()),
+            activeAutomaticSystems$: new BehaviorSubject<TargetSystem[]>([]),
+            load: jest.fn().mockResolvedValue(undefined),
+            setEnabled: jest.fn().mockResolvedValue(undefined),
+            delete: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: DaemonsService,
+          useValue: {
+            daemons$: new BehaviorSubject<AccessConnector[]>([]),
+            forgetTargetSystem: jest.fn(),
+            assign: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        { provide: I18nService, useValue: i18nFake },
+        { provide: DialogService, useValue: mock<DialogService>() },
+        { provide: ToastService, useValue: mock<ToastService>() },
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ organizationId: ORGANIZATION_ID }) },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TargetSystemsTabComponent);
+    component = fixture.componentInstance as unknown as FiltersComp;
+    fixture.detectChanges();
+  }
+
+  function chip(key: string): FilterMenuComponent {
+    return fixture.debugElement.query(By.css(`bit-filter-menu[key="${key}"]`)).componentInstance;
+  }
+
+  function visibleIds(): string[] {
+    return (component.dataSource.filteredData ?? []).map((row) => row.id as string).sort();
+  }
+
+  it("caps the search by making it a flex item, not a block child", () => {
+    setup([entraActive]);
+    const search = fixture.debugElement.query(By.css("bit-search"));
+    expect(search.nativeElement.className).toContain("tw-grow");
+    expect(search.nativeElement.className).toContain("tw-max-w-md");
+    expect(search.nativeElement.parentElement.className).toContain("tw-flex");
+  });
+
+  it("derives the method options from the loaded rows, sorted by label", () => {
+    setup([entraActive, mssqlDisabled, manualActive]);
+    expect(component.methodOptions()).toEqual([
+      { value: TargetSystemMethod.Automatic, label: "pamTargetSystemMethodAutomatic" },
+      { value: TargetSystemMethod.Manual, label: "pamTargetSystemMethodManual" },
+    ]);
+  });
+
+  it("derives the status options from the loaded rows, sorted by label", () => {
+    setup([entraActive, mssqlDisabled, manualActive]);
+    expect(component.statusOptions()).toEqual([
+      { value: TargetSystemStatus.Active, label: "pamTargetSystemStatusActive" },
+      { value: TargetSystemStatus.Disabled, label: "pamTargetSystemStatusDisabled" },
+    ]);
+  });
+
+  it("leaves a manual target out of the kind options, since it has no kind", () => {
+    setup([entraActive, mssqlDisabled, manualActive]);
+    expect(component.kindOptions()).toEqual([
+      { value: TargetSystemKind.Entra, label: "pamTargetSystemKindEntra" },
+      { value: TargetSystemKind.Mssql, label: "pamTargetSystemKindMssql" },
+    ]);
+  });
+
+  it("does not render the kind chip when no loaded target carries a kind", () => {
+    setup([manualActive]);
+    expect(fixture.debugElement.query(By.css('bit-filter-menu[key="kind"]'))).toBeNull();
+  });
+
+  it("narrows rows to the selected method", () => {
+    setup([entraActive, mssqlDisabled, manualActive]);
+    chip("method").toggle(TargetSystemMethod.Manual);
+    fixture.detectChanges();
+    expect(visibleIds()).toEqual([sysId("3") as string]);
+  });
+
+  it("narrows rows to the selected kind", () => {
+    setup([entraActive, mssqlDisabled, manualActive]);
+    chip("kind").toggle(TargetSystemKind.Mssql);
+    fixture.detectChanges();
+    expect(visibleIds()).toEqual([sysId("2") as string]);
+  });
+
+  it("narrows rows to the selected status", () => {
+    setup([entraActive, mssqlDisabled, manualActive]);
+    chip("status").toggle(TargetSystemStatus.Disabled);
+    fixture.detectChanges();
+    expect(visibleIds()).toEqual([sysId("2") as string]);
+  });
+
+  it("ANDs the chips with each other and with the search text", () => {
+    setup([entraActive, mssqlDisabled, manualActive]);
+    component.searchControl.setValue("prod");
+    chip("status").toggle(TargetSystemStatus.Active);
+    fixture.detectChanges();
+    expect(visibleIds()).toEqual([sysId("1") as string]);
+  });
+
+  it("shows the no-results row when the chips alone empty the table", () => {
+    setup([entraActive]);
+    chip("status").toggle(TargetSystemStatus.Disabled);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain("pamTargetSystemNoResults");
   });
 });

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.stories.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.stories.ts
@@ -1,0 +1,113 @@
+import { importProvidersFrom } from "@angular/core";
+import { provideRouter, RouterOutlet, Routes, withHashLocation } from "@angular/router";
+import {
+  applicationConfig,
+  componentWrapperDecorator,
+  Meta,
+  moduleMetadata,
+  StoryObj,
+} from "@storybook/angular";
+import { of } from "rxjs";
+
+import { DialogService, ToastService } from "@bitwarden/components";
+import { PreloadedEnglishI18nModule } from "@bitwarden/web-vault/app/core/tests";
+
+import { DaemonsService } from "../daemons/daemons.service";
+import { AccessConnector, TargetSystem } from "../rotation";
+import { ORGANIZATION_ID, sysId, targetSystem } from "../testing/rotation-builders";
+import { atUrl } from "../testing/story-helpers";
+
+import { TargetSystemsTabComponent } from "./target-systems-tab.component";
+import { TargetSystemsService } from "./target-systems.service";
+
+/**
+ * Every method, kind and status the chips can offer, so each one narrows the table: two methods
+ * (the manual target also being the one with no kind), three kinds, and both statuses.
+ */
+const SYSTEMS: TargetSystem[] = [
+  targetSystem({ id: sysId("1"), name: "Prod Entra", kind: "entra" }),
+  targetSystem({ id: sysId("2"), name: "Reporting SQL", kind: "mssql" }),
+  targetSystem({ id: sysId("3"), name: "Billing rotation script", kind: "custom_script" }),
+  targetSystem({
+    id: sysId("4"),
+    name: "Retired Entra sandbox",
+    kind: "entra",
+    status: "disabled",
+  }),
+  targetSystem({
+    id: sysId("5"),
+    name: "Legacy mainframe",
+    method: "manual",
+    kind: null,
+    supportsSessionTermination: false,
+  }),
+];
+
+function rotationServices(systems: TargetSystem[]) {
+  return moduleMetadata({
+    imports: [RouterOutlet],
+    providers: [
+      {
+        provide: TargetSystemsService,
+        useValue: {
+          loading$: of(false),
+          systems$: of(systems),
+          systemById$: of(new Map(systems.map((s) => [s.id, s] as const))),
+          activeAutomaticSystems$: of(systems.filter((s) => s.status === "active")),
+          load: () => Promise.resolve(),
+          setEnabled: () => Promise.resolve(),
+          delete: () => Promise.resolve(),
+        },
+      },
+      {
+        provide: DaemonsService,
+        useValue: {
+          daemons$: of([] as AccessConnector[]),
+          forgetTargetSystem: () => {},
+          assign: () => Promise.resolve(),
+        },
+      },
+    ],
+  });
+}
+
+/**
+ * Mirrors `rotation.routes.ts` (minus its guards) so the tab reads `organizationId` from a real
+ * route param. The component declares no selector, so the story renders it through the outlet.
+ */
+const routes: Routes = [
+  {
+    path: "organizations/:organizationId/pam/rotation",
+    children: [{ path: "target-systems", component: TargetSystemsTabComponent }],
+  },
+];
+
+export default {
+  title: "Web/PAM/Rotation/Target Systems Tab",
+  component: TargetSystemsTabComponent,
+  render: () => ({ template: `<router-outlet></router-outlet>` }),
+  decorators: [
+    componentWrapperDecorator((story) => `<div class="tw-p-6">${story}</div>`),
+    atUrl(`/organizations/${ORGANIZATION_ID}/pam/rotation/target-systems`),
+    applicationConfig({
+      providers: [
+        importProvidersFrom(PreloadedEnglishI18nModule),
+        provideRouter(routes, withHashLocation()),
+        { provide: ToastService, useValue: { showToast: () => {} } },
+        { provide: DialogService, useValue: { openSimpleDialog: () => Promise.resolve(false) } },
+      ],
+    }),
+  ],
+} as Meta<TargetSystemsTabComponent>;
+
+type Story = StoryObj<TargetSystemsTabComponent>;
+
+/** The full toolbar: search plus the Method, Kind and Status chips, each with options to pick. */
+export const Default: Story = {
+  decorators: [rotationServices(SYSTEMS)],
+};
+
+/** No target systems configured yet, so the starter-template empty state replaces the table. */
+export const Empty: Story = {
+  decorators: [rotationServices([])],
+};

--- a/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
+++ b/bitwarden_license/bit-web/src/app/pam/rotation/target-systems/target-systems-tab.component.ts
@@ -1,5 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectionStrategy, Component, effect, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  viewChild,
+} from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
@@ -12,6 +19,8 @@ import { OrganizationId } from "@bitwarden/common/types/guid";
 import {
   BadgeModule,
   DialogService,
+  FILTER_CONTROL,
+  FilterMenuModule,
   IconButtonModule,
   IconModule,
   MenuModule,
@@ -24,6 +33,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { DaemonsService } from "../daemons/daemons.service";
+import { filterOptions } from "../filter-options";
 import {
   AccessConnector,
   AccessConnectorId,
@@ -74,6 +84,7 @@ export type TargetSystemRow = {
     CommonModule,
     ReactiveFormsModule,
     BadgeModule,
+    FilterMenuModule,
     IconButtonModule,
     IconModule,
     MenuModule,
@@ -106,10 +117,37 @@ export class TargetSystemsTabComponent {
     initialValue: [] as AccessConnector[],
   });
 
+  /** The table's rows, and the set the toolbar chips derive their options from. */
+  private readonly rows = computed(() => this.buildRows(this.systems()));
+
   protected readonly dataSource = new TableDataSource<TargetSystemRow>();
   protected readonly searchControl = new FormControl("", { nonNullable: true });
 
   private readonly searchText = toSignal(this.searchControl.valueChanges, { initialValue: "" });
+
+  /** Method/kind/status toolbar chips; read directly rather than via a form control. */
+  private readonly methodFilterChip = viewChild("methodFilter", { read: FILTER_CONTROL });
+  private readonly kindFilterChip = viewChild("kindFilter", { read: FILTER_CONTROL });
+  private readonly statusFilterChip = viewChild("statusFilter", { read: FILTER_CONTROL });
+
+  protected readonly methodOptions = computed(() =>
+    filterOptions(this.rows().map((row) => [row.system.method, row.methodLabel] as const)),
+  );
+
+  /** Manual targets have no kind, so they contribute no option and this chip can be empty. */
+  protected readonly kindOptions = computed(() =>
+    filterOptions(
+      this.rows().flatMap((row) =>
+        row.system.kind != null && row.kindLabel != null
+          ? [[row.system.kind, row.kindLabel] as const]
+          : [],
+      ),
+    ),
+  );
+
+  protected readonly statusOptions = computed(() =>
+    filterOptions(this.rows().map((row) => [row.system.status, row.statusLabel] as const)),
+  );
 
   /** Expose const objects for template comparisons. */
   protected readonly TargetSystemStatus = TargetSystemStatus;
@@ -121,15 +159,34 @@ export class TargetSystemsTabComponent {
     });
 
     effect(() => {
-      this.dataSource.data = this.buildRows(this.systems());
+      this.dataSource.data = this.rows();
     });
 
     effect(() => {
       const text = this.searchText().trim().toLowerCase();
-      this.dataSource.filter = (row) =>
-        text === "" ||
-        row.name.toLowerCase().includes(text) ||
-        (row.kindLabel?.toLowerCase().includes(text) ?? false);
+      const method = this.methodFilterChip()?.value() as TargetSystemMethod | null | undefined;
+      const kind = this.kindFilterChip()?.value() as TargetSystemKind | null | undefined;
+      const status = this.statusFilterChip()?.value() as TargetSystemStatus | null | undefined;
+
+      this.dataSource.filter = (row) => {
+        if (
+          text !== "" &&
+          !row.name.toLowerCase().includes(text) &&
+          !(row.kindLabel?.toLowerCase().includes(text) ?? false)
+        ) {
+          return false;
+        }
+        if (method != null && row.system.method !== method) {
+          return false;
+        }
+        if (kind != null && row.system.kind !== kind) {
+          return false;
+        }
+        if (status != null && row.system.status !== status) {
+          return false;
+        }
+        return true;
+      };
     });
   }
 


### PR DESCRIPTION
Follow-up to the managed credentials toolbar: the other two rotation tabs had a bare, full-bleed search. Options derive from the row models, chips hide when their option set is empty, and both tabs gain a regression test on the search cap so the inline-box trap cannot silently return. No `messages.json` changes.