### PR TITLE
[PM-42970] Fix folder filter restore race condition

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -2,6 +2,7 @@
   class="[&_[role=row]]:tw-mx-3"
   [tableDef]="table"
   [filter]="filterPredicate"
+  [filters]="filtersToRestore()"
   [loading]="loading()"
   [trackBy]="trackRow"
   presentation="list"

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.ts
@@ -237,6 +237,11 @@ export class VaultPopupListTableComponent {
     initialValue: [] as ChipFilterOption<CipherType>[],
   });
 
+  /**
+   * Cached filter state to seed the table's chips on load.
+   */
+  protected readonly filtersToRestore = toSignal(this.listFiltersService.restoreFilters$());
+
   protected readonly organizationOptions = toSignal(this.listFiltersService.organizations$, {
     initialValue: [] as ChipFilterOption<Organization>[],
   });
@@ -379,25 +384,12 @@ export class VaultPopupListTableComponent {
     // Resolve the keyboard-shortcut tooltip for the legacy (flag-off) autofill chip.
     void this.setAutofillShortcutTooltip();
 
-    // Set up chip lifecycle after the first render (chips are registered by then).
+    // Wire up persistence after the first render so we can access the table reference.
     afterNextRender(() => {
       const table = this.tableEl();
       if (!table) {
         return;
       }
-
-      // Seed chips from the persisted cache once the required data resolves.
-      this.listFiltersService
-        .restoreFilters$()
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe((filters) => {
-          for (const control of table.filterControls()) {
-            const value = (filters as Record<string, unknown>)[control.key()];
-            if (value !== undefined) {
-              control.setValue(value);
-            }
-          }
-        });
 
       // Persist cache and update service state whenever chip selections change.
       toObservable(table.filterValues, { injector: this.injector })


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42970](https://bitwarden.atlassian.net/browse/PM-42970)

## 📔 Objective

### Root Cause
The folder filter chip is wrapped in `@if (folderOptions().length)`, so it isn't rendered until `folders$` emits. The previous restore logic read `table.filterControls()` once inside `afterNextRender`, if `folders$` hadn't emitted yet, the folder chip wasn't registered and its cached value was silently dropped. 
  - The same race could affect any other conditionally-rendered chip.

### Fix
Pass the cached filter state via the table's `[filters]` input instead of manually seeding controls in `afterNextRender`. The table's own reactive seeding effect re-runs whenever a new chip registers, so chips that arrive late are seeded correctly without any custom coordination logic.

## Screenshots

<video src="https://github.com/user-attachments/assets/a0cb9bfc-d86a-49f2-9a0e-85268617ad0e" />

[PM-42970]: https://bitwarden.atlassian.net/browse/PM-42970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ