### PR TITLE
[PM-42825] Filter out provider organizations

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.ts
@@ -279,7 +279,7 @@ export class VaultComponent<C extends CipherViewLike> implements OnInit, OnDestr
   private organizations$: Observable<Organization[]> = this.accountService.activeAccount$.pipe(
     map((a) => a?.id),
     filterOutNullish(),
-    switchMap((id) => this.organizationService.organizations$(id)),
+    switchMap((id) => this.organizationService.memberOrganizations$(id)),
   );
 
   /** The account's vaults nav view model — {@link vaultScope$} resolves against this. */

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
@@ -193,7 +193,7 @@ describe("VaultNextComponent", () => {
     i18nService.t.mockImplementation((key: string) => key);
 
     const organizationService = mock<OrganizationService>();
-    organizationService.organizations$.mockReturnValue(organizations$);
+    organizationService.memberOrganizations$.mockReturnValue(organizations$);
 
     const policyService = mock<PolicyService>();
     policyService.policyAppliesToUser$.mockReturnValue(of(false));

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.ts
@@ -212,7 +212,7 @@ export class VaultNextComponent {
   );
 
   protected readonly organizations = toSignal(
-    this.userId$.pipe(switchMap((userId) => this.organizationService.organizations$(userId))),
+    this.userId$.pipe(switchMap((userId) => this.organizationService.memberOrganizations$(userId))),
     { initialValue: [] },
   );
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42825](https://bitwarden.atlassian.net/browse/PM-42825)

## 📔 Objective

Swap out usages of `organizations$` to `memberOrganizations$` to avoid showing organizations where users can only access via a Provider. 

Stems from claude's feedback here: https://github.com/bitwarden/clients/pull/22761#discussion_r3876615154

## Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/8a3dc90a-460e-4503-a6e7-dca239c83d5e" />|<video src="https://github.com/user-attachments/assets/166b60c4-b668-42a9-9cb8-f8f94d400803" />|

[PM-42825]: https://bitwarden.atlassian.net/browse/PM-42825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ