### PR TITLE
[PM-41548] Consider frame URLs when resolving blocked domain entries

### DIFF
--- a/apps/browser/src/platform/services/browser-script-injector.service.spec.ts
+++ b/apps/browser/src/platform/services/browser-script-injector.service.spec.ts
@@ -40,8 +40,9 @@ const mockEquivalentDomains = [
 
 describe("ScriptInjectorService", () => {
   const tabId = 1;
-  const tabMock = createChromeTabMock({ id: tabId });
-  const mockBlockedURI = new URL(tabMock.url);
+  const tabUrl = "https://example.com";
+  const tabMock = createChromeTabMock({ id: tabId, url: tabUrl });
+  const mockBlockedURI = new URL(tabUrl);
   jest.spyOn(BrowserApi, "executeScriptInTab").mockImplementation();
   jest.spyOn(BrowserApi, "isManifestVersion");
 
@@ -69,6 +70,10 @@ describe("ScriptInjectorService", () => {
   const configService = mock<ConfigService>();
 
   beforeEach(() => {
+    // Spies are installed once for the suite; without this their call history accumulates across
+    // tests, which silently defeats any `not.toHaveBeenCalled()` assertion.
+    jest.clearAllMocks();
+
     jest.spyOn(BrowserApi, "getTab").mockImplementation(async () => tabMock);
 
     const mockEnvironment = mock<Environment>();
@@ -137,19 +142,20 @@ describe("ScriptInjectorService", () => {
         );
       });
 
-      it("skips injecting the script in manifest v3 when the tab domain is a blocked domain", async () => {
-        domainSettingsService.blockedInteractionsUris$ = of({ [mockBlockedURI.host]: null });
-        manifestVersionSpy.mockReturnValue(3);
+      it.each([2, 3] as const)(
+        "skips injecting the script in manifest v%i when the tab domain is a blocked domain",
+        async (manifestVersion) => {
+          domainSettingsService.blockedInteractionsUris$ = of({ [mockBlockedURI.host]: null });
+          manifestVersionSpy.mockReturnValue(manifestVersion);
 
-        await expect(scriptInjectorService["buildInjectionDetails"]).not.toHaveBeenCalled();
-      });
+          await scriptInjectorService.inject({
+            tabId,
+            injectDetails: { file: combinedManifestVersionFile, ...sharedInjectDetails },
+          });
 
-      it("skips injecting the script in manifest v2 when the tab domain is a blocked domain", async () => {
-        domainSettingsService.blockedInteractionsUris$ = of({ [mockBlockedURI.host]: null });
-        manifestVersionSpy.mockReturnValue(2);
-
-        await expect(scriptInjectorService["buildInjectionDetails"]).not.toHaveBeenCalled();
-      });
+          expect(BrowserApi.executeScriptInTab).not.toHaveBeenCalled();
+        },
+      );
 
       it("injects the script in manifest v2 when given combined injection details", async () => {
         manifestVersionSpy.mockReturnValue(2);
@@ -237,7 +243,7 @@ describe("ScriptInjectorService", () => {
             scriptInjectorService.inject({
               mv2Details,
               tabId,
-              injectDetails: { ...sharedInjectDetails, file: null },
+              injectDetails: { ...sharedInjectDetails, file: undefined },
             }),
           ).rejects.toThrow("No file specified for script injection");
         });
@@ -291,6 +297,112 @@ describe("ScriptInjectorService", () => {
             }),
           ).rejects.toThrow("No file specified for script injection");
         });
+      });
+    });
+
+    describe("blocked domains for a frame-targeted injection", () => {
+      const subFrameId = 10;
+      const blockedFrameUrl = "https://blocked-widget.example/embed";
+
+      const injectIntoSubFrame = () =>
+        scriptInjectorService.inject({
+          tabId,
+          injectDetails: {
+            file: combinedManifestVersionFile,
+            frame: subFrameId,
+            ...sharedInjectDetails,
+          },
+        });
+
+      /** Stands in for the frame lookup `BrowserApi.getFrameDetails` performs. */
+      const mockFrameLookup = (url: string | undefined) => {
+        jest
+          .spyOn(BrowserApi, "getFrameDetails")
+          .mockResolvedValue(
+            (url == null ? undefined : { url }) as chrome.webNavigation.GetFrameResultDetails,
+          );
+      };
+
+      beforeEach(() => {
+        manifestVersionSpy.mockReturnValue(3);
+      });
+
+      it("skips the injection when the target frame's own domain is blocked", async () => {
+        domainSettingsService.blockedInteractionsUris$ = of({
+          [new URL(blockedFrameUrl).host]: null,
+        });
+        mockFrameLookup(blockedFrameUrl);
+
+        await injectIntoSubFrame();
+
+        expect(BrowserApi.getFrameDetails).toHaveBeenCalledWith({ tabId, frameId: subFrameId });
+        expect(BrowserApi.executeScriptInTab).not.toHaveBeenCalled();
+      });
+
+      it("injects when the target frame's domain is not blocked, even alongside other blocked domains", async () => {
+        domainSettingsService.blockedInteractionsUris$ = of({ "unrelated.example": null });
+        mockFrameLookup(blockedFrameUrl);
+
+        await injectIntoSubFrame();
+
+        expect(BrowserApi.executeScriptInTab).toHaveBeenCalled();
+      });
+
+      it("still blocks on the tab's domain when the frame's own domain is allowed", async () => {
+        domainSettingsService.blockedInteractionsUris$ = of({ [mockBlockedURI.host]: null });
+        mockFrameLookup(blockedFrameUrl);
+
+        await injectIntoSubFrame();
+
+        // The tab check short-circuits, so an embedded frame the user has not blocked cannot
+        // make a blocked page injectable.
+        expect(BrowserApi.getFrameDetails).not.toHaveBeenCalled();
+        expect(BrowserApi.executeScriptInTab).not.toHaveBeenCalled();
+      });
+
+      it("injects when the frame lookup resolves nothing", async () => {
+        domainSettingsService.blockedInteractionsUris$ = of({
+          [new URL(blockedFrameUrl).host]: null,
+        });
+        mockFrameLookup(undefined);
+
+        await injectIntoSubFrame();
+
+        expect(BrowserApi.executeScriptInTab).toHaveBeenCalled();
+      });
+
+      it("does not look a frame up for a top-level injection", async () => {
+        domainSettingsService.blockedInteractionsUris$ = of({
+          [new URL(blockedFrameUrl).host]: null,
+        });
+        mockFrameLookup(blockedFrameUrl);
+
+        await scriptInjectorService.inject({
+          tabId,
+          injectDetails: { file: combinedManifestVersionFile, frame: 0, ...sharedInjectDetails },
+        });
+
+        expect(BrowserApi.getFrameDetails).not.toHaveBeenCalled();
+        expect(BrowserApi.executeScriptInTab).toHaveBeenCalled();
+      });
+
+      it("does not look a frame up for an all_frames injection", async () => {
+        domainSettingsService.blockedInteractionsUris$ = of({
+          [new URL(blockedFrameUrl).host]: null,
+        });
+        mockFrameLookup(blockedFrameUrl);
+
+        await scriptInjectorService.inject({
+          tabId,
+          injectDetails: {
+            file: combinedManifestVersionFile,
+            frame: "all_frames",
+            ...sharedInjectDetails,
+          },
+        });
+
+        expect(BrowserApi.getFrameDetails).not.toHaveBeenCalled();
+        expect(BrowserApi.executeScriptInTab).toHaveBeenCalled();
       });
     });
   });

--- a/apps/browser/src/platform/services/browser-script-injector.service.ts
+++ b/apps/browser/src/platform/services/browser-script-injector.service.ts
@@ -41,19 +41,11 @@ export class BrowserScriptInjectorService extends ScriptInjectorService {
 
     const tab = tabId && (await BrowserApi.getTab(tabId));
 
-    // Check if the tab URL is on the disabled URLs list
-    let injectionAllowedInTab = true;
-    const blockedDomains = await firstValueFrom(
-      this.domainSettingsService.blockedInteractionsUris$,
-    );
+    const blockedURI = await this.findBlockedInjectionUrl(tabId, tab, injectDetails);
 
-    if (blockedDomains && tab?.url) {
-      injectionAllowedInTab = !isUrlInList(tab?.url, blockedDomains);
-    }
-
-    if (!injectionAllowedInTab) {
+    if (blockedURI !== undefined) {
       this.logService.warning(
-        `${injectDetails.file} was not injected because ${tab?.url || "the tab URL"} is on the user's blocked domains list.`,
+        `${injectDetails.file} was not injected because ${blockedURI || "the tab URL"} is on the user's blocked domains list.`,
       );
       return;
     }
@@ -86,6 +78,44 @@ export class BrowserScriptInjectorService extends ScriptInjectorService {
     }
 
     await BrowserApi.executeScriptInTab(tabId, injectionDetails);
+  }
+
+  /**
+   * Identifies the URL that blocks an injection, or `undefined` when the injection is allowed.
+   *
+   * @param tabId - The id of the tab targeted for injection.
+   * @param tab - The targeted tab, when it could be resolved.
+   * @param injectDetails - The details for the script injection.
+   */
+  private async findBlockedInjectionUrl(
+    tabId: number,
+    tab: chrome.tabs.Tab,
+    injectDetails: CommonScriptInjectionDetails,
+  ): Promise<string | undefined> {
+    const blockedDomains = await firstValueFrom(
+      this.domainSettingsService.blockedInteractionsUris$,
+    );
+
+    // If the tab URL is in blockedDomains, no frame lookups are needed,
+    // so check that first
+    if (!blockedDomains || Object.keys(blockedDomains).length === 0) {
+      return undefined;
+    }
+
+    if (tab?.url && isUrlInList(tab.url, blockedDomains)) {
+      return tab.url;
+    }
+
+    const { frame } = injectDetails;
+    if (typeof frame !== "number" || frame === 0) {
+      return undefined;
+    }
+
+    const frameUrl = await BrowserApi.getFrameDetails({ tabId, frameId: frame })
+      .then((frameDetails) => frameDetails?.url)
+      .catch((): undefined => undefined);
+
+    return frameUrl && isUrlInList(frameUrl, blockedDomains) ? frameUrl : undefined;
   }
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41548](https://bitwarden.atlassian.net/browse/PM-41548)

## 📔 Objective

Blocking a URL that matches the tab URL prevents injection on the page as well as in the iframe. But, blocking only the URL of a subframe of the tab doesn’t prevent injection anywhere, including the iframe at that location. These changes additionally check the frame urls against the blocklist, allowing for the prevention of injection within frames without also blocking the parent frame.

Note, similar frame URL considerations are being coordinated in [PM-43104](https://bitwarden.atlassian.net/browse/PM-43104)

[PM-41548]: https://bitwarden.atlassian.net/browse/PM-41548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-43104]: https://bitwarden.atlassian.net/browse/PM-43104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ