### PR TITLE
chore(desktop): pin AppImage static runtime toolset

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,6 +108,7 @@ apps/desktop/macos                @bitwarden/team-platform-dev
 apps/desktop/scripts              @bitwarden/team-platform-dev
 apps/desktop/src/platform         @bitwarden/team-platform-dev
 apps/desktop/resources            @bitwarden/team-platform-dev
+apps/desktop/electron-builder.json  @bitwarden/team-platform-dev
 apps/web/src/app/platform         @bitwarden/team-platform-dev
 libs/angular/src/platform         @bitwarden/team-platform-dev
 libs/common/src/platform          @bitwarden/team-platform-dev

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -24,6 +24,9 @@
   ],
   "electronVersion": "43.2.0",
   "generateUpdatesFilesForAllChannels": true,
+  "toolsets": {
+    "appimage": "1.0.2"
+  },
   "publish": {
     "provider": "generic",
     "url": "https://artifacts.bitwarden.com/desktop"


### PR DESCRIPTION
## 🎟️ Tracking

- [PM-42189](https://bitwarden.atlassian.net/browse/PM-42189)
- Closes [bitwarden/clients#22528](https://github.com/bitwarden/clients/issues/22528)

## 📔 Objective

The Linux AppImage has a runtime dependency on `libfuse2` because electron-builder 26.x defaults to the legacy FUSE 2 AppImage runtime. Many distros no longer install `libfuse2` by default, causing the AppImage to fail at launch for affected users unless they manually install `libfuse2`.


This opts into the [static type-2 AppImage runtime](https://github.com/AppImage/type2-runtime), which is statically linked against musl libc and requires no `libfuse2` on the host. The `toolsets.appimage` field was introduced in [electron-builder v26.8.0](https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.8.0) ([PR #9558](https://github.com/electron-userland/electron-builder/pull/9558)).

When we update to electron-builder v27, the static runtime may become the default, at which point this `toolsets` block can be removed.

[PM-42189]: https://bitwarden.atlassian.net/browse/PM-42189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ