### PR TITLE
desktop: Refactor packing and signing build phases

### DIFF
--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -8,12 +8,18 @@ const builder = require("electron-builder");
 const fse = require("fs-extra");
 exports.default = run;
 
+const IS_GITHUB_ACTIONS = process.env.GITHUB_ACTIONS == "true";
+
 /**
  *
  * @param {builder.AfterPackContext} context
  */
 async function run(context) {
+  if (IS_GITHUB_ACTIONS) {
+    console.log(`::group::After Pack (${builder.Arch[context.arch]})`);
+  }
   console.log("## After pack");
+  console.log("## After pack, started at", new Date().toISOString());
   // console.log(context);
 
   if (context.packager.platform.nodeName !== "darwin" || context.arch === builder.Arch.universal) {
@@ -119,6 +125,11 @@ async function run(context) {
         `codesign -s '${id}' -i ${packageId} -f --timestamp --options runtime --entitlements "${entitlementsPath}" "${inheritProxyPath}"`,
       );
     }
+  }
+
+  console.log("### After pack ended at", new Date().toISOString());
+  if (IS_GITHUB_ACTIONS) {
+    console.log("::endgroup::");
   }
 }
 

--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -20,7 +20,19 @@ async function run(context) {
   }
   console.log("## After pack");
   // console.log(context);
+  try {
+    await doBuild(context);
+  } catch (error) {
+    console.error("### Error occurred during after-pack phase:", error.stack);
+    throw error;
+  } finally {
+    if (IS_GITHUB_ACTIONS) {
+      console.log(`::endgroup::`);
+    }
+  }
+}
 
+async function doBuild(context) {
   const isMacOsBuild = ["darwin", "mas"].includes(context.electronPlatformName);
 
   let isTargetArch;
@@ -126,11 +138,6 @@ async function run(context) {
         `codesign -s '${id}' -i ${packageId} -f --timestamp --options runtime --entitlements "${entitlementsPath}" "${inheritProxyPath}"`,
       );
     }
-  }
-
-  console.log("### After pack ended");
-  if (IS_GITHUB_ACTIONS) {
-    console.log("::endgroup::");
   }
 }
 

--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -19,7 +19,6 @@ async function run(context) {
     console.log(`::group::After Pack (${builder.Arch[context.arch]})`);
   }
   console.log("## After pack");
-  console.log("## After pack, started at", new Date().toISOString());
   // console.log(context);
 
   const isMacOsBuild = ["darwin", "mas"].includes(context.electronPlatformName);
@@ -59,28 +58,12 @@ async function run(context) {
     console.log("Copied memory-protection wrapper script");
   }
 
-  // The autofill extension is copied in here, before electron-builder signs the app, so that
-  // the app's own signature seals it. Copying it in after signing leaves the outer bundle
-  // invalid ("a sealed resource is missing or invalid") and notarization rejects it unless the
-  // whole package is signed a second time. electron-builder never signs anything under
-  // Contents/PlugIns, so the extension keeps the signature and entitlements Xcode gave it.
-  const isMasDevBuild =
-    context.electronPlatformName === "mas" && context.targets.at(0)?.name === "mas-dev";
-  if (context.electronPlatformName === "darwin" || isMasDevBuild) {
-    console.log("### Copying autofill extension");
-    // cannot use extraFiles because it modifies the extension's .plist and makes it invalid
-    const extensionPath = path.join(__dirname, "../macos/dist/autofill-extension.appex");
-    if (!fse.existsSync(extensionPath)) {
-      console.log("### Autofill extension not found - skipping");
-    } else {
-      const appName = context.packager.appInfo.productFilename;
-      const plugInsPath = path.join(context.appOutDir, `${appName}.app`, "Contents/PlugIns");
-      fse.mkdirSync(plugInsPath, { recursive: true });
-      fse.copySync(extensionPath, path.join(plugInsPath, "autofill-extension.appex"));
+  if (isMacOsBuild) {
+    if (isTargetArch) {
+      console.log("[macOS] Copying extensions...");
+      copyMacOsAutofillExtension(context);
+      copySafariExtension(context);
     }
-  }
-
-  if (["darwin", "mas"].includes(context.electronPlatformName)) {
     const is_mas = context.electronPlatformName === "mas";
 
     let id;
@@ -145,7 +128,7 @@ async function run(context) {
     }
   }
 
-  console.log("### After pack ended at", new Date().toISOString());
+  console.log("### After pack ended");
   if (IS_GITHUB_ACTIONS) {
     console.log("::endgroup::");
   }
@@ -238,4 +221,62 @@ async function addElectronFuses(context) {
     // Enables V8 signal handlers to trap Out of Bounds memory access from WebAssembly
     [FuseV1Options.WasmTrapHandlers]: true,
   });
+}
+
+function copyMacOsAutofillExtension(context) {
+  // Currently because the provisioning profiles in the portal do not have the
+  // correct entitlements, we leave out the autofill extension except for local
+  // dev builds.
+  const isMasDevBuild =
+    context.electronPlatformName === "mas" && context.targets.at(0)?.name === "mas-dev";
+  if (!isMasDevBuild) {
+    console.log("### Autofill extension: needs Apple Developer Portal changes. Skipping.");
+    return;
+  }
+
+  const extensionPath = path.join(__dirname, "../macos/dist/autofill-extension.appex");
+  copyMacOsPlugin(context, "Autofill extension", extensionPath);
+}
+
+function copySafariExtension(context) {
+  const plugIn = path.join(__dirname, "../PlugIns", "safari.appex");
+  copyMacOsPlugin(context, "Safari Extension", plugIn);
+}
+
+function copyMacOsPlugin(context, targetName, extensionPath) {
+  // Pre-signed macOS extensions are copied here in after-pack.js, before electron-builder signs the app, so that
+  // the app's own signature seals it.
+  //
+  // Copying it in after signing leaves the outer bundle invalid ("a sealed
+  // resource is missing or invalid") and notarization rejects it unless the
+  // whole package is signed a second time. electron-builder never signs
+  // anything under Contents/PlugIns, so the extension keeps the signature and
+  // entitlements XCode gave it.
+  //
+  // We cannot use extraFiles because it modifies the extension's .plist and makes it invalid. Cf.
+  // https://github.com/electron-userland/electron-builder/issues/5552.
+
+  if (!["darwin", "mas"].includes(context.electronPlatformName)) {
+    // not a macOS build, skipping.
+    console.log(`### ${targetName}: Not macOS build. Skipping.`);
+    return;
+  }
+
+  if (!fse.existsSync(extensionPath)) {
+    console.log(`### ${targetName}: ${extensionPath} not found - skipping`);
+    return;
+  }
+
+  console.log(`### ${targetName}: Copying plugin...`);
+
+  // Make PlugIns directory.
+  const appName = context.packager.appInfo.productFilename;
+  const plugInsPath = path.join(context.appOutDir, `${appName}.app`, "Contents/PlugIns");
+  fse.mkdirSync(plugInsPath, { recursive: true });
+
+  // Copy extension
+  const name = path.basename(extensionPath);
+  const output = path.join(plugInsPath, name);
+  fse.copySync(extensionPath, output);
+  console.log(`### ${targetName}: Copied ${extensionPath} to ${output}.`);
 }

--- a/apps/desktop/scripts/after-pack.js
+++ b/apps/desktop/scripts/after-pack.js
@@ -22,6 +22,24 @@ async function run(context) {
   console.log("## After pack, started at", new Date().toISOString());
   // console.log(context);
 
+  const isMacOsBuild = ["darwin", "mas"].includes(context.electronPlatformName);
+
+  let isTargetArch;
+  if (!isMacOsBuild) {
+    isTargetArch = true;
+  } else {
+    // When running a universal macOS build, afterPack is called once per arch:
+    // x64, arm64, and then finally for universal. For an explicit single-arch
+    // build (--x64 / --arm64) it is called only once, for that arch.
+    //
+    // To determine whether this is the target arch, we need to compare the
+    // packager's configured targets with the current target.
+    const requestedArchs = context.packager.info.options.targets?.get(context.packager.platform);
+    const isUniversalRequested = requestedArchs?.has(builder.Arch.universal) ?? false;
+    isTargetArch = isUniversalRequested ? context.arch === builder.Arch.universal : true;
+  }
+
+  // TODO: Update this to isTargetArch, and remove resetAdHocDarwinSignature parameter below.
   if (context.packager.platform.nodeName !== "darwin" || context.arch === builder.Arch.universal) {
     await addElectronFuses(context);
   }

--- a/apps/desktop/scripts/after-sign.js
+++ b/apps/desktop/scripts/after-sign.js
@@ -2,10 +2,16 @@
 require("dotenv").config();
 
 const { notarize } = require("@electron/notarize");
+const builder = require("electron-builder");
 
 exports.default = run;
 
+const IS_GITHUB_ACTIONS = process.env.GITHUB_ACTIONS == "true";
+
 async function run(context) {
+  if (IS_GITHUB_ACTIONS) {
+    console.log(`::group::After sign (${builder.Arch[context.arch]})`);
+  }
   console.log("## After sign");
   // console.log(context);
 
@@ -37,5 +43,8 @@ async function run(context) {
         appleIdPassword: appleIdPassword,
       });
     }
+  }
+  if (IS_GITHUB_ACTIONS) {
+    console.log("::endgroup::");
   }
 }

--- a/apps/desktop/scripts/after-sign.js
+++ b/apps/desktop/scripts/after-sign.js
@@ -15,36 +15,48 @@ async function run(context) {
   console.log("## After sign");
   // console.log(context);
 
-  const appName = context.packager.appInfo.productFilename;
   const macBuild = context.electronPlatformName === "darwin";
-
   if (macBuild) {
-    const appPath = `${context.appOutDir}/${appName}.app`;
-    console.log("### Notarizing " + appPath);
-    if (process.env.APP_STORE_CONNECT_TEAM_ISSUER) {
-      const appleApiIssuer = process.env.APP_STORE_CONNECT_TEAM_ISSUER;
-      const appleApiKey = process.env.APP_STORE_CONNECT_AUTH_KEY_PATH;
-      const appleApiKeyId = process.env.APP_STORE_CONNECT_AUTH_KEY_ID;
-      return await notarize({
-        tool: "notarytool",
-        appPath: appPath,
-        appleApiIssuer: appleApiIssuer,
-        appleApiKey: appleApiKey,
-        appleApiKeyId: appleApiKeyId,
-      });
-    } else {
-      const appleId = process.env.APPLE_ID_USERNAME || process.env.APPLEID;
-      const appleIdPassword = process.env.APPLE_ID_PASSWORD || `@keychain:AC_PASSWORD`;
-      return await notarize({
-        tool: "notarytool",
-        appPath: appPath,
-        teamId: "LTZ2PFU5D6",
-        appleId: appleId,
-        appleIdPassword: appleIdPassword,
-      });
-    }
+    await notarizeBuild(context);
   }
+
   if (IS_GITHUB_ACTIONS) {
     console.log("::endgroup::");
+  }
+}
+
+async function notarizeBuild(context) {
+  if (["no", "off", "0", "disable", "false"].includes(process.env.APPLE_NOTARIZE?.toLowerCase())) {
+    console.log(
+      "### Notarizing: notarization disabled by APPLE_NOTARIZE environment variable. Skipping.",
+    );
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = `${context.appOutDir}/${appName}.app`;
+
+  console.log("### Notarizing " + appPath);
+  if (process.env.APP_STORE_CONNECT_TEAM_ISSUER) {
+    const appleApiIssuer = process.env.APP_STORE_CONNECT_TEAM_ISSUER;
+    const appleApiKey = process.env.APP_STORE_CONNECT_AUTH_KEY_PATH;
+    const appleApiKeyId = process.env.APP_STORE_CONNECT_AUTH_KEY_ID;
+    return await notarize({
+      tool: "notarytool",
+      appPath: appPath,
+      appleApiIssuer: appleApiIssuer,
+      appleApiKey: appleApiKey,
+      appleApiKeyId: appleApiKeyId,
+    });
+  } else {
+    const appleId = process.env.APPLE_ID_USERNAME || process.env.APPLEID;
+    const appleIdPassword = process.env.APPLE_ID_PASSWORD || `@keychain:AC_PASSWORD`;
+    return await notarize({
+      tool: "notarytool",
+      appPath: appPath,
+      teamId: "LTZ2PFU5D6",
+      appleId: appleId,
+      appleIdPassword: appleIdPassword,
+    });
   }
 }

--- a/apps/desktop/scripts/after-sign.js
+++ b/apps/desktop/scripts/after-sign.js
@@ -13,15 +13,22 @@ async function run(context) {
     console.log(`::group::After sign (${builder.Arch[context.arch]})`);
   }
   console.log("## After sign");
-  // console.log(context);
+  try {
+    await doBuild(context);
+  } catch (error) {
+    console.error("### Error occurred during after-sign phase:", error.stack);
+    throw error;
+  } finally {
+    if (IS_GITHUB_ACTIONS) {
+      console.log("::endgroup::");
+    }
+  }
+}
 
+async function doBuild(context) {
   const macBuild = context.electronPlatformName === "darwin";
   if (macBuild) {
     await notarizeBuild(context);
-  }
-
-  if (IS_GITHUB_ACTIONS) {
-    console.log("::endgroup::");
   }
 }
 

--- a/apps/desktop/scripts/after-sign.js
+++ b/apps/desktop/scripts/after-sign.js
@@ -1,10 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports, no-console */
 require("dotenv").config();
-const path = require("path");
 
 const { notarize } = require("@electron/notarize");
-const { deepAssign } = require("builder-util");
-const fse = require("fs-extra");
 
 exports.default = run;
 
@@ -13,52 +10,10 @@ async function run(context) {
   // console.log(context);
 
   const appName = context.packager.appInfo.productFilename;
-  const appPath = `${context.appOutDir}/${appName}.app`;
   const macBuild = context.electronPlatformName === "darwin";
-  const copySafariExtension = ["darwin", "mas"].includes(context.electronPlatformName);
-
-  let shouldResign = false;
-
-  if (copySafariExtension) {
-    console.log("### Copying safari extension");
-    // Copy Safari plugin to work-around https://github.com/electron-userland/electron-builder/issues/5552
-    const plugIn = path.join(__dirname, "../PlugIns");
-    if (!fse.existsSync(plugIn)) {
-      console.log("### Safari extension not found - skipping");
-    } else {
-      if (!fse.existsSync(path.join(appPath, "Contents/PlugIns"))) {
-        fse.mkdirSync(path.join(appPath, "Contents/PlugIns"));
-      }
-      fse.copySync(
-        path.join(plugIn, "safari.appex"),
-        path.join(appPath, "Contents/PlugIns/safari.appex"),
-      );
-      shouldResign = true;
-    }
-  }
-
-  if (shouldResign) {
-    // Resign to sign safari extension
-    if (context.electronPlatformName === "mas") {
-      const masBuildOptions = deepAssign(
-        {},
-        context.packager.platformSpecificBuildOptions,
-        context.packager.config.mas,
-      );
-      if (context.targets.some((e) => e.name === "mas-dev")) {
-        deepAssign(masBuildOptions, {
-          type: "development",
-        });
-      }
-      if (context.packager.packagerOptions.prepackaged == null) {
-        await context.packager.sign(appPath, context.appOutDir, masBuildOptions, context.arch);
-      }
-    } else {
-      await context.packager.signApp(context, true);
-    }
-  }
 
   if (macBuild) {
+    const appPath = `${context.appOutDir}/${appName}.app`;
     console.log("### Notarizing " + appPath);
     if (process.env.APP_STORE_CONNECT_TEAM_ISSUER) {
       const appleApiIssuer = process.env.APP_STORE_CONNECT_TEAM_ISSUER;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-43001](https://bitwarden.atlassian.net/browse/PM-43001)

## 📔 Objective

Refactors after-pack and after-sign build phases:
- Moves safari extension copy to after-pack phase to avoid re-signing the app unnecessarily
- Clarifies why we guard on macOS universal builds
- adds GitHub Actions grouping to more easily scan the logs
- Allows skipping notarization for local developer builds.

At this point, we could also remove after-sign.js entirely, as all we need to do there now is to notarize the app. I am _not_ doing that in this PR.

[PM-43001]: https://bitwarden.atlassian.net/browse/PM-43001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ