### PR TITLE
[PM-43127] fix(vault): share in-flight profile fetch to avoid duplicate profile requests

### DIFF
--- a/libs/angular/src/vault/services/vault-profile.service.spec.ts
+++ b/libs/angular/src/vault/services/vault-profile.service.spec.ts
@@ -67,5 +67,31 @@ describe("VaultProfileService", () => {
       expect(date.toISOString()).toBe("2024-02-24T12:00:00.000Z");
       expect(getProfile).not.toHaveBeenCalled();
     });
+
+    it("shares one in-flight `getProfile` call between concurrent callers", async () => {
+      let resolveGetProfile: (value: unknown) => void;
+      getProfile.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveGetProfile = resolve;
+          }),
+      );
+
+      const first = service.getProfileCreationDate(userId);
+      const second = service.getProfileCreationDate(userId);
+
+      resolveGetProfile!({
+        creationDate: hardcodedDateString,
+        twoFactorEnabled: true,
+        id: "new-user-id",
+        organizations: [],
+      });
+
+      const [firstDate, secondDate] = await Promise.all([first, second]);
+
+      expect(getProfile).toHaveBeenCalledTimes(1);
+      expect(firstDate.toISOString()).toBe("2024-02-24T12:00:00.000Z");
+      expect(secondDate.toISOString()).toBe("2024-02-24T12:00:00.000Z");
+    });
   });
 });

--- a/libs/angular/src/vault/services/vault-profile.service.ts
+++ b/libs/angular/src/vault/services/vault-profile.service.ts
@@ -18,6 +18,13 @@ export class VaultProfileService {
   private profileCreatedDate: string | null = null;
 
   /**
+   * Shared promise for an in-flight profile fetch so concurrent callers
+   * (e.g. multiple nudge services during popup init) trigger a single
+   * `getProfile` request.
+   */
+  private profileFetch: Promise<ProfileResponse> | null = null;
+
+  /**
    * Returns the creation date of the profile.
    * Note: `Date`s are mutable in JS, creating a new
    * instance is important to avoid unwanted changes.
@@ -35,12 +42,18 @@ export class VaultProfileService {
     return new Date(profile.creationDate);
   }
 
-  private async fetchAndCacheProfile(): Promise<ProfileResponse> {
-    const profile = await this.apiService.getProfile();
+  private fetchAndCacheProfile(): Promise<ProfileResponse> {
+    this.profileFetch ??= this.apiService
+      .getProfile()
+      .then((profile: ProfileResponse) => {
+        this.userId = profile.id;
+        this.profileCreatedDate = profile.creationDate;
+        return profile;
+      })
+      .finally(() => {
+        this.profileFetch = null;
+      });
 
-    this.userId = profile.id;
-    this.profileCreatedDate = profile.creationDate;
-
-    return profile;
+    return this.profileFetch;
   }
 }


### PR DESCRIPTION
Fixes #22840

## Problem

Two nudge services (`account-security-nudge.service.ts`, `new-account-nudge.service.ts`) each call `VaultProfileService.getProfileCreationDate()` during popup init. `fetchAndCacheProfile()` only caches **after** the request resolves, so both concurrent calls miss the cache and independently fire `GET /accounts/profile` — two identical requests on every popup open (traced in the issue).

## Fix

Deduplicate concurrent fetches with a shared in-flight promise in `fetchAndCacheProfile()` — the same pattern `DefaultSyncService` already uses for `sync`/`refreshToken`. The promise is cleared in `finally` once settled, so a subsequent call after an error or completion re-fetches exactly as before. Behavior for sequential calls is unchanged.

## Validation

- `npx jest libs/angular/src/vault/services/vault-profile.service.spec.ts` — 4 passed, including a new test:
  - `shares one in-flight getProfile call between concurrent callers` — two concurrent `getProfileCreationDate` calls while the API call is still pending result in exactly one `getProfile` invocation; fails on `main` (2 calls), passes with this fix
  - all 3 pre-existing tests unchanged and green