### PR TITLE
[PM-43138] fix(browser): show save login after generated password

### DIFF
--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -2139,8 +2139,12 @@ describe("AutofillOverlayContentService", () => {
         });
         await flushPromises();
 
-        const resolvedValue = await sendExtensionMessageSpy.mock.calls[0][1];
-        expect(resolvedValue).toEqual(formFieldData);
+        expect(sendExtensionMessageSpy).toHaveBeenNthCalledWith(
+          1,
+          "generatedPasswordFilled",
+          formFieldData,
+        );
+        expect(sendExtensionMessageSpy).toHaveBeenNthCalledWith(2, "openAutofillInlineMenu");
       });
     });
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.ts
@@ -313,6 +313,7 @@ export class AutofillOverlayContentService implements AutofillOverlayContentServ
    */
   sendGeneratedPasswordModifyLogin = async () => {
     await this.sendExtensionMessage("generatedPasswordFilled", this.getFormFieldData());
+    await this.sendExtensionMessage("openAutofillInlineMenu");
   };
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

Fixes https://github.com/bitwarden/clients/issues/18167

## 📔 Objective

When a password is generated from the inline autofill menu, the generated value is recorded, but the inline list is closed by the resulting input event. Because the password field can remain focused, there may be no later focus event to reopen the inline menu and expose the existing **Save to Bitwarden** view.

After `generatedPasswordFilled` is recorded, request `openAutofillInlineMenu` again. This reuses the existing filled-field logic and save-login UI rather than introducing a new save path or automatically writing to the vault.

The regression assertion verifies that the generated-password handler first records `generatedPasswordFilled` and then requests the inline menu to reopen.

Validation performed locally:
- `git apply --check`
- `git diff --check`
- patch verified against current `bitwarden/clients` `main`

I did not run the full browser test suite locally because installing the monorepo dependency set exhausted the available worker resources. CI can provide the full project validation.

## 📸 Screenshots

Not included: this does not add or restyle UI; it reopens Bitwarden's existing filled-field **Save to Bitwarden** inline-menu state after generated-password fill.
