### PR TITLE
[PM-43140] fix(browser): detect old password fields in change forms

### DIFF
--- a/apps/browser/src/autofill/services/autofill-constants.ts
+++ b/apps/browser/src/autofill/services/autofill-constants.ts
@@ -168,6 +168,9 @@ export class AutoFillConstants {
     "update password",
     "change password",
     "current password",
+    "current-password",
+    "old password",
+    "old-password",
     "kennwort ändern",
   ];
 

--- a/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill-overlay-content.service.spec.ts
@@ -1536,6 +1536,42 @@ describe("AutofillOverlayContentService", () => {
             InlineMenuFillTypes.CurrentPasswordUpdate,
           );
         });
+
+        it("recognizes oldPassword as the current password in an update password form", async () => {
+          const oldPasswordFieldData = createAutofillFieldMock({
+            opid: "old-password-field",
+            form: "validFormId",
+            elementNumber: 5,
+            htmlName: "oldPassword",
+            type: "password",
+            viewable: true,
+          });
+          const confirmNewPasswordFieldData = createAutofillFieldMock({
+            opid: "confirm-new-password-field",
+            form: "validFormId",
+            elementNumber: 6,
+            autoCompleteType: "new-password",
+            placeholder: "confirm new password",
+            type: "password",
+            viewable: true,
+          });
+          pageDetailsMock.fields = [
+            oldPasswordFieldData,
+            newPasswordFieldData,
+            confirmNewPasswordFieldData,
+          ];
+
+          await autofillOverlayContentService.setupOverlayListeners(
+            autofillFieldElement,
+            oldPasswordFieldData,
+            pageDetailsMock,
+          );
+          await flushPromises();
+
+          expect(oldPasswordFieldData.inlineMenuFillType).toEqual(
+            InlineMenuFillTypes.CurrentPasswordUpdate,
+          );
+        });
       });
     });
 


### PR DESCRIPTION
## 🎟️ Tracking

Relates to https://github.com/bitwarden/clients/issues/1620

## 📔 Objective

Password-change and password-expiry forms commonly use fields such as `oldPassword`, `currentPassword`, `newPassword`, and a confirmation field.

Bitwarden already has change-password notification logic for `password + newPassword`, but the current-password classifier only recognized spaced phrases such as `current password`. Compact field names like `oldPassword` or `currentPassword` therefore could fall through classification on multi-password forms and never be captured as the current password.

Add conservative `current-password` / `old-password` keyword variants to the password-update classifier. Bitwarden's existing tokenizer removes hyphens, so these variants match compact field names (`currentPassword`, `oldPassword`) without broad fuzzy matching.

The regression test covers an expired/change-password style form with `oldPassword`, `newPassword`, and confirmation fields and verifies that the old-password field is classified as `CurrentPasswordUpdate`.

Validation:
- `git diff --check`
- patch applies cleanly to current `main`
- verified tokenizer behavior: `old-password` -> `oldpassword`, matching `oldPassword`

I did not run the full browser test suite locally because the monorepo dependency install previously exhausted the available worker resources. CI can provide full project validation.

## 📸 Screenshots

Not applicable. This changes form-field classification only and reuses Bitwarden's existing change-password UI/notification flow.
