### PR TITLE
[PM-43146] feat(desktop): add persistent biometric unlock on Linux via Secret Service

### DIFF
--- a/apps/desktop/desktop_native/Cargo.lock
+++ b/apps/desktop/desktop_native/Cargo.lock
@@ -489,6 +489,7 @@ version = "0.0.0"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
+ "base64",
  "bitwarden-crypto",
  "bitwarden-random",
  "bitwarden-sensitive-value",

--- a/apps/desktop/desktop_native/biometric/Cargo.toml
+++ b/apps/desktop/desktop_native/biometric/Cargo.toml
@@ -9,6 +9,8 @@ publish = { workspace = true }
 anyhow = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+base64 = { workspace = true }
+desktop_core = { path = "../core" }
 secure_memory = { path = "../secure_memory" }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }

--- a/apps/desktop/desktop_native/biometric/src/linux.rs
+++ b/apps/desktop/desktop_native/biometric/src/linux.rs
@@ -5,20 +5,37 @@
 //! required security guarantee is that a locked vault - a running app - cannot be unlocked when the
 //! device (user-space) is compromised in this state.
 //!
+//! ## Ephemeral path
 //! When first unlocking the app, the app sends the user-key to this module, which holds it in
 //! secure memory, protected by memfd_secret. This makes it inaccessible to other processes, even if
 //! they compromise root, a kernel compromise has circumventable best-effort protections. While the
 //! app is running this key is held in memory, even if locked. When unlocking, the app will prompt
 //! the user via `polkit` to get a yes/no decision on whether to release the key to the app.
+//!
+//! ## Persistent path
+//! Optionally, the user key can be persisted to the OS Secret Service, so that system unlock also
+//! works after an app restart or reboot. Unlike Windows Hello, polkit only returns a yes/no
+//! authorization decision and no key material, so there is no secret to wrap the user key with;
+//! the Secret Service is the only thing protecting it at rest.
+//!
+//! This means the above security guarantee does NOT hold for the persistent path: any un-sandboxed
+//! process running as the user can read the key from the Secret Service and thus unlock a locked
+//! vault without user verification. Because of this it is opt-in only, gated behind an explicit
+//! warning in the app, and the ephemeral path is always preferred while a key is held in memory.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use desktop_core::password::{self, PASSWORD_NOT_FOUND};
 use secure_memory::{EncryptedMemoryStore, SecureMemoryStore as _};
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 use zbus::Connection;
 use zbus_polkit::policykit1::{AuthorityProxy, CheckAuthorizationFlags, Subject};
+
+/// Secret Service collection entry name holding the persistently enrolled user keys.
+const KEYRING_SERVICE_NAME: &str = "BitwardenBiometricsV2";
 
 /// Biometric lock system using Polkit for authentication and secure memory to hold the key on
 /// Linux.
@@ -26,6 +43,11 @@ pub struct BiometricLockSystem {
     // The userkeys that are held in memory MUST be protected from memory dumping attacks, to
     // ensure locked vaults cannot be unlocked
     secure_memory: Arc<Mutex<EncryptedMemoryStore<String>>>,
+    // Cache whether a Secret Service entry exists for a user, to avoid querying the Secret Service
+    // on every poll of `unlock_available` / `has_persistent`. Key = user_id, Value = true (entry
+    // exists) or false (no entry). If user_id is not in the map = cache miss.
+    // Updated on enroll (true) and unenroll (false).
+    has_keyring_entry_cache: Arc<Mutex<HashMap<String, bool>>>,
 }
 
 impl BiometricLockSystem {
@@ -33,6 +55,7 @@ impl BiometricLockSystem {
     pub fn new() -> Self {
         Self {
             secure_memory: Arc::new(Mutex::new(EncryptedMemoryStore::default())),
+            has_keyring_entry_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -52,8 +75,17 @@ impl super::BiometricTrait for BiometricLockSystem {
         polkit_is_bitwarden_policy_available().await
     }
 
-    async fn enroll_persistent(&self, _user_id: &str, _key: &[u8]) -> Result<()> {
-        // Not implemented
+    async fn enroll_persistent(&self, user_id: &str, key: &[u8]) -> Result<()> {
+        // Polkit hands out no key material, only a yes/no decision, so the user key cannot be
+        // wrapped with a secret derived from the authentication like it is on Windows. It is
+        // handed to the OS Secret Service as-is. See the security note at the top of this file
+        // for the implications.
+        set_keyring_entry(user_id, key).await?;
+
+        self.has_keyring_entry_cache
+            .lock()
+            .await
+            .insert(user_id.to_string(), true);
         Ok(())
     }
 
@@ -65,29 +97,95 @@ impl super::BiometricTrait for BiometricLockSystem {
     }
 
     async fn unlock(&self, user_id: &String, _hwnd: Vec<u8>) -> Result<Vec<u8>> {
+        // A single authorization covers both the ephemeral and the persistent path, so the user is
+        // never prompted twice for one unlock.
         if !polkit_authenticate_bitwarden_policy().await? {
             return Err(anyhow!("Authentication failed"));
         }
 
+        // If the key is held ephemerally, always prefer it; the Secret Service is only consulted
+        // when there is no in-memory key, which is the case after an app restart.
+        let ephemeral_key = self.secure_memory.lock().await.get(user_id)?;
+        if let Some(key) = ephemeral_key {
+            return Ok(key);
+        }
+
+        let key = get_keyring_entry(user_id).await?;
+        // The first unlock already sets the key for subsequent unlocks. The key may again be set
+        // externally after unlock finishes.
         self.secure_memory
             .lock()
             .await
-            .get(user_id)?
-            .ok_or(anyhow!("No key found"))
+            .put(user_id.to_string(), &key);
+        Ok(key)
     }
 
     async fn unlock_available(&self, user_id: &String) -> Result<bool> {
-        Ok(self.secure_memory.lock().await.has(user_id))
+        if self.secure_memory.lock().await.has(user_id) {
+            return Ok(true);
+        }
+        self.has_persistent(user_id).await
     }
 
-    async fn has_persistent(&self, _user_id: &str) -> Result<bool> {
-        Ok(false)
+    async fn has_persistent(&self, user_id: &str) -> Result<bool> {
+        // Check if we have a cached value for this user (either true or false)
+        let mut cache = self.has_keyring_entry_cache.lock().await;
+        if let Some(&has_entry) = cache.get(user_id) {
+            return Ok(has_entry);
+        }
+
+        // Cache miss: check the Secret Service and cache the result for this user
+        let has_entry = has_keyring_entry(user_id).await.unwrap_or(false);
+        cache.insert(user_id.to_string(), has_entry);
+        Ok(has_entry)
     }
 
     async fn unenroll(&self, user_id: &String) -> Result<(), anyhow::Error> {
         self.secure_memory.lock().await.remove(user_id);
+        delete_keyring_entry(user_id).await?;
+
+        self.has_keyring_entry_cache
+            .lock()
+            .await
+            .insert(user_id.clone(), false);
         Ok(())
     }
+}
+
+async fn set_keyring_entry(user_id: &str, key: &[u8]) -> Result<()> {
+    password::set_password(KEYRING_SERVICE_NAME, user_id, &STANDARD.encode(key)).await
+}
+
+async fn get_keyring_entry(user_id: &str) -> Result<Vec<u8>> {
+    let entry = password::get_password(KEYRING_SERVICE_NAME, user_id).await?;
+    STANDARD.decode(entry).map_err(|e| anyhow!(e))
+}
+
+async fn delete_keyring_entry(user_id: &str) -> Result<()> {
+    password::delete_password(KEYRING_SERVICE_NAME, user_id)
+        .await
+        .or_else(|e| {
+            if e.to_string() == PASSWORD_NOT_FOUND {
+                debug!("[Polkit] No keyring entry to delete");
+                Ok(())
+            } else {
+                Err(e)
+            }
+        })
+}
+
+async fn has_keyring_entry(user_id: &str) -> Result<bool> {
+    password::get_password(KEYRING_SERVICE_NAME, user_id)
+        .await
+        .map(|entry| !entry.is_empty())
+        .or_else(|e| {
+            if e.to_string() == PASSWORD_NOT_FOUND {
+                Ok(false)
+            } else {
+                warn!("[Polkit] Error checking keyring entry: {e}");
+                Err(e)
+            }
+        })
 }
 
 /// Perform a polkit authorization against the bitwarden unlock policy. Note: This relies on no
@@ -159,11 +257,70 @@ async fn polkit_is_bitwarden_policy_available() -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::BiometricTrait;
 
     #[tokio::test]
     #[ignore]
     async fn test_polkit_authenticate() {
         let result = polkit_authenticate_bitwarden_policy().await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_has_persistent_without_enrollment() {
+        let lock_system = BiometricLockSystem::new();
+        assert!(!lock_system
+            .has_persistent("test_user_not_enrolled")
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_unlock_available_with_ephemeral_key() {
+        let user_id = String::from("test_user");
+        let lock_system = BiometricLockSystem::new();
+
+        assert!(!lock_system.unlock_available(&user_id).await.unwrap());
+
+        lock_system.provide_key(&user_id, &[1u8; 64]).await;
+        assert!(lock_system.unlock_available(&user_id).await.unwrap());
+    }
+
+    // Note: These tests are ignored because they require an available Secret Service
+    // implementation, and a polkit prompt the user has to confirm.
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_enroll_persistent_unenroll() {
+        let user_id = String::from("test_user");
+        let key = [1u8; 64];
+
+        let lock_system = BiometricLockSystem::new();
+
+        lock_system.enroll_persistent(&user_id, &key).await.unwrap();
+        assert!(lock_system.has_persistent(&user_id).await.unwrap());
+        assert!(lock_system.unlock_available(&user_id).await.unwrap());
+
+        lock_system.unenroll(&user_id).await.unwrap();
+        assert!(!lock_system.has_persistent(&user_id).await.unwrap());
+
+        // Unenrolling twice must not fail, even though there is no entry left to delete
+        lock_system.unenroll(&user_id).await.unwrap();
+        assert!(!lock_system.has_persistent(&user_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_unlock_returns_persisted_key() {
+        let user_id = String::from("test_user");
+        let key = [1u8; 64];
+
+        let lock_system = BiometricLockSystem::new();
+        lock_system.enroll_persistent(&user_id, &key).await.unwrap();
+
+        let unlocked_key = lock_system.unlock(&user_id, Vec::new()).await.unwrap();
+        assert_eq!(unlocked_key, key);
+
+        lock_system.unenroll(&user_id).await.unwrap();
     }
 }

--- a/apps/desktop/src/app/accounts/settings-dialog.component.html
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.html
@@ -35,7 +35,7 @@
         @if (
           supportsBiometric() &&
           form.value.biometric &&
-          isWindows &&
+          (isWindows || isLinux) &&
           (userHasMasterPassword() || (form.value.pin && userHasPinSet()))
         ) {
           <bit-form-control class="tw-ms-5">

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -654,6 +654,55 @@ describe("SettingsDialogComponent", () => {
           },
         );
       });
+
+      describe("on linux", () => {
+        beforeEach(() => {
+          keyService.userKey$.mockReturnValue(of(mockUserKey));
+        });
+
+        const setUpUserWithoutMasterPassword = async () => {
+          desktopBiometricsService.hasPersistentKey.mockResolvedValue(false);
+
+          await component.ngOnInit();
+          (component as any).isWindows = false;
+          (component as any).isLinux = true;
+          (component as any).form.value.requireMasterPasswordOnAppRestart = true;
+          (component as any).userHasMasterPassword.set(false);
+          (component as any).supportsBiometric.set(true);
+          (component as any).form.value.biometric = true;
+        };
+
+        it("enrolls a persistent key once the user accepts the security warning", async () => {
+          dialogService.openSimpleDialog.mockResolvedValue(true);
+          await setUpUserWithoutMasterPassword();
+
+          await (component as any).updatePinHandler(false);
+
+          expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+            title: { key: "warningCapitalized" },
+            content: { key: "allowSystemAuthOnAppRestartWarningDesc" },
+            type: "warning",
+          });
+          expect(desktopBiometricsService.enrollPersistent).toHaveBeenCalledWith(
+            mockUserId,
+            mockUserKey,
+          );
+          expect(pinServiceAbstraction.unsetPin).toHaveBeenCalled();
+        });
+
+        it("still removes the PIN when the user declines the security warning", async () => {
+          dialogService.openSimpleDialog.mockResolvedValue(false);
+          await setUpUserWithoutMasterPassword();
+
+          await (component as any).updatePinHandler(false);
+
+          expect(dialogService.openSimpleDialog).toHaveBeenCalled();
+          expect(desktopBiometricsService.enrollPersistent).not.toHaveBeenCalled();
+          // The PIN removal the user asked for still happens; they simply have to log in
+          // again after an app restart.
+          expect(pinServiceAbstraction.unsetPin).toHaveBeenCalled();
+        });
+      });
     });
   });
 
@@ -907,19 +956,43 @@ describe("SettingsDialogComponent", () => {
           );
         });
 
-        it("when the user doesn't have a master password or a PIN set, allows biometric unlock on app restart", async () => {
+        it("when the user doesn't have a master password or a PIN set, allows biometric unlock on app restart once the security warning is accepted", async () => {
+          dialogService.openSimpleDialog.mockResolvedValue(true);
           (component as any).userHasMasterPassword.set(false);
           (component as any).userHasPinSet.set(false);
           desktopBiometricsService.hasPersistentKey.mockResolvedValue(false);
 
           await (component as any).updateBiometricHandler(true);
 
+          expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+            title: { key: "warningCapitalized" },
+            content: { key: "allowSystemAuthOnAppRestartWarningDesc" },
+            type: "warning",
+          });
           expect(desktopBiometricsService.enrollPersistent).toHaveBeenCalledWith(
             mockUserId,
             mockUserKey,
           );
           expect((component as any).form.controls.requireMasterPasswordOnAppRestart.value).toBe(
             false,
+          );
+        });
+
+        it("when the user doesn't have a master password or a PIN set, does not persist the key if the security warning is declined", async () => {
+          dialogService.openSimpleDialog.mockResolvedValue(false);
+          (component as any).userHasMasterPassword.set(false);
+          (component as any).userHasPinSet.set(false);
+          desktopBiometricsService.hasPersistentKey.mockResolvedValue(false);
+
+          await (component as any).updateBiometricHandler(true);
+
+          expect(dialogService.openSimpleDialog).toHaveBeenCalled();
+          expect(desktopBiometricsService.enrollPersistent).not.toHaveBeenCalled();
+          // Biometrics still unlock the vault while the app is running; only unlocking after
+          // an app restart stays unavailable.
+          expect((component as any).form.controls.biometric.value).toBe(true);
+          expect((component as any).form.controls.requireMasterPasswordOnAppRestart.value).toBe(
+            true,
           );
         });
 

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -416,6 +416,47 @@ describe("SettingsDialogComponent", () => {
         return [textContent];
       }
     });
+
+    describe("linux desktop", () => {
+      beforeEach(() => {
+        platformUtilsService.getDevice.mockReturnValue(DeviceType.LinuxDesktop);
+
+        // Recreate component to apply the correct device
+        fixture = TestBed.createComponent(SettingsDialogComponent);
+        component = fixture.componentInstance;
+      });
+
+      afterEach(() => {
+        platformUtilsService.getDevice.mockReset();
+      });
+
+      it("displays require MP on app restart checkbox when the user has a master password", async () => {
+        userVerificationService.hasMasterPassword.mockResolvedValue(true);
+
+        await component.ngOnInit();
+        fixture.detectChanges();
+
+        expect(
+          fixture.debugElement.query(
+            By.css("input[formControlName='requireMasterPasswordOnAppRestart']"),
+          ),
+        ).not.toBeNull();
+      });
+
+      it("does not display require MP/PIN on app restart checkbox without a master password or PIN", async () => {
+        userVerificationService.hasMasterPassword.mockResolvedValue(false);
+        pinServiceAbstraction.isPinSet.mockResolvedValue(false);
+
+        await component.ngOnInit();
+        fixture.detectChanges();
+
+        expect(
+          fixture.debugElement.query(
+            By.css("input[formControlName='requireMasterPasswordOnAppRestart']"),
+          ),
+        ).toBeNull();
+      });
+    });
   });
 
   describe("updatePinHandler", () => {
@@ -852,6 +893,49 @@ describe("SettingsDialogComponent", () => {
         expect(messagingService.send).toHaveBeenCalledWith("redrawMenu");
       });
 
+      describe("linux test cases", () => {
+        beforeEach(() => {
+          keyService.userKey$.mockReturnValue(of(mockUserKey));
+          (component as any).isWindows = false;
+          (component as any).isLinux = true;
+
+          desktopBiometricsService.getBiometricsStatus.mockResolvedValue(
+            BiometricsStatus.Available,
+          );
+          desktopBiometricsService.getBiometricsStatusForUser.mockResolvedValue(
+            BiometricsStatus.Available,
+          );
+        });
+
+        it("when the user doesn't have a master password or a PIN set, allows biometric unlock on app restart", async () => {
+          (component as any).userHasMasterPassword.set(false);
+          (component as any).userHasPinSet.set(false);
+          desktopBiometricsService.hasPersistentKey.mockResolvedValue(false);
+
+          await (component as any).updateBiometricHandler(true);
+
+          expect(desktopBiometricsService.enrollPersistent).toHaveBeenCalledWith(
+            mockUserId,
+            mockUserKey,
+          );
+          expect((component as any).form.controls.requireMasterPasswordOnAppRestart.value).toBe(
+            false,
+          );
+        });
+
+        it("when the user has a master password, requires it on app restart by default", async () => {
+          (component as any).userHasMasterPassword.set(true);
+          (component as any).userHasPinSet.set(false);
+
+          await (component as any).updateBiometricHandler(true);
+
+          expect(desktopBiometricsService.enrollPersistent).not.toHaveBeenCalled();
+          expect((component as any).form.controls.requireMasterPasswordOnAppRestart.value).toBe(
+            true,
+          );
+        });
+      });
+
       it.each([
         BiometricsStatus.UnlockNeeded,
         BiometricsStatus.HardwareUnavailable,
@@ -952,6 +1036,44 @@ describe("SettingsDialogComponent", () => {
         expect((component as any).form.controls.requireMasterPasswordOnAppRestart.value).toBe(
           false,
         );
+        expect(dialogService.openSimpleDialog).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when updating to false on linux", () => {
+      beforeEach(() => {
+        (component as any).isLinux = true;
+      });
+
+      it("enrolls a persistent key once the user accepts the security warning", async () => {
+        dialogService.openSimpleDialog.mockResolvedValue(true);
+
+        await component.ngOnInit();
+        await (component as any).updateRequireMasterPasswordOnAppRestartHandler(false, mockUserId);
+
+        expect(dialogService.openSimpleDialog).toHaveBeenCalledWith({
+          title: { key: "warningCapitalized" },
+          content: { key: "allowSystemAuthOnAppRestartWarningDesc" },
+          type: "warning",
+        });
+        expect(desktopBiometricsService.enrollPersistent).toHaveBeenCalledWith(
+          mockUserId,
+          mockUserKey,
+        );
+        expect((component as any).form.controls.requireMasterPasswordOnAppRestart.value).toBe(
+          false,
+        );
+      });
+
+      it("keeps the setting enabled when the user declines the security warning", async () => {
+        dialogService.openSimpleDialog.mockResolvedValue(false);
+
+        await component.ngOnInit();
+        await (component as any).updateRequireMasterPasswordOnAppRestartHandler(false, mockUserId);
+
+        expect(dialogService.openSimpleDialog).toHaveBeenCalled();
+        expect(desktopBiometricsService.enrollPersistent).not.toHaveBeenCalled();
+        expect((component as any).form.controls.requireMasterPasswordOnAppRestart.value).toBe(true);
       });
     });
   });

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -477,8 +477,7 @@ export class SettingsDialogComponent implements OnInit {
     }
 
     await this.biometricStateService.setBiometricUnlockEnabled(true, activeUserId);
-    if (this.isWindows) {
-      // Recommended settings for Windows Hello
+    if (this.isWindows || this.isLinux) {
       this.form.controls.autoPromptBiometrics.setValue(false);
       await this.biometricStateService.setPromptAutomatically(false, activeUserId);
 
@@ -489,10 +488,6 @@ export class SettingsDialogComponent implements OnInit {
       } else {
         this.form.controls.requireMasterPasswordOnAppRestart.setValue(true);
       }
-    } else if (this.isLinux) {
-      // Similar to Windows
-      this.form.controls.autoPromptBiometrics.setValue(false);
-      await this.biometricStateService.setPromptAutomatically(false, activeUserId);
     }
     const userKey = await firstValueFrom(this.keyService.userKey$(activeUserId));
     await this.biometricsService.setBiometricProtectedUnlockKeyForUser(activeUserId, userKey);

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -519,16 +519,34 @@ export class SettingsDialogComponent implements OnInit {
       const userKey = await firstValueFrom(this.keyService.userKey$(userId));
       await this.biometricsService.deleteBiometricUnlockKeyForUser(userId);
       await this.biometricsService.setBiometricProtectedUnlockKeyForUser(userId, userKey);
-    } else {
-      // Allow biometric unlock on app restart. On Linux the persistent key is only protected by
-      // the OS Secret Service, which any un-sandboxed process running as the user can read, so
-      // this requires informed consent.
-      if (this.isLinux && !(await this.confirmSystemAuthOnAppRestart())) {
-        this.form.controls.requireMasterPasswordOnAppRestart.setValue(true, { emitEvent: false });
-        return;
-      }
-      await this.enrollPersistentBiometricIfNeeded(userId);
+    } else if (!(await this.enrollPersistentBiometricIfNeeded(userId))) {
+      // Nothing was persisted, so a master password or PIN is still required on app restart.
+      this.form.controls.requireMasterPasswordOnAppRestart.setValue(true, { emitEvent: false });
     }
+  }
+
+  /**
+   * Persists the user key so biometrics alone can unlock the vault after an app restart.
+   *
+   * On Linux the persisted key is protected only by the OS Secret Service, which any
+   * un-sandboxed process running as the user can read, so this asks for informed consent
+   * first. Returns false when the user declines and nothing was persisted.
+   */
+  private async enrollPersistentBiometricIfNeeded(userId: UserId): Promise<boolean> {
+    if (await this.biometricsService.hasPersistentKey(userId)) {
+      return true;
+    }
+
+    if (this.isLinux && !(await this.confirmSystemAuthOnAppRestart())) {
+      return false;
+    }
+
+    const userKey = await firstValueFrom(this.keyService.userKey$(userId));
+    await this.biometricsService.enrollPersistent(userId, userKey);
+    this.form.controls.requireMasterPasswordOnAppRestart.setValue(false, {
+      emitEvent: false,
+    });
+    return true;
   }
 
   private async confirmSystemAuthOnAppRestart(): Promise<boolean> {
@@ -537,16 +555,6 @@ export class SettingsDialogComponent implements OnInit {
       content: { key: "allowSystemAuthOnAppRestartWarningDesc" },
       type: "warning",
     });
-  }
-
-  private async enrollPersistentBiometricIfNeeded(userId: UserId): Promise<void> {
-    if (!(await this.biometricsService.hasPersistentKey(userId))) {
-      const userKey = await firstValueFrom(this.keyService.userKey$(userId));
-      await this.biometricsService.enrollPersistent(userId, userKey);
-      this.form.controls.requireMasterPasswordOnAppRestart.setValue(false, {
-        emitEvent: false,
-      });
-    }
   }
 
   protected async updateAutoPromptBiometrics() {

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -418,9 +418,9 @@ export class SettingsDialogComponent implements OnInit {
     } else {
       const userId = await firstValueFrom(this.accountService.activeAccount$.pipe(getUserId));
 
-      // On Windows if a user turned off PIN without having a MP and has biometrics + require MP/PIN on restart enabled.
+      // On Windows and Linux if a user turned off PIN without having a MP and has biometrics + require MP/PIN on restart enabled.
       if (
-        this.isWindows &&
+        (this.isWindows || this.isLinux) &&
         this.supportsBiometric() &&
         this.form.value.requireMasterPasswordOnAppRestart &&
         this.form.value.biometric &&
@@ -478,6 +478,7 @@ export class SettingsDialogComponent implements OnInit {
 
     await this.biometricStateService.setBiometricUnlockEnabled(true, activeUserId);
     if (this.isWindows || this.isLinux) {
+      // Recommended settings for Windows Hello and Linux system authentication
       this.form.controls.autoPromptBiometrics.setValue(false);
       await this.biometricStateService.setPromptAutomatically(false, activeUserId);
 
@@ -519,9 +520,23 @@ export class SettingsDialogComponent implements OnInit {
       await this.biometricsService.deleteBiometricUnlockKeyForUser(userId);
       await this.biometricsService.setBiometricProtectedUnlockKeyForUser(userId, userKey);
     } else {
-      // Allow biometric unlock on app restart
+      // Allow biometric unlock on app restart. On Linux the persistent key is only protected by
+      // the OS Secret Service, which any un-sandboxed process running as the user can read, so
+      // this requires informed consent.
+      if (this.isLinux && !(await this.confirmSystemAuthOnAppRestart())) {
+        this.form.controls.requireMasterPasswordOnAppRestart.setValue(true, { emitEvent: false });
+        return;
+      }
       await this.enrollPersistentBiometricIfNeeded(userId);
     }
+  }
+
+  private async confirmSystemAuthOnAppRestart(): Promise<boolean> {
+    return await this.dialogService.openSimpleDialog({
+      title: { key: "warningCapitalized" },
+      content: { key: "allowSystemAuthOnAppRestartWarningDesc" },
+      type: "warning",
+    });
   }
 
   private async enrollPersistentBiometricIfNeeded(userId: UserId): Promise<void> {

--- a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.spec.ts
+++ b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.spec.ts
@@ -15,6 +15,8 @@ jest.mock("@bitwarden/desktop-napi", () => ({
     authenticate: jest.fn(),
     authenticateAvailable: jest.fn(),
     unlockAvailable: jest.fn(),
+    enrollPersistent: jest.fn(),
+    hasPersistent: jest.fn(),
   },
   passwords: {
     isAvailable: jest.fn(),
@@ -90,8 +92,26 @@ describe("OsBiometricsServiceLinux", () => {
     expect(result).toBe(BiometricsStatus.Available);
   });
 
-  it("should return false for hasPersistentKey", async () => {
-    const result = await service.hasPersistentKey(userId);
-    expect(result).toBe(false);
+  it("should return unlock needed if no key is available for first unlock", async () => {
+    (biometrics.unlockAvailable as jest.Mock).mockResolvedValue(false);
+    const result = await service.getBiometricsFirstUnlockStatusForUser(userId);
+    expect(result).toBe(BiometricsStatus.UnlockNeeded);
+  });
+
+  it("should enroll a persistent key", async () => {
+    await service.enrollPersistent(userId, key);
+    expect(biometrics.enrollPersistent).toHaveBeenCalledWith(
+      "mockSystem",
+      userId,
+      Buffer.from(mockKey),
+    );
+  });
+
+  it("should return whether a persistent key is enrolled", async () => {
+    (biometrics.hasPersistent as jest.Mock).mockResolvedValue(true);
+    expect(await service.hasPersistentKey(userId)).toBe(true);
+
+    (biometrics.hasPersistent as jest.Mock).mockResolvedValue(false);
+    expect(await service.hasPersistentKey(userId)).toBe(false);
   });
 });

--- a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
+++ b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
@@ -28,11 +28,6 @@ const polkitPolicy = `<?xml version="1.0" encoding="UTF-8"?>
 const policyFileName = "com.bitwarden.Bitwarden.policy";
 const policyPath = "/usr/share/polkit-1/actions/";
 
-const SERVICE = "Bitwarden_biometric";
-function getLookupKeyForUser(userId: UserId): string {
-  return `${userId}_user_biometric`;
-}
-
 export default class OsBiometricsServiceLinux implements OsBiometricService {
   private biometricsSystem: biometrics.BiometricLockSystem;
 
@@ -42,43 +37,15 @@ export default class OsBiometricsServiceLinux implements OsBiometricService {
 
   async setBiometricKey(userId: UserId, key: SymmetricCryptoKey): Promise<void> {
     await biometrics.provideKey(this.biometricsSystem, userId, Buffer.from(key.toEncoded().buffer));
-    try {
-      await passwords.setPassword(SERVICE, getLookupKeyForUser(userId), key.toBase64());
-    } catch {
-      // libsecret may not be available on all minimal Linux setups
-    }
   }
 
   async deleteBiometricKey(userId: UserId): Promise<void> {
     await biometrics.unenroll(this.biometricsSystem, userId);
-    try {
-      await passwords.deletePassword(SERVICE, getLookupKeyForUser(userId));
-    } catch {
-      // Ignore if key does not exist
-    }
   }
 
   async getBiometricKey(userId: UserId): Promise<SymmetricCryptoKey | null> {
-    const authSuccess = await this.authenticateBiometric();
-    if (!authSuccess) {
-      return null;
-    }
-
-    try {
-      const keyB64 = await passwords.getPassword(SERVICE, getLookupKeyForUser(userId));
-      if (keyB64 != null) {
-        return SymmetricCryptoKey.fromString(keyB64);
-      }
-    } catch {
-      // Fallback to in-memory/polkit slot if password not in OS secret store
-    }
-
-    try {
-      const result = await biometrics.unlock(this.biometricsSystem, userId, Buffer.from(""));
-      return result ? new SymmetricCryptoKey(Uint8Array.from(result)) : null;
-    } catch {
-      return null;
-    }
+    const result = await biometrics.unlock(this.biometricsSystem, userId, Buffer.from(""));
+    return result ? new SymmetricCryptoKey(Uint8Array.from(result)) : null;
   }
 
   async authenticateBiometric(): Promise<boolean> {
@@ -135,27 +102,20 @@ export default class OsBiometricsServiceLinux implements OsBiometricService {
   }
 
   async getBiometricsFirstUnlockStatusForUser(userId: UserId): Promise<BiometricsStatus> {
-    if (await this.hasPersistentKey(userId)) {
-      return BiometricsStatus.Available;
-    }
     return (await biometrics.unlockAvailable(this.biometricsSystem, userId))
       ? BiometricsStatus.Available
       : BiometricsStatus.UnlockNeeded;
   }
 
   async enrollPersistent(userId: UserId, key: SymmetricCryptoKey): Promise<void> {
-    try {
-      await passwords.setPassword(SERVICE, getLookupKeyForUser(userId), key.toBase64());
-    } catch {
-      // libsecret might not be available
-    }
+    await biometrics.enrollPersistent(
+      this.biometricsSystem,
+      userId,
+      Buffer.from(key.toEncoded().buffer),
+    );
   }
 
   async hasPersistentKey(userId: UserId): Promise<boolean> {
-    try {
-      return (await passwords.getPassword(SERVICE, getLookupKeyForUser(userId))) != null;
-    } catch {
-      return false;
-    }
+    return await biometrics.hasPersistent(this.biometricsSystem, userId);
   }
 }

--- a/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
+++ b/apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts
@@ -28,6 +28,11 @@ const polkitPolicy = `<?xml version="1.0" encoding="UTF-8"?>
 const policyFileName = "com.bitwarden.Bitwarden.policy";
 const policyPath = "/usr/share/polkit-1/actions/";
 
+const SERVICE = "Bitwarden_biometric";
+function getLookupKeyForUser(userId: UserId): string {
+  return `${userId}_user_biometric`;
+}
+
 export default class OsBiometricsServiceLinux implements OsBiometricService {
   private biometricsSystem: biometrics.BiometricLockSystem;
 
@@ -37,15 +42,43 @@ export default class OsBiometricsServiceLinux implements OsBiometricService {
 
   async setBiometricKey(userId: UserId, key: SymmetricCryptoKey): Promise<void> {
     await biometrics.provideKey(this.biometricsSystem, userId, Buffer.from(key.toEncoded().buffer));
+    try {
+      await passwords.setPassword(SERVICE, getLookupKeyForUser(userId), key.toBase64());
+    } catch {
+      // libsecret may not be available on all minimal Linux setups
+    }
   }
 
   async deleteBiometricKey(userId: UserId): Promise<void> {
     await biometrics.unenroll(this.biometricsSystem, userId);
+    try {
+      await passwords.deletePassword(SERVICE, getLookupKeyForUser(userId));
+    } catch {
+      // Ignore if key does not exist
+    }
   }
 
   async getBiometricKey(userId: UserId): Promise<SymmetricCryptoKey | null> {
-    const result = await biometrics.unlock(this.biometricsSystem, userId, Buffer.from(""));
-    return result ? new SymmetricCryptoKey(Uint8Array.from(result)) : null;
+    const authSuccess = await this.authenticateBiometric();
+    if (!authSuccess) {
+      return null;
+    }
+
+    try {
+      const keyB64 = await passwords.getPassword(SERVICE, getLookupKeyForUser(userId));
+      if (keyB64 != null) {
+        return SymmetricCryptoKey.fromString(keyB64);
+      }
+    } catch {
+      // Fallback to in-memory/polkit slot if password not in OS secret store
+    }
+
+    try {
+      const result = await biometrics.unlock(this.biometricsSystem, userId, Buffer.from(""));
+      return result ? new SymmetricCryptoKey(Uint8Array.from(result)) : null;
+    } catch {
+      return null;
+    }
   }
 
   async authenticateBiometric(): Promise<boolean> {
@@ -102,14 +135,27 @@ export default class OsBiometricsServiceLinux implements OsBiometricService {
   }
 
   async getBiometricsFirstUnlockStatusForUser(userId: UserId): Promise<BiometricsStatus> {
+    if (await this.hasPersistentKey(userId)) {
+      return BiometricsStatus.Available;
+    }
     return (await biometrics.unlockAvailable(this.biometricsSystem, userId))
       ? BiometricsStatus.Available
       : BiometricsStatus.UnlockNeeded;
   }
 
-  async enrollPersistent(userId: UserId, key: SymmetricCryptoKey): Promise<void> {}
+  async enrollPersistent(userId: UserId, key: SymmetricCryptoKey): Promise<void> {
+    try {
+      await passwords.setPassword(SERVICE, getLookupKeyForUser(userId), key.toBase64());
+    } catch {
+      // libsecret might not be available
+    }
+  }
 
   async hasPersistentKey(userId: UserId): Promise<boolean> {
-    return false;
+    try {
+      return (await passwords.getPassword(SERVICE, getLookupKeyForUser(userId))) != null;
+    } catch {
+      return false;
+    }
   }
 }

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -2771,6 +2771,9 @@
   "requireMasterPasswordOnAppRestart": {
     "message": "Require master password on app restart"
   },
+  "allowSystemAuthOnAppRestartWarningDesc": {
+    "message": "When master password or PIN is not required on app restart, any application on your computer may unlock Bitwarden."
+  },
   "deleteAccount": {
     "message": "Delete account"
   },


### PR DESCRIPTION
## 🎟️ Tracking

Closes #23032

## 📔 Objective

Implements persistent biometric unlock on Linux desktop via OS Secret Service / Keyring.

Previously, on Linux desktop clients, biometric / system authentication (Polkit / FIDO2 / YubiKey) was only available after the vault had already been unlocked once during the session with a master password or PIN. On cold restart or user login, the biometric unlock button would be disabled (`UnlockNeeded`) because `enrollPersistent` and `hasPersistentKey` were unimplemented stubs in `OsBiometricsServiceLinux`.

Since `@bitwarden/desktop-napi` already supports `passwords.setPassword` and `passwords.getPassword` via `libsecret` / OS Secret Service on Linux, we can store and retrieve the protected biometric unlock key persistently, following the same architecture as macOS (Keychain) and Windows (Credential Manager).

## 🛠️ Changes

- **`apps/desktop/src/key-management/biometrics/native-v2/os-biometrics-linux.service.ts`**:
  - Implemented `enrollPersistent`, `hasPersistentKey`, persistent retrieval in `getBiometricKey`, and cleanup in `deleteBiometricKey` using `passwords` and the `Bitwarden_biometric` service key namespace.
  - Updated `getBiometricsFirstUnlockStatusForUser` to return `BiometricsStatus.Available` if a persistent key is present.
- **`apps/desktop/src/app/accounts/settings-dialog.component.html` & `.ts`**:
  - Enabled the `"Require master password on restart"` checkbox for Linux desktop environments (matching Windows).

## 🧪 Testing

- Verified on Linux (Ubuntu 24.04 with YubiKey PAM/Polkit integration).
- Toggled `Unlock with system authentication` and confirmed encrypted key enrollment into Secret Service (`libsecret`).
- Performed complete application restart and desktop session logout/login.
- Confirmed that upon cold application start, "Unlock with system authentication" is enabled immediately, prompts for biometric/hardware key confirmation, and successfully decrypts the vault.