### PR TITLE
PM-42722 resolved unbounded kdf parameters

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -4964,6 +4964,9 @@
   "importFormatError": {
     "message": "Data is not formatted correctly. Please check your import file and try again."
   },
+  "importUnsupportedKdfSettings": {
+    "message": "This file uses unsupported encryption settings and cannot be imported."
+  },
   "importNothingError": {
     "message": "Nothing was imported."
   },

--- a/apps/cli/src/locales/en/messages.json
+++ b/apps/cli/src/locales/en/messages.json
@@ -47,6 +47,9 @@
   "importFormatError": {
     "message": "Data is not formatted correctly. Please check your import file and try again."
   },
+  "importUnsupportedKdfSettings": {
+    "message": "This file uses unsupported encryption settings and cannot be imported."
+  },
   "importNothingError": {
     "message": "Nothing was imported."
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -4504,6 +4504,9 @@
   "importFormatError": {
     "message": "Data is not formatted correctly. Please check your import file and try again."
   },
+  "importUnsupportedKdfSettings": {
+    "message": "This file uses unsupported encryption settings and cannot be imported."
+  },
   "importNothingError": {
     "message": "Nothing was imported."
   },

--- a/apps/web/src/locales/en/messages.json
+++ b/apps/web/src/locales/en/messages.json
@@ -3275,6 +3275,9 @@
   "importFormatError": {
     "message": "Data is not formatted correctly. Please check your import file and try again."
   },
+  "importUnsupportedKdfSettings": {
+    "message": "This file uses unsupported encryption settings and cannot be imported."
+  },
   "importNothingError": {
     "message": "Nothing was imported."
   },

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.spec.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.spec.ts
@@ -140,6 +140,8 @@ describe("BitwardenPasswordProtectedImporter", () => {
       passwordProtected?: boolean;
       salt?: string;
       kdfIterations?: any;
+      kdfMemory?: any;
+      kdfParallelism?: any;
       kdfType?: any;
       encKeyValidation_DO_NOT_EDIT?: string;
       data?: string;
@@ -201,6 +203,75 @@ describe("BitwardenPasswordProtectedImporter", () => {
     it("fails if data === null", async () => {
       jDoc.data = null;
       expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(false);
+    });
+
+    describe("KDF parameter bounds", () => {
+      beforeEach(() => {
+        i18nService.t.mockImplementation((key) => key);
+      });
+
+      it("succeeds with in-range Argon2id parameters", async () => {
+        encryptService.decryptString.mockResolvedValue(emptyUnencryptedExport);
+        jDoc.kdfType = KdfType.Argon2id;
+        jDoc.kdfIterations = 3;
+        jDoc.kdfMemory = 64;
+        jDoc.kdfParallelism = 4;
+
+        expect((await importer.parse(JSON.stringify(jDoc))).success).toEqual(true);
+      });
+
+      it("fails without deriving a key when kdfMemory is out of bounds", async () => {
+        jDoc.kdfType = KdfType.Argon2id;
+        jDoc.kdfIterations = 3;
+        jDoc.kdfMemory = 999999;
+        jDoc.kdfParallelism = 4;
+
+        const result = await importer.parse(JSON.stringify(jDoc));
+
+        expect(result.success).toBe(false);
+        expect(result.errorMessage).toBe("importUnsupportedKdfSettings");
+        expect(keyGenerationService.deriveVaultExportKey).not.toHaveBeenCalled();
+      });
+
+      it("fails without prompting for a password when kdfMemory is out of bounds", async () => {
+        const promptForPassword = jest.fn(async () => password);
+        importer = new BitwardenPasswordProtectedImporter(
+          keyService,
+          encryptService,
+          i18nService,
+          cipherService,
+          keyGenerationService,
+          accountService,
+          promptForPassword,
+        );
+        jDoc.kdfType = KdfType.Argon2id;
+        jDoc.kdfIterations = 3;
+        jDoc.kdfMemory = 999999;
+        jDoc.kdfParallelism = 4;
+
+        expect((await importer.parse(JSON.stringify(jDoc))).success).toBe(false);
+        expect(promptForPassword).not.toHaveBeenCalled();
+      });
+
+      it("fails when Argon2id parameters are missing entirely", async () => {
+        jDoc.kdfType = KdfType.Argon2id;
+
+        const result = await importer.parse(JSON.stringify(jDoc));
+
+        expect(result.success).toBe(false);
+        expect(result.errorMessage).toBe("importUnsupportedKdfSettings");
+        expect(keyGenerationService.deriveVaultExportKey).not.toHaveBeenCalled();
+      });
+
+      it("fails without deriving a key when PBKDF2 iterations are out of bounds", async () => {
+        jDoc.kdfIterations = 999999999;
+
+        const result = await importer.parse(JSON.stringify(jDoc));
+
+        expect(result.success).toBe(false);
+        expect(result.errorMessage).toBe("importUnsupportedKdfSettings");
+        expect(keyGenerationService.deriveVaultExportKey).not.toHaveBeenCalled();
+      });
     });
 
     it("returns invalidFilePassword errorMessage if decryptString throws", async () => {

--- a/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
+++ b/libs/importer/src/importers/bitwarden/bitwarden-password-protected-importer.ts
@@ -6,13 +6,10 @@ import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.servi
 import { KeyService } from "@bitwarden/key-management";
 // eslint-disable-next-line no-restricted-imports
 import {
-  Argon2KdfConfig,
   EncryptService,
   EncString,
   KdfConfig,
-  KdfType,
   KeyGenerationService,
-  PBKDF2KdfConfig,
   SymmetricCryptoKey,
 } from "@bitwarden/legacy-crypto";
 import {
@@ -25,6 +22,7 @@ import { ImportResult } from "../../models/import-result";
 import { Importer } from "../importer";
 
 import { BitwardenEncryptedJsonImporter } from "./bitwarden-encrypted-json-importer";
+import { kdfConfigFromPasswordProtectedExport } from "./password-protected-kdf-config";
 
 export class BitwardenPasswordProtectedImporter
   extends BitwardenEncryptedJsonImporter
@@ -62,9 +60,17 @@ export class BitwardenPasswordProtectedImporter
       return result;
     }
 
+    // Bound the attacker-controlled KDF parameters before any key derivation allocates for them.
+    const kdfConfig = kdfConfigFromPasswordProtectedExport(parsedData);
+    if (kdfConfig == null) {
+      result.success = false;
+      result.errorMessage = this.i18nService.t("importUnsupportedKdfSettings");
+      return result;
+    }
+
     // File is password-protected
     const password = await this.promptForPassword_callback();
-    if (!(await this.checkPassword(parsedData, password))) {
+    if (!(await this.checkPassword(parsedData, password, kdfConfig))) {
       result.success = false;
       result.errorMessage = this.i18nService.t("invalidFilePassword");
       return result;
@@ -78,15 +84,11 @@ export class BitwardenPasswordProtectedImporter
   private async checkPassword(
     jdoc: BitwardenPasswordProtectedFileFormat,
     password: string,
+    kdfConfig: KdfConfig,
   ): Promise<boolean> {
     if (this.isNullOrWhitespace(password)) {
       return false;
     }
-
-    const kdfConfig: KdfConfig =
-      jdoc.kdfType === KdfType.PBKDF2_SHA256
-        ? new PBKDF2KdfConfig(jdoc.kdfIterations)
-        : new Argon2KdfConfig(jdoc.kdfIterations, jdoc.kdfMemory, jdoc.kdfParallelism);
 
     this.key = await this.keyGenerationService.deriveVaultExportKey(password, jdoc.salt, kdfConfig);
 
@@ -100,16 +102,16 @@ export class BitwardenPasswordProtectedImporter
     }
   }
 
+  /**
+   * Checks the fields that are not KDF parameters; those are validated by
+   * {@link kdfConfigFromPasswordProtectedExport}.
+   */
   private cannotParseFile(jdoc: BitwardenPasswordProtectedFileFormat): boolean {
     return (
       !jdoc ||
       !jdoc.encrypted ||
       !jdoc.passwordProtected ||
       !jdoc.salt ||
-      !jdoc.kdfIterations ||
-      typeof jdoc.kdfIterations !== "number" ||
-      jdoc.kdfType == null ||
-      KdfType[jdoc.kdfType] == null ||
       !jdoc.encKeyValidation_DO_NOT_EDIT ||
       !jdoc.data
     );

--- a/libs/importer/src/importers/bitwarden/password-protected-kdf-config.spec.ts
+++ b/libs/importer/src/importers/bitwarden/password-protected-kdf-config.spec.ts
@@ -1,0 +1,142 @@
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
+import { BitwardenPasswordProtectedFileFormat } from "@bitwarden/vault-export-core";
+
+import { kdfConfigFromPasswordProtectedExport } from "./password-protected-kdf-config";
+
+describe("kdfConfigFromPasswordProtectedExport", () => {
+  function fileWith(
+    kdf: Partial<
+      Pick<
+        BitwardenPasswordProtectedFileFormat,
+        "kdfType" | "kdfIterations" | "kdfMemory" | "kdfParallelism"
+      >
+    >,
+  ): BitwardenPasswordProtectedFileFormat {
+    return {
+      encrypted: true,
+      passwordProtected: true,
+      salt: "c2FsdA==",
+      kdfType: KdfType.PBKDF2_SHA256,
+      kdfIterations: 600_000,
+      encKeyValidation_DO_NOT_EDIT: "encKeyValidation",
+      data: "data",
+      ...kdf,
+    };
+  }
+
+  describe("PBKDF2", () => {
+    it("accepts the current default iteration count", () => {
+      const config = kdfConfigFromPasswordProtectedExport(fileWith({ kdfIterations: 600_000 }));
+
+      expect(config).toEqual(new PBKDF2KdfConfig(600_000));
+    });
+
+    it.each([5_000, 100_000, 2_000_000])(
+      "accepts %i iterations, as produced by older clients",
+      (kdfIterations) => {
+        const config = kdfConfigFromPasswordProtectedExport(fileWith({ kdfIterations }));
+
+        expect(config).toEqual(new PBKDF2KdfConfig(kdfIterations));
+      },
+    );
+
+    it.each([
+      ["above the maximum", 2_000_001],
+      ["absurdly high", 999_999_999],
+      ["below the minimum", 4_999],
+      ["zero", 0],
+      ["negative", -1],
+      ["fractional", 600_000.5],
+      ["NaN", NaN],
+      ["Infinity", Infinity],
+      ["null", null as unknown as number],
+      ["undefined", undefined as unknown as number],
+    ])("rejects iterations that are %s", (_description, kdfIterations) => {
+      expect(kdfConfigFromPasswordProtectedExport(fileWith({ kdfIterations }))).toBeNull();
+    });
+
+    it("rejects a non-numeric iteration count", () => {
+      const file = fileWith({ kdfIterations: "600000" as unknown as number });
+
+      expect(kdfConfigFromPasswordProtectedExport(file)).toBeNull();
+    });
+  });
+
+  describe("Argon2id", () => {
+    function argon2FileWith(
+      kdf: Partial<
+        Pick<BitwardenPasswordProtectedFileFormat, "kdfIterations" | "kdfMemory" | "kdfParallelism">
+      > = {},
+    ): BitwardenPasswordProtectedFileFormat {
+      return fileWith({
+        kdfType: KdfType.Argon2id,
+        kdfIterations: 3,
+        kdfMemory: 64,
+        kdfParallelism: 4,
+        ...kdf,
+      });
+    }
+
+    it("accepts parameters within the supported ranges", () => {
+      const config = kdfConfigFromPasswordProtectedExport(argon2FileWith());
+
+      expect(config).toEqual(new Argon2KdfConfig(3, 64, 4));
+    });
+
+    it("accepts the maximum supported parameters", () => {
+      const config = kdfConfigFromPasswordProtectedExport(
+        argon2FileWith({ kdfIterations: 10, kdfMemory: 1024, kdfParallelism: 16 }),
+      );
+
+      expect(config).toEqual(new Argon2KdfConfig(10, 1024, 16));
+    });
+
+    it("rejects the memory value from the reported finding without allocating", () => {
+      expect(
+        kdfConfigFromPasswordProtectedExport(argon2FileWith({ kdfMemory: 999_999 })),
+      ).toBeNull();
+    });
+
+    it.each([
+      ["above the maximum", 1_025],
+      ["below the minimum", 15],
+      ["fractional", 64.5],
+      ["null", null as unknown as number],
+      ["undefined", undefined as unknown as number],
+    ])("rejects memory that is %s", (_description, kdfMemory) => {
+      expect(kdfConfigFromPasswordProtectedExport(argon2FileWith({ kdfMemory }))).toBeNull();
+    });
+
+    it.each([
+      ["above the maximum", 17],
+      ["below the minimum", 0],
+      ["fractional", 4.5],
+      ["null", null as unknown as number],
+      ["undefined", undefined as unknown as number],
+    ])("rejects parallelism that is %s", (_description, kdfParallelism) => {
+      expect(kdfConfigFromPasswordProtectedExport(argon2FileWith({ kdfParallelism }))).toBeNull();
+    });
+
+    it.each([
+      ["above the maximum", 11],
+      ["absurdly high", 999_999_999],
+      ["below the minimum", 1],
+      ["fractional", 3.5],
+      ["null", null as unknown as number],
+      ["undefined", undefined as unknown as number],
+    ])("rejects iterations that are %s", (_description, kdfIterations) => {
+      expect(kdfConfigFromPasswordProtectedExport(argon2FileWith({ kdfIterations }))).toBeNull();
+    });
+  });
+
+  it.each([
+    ["unknown", -1],
+    ["out of range", 2],
+    ["null", null as unknown as number],
+    ["undefined", undefined as unknown as number],
+    ["a string", "PBKDF2" as unknown as number],
+  ])("rejects a KDF type that is %s", (_description, kdfType) => {
+    expect(kdfConfigFromPasswordProtectedExport(fileWith({ kdfType }))).toBeNull();
+  });
+});

--- a/libs/importer/src/importers/bitwarden/password-protected-kdf-config.ts
+++ b/libs/importer/src/importers/bitwarden/password-protected-kdf-config.ts
@@ -1,0 +1,56 @@
+import { RangeWithDefault } from "@bitwarden/common/platform/misc/range-with-default";
+// eslint-disable-next-line no-restricted-imports
+import { Argon2KdfConfig, KdfConfig, KdfType, PBKDF2KdfConfig } from "@bitwarden/legacy-crypto";
+import { BitwardenPasswordProtectedFileFormat } from "@bitwarden/vault-export-core";
+
+/**
+ * Iteration bounds accepted for a PBKDF2 import file.
+ *
+ * Wider than {@link PBKDF2KdfConfig.ITERATIONS} on the low end, because an export carries the
+ * KDF configuration that was current when it was created and older clients allowed lower
+ * iteration counts. The upper bound is the same one the settings UI enforces.
+ */
+const PBKDF2_IMPORT_ITERATIONS = new RangeWithDefault(
+  PBKDF2KdfConfig.PRELOGIN_ITERATIONS_MIN,
+  PBKDF2KdfConfig.ITERATIONS.max,
+  PBKDF2KdfConfig.ITERATIONS.defaultValue,
+);
+
+/**
+ * Builds the KDF configuration for a password-protected export, rejecting parameters outside the
+ * range Bitwarden clients produce.
+ *
+ * Import files come from wherever the user obtained them, so the parameters are attacker
+ * controlled. Argon2 in particular allocates `kdfMemory` MiB up front, so an unbounded value is a
+ * client denial of service. Validate before deriving anything.
+ *
+ * @returns the configuration, or `null` if any parameter is out of bounds or the KDF type is unknown.
+ */
+export function kdfConfigFromPasswordProtectedExport(
+  jdoc: BitwardenPasswordProtectedFileFormat,
+): KdfConfig | null {
+  switch (jdoc.kdfType) {
+    case KdfType.PBKDF2_SHA256:
+      if (inBounds(jdoc.kdfIterations, PBKDF2_IMPORT_ITERATIONS)) {
+        return new PBKDF2KdfConfig(jdoc.kdfIterations);
+      }
+      return null;
+
+    case KdfType.Argon2id:
+      if (
+        inBounds(jdoc.kdfIterations, Argon2KdfConfig.ITERATIONS) &&
+        inBounds(jdoc.kdfMemory, Argon2KdfConfig.MEMORY) &&
+        inBounds(jdoc.kdfParallelism, Argon2KdfConfig.PARALLELISM)
+      ) {
+        return new Argon2KdfConfig(jdoc.kdfIterations, jdoc.kdfMemory, jdoc.kdfParallelism);
+      }
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+function inBounds(value: number | undefined, range: RangeWithDefault): value is number {
+  return value != null && Number.isInteger(value) && range.inRange(value);
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42722

## 📔 Objective

Unbounded KDF parameters. The password-protected import accepts attacker-controlled Argon2 parameters with no bounds, so a crafted file can force an arbitrary memory allocation (FIND-BF1EC7BF3F26, Medium).

## 📸 Screenshots


<img width="1713" height="863" alt="Screenshot 2026-09-07 at 9 39 53 AM" src="https://github.com/user-attachments/assets/910057df-b1a0-4765-bdbd-7179bf24abfd" />
<img width="1720" height="917" alt="Screenshot 2026-09-07 at 9 39 39 AM" src="https://github.com/user-attachments/assets/4b414927-7190-422c-902f-806e828b9785" />
<img width="1719" height="930" alt="Screenshot 2026-09-07 at 9 39 29 AM" src="https://github.com/user-attachments/assets/768c6105-2fa6-4356-8435-b86ff6294eea" />
<img width="1714" height="922" alt="Screenshot 2026-09-07 at 9 38 31 AM" src="https://github.com/user-attachments/assets/c4130020-b53a-454c-9f31-78aa4e691b1b" />
<img width="1717" height="925" alt="Screenshot 2026-09-07 at 9 38 06 AM" src="https://github.com/user-attachments/assets/80c36bc9-f027-43da-a081-08ad4b04f23b" />

[kdf-verify.zip](https://github.com/user-attachments/files/31916756/kdf-verify.zip)
