### PR TITLE
[PM-43167] Resolve Autotype GA UI Bug

### DIFF
--- a/libs/common/src/desktop-native/services/autotype-feature-flags.spec.ts
+++ b/libs/common/src/desktop-native/services/autotype-feature-flags.spec.ts
@@ -3,9 +3,9 @@ import { BehaviorSubject, firstValueFrom } from "rxjs";
 import { FeatureFlag } from "../../enums/feature-flag.enum";
 import { ConfigService } from "../../platform/abstractions/config/config.service";
 
-import { autotypeFeatureFlagEnabled$ } from "./autotype-feature-flags";
+import { autotypeFeatureFlagEnabled$, autotypeFeatureFlags$ } from "./autotype-feature-flags";
 
-describe("autotypeFeatureFlagEnabled$", () => {
+describe("Autotype feature flags", () => {
   let mockConfigService: jest.Mocked<ConfigService>;
   let mvpFeatureFlagSubject: BehaviorSubject<boolean>;
   let gaFeatureFlagSubject: BehaviorSubject<boolean>;
@@ -28,69 +28,82 @@ describe("autotypeFeatureFlagEnabled$", () => {
     jest.clearAllMocks();
   });
 
-  it("reads the MVP and GA feature flags", () => {
-    const subscription = autotypeFeatureFlagEnabled$(mockConfigService).subscribe();
+  describe("autotypeFeatureFlags$", () => {
+    it("emits the flags as an [mvp, ga] tuple", async () => {
+      mvpFeatureFlagSubject.next(true);
+      gaFeatureFlagSubject.next(false);
 
-    expect(mockConfigService.getFeatureFlag$).toHaveBeenCalledWith(
-      FeatureFlag.WindowsDesktopAutotype,
-    );
-    expect(mockConfigService.getFeatureFlag$).toHaveBeenCalledWith(
-      FeatureFlag.WindowsDesktopAutotypeGA,
-    );
+      const result = await firstValueFrom(autotypeFeatureFlags$(mockConfigService));
 
-    subscription.unsubscribe();
+      expect(result).toEqual([true, false]);
+    });
   });
 
-  it("emits false when neither flag is enabled", async () => {
-    mvpFeatureFlagSubject.next(false);
-    gaFeatureFlagSubject.next(false);
+  describe("autotypeFeatureFlagEnabled$", () => {
+    it("reads the MVP and GA feature flags", () => {
+      const subscription = autotypeFeatureFlagEnabled$(mockConfigService).subscribe();
 
-    const result = await firstValueFrom(autotypeFeatureFlagEnabled$(mockConfigService));
+      expect(mockConfigService.getFeatureFlag$).toHaveBeenCalledWith(
+        FeatureFlag.WindowsDesktopAutotype,
+      );
+      expect(mockConfigService.getFeatureFlag$).toHaveBeenCalledWith(
+        FeatureFlag.WindowsDesktopAutotypeGA,
+      );
 
-    expect(result).toBe(false);
-  });
+      subscription.unsubscribe();
+    });
 
-  it("emits true when only the MVP flag is enabled", async () => {
-    mvpFeatureFlagSubject.next(true);
-    gaFeatureFlagSubject.next(false);
+    it("emits false when neither flag is enabled", async () => {
+      mvpFeatureFlagSubject.next(false);
+      gaFeatureFlagSubject.next(false);
 
-    const result = await firstValueFrom(autotypeFeatureFlagEnabled$(mockConfigService));
+      const result = await firstValueFrom(autotypeFeatureFlagEnabled$(mockConfigService));
 
-    expect(result).toBe(true);
-  });
+      expect(result).toBe(false);
+    });
 
-  it("emits true when only the GA flag is enabled", async () => {
-    mvpFeatureFlagSubject.next(false);
-    gaFeatureFlagSubject.next(true);
+    it("emits true when only the MVP flag is enabled", async () => {
+      mvpFeatureFlagSubject.next(true);
+      gaFeatureFlagSubject.next(false);
 
-    const result = await firstValueFrom(autotypeFeatureFlagEnabled$(mockConfigService));
+      const result = await firstValueFrom(autotypeFeatureFlagEnabled$(mockConfigService));
 
-    expect(result).toBe(true);
-  });
+      expect(result).toBe(true);
+    });
 
-  it("emits true when both flags are enabled", async () => {
-    mvpFeatureFlagSubject.next(true);
-    gaFeatureFlagSubject.next(true);
+    it("emits true when only the GA flag is enabled", async () => {
+      mvpFeatureFlagSubject.next(false);
+      gaFeatureFlagSubject.next(true);
 
-    const result = await firstValueFrom(autotypeFeatureFlagEnabled$(mockConfigService));
+      const result = await firstValueFrom(autotypeFeatureFlagEnabled$(mockConfigService));
 
-    expect(result).toBe(true);
-  });
+      expect(result).toBe(true);
+    });
 
-  it("does not re-emit when the resolved value is unchanged", () => {
-    mvpFeatureFlagSubject.next(false);
-    gaFeatureFlagSubject.next(false);
+    it("emits true when both flags are enabled", async () => {
+      mvpFeatureFlagSubject.next(true);
+      gaFeatureFlagSubject.next(true);
 
-    const emissions: boolean[] = [];
-    const subscription = autotypeFeatureFlagEnabled$(mockConfigService).subscribe((value) =>
-      emissions.push(value),
-    );
+      const result = await firstValueFrom(autotypeFeatureFlagEnabled$(mockConfigService));
 
-    mvpFeatureFlagSubject.next(true); // false -> true: a real change
-    gaFeatureFlagSubject.next(true); // true || true is still true: no new emission
+      expect(result).toBe(true);
+    });
 
-    subscription.unsubscribe();
+    it("does not re-emit when the resolved value is unchanged", () => {
+      mvpFeatureFlagSubject.next(false);
+      gaFeatureFlagSubject.next(false);
 
-    expect(emissions).toEqual([false, true]);
+      const emissions: boolean[] = [];
+      const subscription = autotypeFeatureFlagEnabled$(mockConfigService).subscribe((value) =>
+        emissions.push(value),
+      );
+
+      mvpFeatureFlagSubject.next(true); // false -> true: a real change
+      gaFeatureFlagSubject.next(true); // true || true is still true: no new emission
+
+      subscription.unsubscribe();
+
+      expect(emissions).toEqual([false, true]);
+    });
   });
 });

--- a/libs/common/src/desktop-native/services/autotype-feature-flags.ts
+++ b/libs/common/src/desktop-native/services/autotype-feature-flags.ts
@@ -3,9 +3,18 @@ import { combineLatest, distinctUntilChanged, map, Observable } from "rxjs";
 import { FeatureFlag } from "../../enums/feature-flag.enum";
 import { ConfigService } from "../../platform/abstractions/config/config.service";
 
-// Combines all Autotype feature flags into a single observable so the feature flags
-// are only subscribed to in one location.
-function autotypeFeatureFlags$(configService: ConfigService): Observable<[boolean, boolean]> {
+/**
+ * Combines all Autotype feature flags into a single observable so the feature flags
+ * are only subscribed to in one location. Emits `[mvpEnabled, gaEnabled]`.
+ *
+ * Consumers that need to distinguish the MVP implementation from the GA implementation
+ * (for example, GA-only UI that must stay hidden while MVP is active) should use this.
+ * Consumers that only care "is some Autotype implementation available" should use
+ * {@link autotypeFeatureFlagEnabled$} instead.
+ */
+export function autotypeFeatureFlags$(
+  configService: ConfigService,
+): Observable<[boolean, boolean]> {
   return combineLatest([
     configService.getFeatureFlag$(FeatureFlag.WindowsDesktopAutotype), // mvp
     configService.getFeatureFlag$(FeatureFlag.WindowsDesktopAutotypeGA), // ga

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.spec.ts
@@ -7,6 +7,7 @@ import { BehaviorSubject } from "rxjs";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
 import { DeviceType } from "@bitwarden/common/enums";
+import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { UriMatchStrategy } from "@bitwarden/common/models/domain/domain-service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -38,7 +39,8 @@ describe("AutofillOptionsComponent", () => {
   let autofillSettingsService: MockProxy<AutofillSettingsServiceAbstraction>;
   let platformUtilsService: MockProxy<PlatformUtilsService>;
   let configService: MockProxy<ConfigService>;
-  let featureFlagSubject: BehaviorSubject<boolean>;
+  let mvpFeatureFlagSubject: BehaviorSubject<boolean>;
+  let gaFeatureFlagSubject: BehaviorSubject<boolean>;
   const getInitialCipherView = jest.fn((): any => null);
   const formStatusChange$ = new BehaviorSubject<"enabled" | "disabled">("enabled");
 
@@ -48,8 +50,12 @@ describe("AutofillOptionsComponent", () => {
     cipherFormContainer.formStatusChange$ = formStatusChange$.asObservable();
     liveAnnouncer = mock<LiveAnnouncer>();
     platformUtilsService = mock<PlatformUtilsService>();
-    featureFlagSubject = new BehaviorSubject<boolean>(false);
+    mvpFeatureFlagSubject = new BehaviorSubject<boolean>(false);
+    gaFeatureFlagSubject = new BehaviorSubject<boolean>(false);
     configService = mock<ConfigService>();
+    configService.getFeatureFlag$.mockImplementation((flag) =>
+      flag === FeatureFlag.WindowsDesktopAutotype ? mvpFeatureFlagSubject : gaFeatureFlagSubject,
+    );
     domainSettingsService = mock<DomainSettingsService>();
     domainSettingsService.resolvedDefaultUriMatchStrategy$ = new BehaviorSubject(null);
 
@@ -300,9 +306,8 @@ describe("AutofillOptionsComponent", () => {
       expect(component["showAddAppDropdown"]()).toBe(false);
     });
 
-    it("is false when device type is Windows Desktop but windows-desktop-autotype-ga feature flag is off", () => {
+    it("is false when device type is Windows Desktop but both Autotype feature flags are off", () => {
       platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
-      configService.getFeatureFlag$.mockReturnValue(featureFlagSubject);
 
       const localFixture = TestBed.createComponent(AutofillOptionsComponent);
       localFixture.detectChanges();
@@ -310,16 +315,38 @@ describe("AutofillOptionsComponent", () => {
       expect(localFixture.componentInstance["showAddAppDropdown"]()).toBe(false);
     });
 
-    it("is true when device is Windows Desktop and windows-desktop-autotype-ga feature flag is on", () => {
+    it("is true when device is Windows Desktop, the GA feature flag is on, and the MVP feature flag is off", () => {
       platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
-      configService.getFeatureFlag$.mockReturnValue(featureFlagSubject);
 
-      featureFlagSubject.next(true);
+      gaFeatureFlagSubject.next(true);
 
       const localFixture = TestBed.createComponent(AutofillOptionsComponent);
       localFixture.detectChanges();
 
       expect(localFixture.componentInstance["showAddAppDropdown"]()).toBe(true);
+    });
+
+    it("is false when device is Windows Desktop and only the MVP feature flag is on", () => {
+      platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
+
+      mvpFeatureFlagSubject.next(true);
+
+      const localFixture = TestBed.createComponent(AutofillOptionsComponent);
+      localFixture.detectChanges();
+
+      expect(localFixture.componentInstance["showAddAppDropdown"]()).toBe(false);
+    });
+
+    it("is false when device is Windows Desktop and both feature flags are on", () => {
+      platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
+
+      mvpFeatureFlagSubject.next(true);
+      gaFeatureFlagSubject.next(true);
+
+      const localFixture = TestBed.createComponent(AutofillOptionsComponent);
+      localFixture.detectChanges();
+
+      expect(localFixture.componentInstance["showAddAppDropdown"]()).toBe(false);
     });
   });
 
@@ -340,9 +367,8 @@ describe("AutofillOptionsComponent", () => {
 
     it("renders an 'Add website or app' dropdown button with 'Website' and 'App' options when showAddAppDropdown is true", () => {
       platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
-      configService.getFeatureFlag$.mockReturnValue(featureFlagSubject);
 
-      featureFlagSubject.next(true);
+      gaFeatureFlagSubject.next(true);
 
       const localFixture = TestBed.createComponent(AutofillOptionsComponent);
       localFixture.detectChanges();
@@ -370,8 +396,7 @@ describe("AutofillOptionsComponent", () => {
 
     it("clicking 'App' menu item calls addUri with the desktopapp:// prefix", () => {
       platformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
-      configService.getFeatureFlag$.mockReturnValue(featureFlagSubject);
-      featureFlagSubject.next(true);
+      gaFeatureFlagSubject.next(true);
 
       const localFixture = TestBed.createComponent(AutofillOptionsComponent);
       const localComponent = localFixture.componentInstance;

--- a/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.ts
+++ b/libs/vault/src/cipher-form/components/autofill-options/autofill-options.component.ts
@@ -6,13 +6,13 @@ import { AsyncPipe } from "@angular/common";
 import { Component, OnInit, QueryList, ViewChildren } from "@angular/core";
 import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { FormBuilder, ReactiveFormsModule } from "@angular/forms";
-import { filter, of, Subject, switchMap, take } from "rxjs";
+import { filter, map, of, Subject, switchMap, take } from "rxjs";
 
 import { JslibModule } from "@bitwarden/angular/jslib.module";
 import { AutofillSettingsServiceAbstraction } from "@bitwarden/common/autofill/services/autofill-settings.service";
 import { DomainSettingsService } from "@bitwarden/common/autofill/services/domain-settings.service";
+import { autotypeFeatureFlags$ } from "@bitwarden/common/desktop-native/services/autotype-feature-flags";
 import { ClientType, DeviceType } from "@bitwarden/common/enums";
-import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import { UriMatchStrategySetting } from "@bitwarden/common/models/domain/domain-service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
@@ -105,9 +105,16 @@ export class AutofillOptionsComponent implements OnInit {
   private readonly isWindowsDesktop =
     this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop;
 
+  /**
+   * The "Add app" dropdown belongs to the GA Autotype implementation, so it is only shown
+   * when GA is on and the MVP implementation is off. While MVP is active it owns the
+   * Autotype experience and the GA UI must stay hidden.
+   */
   protected readonly showAddAppDropdown = toSignal(
     this.isWindowsDesktop
-      ? this.configService.getFeatureFlag$(FeatureFlag.WindowsDesktopAutotypeGA)
+      ? autotypeFeatureFlags$(this.configService).pipe(
+          map(([mvpEnabled, gaEnabled]) => gaEnabled && !mvpEnabled),
+        )
       : of(false),
     { initialValue: false },
   );


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-43167

## 📔 Objective

When both the MVP and GA feature flags are on, the MVP implementation should take priority. This is so that organizations using MVP are not impacted when GA rolls out and is turned on in production.

There is a bug when both MVP and GA flags are on, where the dropdown in the login uri’s section is showing the GA version rather than respecting the MVP flag and staying hidden. Screenshot is below. This PR fixes this bug, so that only the MVP behavior is shown, and GA is hidden.

## 📸 Screenshots

### Bugged UI

<img width="853" height="628" alt="image" src="https://github.com/user-attachments/assets/a8629339-d718-48b9-9d9b-d54e653b125e" />

### Fixed UI

<img width="398" height="178" alt="image" src="https://github.com/user-attachments/assets/f19a6cd5-eef5-4760-bad7-5f010a0d080d" />

