### PR TITLE
[PM-41885] Create initial desktop main process service for Autotype GA

### DIFF
--- a/apps/desktop/src/app/services/init.service.ts
+++ b/apps/desktop/src/app/services/init.service.ts
@@ -28,6 +28,7 @@ import { UnlockService } from "@bitwarden/unlock";
 
 import { DesktopAutofillService } from "../../autofill/services/desktop-autofill.service";
 import { DesktopAutotypeMvpService } from "../../autofill/services/desktop-autotype-mvp.service";
+import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
 import { SshAgentService } from "../../autofill/services/ssh-agent.service";
 import { I18nRendererService } from "../../platform/services/i18n.renderer.service";
 import { ServerCommunicationConfigService } from "../../platform/services/server-communication-config/server-communication-config.service";
@@ -59,6 +60,7 @@ export class InitService {
     private sshAgentService: SshAgentService,
     private autofillService: DesktopAutofillService,
     private autotypeMvpService: DesktopAutotypeMvpService,
+    private autotypeService: DesktopAutotypeService,
     private sdkLoadService: SdkLoadService,
     private ipcService: IpcService,
     private sharedUnlockPeerService: SharedUnlockPeerService,
@@ -128,6 +130,7 @@ export class InitService {
       await this.biometricMessageHandlerService.init();
       await this.autofillService.init();
       await this.autotypeMvpService.init();
+      await this.autotypeService.init();
     };
   }
 }

--- a/apps/desktop/src/app/services/services.module.ts
+++ b/apps/desktop/src/app/services/services.module.ts
@@ -173,6 +173,7 @@ import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-
 import { DesktopAutofillService } from "../../autofill/services/desktop-autofill.service";
 import { DesktopAutotypeMvpService } from "../../autofill/services/desktop-autotype-mvp.service";
 import { DesktopAutotypeDefaultSettingPolicy } from "../../autofill/services/desktop-autotype-policy.service";
+import { DesktopAutotypeService } from "../../autofill/services/desktop-autotype.service";
 import { DesktopFido2MacOsUserVerificationService } from "../../autofill/services/desktop-fido2-macos-user-verification.service";
 import { DesktopFido2UnsupportedUserVerificationService } from "../../autofill/services/desktop-fido2-unsupported-user-verification.service";
 import { DesktopFido2UserInterfaceService } from "../../autofill/services/desktop-fido2-user-interface.service";
@@ -634,6 +635,21 @@ const safeProviders: SafeProvider[] = [
   safeProvider({
     provide: DesktopAutotypeMvpService,
     useClass: DesktopAutotypeMvpService,
+    deps: [
+      AccountService,
+      AuthService,
+      CipherServiceAbstraction,
+      ConfigService,
+      GlobalStateProvider,
+      PlatformUtilsServiceAbstraction,
+      BillingAccountProfileStateService,
+      DesktopAutotypeDefaultSettingPolicy,
+      LogService,
+    ],
+  }),
+  safeProvider({
+    provide: DesktopAutotypeService,
+    useClass: DesktopAutotypeService,
     deps: [
       AccountService,
       AuthService,

--- a/apps/desktop/src/autofill/main/main-desktop-autotype-mvp.service.spec.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autotype-mvp.service.spec.ts
@@ -13,7 +13,7 @@ import { AutotypeConfig } from "../models/autotype-config";
 import { AutotypeMatchError } from "../models/autotype-errors";
 import { AutotypeVaultData } from "../models/autotype-vault-data";
 import { AUTOTYPE_MVP_IPC_CHANNELS } from "../models/ipc-channels";
-import { AutotypeKeyboardShortcut } from "../models/main-autotype-keyboard-shortcut";
+import { AutotypeMvpKeyboardShortcut } from "../models/main-autotype-mvp-keyboard-shortcut";
 
 import { MainDesktopAutotypeMvpService } from "./main-desktop-autotype-mvp.service";
 
@@ -41,9 +41,9 @@ jest.mock("@bitwarden/desktop-napi", () => ({
   },
 }));
 
-// Mock AutotypeKeyboardShortcut
-jest.mock("../models/main-autotype-keyboard-shortcut", () => ({
-  AutotypeKeyboardShortcut: jest.fn().mockImplementation(() => ({
+// Mock AutotypeMvpKeyboardShortcut
+jest.mock("../models/main-autotype-mvp-keyboard-shortcut", () => ({
+  AutotypeMvpKeyboardShortcut: jest.fn().mockImplementation(() => ({
     set: jest.fn().mockReturnValue(true),
     getElectronFormat: jest.fn().mockReturnValue("Control+Alt+B"),
     getArrayFormat: jest.fn().mockReturnValue(["Control", "Alt", "B"]),
@@ -163,7 +163,7 @@ describe("MainDesktopAutotypeMvpService", () => {
         getElectronFormat: jest.fn().mockReturnValue("Control+Alt+A"),
         getArrayFormat: jest.fn().mockReturnValue(["Control", "Alt", "A"]),
       };
-      (AutotypeKeyboardShortcut as jest.Mock).mockReturnValue(mockNewShortcut);
+      (AutotypeMvpKeyboardShortcut as jest.Mock).mockReturnValue(mockNewShortcut);
 
       const configureHandler = ipcHandlers.get(AUTOTYPE_MVP_IPC_CHANNELS.CONFIGURE);
       configureHandler({}, config);
@@ -181,7 +181,7 @@ describe("MainDesktopAutotypeMvpService", () => {
         getElectronFormat: jest.fn(),
         getArrayFormat: jest.fn(),
       };
-      (AutotypeKeyboardShortcut as jest.Mock).mockReturnValue(mockNewShortcut);
+      (AutotypeMvpKeyboardShortcut as jest.Mock).mockReturnValue(mockNewShortcut);
 
       const configureHandler = ipcHandlers.get(AUTOTYPE_MVP_IPC_CHANNELS.CONFIGURE);
       configureHandler({}, config);
@@ -206,7 +206,7 @@ describe("MainDesktopAutotypeMvpService", () => {
         getElectronFormat: jest.fn().mockReturnValue("Control+Alt+B"),
         getArrayFormat: jest.fn().mockReturnValue(["Control", "Alt", "B"]),
       };
-      (AutotypeKeyboardShortcut as jest.Mock).mockReturnValue(mockNewShortcut);
+      (AutotypeMvpKeyboardShortcut as jest.Mock).mockReturnValue(mockNewShortcut);
 
       const configureHandler = ipcHandlers.get(AUTOTYPE_MVP_IPC_CHANNELS.CONFIGURE);
       configureHandler({}, config);
@@ -287,7 +287,7 @@ describe("MainDesktopAutotypeMvpService", () => {
         getArrayFormat: jest.fn().mockReturnValue(["Control", "Alt", "B"]),
       };
 
-      (AutotypeKeyboardShortcut as jest.Mock).mockReturnValue(mockNewShortcut);
+      (AutotypeMvpKeyboardShortcut as jest.Mock).mockReturnValue(mockNewShortcut);
 
       const vaultData: AutotypeVaultData = {
         username: "user",

--- a/apps/desktop/src/autofill/main/main-desktop-autotype-mvp.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autotype-mvp.service.ts
@@ -11,16 +11,16 @@ import { AutotypeConfig } from "../models/autotype-config";
 import { AutotypeMatchError } from "../models/autotype-errors";
 import { AutotypeVaultData } from "../models/autotype-vault-data";
 import { AUTOTYPE_MVP_IPC_CHANNELS } from "../models/ipc-channels";
-import { AutotypeKeyboardShortcut } from "../models/main-autotype-keyboard-shortcut";
+import { AutotypeMvpKeyboardShortcut } from "../models/main-autotype-mvp-keyboard-shortcut";
 
 export class MainDesktopAutotypeMvpService {
-  private autotypeKeyboardShortcut: AutotypeKeyboardShortcut;
+  private autotypeKeyboardShortcut: AutotypeMvpKeyboardShortcut;
 
   constructor(
     private logService: LogService,
     private windowMain: WindowMain,
   ) {
-    this.autotypeKeyboardShortcut = new AutotypeKeyboardShortcut();
+    this.autotypeKeyboardShortcut = new AutotypeMvpKeyboardShortcut();
 
     this.registerIpcListeners();
   }
@@ -35,7 +35,7 @@ export class MainDesktopAutotypeMvpService {
     });
 
     ipcMain.on(AUTOTYPE_MVP_IPC_CHANNELS.CONFIGURE, (_event, config: AutotypeConfig) => {
-      const newKeyboardShortcut = new AutotypeKeyboardShortcut();
+      const newKeyboardShortcut = new AutotypeMvpKeyboardShortcut();
       const newKeyboardShortcutIsValid = newKeyboardShortcut.set(config.keyboardShortcut);
 
       if (!newKeyboardShortcutIsValid) {
@@ -123,7 +123,7 @@ export class MainDesktopAutotypeMvpService {
 
   // Set the keyboard shortcut if it differs from the present one. If
   // the keyboard shortcut is set, de-register the old shortcut first.
-  private setKeyboardShortcut(keyboardShortcut: AutotypeKeyboardShortcut) {
+  private setKeyboardShortcut(keyboardShortcut: AutotypeMvpKeyboardShortcut) {
     if (
       keyboardShortcut.getElectronFormat() !== this.autotypeKeyboardShortcut.getElectronFormat()
     ) {

--- a/apps/desktop/src/autofill/main/main-desktop-autotype.service.spec.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autotype.service.spec.ts
@@ -1,0 +1,111 @@
+import { globalShortcut } from "electron";
+import { mock, MockProxy } from "jest-mock-extended";
+
+import { LogService } from "@bitwarden/logging";
+
+import { WindowMain } from "../../main/window.main";
+import { DEFAULT_KEYBOARD_SHORTCUT } from "../models/main-autotype-keyboard-shortcut";
+
+import { MainDesktopAutotypeService } from "./main-desktop-autotype.service";
+
+/*
+  Only the `globalShortcut` surface the reachable code paths touch is mocked.
+  This service registers no IPC listeners, so `ipcMain` is not needed.
+*/
+jest.mock("electron", () => ({
+  globalShortcut: {
+    unregister: jest.fn(),
+    isRegistered: jest.fn(),
+  },
+}));
+
+/*
+  This suite intentionally only covers the code that is reachable today:
+  the constructor, `disableAutotype()` and `dispose()`. The private
+  `enableAutotype()` and `setKeyboardShortcut()` methods have no caller yet
+  (no IPC listeners are registered by this service), so they are left for the
+  tickets that wire them up.
+*/
+describe("MainDesktopAutotypeService", () => {
+  const defaultKeyboardShortcut = DEFAULT_KEYBOARD_SHORTCUT.join("+");
+
+  let mockLogService: MockProxy<LogService>;
+  let mockWindowMain: MockProxy<WindowMain>;
+  let service: MainDesktopAutotypeService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockLogService = mock<LogService>();
+    mockWindowMain = mock<WindowMain>();
+
+    (globalShortcut.isRegistered as jest.Mock).mockReturnValue(false);
+
+    // Created manually since this service does not use Angular DI
+    service = new MainDesktopAutotypeService(mockLogService, mockWindowMain);
+  });
+
+  describe("constructor", () => {
+    it("should create the service", () => {
+      expect(service).toBeTruthy();
+    });
+
+    it("should initialize the keyboard shortcut to the default", () => {
+      // Read the private field rather than widening its visibility in
+      // production code; there is no accessor for it yet.
+      const keyboardShortcut = service["autotypeKeyboardShortcut"];
+
+      expect(keyboardShortcut).toBeDefined();
+      expect(keyboardShortcut.getArrayFormat()).toEqual(DEFAULT_KEYBOARD_SHORTCUT);
+      expect(keyboardShortcut.getElectronFormat()).toEqual(defaultKeyboardShortcut);
+    });
+  });
+
+  describe("disableAutotype", () => {
+    it("should unregister the keyboard shortcut when it is registered", () => {
+      (globalShortcut.isRegistered as jest.Mock).mockReturnValue(true);
+
+      service.disableAutotype();
+
+      expect(globalShortcut.unregister).toHaveBeenCalledWith(defaultKeyboardShortcut);
+      expect(mockLogService.debug).toHaveBeenCalledWith("Autotype disabled.");
+    });
+
+    it("should log that autotype is implicitly disabled when the keyboard shortcut is not registered", () => {
+      (globalShortcut.isRegistered as jest.Mock).mockReturnValue(false);
+
+      service.disableAutotype();
+
+      expect(globalShortcut.unregister).not.toHaveBeenCalled();
+      expect(mockLogService.debug).toHaveBeenCalledWith(
+        "Autotype is not registered, implicitly disabled.",
+      );
+    });
+  });
+
+  describe("dispose", () => {
+    it("should disable autotype when the keyboard shortcut is registered", () => {
+      (globalShortcut.isRegistered as jest.Mock).mockReturnValue(true);
+
+      service.dispose();
+
+      expect(globalShortcut.unregister).toHaveBeenCalledWith(defaultKeyboardShortcut);
+      expect(mockLogService.debug).toHaveBeenCalledWith("Autotype disabled.");
+    });
+
+    it("should not unregister the keyboard shortcut when it is not registered", () => {
+      (globalShortcut.isRegistered as jest.Mock).mockReturnValue(false);
+
+      service.dispose();
+
+      expect(globalShortcut.unregister).not.toHaveBeenCalled();
+      expect(mockLogService.debug).toHaveBeenCalledWith(
+        "Autotype is not registered, implicitly disabled.",
+      );
+    });
+
+    it("should not throw", () => {
+      expect(() => service.dispose()).not.toThrow();
+    });
+  });
+});

--- a/apps/desktop/src/autofill/main/main-desktop-autotype.service.ts
+++ b/apps/desktop/src/autofill/main/main-desktop-autotype.service.ts
@@ -1,0 +1,98 @@
+import { globalShortcut } from "electron";
+
+import { LogService } from "@bitwarden/logging";
+
+import { WindowMain } from "../../main/window.main";
+import { AutotypeKeyboardShortcut } from "../models/main-autotype-keyboard-shortcut";
+
+export class MainDesktopAutotypeService {
+  private autotypeKeyboardShortcut: AutotypeKeyboardShortcut;
+
+  constructor(
+    private logService: LogService,
+    private windowMain: WindowMain,
+  ) {
+    this.autotypeKeyboardShortcut = new AutotypeKeyboardShortcut();
+  }
+
+  // Enabling Autotype will:
+  //   - Register the keyboard shortcut, if it's not registered
+  //   - Define the function that executes the Autotype when the
+  //     keyboard shortcut is pressed (if the keyboard shortcut isn't registered already)
+  private enableAutotype() {
+    const formattedKeyboardShortcut = this.autotypeKeyboardShortcut.getElectronFormat();
+    if (globalShortcut.isRegistered(formattedKeyboardShortcut)) {
+      this.logService.debug(
+        "Autotype is already enabled with this keyboard shortcut: " + formattedKeyboardShortcut,
+      );
+      return;
+    }
+
+    const result = globalShortcut.register(
+      this.autotypeKeyboardShortcut.getElectronFormat(),
+      () => {
+        if (this.windowMain.win != null && !this.windowMain.win.isDestroyed()) {
+          // TODO: For Autotype GA, from this location, we need to...
+          //   - Get the autotype app data for the currently focused application
+          //     (multiple tickets, culminates in PM-38921)
+          //   - Send this app data to the render process via encrypted IPC for
+          //     the Autotype Verification Flow (PM-38967)
+          //   - If the Verification Flow passes, we need to execute Autotype
+          //     (multiple tickets, culminates in PM-38921), with the following
+          //     caveats:
+          //     - Show the confirmation dialog, if it should be shown (PM-38917)
+          //     - Verify the window is the same (PM-38968)
+        } else {
+          this.logService.debug(
+            "Autotype keyboard shortcut activated, but the main window does not exist.",
+          );
+        }
+      },
+    );
+
+    result
+      ? this.logService.debug("Autotype enabled.")
+      : this.logService.error("Failed to enable Autotype.");
+  }
+
+  // Disabling Autotype will:
+  //   - Deregister the keyboard shortcut, if it's registered
+  disableAutotype() {
+    const formattedKeyboardShortcut = this.autotypeKeyboardShortcut.getElectronFormat();
+
+    if (globalShortcut.isRegistered(formattedKeyboardShortcut)) {
+      globalShortcut.unregister(formattedKeyboardShortcut);
+      this.logService.debug("Autotype disabled.");
+    } else {
+      this.logService.debug("Autotype is not registered, implicitly disabled.");
+    }
+  }
+
+  dispose() {
+    // Disable Autotype
+    this.disableAutotype();
+  }
+
+  // Set the keyboard shortcut if it differs from the present one. If
+  // the keyboard shortcut is set, de-register the old shortcut first.
+  private setKeyboardShortcut(keyboardShortcut: AutotypeKeyboardShortcut) {
+    if (
+      keyboardShortcut.getElectronFormat() !== this.autotypeKeyboardShortcut.getElectronFormat()
+    ) {
+      const registered = globalShortcut.isRegistered(
+        this.autotypeKeyboardShortcut.getElectronFormat(),
+      );
+      if (registered) {
+        this.disableAutotype();
+      }
+      this.autotypeKeyboardShortcut = keyboardShortcut;
+      if (registered) {
+        this.enableAutotype();
+      }
+    } else {
+      this.logService.debug(
+        "setKeyboardShortcut() called but shortcut is not different from current.",
+      );
+    }
+  }
+}

--- a/apps/desktop/src/autofill/models/main-autotype-mvp-keyboard-shortcut.ts
+++ b/apps/desktop/src/autofill/models/main-autotype-mvp-keyboard-shortcut.ts
@@ -1,0 +1,112 @@
+// MVP, delete with PM-41067
+
+/**
+ Electron's representation of modifier keys
+ <https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts#cross-platform-modifiers>
+*/
+export const CONTROL_KEY_STR = "Control";
+export const ALT_KEY_STR = "Alt";
+export const SUPER_KEY_STR = "Super";
+
+export const VALID_SHORTCUT_MODIFIER_KEYS: string[] = [CONTROL_KEY_STR, ALT_KEY_STR, SUPER_KEY_STR];
+
+export const DEFAULT_KEYBOARD_SHORTCUT: string[] = [CONTROL_KEY_STR, ALT_KEY_STR, "B"];
+
+/*
+  This class provides the following:
+  - A way to get and set an AutotypeKeyboardShortcut value within the main process
+  - A way to set an AutotypeKeyboardShortcut with validation
+  - A way to "get" the value in string array format or a single string format for electron
+  - Default shortcut support
+
+  This is currently only supported for Windows operating systems.
+*/
+export class AutotypeMvpKeyboardShortcut {
+  private autotypeKeyboardShortcut: string[];
+
+  constructor() {
+    this.autotypeKeyboardShortcut = DEFAULT_KEYBOARD_SHORTCUT;
+  }
+
+  /*
+    Returns a boolean value indicating if the autotypeKeyboardShortcut
+    was valid and set or not.
+  */
+  set(newAutotypeKeyboardShortcut: string[]) {
+    if (!this.#keyboardShortcutIsValid(newAutotypeKeyboardShortcut)) {
+      return false;
+    }
+
+    this.autotypeKeyboardShortcut = newAutotypeKeyboardShortcut;
+    return true;
+  }
+
+  /*
+    Returns the autotype keyboard shortcut as a string array.
+  */
+  getArrayFormat() {
+    return this.autotypeKeyboardShortcut;
+  }
+
+  /*
+    Returns the autotype keyboard shortcut as a single string, as
+    Electron expects. Please note this does not reorder the keys.
+
+    See Electron keyboard shortcut docs for more info:
+    https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts
+  */
+  getElectronFormat() {
+    return this.autotypeKeyboardShortcut.join("+");
+  }
+
+  /*
+    This private function validates the strArray input to make sure the array contains
+    valid, currently accepted shortcut keys for Windows.
+
+    Valid shortcut keys: Control, Alt, Super, letters A - Z
+    Platform specifics:
+      - On Windows, Super maps to the Windows key.
+      - On MacOS, Super maps to the Command key.
+      - On MacOS, Alt maps to the Option key.
+
+    See Electron keyboard shortcut docs for more info:
+    https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts
+  */
+  #keyboardShortcutIsValid(strArray: string[]) {
+    const UNICODE_LOWER_BOUND = 65; // unicode 'A'
+    const UNICODE_UPPER_BOUND = 90; // unicode 'Z'
+    const MIN_LENGTH: number = 2;
+    const MAX_LENGTH: number = 3;
+
+    // Ensure strArray is a string array of valid length
+    if (
+      strArray === undefined ||
+      strArray === null ||
+      strArray.length < MIN_LENGTH ||
+      strArray.length > MAX_LENGTH
+    ) {
+      return false;
+    }
+
+    // Ensure strArray is all modifier keys, and that the last key is a letter
+    for (let i = 0; i < strArray.length; i++) {
+      if (i < strArray.length - 1) {
+        if (!VALID_SHORTCUT_MODIFIER_KEYS.includes(strArray[i])) {
+          return false;
+        }
+      } else {
+        const unicodeValue: number = strArray[i].charCodeAt(0);
+
+        if (
+          Number.isNaN(unicodeValue) ||
+          unicodeValue < UNICODE_LOWER_BOUND ||
+          unicodeValue > UNICODE_UPPER_BOUND
+        ) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+}

--- a/apps/desktop/src/autofill/services/desktop-autotype.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-autotype.service.spec.ts
@@ -44,7 +44,7 @@ describe("DesktopAutotypeService", () => {
   let mockGlobalStateProvider: jest.Mocked<GlobalStateProvider>;
   let mockPlatformUtilsService: MockProxy<PlatformUtilsService>;
   let mockBillingAccountProfileStateService: MockProxy<BillingAccountProfileStateService>;
-  let mockDesktopAutotypePolicy: MockProxy<DesktopAutotypeDefaultSettingPolicy>;
+  let mockDesktopAutotypePolicy: jest.Mocked<DesktopAutotypeDefaultSettingPolicy>;
   let mockLogService: MockProxy<LogService>;
 
   // Mock GlobalState objects
@@ -145,9 +145,14 @@ describe("DesktopAutotypeService", () => {
       hasPremiumSubject.asObservable(),
     );
 
-    mockDesktopAutotypePolicy = mock<DesktopAutotypeDefaultSettingPolicy>({
+    /*
+      autotypeDefaultSetting$ is readonly, so it can't be assigned post-construction like
+      activeAccount$/activeAccountStatus$ above; passing it into mock<T>()'s partial hits the same
+      proxied-observable hazard described above, so the whole mock is a plain object cast instead.
+    */
+    mockDesktopAutotypePolicy = {
       autotypeDefaultSetting$: autotypeDefaultPolicySubject.asObservable(),
-    });
+    } as unknown as jest.Mocked<DesktopAutotypeDefaultSettingPolicy>;
 
     mockLogService = mock<LogService>();
 

--- a/apps/desktop/src/autofill/services/desktop-autotype.service.spec.ts
+++ b/apps/desktop/src/autofill/services/desktop-autotype.service.spec.ts
@@ -1,0 +1,259 @@
+import { TestBed } from "@angular/core/testing";
+import { mock, MockProxy } from "jest-mock-extended";
+import { BehaviorSubject, Observable } from "rxjs";
+
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
+import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
+import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
+import { DeviceType } from "@bitwarden/common/enums";
+import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { GlobalStateProvider, KeyDefinition } from "@bitwarden/common/platform/state";
+import { UserId } from "@bitwarden/common/types/guid";
+import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
+import { LogService } from "@bitwarden/logging";
+
+import { DesktopAutotypeDefaultSettingPolicy } from "./desktop-autotype-policy.service";
+import { DesktopAutotypeService } from "./desktop-autotype.service";
+
+/*
+  The GlobalState objects handed back by the GlobalStateProvider need custom
+  `state$` and `update()` behavior wired to a BehaviorSubject, which `mock<T>()`
+  does not model well, so they are hand-built.
+*/
+type FakeGlobalState<T> = {
+  state$: Observable<T | null>;
+  update: jest.Mock;
+};
+
+/*
+  This suite intentionally only covers the code that is reachable today. The
+  `concatMap` subscriptions in `init()` that will inform the main process of
+  setting changes are still commented out (PM-38967), so there is nothing to
+  assert about `ipc.autofill` from this service yet.
+*/
+describe("DesktopAutotypeService", () => {
+  let service: DesktopAutotypeService;
+
+  // Mock dependencies
+  let mockAccountService: MockProxy<AccountService>;
+  let mockAuthService: MockProxy<AuthService>;
+  let mockCipherService: MockProxy<CipherService>;
+  let mockConfigService: MockProxy<ConfigService>;
+  let mockGlobalStateProvider: jest.Mocked<GlobalStateProvider>;
+  let mockPlatformUtilsService: MockProxy<PlatformUtilsService>;
+  let mockBillingAccountProfileStateService: MockProxy<BillingAccountProfileStateService>;
+  let mockDesktopAutotypePolicy: MockProxy<DesktopAutotypeDefaultSettingPolicy>;
+  let mockLogService: MockProxy<LogService>;
+
+  // Mock GlobalState objects
+  let mockAutotypeEnabledState: FakeGlobalState<boolean>;
+  let mockAutotypeKeyboardShortcutState: FakeGlobalState<string[]>;
+
+  // BehaviorSubjects for reactive state
+  let autotypeEnabledSubject: BehaviorSubject<boolean | null>;
+  let autotypeKeyboardShortcutSubject: BehaviorSubject<string[]>;
+  let activeAccountSubject: BehaviorSubject<Account | null>;
+  let activeAccountStatusSubject: BehaviorSubject<AuthenticationStatus>;
+  let hasPremiumSubject: BehaviorSubject<boolean>;
+  let featureFlagSubject: BehaviorSubject<boolean>;
+  let autotypeDefaultPolicySubject: BehaviorSubject<boolean | null>;
+
+  beforeEach(() => {
+    // Initialize BehaviorSubjects
+    autotypeEnabledSubject = new BehaviorSubject<boolean | null>(null);
+    autotypeKeyboardShortcutSubject = new BehaviorSubject<string[]>(["Control", "Alt", "B"]);
+    activeAccountSubject = new BehaviorSubject<Account | null>({
+      id: "user-123" as UserId,
+      email: "user@bitwarden.com",
+      emailVerified: true,
+      name: "Test User",
+      creationDate: undefined,
+    });
+    activeAccountStatusSubject = new BehaviorSubject<AuthenticationStatus>(
+      AuthenticationStatus.Unlocked,
+    );
+    hasPremiumSubject = new BehaviorSubject<boolean>(true);
+    featureFlagSubject = new BehaviorSubject<boolean>(true);
+    autotypeDefaultPolicySubject = new BehaviorSubject<boolean | null>(null);
+
+    // Mock GlobalState objects
+    mockAutotypeEnabledState = {
+      state$: autotypeEnabledSubject.asObservable(),
+      update: jest.fn().mockImplementation(async (configureState, options) => {
+        const newState = configureState(autotypeEnabledSubject.value, null);
+
+        // Handle shouldUpdate option
+        if (options?.shouldUpdate && !options.shouldUpdate(autotypeEnabledSubject.value)) {
+          return autotypeEnabledSubject.value;
+        }
+
+        autotypeEnabledSubject.next(newState);
+        return newState;
+      }),
+    };
+
+    mockAutotypeKeyboardShortcutState = {
+      state$: autotypeKeyboardShortcutSubject.asObservable(),
+      update: jest.fn().mockImplementation(async (configureState) => {
+        const newState = configureState(autotypeKeyboardShortcutSubject.value, null);
+        autotypeKeyboardShortcutSubject.next(newState);
+        return newState;
+      }),
+    };
+
+    // Mock GlobalStateProvider, keyed on the Autotype GA storage keys
+    mockGlobalStateProvider = {
+      get: jest.fn().mockImplementation((keyDefinition: KeyDefinition<unknown>) => {
+        if (keyDefinition.key === "autotypeGaEnabled") {
+          return mockAutotypeEnabledState;
+        }
+        if (keyDefinition.key === "autotypeGaKeyboardShortcut") {
+          return mockAutotypeKeyboardShortcutState;
+        }
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<GlobalStateProvider>;
+
+    /*
+      Observable-valued members are assigned after the mock is created rather
+      than passed into `mock<T>()`: jest-mock-extended proxies object-valued
+      members of the partial it is handed, and that proxy stubs out the
+      internals RxJS relies on, leaving an observable that never emits.
+    */
+    mockAccountService = mock<AccountService>();
+    mockAccountService.activeAccount$ = activeAccountSubject.asObservable();
+
+    mockAuthService = mock<AuthService>();
+    mockAuthService.activeAccountStatus$ = activeAccountStatusSubject.asObservable();
+
+    mockCipherService = mock<CipherService>();
+
+    /*
+      Wired up only so the feature-enabled subscription in `init()` does not
+      error; nothing in this suite asserts on the flag value.
+    */
+    mockConfigService = mock<ConfigService>();
+    mockConfigService.getFeatureFlag$.mockReturnValue(featureFlagSubject.asObservable());
+
+    mockPlatformUtilsService = mock<PlatformUtilsService>();
+    mockPlatformUtilsService.getDevice.mockReturnValue(DeviceType.WindowsDesktop);
+
+    mockBillingAccountProfileStateService = mock<BillingAccountProfileStateService>();
+    mockBillingAccountProfileStateService.hasPremiumFromAnySource$.mockReturnValue(
+      hasPremiumSubject.asObservable(),
+    );
+
+    mockDesktopAutotypePolicy = mock<DesktopAutotypeDefaultSettingPolicy>({
+      autotypeDefaultSetting$: autotypeDefaultPolicySubject.asObservable(),
+    });
+
+    mockLogService = mock<LogService>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        DesktopAutotypeService,
+        { provide: AccountService, useValue: mockAccountService },
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: CipherService, useValue: mockCipherService },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: GlobalStateProvider, useValue: mockGlobalStateProvider },
+        { provide: PlatformUtilsService, useValue: mockPlatformUtilsService },
+        {
+          provide: BillingAccountProfileStateService,
+          useValue: mockBillingAccountProfileStateService,
+        },
+        { provide: DesktopAutotypeDefaultSettingPolicy, useValue: mockDesktopAutotypePolicy },
+        { provide: LogService, useValue: mockLogService },
+      ],
+    });
+
+    service = TestBed.inject(DesktopAutotypeService);
+  });
+
+  afterEach(() => {
+    service.ngOnDestroy();
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should create the service", () => {
+      expect(service).toBeTruthy();
+    });
+
+    it("should initialize observables", () => {
+      expect(service.autotypeEnabledUserSetting$).toBeDefined();
+      expect(service.autotypeKeyboardShortcut$).toBeDefined();
+    });
+  });
+
+  describe("init", () => {
+    it("should not apply the organization default policy on non-Windows platforms", async () => {
+      mockPlatformUtilsService.getDevice.mockReturnValue(DeviceType.MacOsDesktop);
+      autotypeEnabledSubject.next(null);
+      autotypeDefaultPolicySubject.next(true);
+
+      await service.init();
+
+      // Allow observables to emit
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockAutotypeEnabledState.update).not.toHaveBeenCalled();
+      expect(autotypeEnabledSubject.value).toBeNull();
+    });
+
+    it("should enable autotype when policy is true and user setting is null", async () => {
+      autotypeEnabledSubject.next(null);
+      autotypeDefaultPolicySubject.next(true);
+
+      await service.init();
+
+      // Allow observables to emit
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockAutotypeEnabledState.update).toHaveBeenCalled();
+      expect(autotypeEnabledSubject.value).toBe(true);
+    });
+  });
+
+  describe("setAutotypeEnabledState", () => {
+    it("should update autotype enabled state", async () => {
+      await service.setAutotypeEnabledState(true);
+
+      expect(mockAutotypeEnabledState.update).toHaveBeenCalled();
+      expect(autotypeEnabledSubject.value).toBe(true);
+    });
+
+    it("should not update if value has not changed", async () => {
+      autotypeEnabledSubject.next(true);
+
+      await service.setAutotypeEnabledState(true);
+
+      // Update was called but shouldUpdate prevented the change
+      expect(mockAutotypeEnabledState.update).toHaveBeenCalled();
+      expect(autotypeEnabledSubject.value).toBe(true);
+    });
+  });
+
+  describe("setAutotypeKeyboardShortcutState", () => {
+    it("should update keyboard shortcut state", async () => {
+      const newKeyboardShortcut = ["Control", "Alt", "A"];
+
+      await service.setAutotypeKeyboardShortcutState(newKeyboardShortcut);
+
+      expect(mockAutotypeKeyboardShortcutState.update).toHaveBeenCalled();
+      expect(autotypeKeyboardShortcutSubject.value).toEqual(newKeyboardShortcut);
+    });
+  });
+
+  describe("ngOnDestroy", () => {
+    it("should complete destroy subject", () => {
+      const destroySpy = jest.spyOn(service["destroy$"], "complete");
+
+      service.ngOnDestroy();
+
+      expect(destroySpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/desktop/src/autofill/services/desktop-autotype.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autotype.service.ts
@@ -1,12 +1,9 @@
-// MVP, delete with PM-41067
-
 import { Injectable, OnDestroy } from "@angular/core";
 import {
   combineLatest,
   concatMap,
   distinctUntilChanged,
   filter,
-  firstValueFrom,
   map,
   Observable,
   of,
@@ -29,52 +26,58 @@ import {
   KeyDefinition,
 } from "@bitwarden/common/platform/state";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
-import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { LogService } from "@bitwarden/logging";
-import { UserId } from "@bitwarden/user-core";
 
-import { AutotypeConfig } from "../models/autotype-config";
-import { AutotypeVaultData } from "../models/autotype-vault-data";
-import { DEFAULT_KEYBOARD_SHORTCUT } from "../models/main-autotype-mvp-keyboard-shortcut";
+import { DEFAULT_KEYBOARD_SHORTCUT } from "../models/main-autotype-keyboard-shortcut";
 
 import { DesktopAutotypeDefaultSettingPolicy } from "./desktop-autotype-policy.service";
 
-export const AUTOTYPE_ENABLED = new KeyDefinition<boolean | null>(
+/*
+  The storage key definition for whether the user's local Autotype GA
+  setting is enabled or not.
+*/
+export const AUTOTYPE_GA_ENABLED = new KeyDefinition<boolean | null>(
   AUTOTYPE_SETTINGS_DISK,
-  "autotypeEnabled",
+  "autotypeGaEnabled",
   { deserializer: (b) => b },
 );
 
-export type Result<T, E = Error> = [E, null] | [null, T];
-
 /*
+  The storage key definition for the keyboard shortcut used to activate
+  Autotype GA.
+
   Valid windows shortcut keys: Control, Alt, Super, Shift, letters A - Z
   Valid macOS shortcut keys: Control, Alt, Command, Shift, letters A - Z
 
   See Electron keyboard shortcut docs for more info:
   https://www.electronjs.org/docs/latest/tutorial/keyboard-shortcuts
 */
-export const AUTOTYPE_KEYBOARD_SHORTCUT = new KeyDefinition<string[]>(
+export const AUTOTYPE_GA_KEYBOARD_SHORTCUT = new KeyDefinition<string[]>(
   AUTOTYPE_SETTINGS_DISK,
-  "autotypeKeyboardShortcut",
+  "autotypeGaKeyboardShortcut",
   { deserializer: (b) => b },
 );
+
+export type Result<T, E = Error> = [E, null] | [null, T];
 
 @Injectable({
   providedIn: "root",
 })
-export class DesktopAutotypeMvpService implements OnDestroy {
-  private readonly autotypeEnabledState = this.globalStateProvider.get(AUTOTYPE_ENABLED);
-  private readonly autotypeKeyboardShortcut = this.globalStateProvider.get(
-    AUTOTYPE_KEYBOARD_SHORTCUT,
+export class DesktopAutotypeService implements OnDestroy {
+  private readonly autotypeEnabledState = this.globalStateProvider.get(AUTOTYPE_GA_ENABLED);
+  private readonly autotypeKeyboardShortcutState = this.globalStateProvider.get(
+    AUTOTYPE_GA_KEYBOARD_SHORTCUT,
   );
 
-  // if the user's account is Premium
+  // If the user's account is Premium
   private readonly isPremiumAccount$: Observable<boolean>;
 
-  // The enabled/disabled state from the user settings menu
+  // The observable representing if the user has enabled or disabled
+  // Autotype in the user settings menu
   autotypeEnabledUserSetting$: Observable<boolean> = of(false);
 
+  // The observable representing the keyboard shortcut the user
+  // has defined in the user settings menu
   autotypeKeyboardShortcut$: Observable<string[]> = of(DEFAULT_KEYBOARD_SHORTCUT);
 
   private destroy$ = new Subject<void>();
@@ -105,7 +108,7 @@ export class DesktopAutotypeMvpService implements OnDestroy {
       takeUntil(this.destroy$),
     );
 
-    this.autotypeKeyboardShortcut$ = this.autotypeKeyboardShortcut.state$.pipe(
+    this.autotypeKeyboardShortcut$ = this.autotypeKeyboardShortcutState.state$.pipe(
       map((shortcut) => shortcut ?? DEFAULT_KEYBOARD_SHORTCUT),
       takeUntil(this.destroy$),
     );
@@ -116,13 +119,6 @@ export class DesktopAutotypeMvpService implements OnDestroy {
     if (this.platformUtilsService.getDevice() !== DeviceType.WindowsDesktop) {
       return;
     }
-
-    ipc.autofill.autotypeMvp.listenRequest(async (windowTitle, callback) => {
-      const possibleCiphers = await this.matchCiphersToWindowTitle(windowTitle);
-      const firstCipher = possibleCiphers?.at(0);
-      const [error, vaultData] = getAutotypeVaultData(firstCipher);
-      callback(error, vaultData);
-    });
 
     // If `autotypeDefaultPolicy` is `true` for a user's organization, and the
     // user has never changed their local autotype setting (`autotypeEnabledState`),
@@ -151,10 +147,11 @@ export class DesktopAutotypeMvpService implements OnDestroy {
     this.autotypeKeyboardShortcut$
       .pipe(
         concatMap(async (keyboardShortcut) => {
-          const config: AutotypeConfig = {
-            keyboardShortcut,
-          };
-          ipc.autofill.autotypeMvp.configure(config);
+          //const config: AutotypeConfig = {
+          //  keyboardShortcut,
+          //};
+          // TODO: inform the main process the keyboard shortcut setting changed
+          //       (PM-38967)
         }),
         takeUntil(this.destroy$),
       )
@@ -163,7 +160,8 @@ export class DesktopAutotypeMvpService implements OnDestroy {
     this.autotypeFeatureEnabled$
       .pipe(
         concatMap(async (enabled) => {
-          ipc.autofill.autotypeMvp.toggle(enabled);
+          // TODO: inform the main process the keyboard shortcut setting changed
+          //       (PM-38967)
         }),
         takeUntil(this.destroy$),
       )
@@ -176,7 +174,7 @@ export class DesktopAutotypeMvpService implements OnDestroy {
       // if the user has enabled the setting
       this.autotypeEnabledUserSetting$,
       // if the feature flag is set
-      this.configService.getFeatureFlag$(FeatureFlag.WindowsDesktopAutotype),
+      this.configService.getFeatureFlag$(FeatureFlag.WindowsDesktopAutotypeGA),
       // if there is an active account with an unlocked vault
       this.authService.activeAccountStatus$,
       // if the active user's account is Premium
@@ -201,63 +199,11 @@ export class DesktopAutotypeMvpService implements OnDestroy {
   }
 
   async setAutotypeKeyboardShortcutState(keyboardShortcut: string[]): Promise<void> {
-    await this.autotypeKeyboardShortcut.update(() => keyboardShortcut);
-  }
-
-  async matchCiphersToWindowTitle(windowTitle: string): Promise<CipherView[]> {
-    const URI_PREFIX = "apptitle://";
-    windowTitle = windowTitle.toLowerCase();
-
-    const ciphers = await firstValueFrom(
-      this.accountService.activeAccount$.pipe(
-        map((account) => account?.id),
-        filter((userId): userId is UserId => userId != null),
-        switchMap((userId) => this.cipherService.cipherViews$(userId)),
-      ),
-    );
-
-    const possibleCiphers = ciphers.filter((c) => {
-      return (
-        c.login?.username &&
-        c.login?.password &&
-        c.deletedDate == null &&
-        c.login?.uris.some((u) => {
-          if (u.uri?.indexOf(URI_PREFIX) !== 0) {
-            return false;
-          }
-
-          const uri = u.uri.substring(URI_PREFIX.length).toLowerCase();
-
-          return windowTitle.indexOf(uri) > -1;
-        })
-      );
-    });
-
-    return possibleCiphers;
+    await this.autotypeKeyboardShortcutState.update(() => keyboardShortcut);
   }
 
   ngOnDestroy() {
     this.destroy$.next();
     this.destroy$.complete();
-  }
-}
-
-/**
- * @return an `AutotypeVaultData` object or an `Error` if the
- * cipher or vault data within are undefined.
- */
-export function getAutotypeVaultData(
-  cipherView: CipherView | undefined,
-): Result<AutotypeVaultData> {
-  if (!cipherView) {
-    return [Error("No matching vault item."), null];
-  } else if (cipherView.login.username === undefined || cipherView.login.password === undefined) {
-    return [Error("Vault item is undefined."), null];
-  } else {
-    const vaultData: AutotypeVaultData = {
-      username: cipherView.login.username,
-      password: cipherView.login.password,
-    };
-    return [null, vaultData];
   }
 }

--- a/apps/desktop/src/autofill/services/desktop-autotype.service.ts
+++ b/apps/desktop/src/autofill/services/desktop-autotype.service.ts
@@ -143,13 +143,10 @@ export class DesktopAutotypeService implements OnDestroy {
       )
       .subscribe();
 
-    // listen for changes in keyboard shortcut settings
+    // Listen for changes in keyboard shortcut settings
     this.autotypeKeyboardShortcut$
       .pipe(
         concatMap(async (keyboardShortcut) => {
-          //const config: AutotypeConfig = {
-          //  keyboardShortcut,
-          //};
           // TODO: inform the main process the keyboard shortcut setting changed
           //       (PM-38967)
         }),
@@ -157,6 +154,7 @@ export class DesktopAutotypeService implements OnDestroy {
       )
       .subscribe();
 
+    // Enable or disable Autotype
     this.autotypeFeatureEnabled$
       .pipe(
         concatMap(async (enabled) => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -43,6 +43,7 @@ import { SerializedMemoryStorageService, StorageServiceProvider } from "@bitward
 import { SSOLocalhostCallbackService } from "./auth/services/sso-localhost-callback.service";
 import { DesktopAutofillMain } from "./autofill/main/main-desktop-autofill.service";
 import { MainDesktopAutotypeMvpService } from "./autofill/main/main-desktop-autotype-mvp.service";
+import { MainDesktopAutotypeService } from "./autofill/main/main-desktop-autotype.service";
 import { MainSshAgentService } from "./autofill/main/main-ssh-agent.service";
 import { DesktopAutofillSettingsService } from "./autofill/services/desktop-autofill-settings.service";
 import { DesktopBiometricsService } from "./key-management/biometrics/desktop.biometrics.service";
@@ -107,6 +108,7 @@ export class Main {
   sshAgentService: MainSshAgentService;
   sdkLoadService: SdkLoadService;
   mainDesktopAutotypeMvpService: MainDesktopAutotypeMvpService;
+  mainDesktopAutotypeService: MainDesktopAutotypeService;
   ssoCookieMain: SsoCookieMain;
   ipcService: IpcService;
 
@@ -355,9 +357,14 @@ export class Main {
       this.logService,
       this.windowMain,
     );
+    this.mainDesktopAutotypeService = new MainDesktopAutotypeService(
+      this.logService,
+      this.windowMain,
+    );
 
     app.on("will-quit", () => {
       this.mainDesktopAutotypeMvpService.dispose();
+      this.mainDesktopAutotypeService.dispose();
       this.storageService.dispose();
     });
   }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41885

## 📔 Objective

This PR:
- Adds the render and main process Autotype services, based on the MVP equivalents
- Duplicates `AutotypeKeyboardShortcut` so there is one for MVP and one for GA

These services don't wire up GA yet, but are required for in-flight work to land.
