### PR TITLE
Pick up local SDK rebuilds in desktop watch mode

### DIFF
--- a/apps/desktop/webpack.base.js
+++ b/apps/desktop/webpack.base.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const path = require("path");
 const webpack = require("webpack");
 const { merge } = require("webpack-merge");
@@ -64,6 +65,48 @@ module.exports.buildConfig = function buildConfig(params) {
     },
   };
 
+  // When the @bitwarden SDK is linked to a local build (a `file:` dependency or
+  // `npm link`, which npm materializes as a symlink under node_modules), rebuilding
+  // the SDK does not get picked up by `--watch` for two independent reasons, both of
+  // which must be addressed:
+  //
+  //  1. Webpack treats node_modules as "managed" by default and validates those
+  //     packages by their package.json version rather than by file content. The
+  //     local SDK build keeps a static version, so a rebuild looks unchanged and the
+  //     stale module is served from cache. Excluding the SDK from managedPaths makes
+  //     webpack content-hash it like first-party source.
+  //  2. resolve.symlinks is false, so webpack watches the SDK via its node_modules
+  //     symlink path, but macOS FSEvents delivers change events against the SDK's
+  //     real path, so the native watcher never sees the rebuild. Polling observes
+  //     the files directly and catches it.
+  //
+  // Both are gated on the SDK actually being a local symlink: a normal install pulls
+  // the SDK from the registry as a plain directory, where managed-path caching is
+  // correct and polling would only waste CPU.
+  const sdkLinkPaths = [
+    path.resolve(__dirname, "../../node_modules/@bitwarden/sdk-internal"),
+    path.resolve(process.cwd(), "node_modules/@bitwarden/sdk-internal"),
+  ];
+  const isLocalLinkedSdk = sdkLinkPaths.some((p) => {
+    try {
+      return fs.lstatSync(p).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  });
+  const localSdkWatch = isLocalLinkedSdk
+    ? {
+        snapshot: {
+          managedPaths: [
+            /^(.+?[\\/]node_modules[\\/](?!@bitwarden[\\/](commercial-)?sdk-internal[\\/]))/,
+          ],
+        },
+        watchOptions: {
+          poll: 1000,
+        },
+      }
+    : {};
+
   const getOutputConfig = (isDev) => ({
     filename: "[name].js",
     path: params.outputPath,
@@ -73,6 +116,7 @@ module.exports.buildConfig = function buildConfig(params) {
   const mainConfig = {
     name: "main",
     mode: NODE_ENV,
+    ...localSdkWatch,
     target: "electron-main",
     node: {
       __dirname: false,
@@ -156,6 +200,7 @@ module.exports.buildConfig = function buildConfig(params) {
   const preloadConfig = {
     name: "preload",
     mode: NODE_ENV,
+    ...localSdkWatch,
     target: "electron-preload",
     node: {
       __dirname: false,
@@ -195,6 +240,7 @@ module.exports.buildConfig = function buildConfig(params) {
   const rendererConfig = {
     name: "renderer",
     mode: NODE_ENV,
+    ...localSdkWatch,
     devtool: "source-map",
     target: "web",
     node: {


### PR DESCRIPTION
## 🎟️ Tracking

No Jira ticket — local development DX fix. Surfaced while working with an npm-linked local `@bitwarden/sdk-internal` build: rebuilding the SDK never showed up in the running desktop app under watch mode.

## 📔 Objective

When `@bitwarden/sdk-internal` is linked to a local build (a `file:` dependency or `npm link`, which npm materializes as a `node_modules` symlink), rebuilding the SDK was not picked up by the desktop `--watch` builds. Two independent causes:

1. **Managed-path caching:** webpack validates `node_modules` packages by their `package.json` version rather than by file content. The local SDK build keeps a static version, so a rebuild looks unchanged and the stale module is served from cache.
2. **Watcher misses the change:** `resolve.symlinks` is `false`, so webpack watches the SDK via its `node_modules` symlink path, but macOS FSEvents delivers change events against the SDK's *real* path — so the native watcher never fires on a rebuild.

This change excludes the linked SDK from `snapshot.managedPaths` (so webpack content-hashes it like first-party source) and enables `watchOptions.poll`. Both are **gated on the SDK actually being a local symlink**, so a normal registry install and CI are unaffected: no polling cost, and managed-path caching stays correct for published packages.

Verified against the real desktop renderer config: with the fix a changed SDK wasm is re-emitted on rebuild; without it the watcher never fires. Desktop-only — web/browser use `resolve.symlinks: true` and don't have this problem.

## 📸 Screenshots

N/A — build tooling only, no UI changes.
