### PR TITLE
fix(table-v2): do not accept undefined urlStore values as seeded filter values

### DIFF
--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.stories.ts
@@ -239,12 +239,13 @@ type StoryArgs = {
 // these also control which chips appear.
 const ORGANIZATION_OPTIONS = [
   {
-    value: { id: MY_VAULT } as Organization,
+    value: { id: MY_VAULT, enabled: true } as Organization,
     label: "My vault",
     iconTile: personalIconTile("brand"),
+    enabled: true,
   },
   {
-    value: { id: "org-engineering" } as Organization,
+    value: { id: "org-engineering", enabled: true } as Organization,
     label: "Acme Co",
     iconTile: orgIconTile(ProductTierType.Enterprise),
   },

--- a/libs/components/src/table/v2/table-v2.component.router.spec.ts
+++ b/libs/components/src/table/v2/table-v2.component.router.spec.ts
@@ -68,6 +68,33 @@ class TestHostComponent {
   readonly collectionIds = signal<string[]>([]);
 }
 
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    BitTableV2Component,
+    BitColumnComponent,
+    BitCellDefDirective,
+    BitHeaderCellComponent,
+    BitCellComponent,
+    FilterMenuModule,
+  ],
+  template: `
+    <bit-table-v2 [tableDef]="table" [filters]="filtersInput()">
+      <bit-filter-menu key="type" placeholderText="Type">
+        <bit-filter-option [value]="'login'">Login</bit-filter-option>
+      </bit-filter-menu>
+      <bit-column>
+        <bit-header-cell>Name</bit-header-cell>
+        <bit-cell *bitCellDef="table.columns.name; let row">{{ row.name }}</bit-cell>
+      </bit-column>
+    </bit-table-v2>
+  `,
+})
+class FilterSeedHostComponent {
+  protected readonly table = defineTable<Row>(signal<Row[]>([]));
+  readonly filtersInput = signal<{ type?: string } | undefined>(undefined);
+}
+
 describe("BitTableV2Component (router integration)", () => {
   async function setup(url: string) {
     TestBed.configureTestingModule({
@@ -97,6 +124,29 @@ describe("BitTableV2Component (router integration)", () => {
 
     // Its own seeding effect should have picked up the still-present URL value...
     expect(router.url).toContain("vault.sharedFolder=abc123");
+  });
+
+  it("applies [filters] values that resolve after the write-back effect has fired", async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([{ path: "**", component: FilterSeedHostComponent }]),
+        { provide: I18nService, useValue: mockI18nService },
+        { provide: DialogService, useValue: mockDialogService },
+      ],
+    });
+    const harness = await RouterTestingHarness.create("/");
+    const host = harness.routeDebugElement!.componentInstance as FilterSeedHostComponent;
+    const table = harness.fixture.debugElement.query(By.directive(BitTableV2Component))
+      .componentInstance as BitTableV2Component<Row>;
+
+    expect(table.filterValues()["type"]).toBeUndefined();
+
+    // Async data resolves and [filters] receives its real value.
+    host.filtersInput.set({ type: "login" });
+    harness.detectChanges();
+    await harness.fixture.whenStable();
+
+    expect(table.filterValues()["type"]).toBe("login");
   });
 
   // The store types params by shape, so an all-digit term decodes to a number. It has to

--- a/libs/components/src/table/v2/table-v2.component.ts
+++ b/libs/components/src/table/v2/table-v2.component.ts
@@ -413,7 +413,7 @@ export class BitTableV2Component<T = unknown, S extends string = never, F = Reco
           continue;
         }
         let value: unknown;
-        if (key in fromUrl) {
+        if (fromUrl[key] != null) {
           value = fromUrl[key];
         } else if (initial && key in initial) {
           value = initial[key];


### PR DESCRIPTION
## Tracking

[PM-42970](https://bitwarden.atlassian.net/browse/PM-42970)

## Objective

Fixes an issue where filter values passed via `[filters]` were silently dropped on initial load.

### Root cause
 - `bit-table-v2` has two effects that interact on startup:
   - A seeding effect that initializes filter chips from either the URL store or the `[filters]` input, whichever has the key first. Once a chip is seeded it is skipped on future runs.
  - A write-back effect that mirrors active filter state back to the URL store.
 
    When `filters` depends on data that resolves asynchronously (like pulling save data from state), the write-back effect can fire first before the real values are available, and populate the URL store with `{ organization: undefined, cipherType: undefined, ... }`. On the seeding effect's next run, `key in fromUrl` matched those keys, the chips were seeded with `undefined` and marked done, and the real values from `[filters]` were never applied.

### Fix
- Added a `!= null` guard to the URL-store branch so that an `undefined` entry in the store is treated as absent, allowing the `[filters]` fallback to apply normally. This feels like an appropriate fix as I would not expect an `undefined/null` value to come via a query parameter. But I'm open to feedback if there is another way to address.

## Screenshots

<video src="https://github.com/user-attachments/assets/fdf72d15-fe82-4cf6-bb10-3e22cf5e66de" />

 

[PM-42970]: https://bitwarden.atlassian.net/browse/PM-42970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ