### PR TITLE
[PM-43219] Fix autosave notifications after switching tabs

### DIFF
--- a/apps/browser/src/autofill/background/abstractions/notification.background.ts
+++ b/apps/browser/src/autofill/background/abstractions/notification.background.ts
@@ -3,6 +3,7 @@ import { ServerConfig } from "@bitwarden/common/platform/abstractions/config/ser
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 
+import { NotificationCipherData } from "../../content/components/cipher/types";
 import { CollectionView } from "../../content/components/common-types";
 import { NotificationType } from "../../enums/notification-type.enum";
 import AutofillPageDetails from "../../models/autofill-page-details";
@@ -126,6 +127,7 @@ type BackgroundOnMessageHandlerParams = BackgroundMessageParam & BackgroundSende
 export type NotificationBackgroundExtensionMessageHandlers = {
   [key: string]: CallableFunction;
   unlockCompleted: ({ message, sender }: BackgroundOnMessageHandlerParams) => Promise<void>;
+  bgGetDecryptedCiphers: ({ sender }: BackgroundSenderParam) => Promise<NotificationCipherData[]>;
   bgGetFolderData: ({ message, sender }: BackgroundOnMessageHandlerParams) => Promise<FolderView[]>;
   bgGetCollectionData: ({
     message,

--- a/apps/browser/src/autofill/background/notification.background.spec.ts
+++ b/apps/browser/src/autofill/background/notification.background.spec.ts
@@ -1,5 +1,5 @@
 import { mock, MockProxy } from "jest-mock-extended";
-import { BehaviorSubject, firstValueFrom, of } from "rxjs";
+import { BehaviorSubject, firstValueFrom, of, Subject } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
@@ -348,6 +348,174 @@ describe("NotificationBackground", () => {
       sendMockExtensionMessage(message);
 
       expect(notificationBackground["handleSaveCipherMessage"]).not.toHaveBeenCalled();
+    });
+
+    describe("bgGetDecryptedCiphers message handler", () => {
+      beforeEach(() => {
+        activeAccountStatusMock$.next(AuthenticationStatus.Unlocked);
+        domainSettingsService.showFavicons$ = of(false);
+        environmentService.environment$ = of(new SelfHostedEnvironment({}));
+        organizationService.organizations$.mockReturnValue(of([]));
+        cipherService.getAllDecryptedForUrl.mockResolvedValue([]);
+        jest.spyOn(BrowserApi, "tabSendMessageData").mockResolvedValue(undefined);
+      });
+
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      it("returns the sender's new login preview when another tab is active", async () => {
+        const tab = createChromeTabMock({ url: "https://example.com", active: false });
+        await notificationBackground.triggerAddLoginNotification(
+          {
+            uri: "https://example.com",
+            username: "source-user",
+            password: "test-password",
+            newPassword: "",
+          },
+          tab,
+        );
+        jest
+          .spyOn(BrowserApi, "getTabFromCurrentWindow")
+          .mockResolvedValue(createChromeTabMock({ id: 2, url: "https://example.org" }));
+        const sendResponse = jest.fn();
+
+        sendMockExtensionMessage({ command: "bgGetDecryptedCiphers" }, { tab }, sendResponse);
+        await flushPromises();
+
+        expect(sendResponse).toHaveBeenCalledWith([
+          expect.objectContaining({ name: "example.com", login: { username: "source-user" } }),
+        ]);
+      });
+
+      it("returns only the sender's update candidates when another tab has a notification", async () => {
+        const tab = createChromeTabMock({ url: "https://example.com", active: false });
+        const otherTab = createChromeTabMock({ id: 2, url: "https://example.org" });
+        const sourceCipher = mock<CipherView>({
+          id: "source-login",
+          name: "Source login",
+          login: { username: "source-user", password: "saved-password" },
+        });
+        const otherCipher = mock<CipherView>({
+          id: "other-login",
+          name: "Other login",
+          login: { username: "other-user", password: "saved-password" },
+        });
+        cipherService.getAllDecryptedForUrl
+          .mockResolvedValueOnce([sourceCipher])
+          .mockResolvedValueOnce([otherCipher]);
+        await notificationBackground.triggerChangedPasswordNotification(
+          {
+            uri: "https://example.com",
+            username: "source-user",
+            password: "",
+            newPassword: "new-password",
+          },
+          tab,
+        );
+        await notificationBackground.triggerChangedPasswordNotification(
+          {
+            uri: "https://example.org",
+            username: "other-user",
+            password: "",
+            newPassword: "new-password",
+          },
+          otherTab,
+        );
+        cipherService.getAllDecrypted.mockResolvedValue([sourceCipher, otherCipher]);
+        jest.spyOn(BrowserApi, "getTabFromCurrentWindow").mockResolvedValue(otherTab);
+        const sendResponse = jest.fn();
+
+        sendMockExtensionMessage({ command: "bgGetDecryptedCiphers" }, { tab }, sendResponse);
+        await flushPromises();
+
+        expect(sendResponse).toHaveBeenCalledWith([
+          expect.objectContaining({ id: "source-login", name: "Source login" }),
+        ]);
+      });
+
+      it("preserves the sender's login while notification metadata is loading", async () => {
+        const tab = createChromeTabMock({ url: "https://example.com" });
+        await notificationBackground.triggerAddLoginNotification(
+          {
+            uri: "https://example.com",
+            username: "source-user",
+            password: "test-password",
+            newPassword: "",
+          },
+          tab,
+        );
+        const environment = new Subject<SelfHostedEnvironment>();
+        environmentService.environment$ = environment;
+        const activeTab = jest.spyOn(BrowserApi, "getTabFromCurrentWindow").mockResolvedValue(tab);
+        const sendResponse = jest.fn();
+
+        sendMockExtensionMessage({ command: "bgGetDecryptedCiphers" }, { tab }, sendResponse);
+        await flushPromises();
+        expect(sendResponse).not.toHaveBeenCalled();
+        activeTab.mockResolvedValue(createChromeTabMock({ id: 2, url: "https://example.org" }));
+        environment.next(new SelfHostedEnvironment({}));
+        environment.complete();
+        await flushPromises();
+
+        expect(sendResponse).toHaveBeenCalledWith([
+          expect.objectContaining({ name: "example.com", login: { username: "source-user" } }),
+        ]);
+      });
+
+      it("looks up the sender's saved logins when no notification is queued", async () => {
+        const tab = createChromeTabMock({ url: "https://example.com", active: false });
+        const sourceCipher = mock<CipherView>({ id: "source-login", name: "Source login" });
+        const savedLogins = new Map([["https://example.com", [sourceCipher]]]);
+        cipherService.getAllDecryptedForUrl.mockImplementation(
+          async (url) => savedLogins.get(url) ?? [],
+        );
+        jest
+          .spyOn(BrowserApi, "getTabFromCurrentWindow")
+          .mockResolvedValue(createChromeTabMock({ id: 2, url: "https://example.org" }));
+        const sendResponse = jest.fn();
+
+        sendMockExtensionMessage({ command: "bgGetDecryptedCiphers" }, { tab }, sendResponse);
+        await flushPromises();
+
+        expect(sendResponse).toHaveBeenCalledWith([
+          expect.objectContaining({ id: "source-login", name: "Source login" }),
+        ]);
+      });
+
+      it.each([
+        ["tab", undefined],
+        ["tab ID", createChromeTabMock({ id: undefined })],
+        ["tab URL", createChromeTabMock({ url: undefined })],
+      ])("returns no notification data when the sender's %s is missing", async (_, tab) => {
+        const sendResponse = jest.fn();
+
+        sendMockExtensionMessage({ command: "bgGetDecryptedCiphers" }, { tab }, sendResponse);
+        await flushPromises();
+
+        expect(sendResponse).toHaveBeenCalledWith([]);
+      });
+
+      it.each([
+        ["another tab", createChromeTabMock({ id: 2, url: "https://example.com" })],
+        ["another domain", createChromeTabMock({ url: "https://example.org" })],
+      ])("keeps a queued login separate from %s", async (_, tab) => {
+        await notificationBackground.triggerAddLoginNotification(
+          {
+            uri: "https://example.com",
+            username: "source-user",
+            password: "test-password",
+            newPassword: "",
+          },
+          createChromeTabMock({ url: "https://example.com" }),
+        );
+        const sendResponse = jest.fn();
+
+        sendMockExtensionMessage({ command: "bgGetDecryptedCiphers" }, { tab }, sendResponse);
+        await flushPromises();
+
+        expect(sendResponse).toHaveBeenCalledWith([]);
+      });
     });
 
     describe("unlockCompleted message handler", () => {
@@ -2732,11 +2900,42 @@ describe("NotificationBackground", () => {
           expect(createWithServerSpy).not.toHaveBeenCalled();
         });
 
+        it.each([undefined, "unlisted-cipher"])(
+          "ignores an update target outside the notification's candidates (%s)",
+          async (cipherId) => {
+            const tab = createChromeTabMock({ url: "https://example.com" });
+            const storedCipher = mock<CipherView>({
+              id: "candidate-cipher",
+              login: { username: "testUser" },
+            });
+            enableChangedPasswordPromptMock$.next(true);
+            getAllDecryptedForUrlSpy.mockResolvedValueOnce([storedCipher]);
+            await expect(
+              notificationBackground.triggerChangedPasswordNotification(
+                {
+                  uri: "https://example.com",
+                  username: "testUser",
+                  password: "",
+                  newPassword: "new-password",
+                },
+                tab,
+              ),
+            ).resolves.toBe(true);
+
+            sendMockExtensionMessage({ command: "bgSaveCipher", cipherId }, { tab });
+            await flushPromises();
+
+            expect(cipherService.get).not.toHaveBeenCalled();
+            expect(updateWithServerSpy).not.toHaveBeenCalled();
+          },
+        );
+
         it("updates the password if the notification message type is for ChangePassword", async () => {
           const tab = createChromeTabMock({ id: 1, url: "https://example.com" });
           const sender = mock<chrome.runtime.MessageSender>({ tab });
           const message: NotificationBackgroundExtensionMessage = {
             command: "bgSaveCipher",
+            cipherId: "testId",
             edit: false,
             folder: "folder-id",
           };
@@ -2744,7 +2943,7 @@ describe("NotificationBackground", () => {
             type: NotificationType.ChangePassword,
             tab,
             domain: "example.com",
-            data: { newPassword: "newPassword" },
+            data: { cipherIds: ["testId"], newPassword: "newPassword" },
           });
           notificationBackground["notificationQueue"] = [queueMessage];
           const cipherView = mock<CipherView>({
@@ -2786,6 +2985,7 @@ describe("NotificationBackground", () => {
           const sender = mock<chrome.runtime.MessageSender>({ tab });
           const message: NotificationBackgroundExtensionMessage = {
             command: "bgSaveCipher",
+            cipherId: "testId",
             edit: false,
             folder: "folder-id",
           };
@@ -2793,7 +2993,7 @@ describe("NotificationBackground", () => {
             type: NotificationType.ChangePassword,
             tab,
             domain: "example.com",
-            data: { newPassword: "newPassword" },
+            data: { cipherIds: ["testId"], newPassword: "newPassword" },
           });
           notificationBackground["notificationQueue"] = [queueMessage];
           const cipherView = mock<CipherView>({
@@ -2863,6 +3063,7 @@ describe("NotificationBackground", () => {
           const sender = mock<chrome.runtime.MessageSender>({ tab });
           const message: NotificationBackgroundExtensionMessage = {
             command: "bgSaveCipher",
+            cipherId: "testId",
             edit: false,
             folder: "folder-id",
           };
@@ -2870,7 +3071,7 @@ describe("NotificationBackground", () => {
             type: NotificationType.ChangePassword,
             tab,
             domain: "example.com",
-            data: { newPassword: "newPassword" },
+            data: { cipherIds: ["testId"], newPassword: "newPassword" },
           });
           notificationBackground["notificationQueue"] = [queueMessage];
           const cipherView = mock<CipherView>({
@@ -2953,6 +3154,7 @@ describe("NotificationBackground", () => {
           const sender = mock<chrome.runtime.MessageSender>({ tab });
           const message: NotificationBackgroundExtensionMessage = {
             command: "bgSaveCipher",
+            cipherId: "testId",
             edit: true,
             folder: "folder-id",
           };
@@ -2960,7 +3162,7 @@ describe("NotificationBackground", () => {
             type: NotificationType.ChangePassword,
             tab,
             domain: "example.com",
-            data: { newPassword: "newPassword" },
+            data: { cipherIds: ["testId"], newPassword: "newPassword" },
           });
           notificationBackground["notificationQueue"] = [queueMessage];
           const cipherView = mock<CipherView>();
@@ -3148,6 +3350,7 @@ describe("NotificationBackground", () => {
           const sender = mock<chrome.runtime.MessageSender>({ tab });
           const message: NotificationBackgroundExtensionMessage = {
             command: "bgSaveCipher",
+            cipherId: "testId",
             edit: false,
             folder: "folder-id",
           };
@@ -3155,7 +3358,7 @@ describe("NotificationBackground", () => {
             type: NotificationType.ChangePassword,
             tab,
             domain: "example.com",
-            data: { newPassword: "newPassword" },
+            data: { cipherIds: ["testId"], newPassword: "newPassword" },
           });
           notificationBackground["notificationQueue"] = [queueMessage];
           const cipherView = mock<CipherView>({ reprompt: CipherRepromptType.None });

--- a/apps/browser/src/autofill/background/notification.background.ts
+++ b/apps/browser/src/autofill/background/notification.background.ts
@@ -125,7 +125,7 @@ export default class NotificationBackground {
     bgOpenChangePasswordUrl: ({ message, sender }) =>
       this.handleOpenChangePasswordUrlMessage(message, sender),
     bgGetActiveUserServerConfig: () => this.getActiveUserServerConfig(),
-    bgGetDecryptedCiphers: () => this.getNotificationCipherData(),
+    bgGetDecryptedCiphers: ({ sender }) => this.getNotificationCipherData(sender.tab),
     bgGetEnableChangedPasswordPrompt: () => this.getEnableChangedPasswordPrompt(),
     bgGetEnableAddedLoginPrompt: () => this.getEnableAddedLoginPrompt(),
     bgGetExcludedDomains: () => this.getExcludedDomains(),
@@ -223,28 +223,32 @@ export default class NotificationBackground {
 
   /**
    *
-   * Gets the current active tab and retrieves the relevant decrypted cipher
-   * for the tab's URL. It constructs and returns an array of `NotificationCipherData` objects or a singular object.
-   * If no active tab or URL is found, it returns an empty array.
+   * Retrieves the relevant decrypted ciphers for the tab hosting the notification.
+   * It constructs and returns an array of `NotificationCipherData` objects.
+   * If the tab or its URL is missing, it returns an empty array.
    * If new login, returns a preview of the cipher.
    *
+   * @param tab - The tab that requested the notification data
    * @returns {Promise<NotificationCipherData[]>}
    */
 
-  async getNotificationCipherData(): Promise<NotificationCipherData[]> {
-    const [currentTab, showFavicons, env, activeUserId] = await Promise.all([
-      BrowserApi.getTabFromCurrentWindow(),
+  async getNotificationCipherData(tab?: chrome.tabs.Tab): Promise<NotificationCipherData[]> {
+    if (tab?.id == null || !tab.url) {
+      return [];
+    }
+
+    const [showFavicons, env, activeUserId] = await Promise.all([
       firstValueFrom(this.domainSettingsService.showFavicons$),
       firstValueFrom(this.environmentService.environment$),
       firstValueFrom(this.accountService.activeAccount$.pipe(getOptionalUserId)),
     ]);
 
-    if (!currentTab?.url || !activeUserId) {
+    if (!activeUserId) {
       return [];
     }
 
     const [decryptedCiphers, organizations] = await Promise.all([
-      this.cipherService.getAllDecryptedForUrl(currentTab.url, activeUserId),
+      this.cipherService.getAllDecryptedForUrl(tab.url, activeUserId),
       firstValueFrom(this.organizationService.organizations$(activeUserId)),
     ]);
 
@@ -257,9 +261,8 @@ export default class NotificationBackground {
       (message): message is AddChangePasswordNotificationQueueMessage | AddLoginQueueMessage =>
         (message.type === NotificationType.ChangePassword ||
           message.type === NotificationType.AddLogin) &&
-        currentTab.id != null &&
-        message.tab.id === currentTab.id &&
-        this.queueMessageIsFromTabOrigin(message, currentTab),
+        message.tab.id === tab.id &&
+        this.queueMessageIsFromTabOrigin(message, tab),
     );
 
     if (cipherQueueMessage) {
@@ -1432,8 +1435,12 @@ export default class NotificationBackground {
 
       if (queueMessage.type === NotificationType.ChangePassword) {
         const {
-          data: { newPassword },
+          data: { cipherIds, newPassword },
         } = queueMessage;
+        if (!cipherIds.includes(cipherId)) {
+          continue;
+        }
+
         const cipherView = await this.getDecryptedCipherById(cipherId, activeUserId);
         if (cipherView == null) {
           continue;


### PR DESCRIPTION
## 🎟️ Tracking

Discovered in the browser extension; related to #19711.

## 📔 Objective

Switching tabs while an autosave notification loads can show another site's logins. Use the sender's tab for notification data and validate update targets against the queued candidates.

### Reproduction

1. Submit a login or password-change form.
2. Before the form submission response triggers the notification, switch to another existing tab with a saved login.
3. Check the resulting autosave notification.

It can show the other tab's login.
