### PR TITLE
[CL-1318] Prevent pages with small y-scroll from snapping back to top when scrolled

### DIFF
--- a/apps/browser/src/platform/popup/layout/popup-header.component.html
+++ b/apps/browser/src/platform/popup/layout/popup-header.component.html
@@ -53,7 +53,12 @@
     </div>
   }
 
-  <div data-testid="title-bar" [attr.data-state]="titleBarState()" [class]="titleBarClasses()">
+  <div
+    #titleBar
+    data-testid="title-bar"
+    [attr.data-state]="titleBarState()"
+    [class]="titleBarClasses()"
+  >
     <!-- `tw-min-h-0` lets the grid row shrink past this row's content height as the bar collapses. -->
     <div class="tw-max-w-screen-sm tw-mx-auto tw-flex tw-justify-between tw-w-full tw-min-h-0">
       <!--

--- a/apps/browser/src/platform/popup/layout/popup-header.component.ts
+++ b/apps/browser/src/platform/popup/layout/popup-header.component.ts
@@ -2,11 +2,13 @@ import { NgTemplateOutlet } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   booleanAttribute,
   computed,
   inject,
   input,
   linkedSignal,
+  viewChild,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { of } from "rxjs";
@@ -100,11 +102,16 @@ export class PopupHeaderComponent {
     return this.popupRouterCacheService.back();
   });
 
+  private readonly titleBar = viewChild<ElementRef<HTMLElement>>("titleBar");
+
   /**
    * The popup viewport is short, so the title bar gets out of the way while the user reads down the
    * page. The app bar stays pinned.
    */
-  private readonly scrollDirection = scrollDirection(this.scrollLayout.scrollableRef);
+  private readonly scrollDirection = scrollDirection(this.scrollLayout.scrollableRef, {
+    // Measured live because the height moves with compact mode and with a title that wraps
+    minScrollable: () => this.titleBar()?.nativeElement.offsetHeight ?? 0,
+  });
 
   /**
    * TODO: remove with the VFO1Foundation flag. Grows a border under an `alt` bar once the page

--- a/libs/components/src/utils/scroll-direction.spec.ts
+++ b/libs/components/src/utils/scroll-direction.spec.ts
@@ -146,6 +146,65 @@ describe("scrollDirection", () => {
     expect(direction()).toBe("down");
   });
 
+  describe("minScrollable", () => {
+    /**
+     * Redefinable because collapsing chrome hands its height back to the scroll region, which is
+     * the whole reason a floor is needed.
+     */
+    const setClientHeight = (element: HTMLElement, clientHeight: number) =>
+      Object.defineProperty(element, "clientHeight", { value: clientHeight, configurable: true });
+
+    it("holds up when the region cannot outscroll the chrome a consumer would collapse", async () => {
+      // 40px of overflow against a 48px title bar: collapsing it would leave nothing to scroll, so
+      // the browser would clamp the offset back to the top and the bar would expand again.
+      const element = createScrollable(540, 500);
+      const direction = create(signal(element), { minScrollable: 48 });
+
+      await scrollTo(element, 30);
+      expect(direction()).toBe("up");
+    });
+
+    it("flips once the region can outscroll that chrome", async () => {
+      const element = createScrollable(600, 500);
+      const direction = create(signal(element), { minScrollable: 48 });
+
+      await scrollTo(element, 30);
+      expect(direction()).toBe("down");
+    });
+
+    it("holds down after the collapse shrinks maxTop past the floor", async () => {
+      const element = createScrollable(560, 500);
+      const direction = create(signal(element), { minScrollable: 48 });
+
+      // maxTop is 60, which clears the floor, so the consumer collapses its chrome.
+      await scrollTo(element, 55);
+      expect(direction()).toBe("down");
+
+      // That hands 48px back to the scroll region, leaving 12px of overflow and clamping the
+      // offset. Re-testing the floor here would expand the chrome and start the cycle over.
+      setClientHeight(element, 548);
+      await scrollTo(element, 12);
+      expect(direction()).toBe("down");
+    });
+
+    it("reads a callback floor on each flip, for chrome that is measured after the first render", async () => {
+      const element = createScrollable(540, 500);
+      let chromeHeight = 0;
+      const direction = create(signal(element), { minScrollable: () => chromeHeight });
+
+      await scrollTo(element, 30);
+      expect(direction()).toBe("down");
+
+      await scrollTo(element, 0);
+      expect(direction()).toBe("up");
+
+      chromeHeight = 48;
+
+      await scrollTo(element, 30);
+      expect(direction()).toBe("up");
+    });
+  });
+
   it("does not flip on a viewport-sized jump", async () => {
     const element = createScrollable(2000, 500);
     const direction = create(signal(element));

--- a/libs/components/src/utils/scroll-direction.ts
+++ b/libs/components/src/utils/scroll-direction.ts
@@ -22,6 +22,19 @@ export type ScrollDirectionOptions = {
    * clamps `scrollTop`, and the smaller offset would otherwise read as `"up"`.
    */
   bottomOffset?: number;
+
+  /**
+   * How far the region must be able to scroll before `"down"` is reported at all.
+   *
+   * Without a floor here, a consumer that collapses chrome on `"down"` can get stuck in a loop: the
+   * collapse gives that height back to the scroll region, and if there wasn't much to scroll to
+   * begin with, the browser snaps back to the top — which reads as `"up"`, reopens the chrome, and
+   * leaves the next scroll to start the loop over.
+   *
+   * Pass the height of the chrome being collapsed. Use a callback to measure it live — it is only
+   * read while scrolling `"up"`, when that chrome is expanded.
+   */
+  minScrollable?: number | (() => number);
 };
 
 type ScrollDirectionState = {
@@ -55,8 +68,16 @@ const nativeElement = (
  */
 export const scrollDirection = (
   scrollable: Signal<ElementRef<HTMLElement> | HTMLElement | null | undefined>,
-  { threshold = 16, topOffset = 0, bottomOffset = 24 }: ScrollDirectionOptions = {},
+  {
+    threshold = 16,
+    topOffset = 0,
+    bottomOffset = 24,
+    minScrollable = 0,
+  }: ScrollDirectionOptions = {},
 ): Signal<ScrollDirection> => {
+  const readMinScrollable =
+    typeof minScrollable === "function" ? minScrollable : () => minScrollable;
+
   const element$ = toObservable(scrollable).pipe(map(nativeElement));
 
   const direction$ = element$.pipe(
@@ -75,6 +96,13 @@ export const scrollDirection = (
         })),
         scan((state: ScrollDirectionState, { top, maxTop, viewport }): ScrollDirectionState => {
           if (maxTop <= 0 || top <= topOffset) {
+            return { direction: "up", anchor: top };
+          }
+
+          // Gates the flip only. Once `"down"`, the collapsed chrome has legitimately reduced
+          // `maxTop`, and re-testing it here would expand the chrome again. Equality still fails:
+          // giving back exactly `maxTop` leaves nothing to scroll.
+          if (state.direction === "up" && maxTop <= readMinScrollable()) {
             return { direction: "up", anchor: top };
           }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1318](https://bitwarden.atlassian.net/browse/CL-1318)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix a bug where extension pages with only a small amount of y-axis scroll were unable to be scrolled, because the title collapse animation snapped the page back to the top too quickly.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:

https://github.com/user-attachments/assets/d8153dff-00e5-4222-9933-d202c8fe27ed


After:


https://github.com/user-attachments/assets/8a5f1e87-47a2-46c3-a2d6-1af48e596eb5



[CL-1318]: https://bitwarden.atlassian.net/browse/CL-1318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ