### PR TITLE
[PM-42490] feat: Add right click menu to the VFO1 vault table

### DIFF
--- a/libs/vault/src/components/vault-items-table/vault-items-table-actions-column.component.html
+++ b/libs/vault/src/components/vault-items-table/vault-items-table-actions-column.component.html
@@ -42,6 +42,7 @@
           size="small"
           [label]="'optionsForItem' | i18n: row.name"
           [bitMenuTriggerFor]="rowMenu"
+          vaultItemsTableRowContextMenu
         ></button>
         <bit-menu #rowMenu>
           @for (rowAction of actions; track rowAction.id) {

--- a/libs/vault/src/components/vault-items-table/vault-items-table-actions-column.component.spec.ts
+++ b/libs/vault/src/components/vault-items-table/vault-items-table-actions-column.component.spec.ts
@@ -364,4 +364,70 @@ describe("VaultItemsTableActionsColumnComponent", () => {
       expect(cipherService.updateLastLaunchedDate).not.toHaveBeenCalled();
     });
   });
+
+  describe("right-click context menu", () => {
+    /** The rendered data rows, which are what the context menu listener binds to. */
+    function rows(): HTMLElement[] {
+      return Array.from(fixture.nativeElement.querySelectorAll('bit-row[role="row"]'));
+    }
+
+    /**
+     * Right-clicks a row at a point well away from the actions cell, so a menu that opens proves
+     * the listener covers the whole row rather than just the trigger button.
+     */
+    function rightClickRow(rowIndex: number, init: MouseEventInit = {}): MouseEvent {
+      const event = new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 10,
+        ...init,
+      });
+      rows()[rowIndex].dispatchEvent(event);
+      fixture.detectChanges();
+      return event;
+    }
+
+    function openMenuItems(): HTMLButtonElement[] {
+      return Array.from(document.querySelectorAll("[bitMenuItem]"));
+    }
+
+    beforeEach(() => {
+      host.ciphers.set([loginCipher({ id: "a" }), loginCipher({ id: "b", name: "Apple" })]);
+      host.rowActions.set([
+        { id: "edit", label: "Edit", icon: "bwi-pencil-square", run: jest.fn() },
+      ]);
+      fixture.detectChanges();
+    });
+
+    it("opens the row's overflow menu when the row is right-clicked", () => {
+      rightClickRow(0);
+
+      expect(openMenuItems().length).toBeGreaterThan(0);
+    });
+
+    it("suppresses the native menu so the row menu replaces it", () => {
+      const event = rightClickRow(0);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("gives each row's menu that row's own item", () => {
+      const run = jest.fn();
+      host.rowActions.set([{ id: "edit", label: "Edit", icon: "bwi-pencil-square", run }]);
+      fixture.detectChanges();
+
+      rightClickRow(1);
+      openMenuItems()[0].click();
+
+      expect(run).toHaveBeenCalledWith(expect.objectContaining({ id: "b" }));
+    });
+
+    it("lets shift+ctrl through to the native browser menu", () => {
+      const event = rightClickRow(0, { shiftKey: true, ctrlKey: true });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(openMenuItems()).toHaveLength(0);
+    });
+  });
 });

--- a/libs/vault/src/components/vault-items-table/vault-items-table-actions-column.component.ts
+++ b/libs/vault/src/components/vault-items-table/vault-items-table-actions-column.component.ts
@@ -32,6 +32,7 @@ import {
   VaultItemsTableCopyPresentation,
 } from "./vault-items-table-copy-presentation";
 import { VaultItemsTableRowAction } from "./vault-items-table-row-action";
+import { VaultItemsTableRowContextMenuDirective } from "./vault-items-table-row-context-menu.directive";
 import type { VaultItemsTableColumn } from "./vault-items-table.component";
 
 /**
@@ -63,6 +64,7 @@ import type { VaultItemsTableColumn } from "./vault-items-table.component";
     MenuModule,
     PremiumBadgeComponent,
     VaultItemCopyActionsComponent,
+    VaultItemsTableRowContextMenuDirective,
     SkeletonTextComponent,
   ],
 })

--- a/libs/vault/src/components/vault-items-table/vault-items-table-row-context-menu.directive.ts
+++ b/libs/vault/src/components/vault-items-table/vault-items-table-row-context-menu.directive.ts
@@ -23,7 +23,7 @@ export class VaultItemsTableRowContextMenuDirective implements AfterViewInit, On
   private row: HTMLElement | null = null;
 
   private readonly onContextMenu = (event: MouseEvent) => {
-    // Shift+Ctrl is the escape hatch to the native browser/Electron menu, matching the pre-VFO1 rows.
+    // Shift+Ctrl is the escape hatch to the native browser/Electron menu.
     if (event.shiftKey && event.ctrlKey) {
       return;
     }

--- a/libs/vault/src/components/vault-items-table/vault-items-table-row-context-menu.directive.ts
+++ b/libs/vault/src/components/vault-items-table/vault-items-table-row-context-menu.directive.ts
@@ -1,0 +1,44 @@
+import { AfterViewInit, Directive, ElementRef, OnDestroy, inject } from "@angular/core";
+
+import { MenuTriggerForDirective } from "@bitwarden/components";
+
+/**
+ * Opens a row's overflow menu on right-click, anchored at the cursor.
+ *
+ * Applied to the overflow trigger in the actions cell, but the listener is bound to the enclosing
+ * `role="row"` element: right-click has to work anywhere on the row, while the menu it opens lives
+ * in this cell. The row element is rendered by `bit-table-v2`, which is generic and knows nothing
+ * about vault menus, so the ancestor is resolved from the DOM rather than injected.
+ *
+ * The listener is added natively rather than through a host binding because the target is outside
+ * this directive's own host.
+ */
+@Directive({
+  selector: "[vaultItemsTableRowContextMenu]",
+})
+export class VaultItemsTableRowContextMenuDirective implements AfterViewInit, OnDestroy {
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly menuTrigger = inject(MenuTriggerForDirective, { self: true });
+
+  private row: HTMLElement | null = null;
+
+  private readonly onContextMenu = (event: MouseEvent) => {
+    // Shift+Ctrl is the escape hatch to the native browser/Electron menu, matching the pre-VFO1 rows.
+    if (event.shiftKey && event.ctrlKey) {
+      return;
+    }
+
+    this.menuTrigger.toggleMenuOnRightClick(event);
+  };
+
+  /** Resolved here rather than in the constructor: the host isn't in the DOM until the view inits. */
+  ngAfterViewInit() {
+    this.row = this.elementRef.nativeElement.closest<HTMLElement>('[role="row"]');
+    this.row?.addEventListener("contextmenu", this.onContextMenu);
+  }
+
+  ngOnDestroy() {
+    this.row?.removeEventListener("contextmenu", this.onContextMenu);
+    this.row = null;
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42490

## 📔 Objective

Re-adds right-click support to the vault item table under the VFO1 UX, for both web and desktop.

The pre-VFO1 vault rows opened their overflow menu on right-click through a `@HostListener("contextmenu")` on the row component itself, with the menu trigger available as a `@ViewChild`. The VFO1 table renders rows with the generic `bit-row` primitive from the component library, which knows nothing about vault menus, so that listener had nowhere to live and the affordance was dropped in the rewrite.

This adds `VaultItemsTableRowContextMenuDirective`, applied to the existing overflow trigger in the actions column:

- It sits **on the ellipsis button** so it can `inject(MenuTriggerForDirective, { self: true })` — that button is what instantiates the trigger which owns the `bit-menu`.
- It binds its listener to the **enclosing `role="row"` ancestor**, resolved with `closest()`, so right-click works anywhere on the row rather than only over the narrow actions cell.

Splitting those two elements is what makes a directive necessary; a plain `(contextmenu)` binding in the template could only ever attach to the actions cell. Keeping the logic in `libs/vault` also avoids pushing a context-menu concept into the shared table primitive.

Notes on scope:

- **Menu contents are unchanged.** Right-click opens the same overflow menu the ellipsis button already opens, built from `CipherRowMenuService`. On web that is a smaller set than the pre-VFO1 menu (no copy-field submenu, launch, or events items); restoring those is separate work if wanted.
- **Quick copy actions are untouched** — they remain hover-revealed in the actions column and are not duplicated into the context menu.
- **Shift+Ctrl still falls through** to the native browser/Electron menu, matching the previous rows.
- Web and desktop share this component, so both clients pick the behavior up with no per-app changes.

## 📸 Screenshots


https://github.com/user-attachments/assets/b763d786-73cf-46f8-92e1-6d20f594a4ed


