### PR TITLE
[PM-43238] [PM-43202] Fix Dashlane payment_card CSV rows importing as blank cards

### DIFF
--- a/libs/importer/src/importers/dashlane/dashlane-csv-importer.spec.ts
+++ b/libs/importer/src/importers/dashlane/dashlane-csv-importer.spec.ts
@@ -8,6 +8,7 @@ import { credentialsData_otpUrl } from "../spec-data/dashlane-csv/credentials-ot
 import { credentialsData } from "../spec-data/dashlane-csv/credentials.csv";
 import { identityData } from "../spec-data/dashlane-csv/id.csv";
 import { multiplePersonalInfoData } from "../spec-data/dashlane-csv/multiple-personal-info.csv";
+import { paymentsPaymentCardData } from "../spec-data/dashlane-csv/payments-payment-card.csv";
 import { paymentsData } from "../spec-data/dashlane-csv/payments.csv";
 import { personalInfoData } from "../spec-data/dashlane-csv/personal-info.csv";
 import { secureNoteData } from "../spec-data/dashlane-csv/securenotes.csv";
@@ -100,6 +101,27 @@ describe("Dashlane CSV Importer", () => {
 
       assertCustomFieldsStructure(cipher2.fields, [
         ["type", "credit_card"],
+        ["country", "US"],
+      ]);
+    });
+
+    it("parses the current payment_card export format", async () => {
+      const result = await getImportResult(paymentsPaymentCardData);
+
+      expect(result.ciphers.length).toEqual(1);
+
+      const cipher = result.ciphers[0];
+      expect(cipher.type).toEqual(CipherType.Card);
+      expect(cipher.name).toEqual("Work Visa");
+      expect(cipher.card.brand).toEqual("Visa");
+      expect(cipher.card.cardholderName).toEqual("Jane M Doe");
+      expect(cipher.card.number).toEqual("41111111111111111");
+      expect(cipher.card.code).toEqual("123");
+      expect(cipher.card.expMonth).toEqual("1");
+      expect(cipher.card.expYear).toEqual("2030");
+
+      assertCustomFieldsStructure(cipher.fields, [
+        ["type", "payment_card"],
         ["country", "US"],
       ]);
     });

--- a/libs/importer/src/importers/dashlane/dashlane-csv-importer.ts
+++ b/libs/importer/src/importers/dashlane/dashlane-csv-importer.ts
@@ -147,7 +147,10 @@ export class DashlaneCsvImporter extends BaseImporter implements Importer {
     let mappedValues: string[] = [];
     switch (row.type) {
       case "credit_card":
-        cipher.card.cardholderName = row.account_name;
+      case "payment_card":
+        // Dashlane's current CSV export uses `payment_card` (was `credit_card`)
+        // and carries the cardholder name in a separate `name` column.
+        cipher.card.cardholderName = row.name ?? row.account_name;
         cipher.card.number = row.cc_number;
         cipher.card.brand = CardView.getCardBrandByPatterns(cipher.card.number);
         cipher.card.code = row.code;
@@ -161,6 +164,7 @@ export class DashlaneCsvImporter extends BaseImporter implements Importer {
           "code",
           "expiration_month",
           "expiration_year",
+          "name",
         ];
         break;
       case "bank":

--- a/libs/importer/src/importers/dashlane/types/dashlane-csv-types.ts
+++ b/libs/importer/src/importers/dashlane/types/dashlane-csv-types.ts
@@ -18,6 +18,7 @@ export class PaymentsRecord {
   type: string;
   account_name: string;
   account_holder: string;
+  name?: string;
   cc_number: string;
   code: string;
   expiration_month: string;

--- a/libs/importer/src/importers/spec-data/dashlane-csv/payments-payment-card.csv.ts
+++ b/libs/importer/src/importers/spec-data/dashlane-csv/payments-payment-card.csv.ts
@@ -1,0 +1,2 @@
+export const paymentsPaymentCardData = `type,account_name,cc_number,code,expiration_month,expiration_year,country,name
+payment_card,Work Visa,41111111111111111,123,01,2030,US,Jane M Doe`;


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-43238


Fixes #23045

## Problem

Importing a current Dashlane CSV export creates a Card item with every card field blank and all values (type, account_name, cc_number, code, expiration dates, country, name) dumped into custom fields. Confirmed by the reporter's screenshot in #23045 and reproduced locally.

## Root cause

Dashlane changed its payments CSV export: card rows now carry `type=payment_card` (previously `credit_card`) and the cardholder name moved to a separate `name` column. `DashlaneCsvImporter.parsePaymentRecord`'s switch only matches `credit_card` and `bank`, so `payment_card` rows fall through to the default branch: the cipher stays a Card (set before the switch) with nothing mapped, and `importUnmappedFields` writes every column to custom fields.

## Fix

- Match `payment_card` alongside `credit_card` in the switch.
- Prefer the new `name` column for `cardholderName`, falling back to `account_name` for the legacy format (legacy exports have no `name` column, so behavior there is unchanged).
- Add `name` to the mapped-values set so it doesn't leak into custom fields.

## Verification

- New spec-data fixture matching the current export header (`type,account_name,cc_number,code,expiration_month,expiration_year,country,name`) with a `payment_card` row.
- New spec asserts the row imports as a fully populated Card (name, brand, cardholder, number, code, expiry) with only `type` and `country` left as custom fields - matching how the existing `credit_card` row behaves.
- Full Dashlane CSV importer suite passes: 11/11 (including all pre-existing specs, so the legacy format still imports identically).

> Built by breken, your AI support engineer - breken.ai - this one's on us.
