### PR TITLE
[PM-42878] Add subscription ended callout to VFO1 archive view

### DIFF
--- a/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.html
@@ -1,5 +1,5 @@
 @if (showPremiumCallout()) {
-  <div class="tw-m-4">
+  <div class="tw-mx-8">
     <bit-callout type="subtle" [title]="'premiumSubscriptionEnded' | i18n">
       <div>{{ "premiumSubscriptionEndedDesc" | i18n }}</div>
       <a bitLink href="#" appStopClick (click)="navigateToGetPremium()">

--- a/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.spec.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.spec.ts
@@ -1,16 +1,19 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
-import { mock } from "jest-mock-extended";
-import { EMPTY } from "rxjs";
+import { mock, MockProxy } from "jest-mock-extended";
+import { BehaviorSubject, EMPTY, of } from "rxjs";
 
 import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
+import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { UserId } from "@bitwarden/common/types/guid";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
 import { CipherView } from "@bitwarden/common/vault/models/view/cipher.view";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { I18nPipe } from "@bitwarden/ui-common";
-import { CipherRowMenuService, VaultBatchBarService } from "@bitwarden/vault";
+import { CipherRowMenuService, VaultBatchBarService, VaultScopeType } from "@bitwarden/vault";
 
 import { VaultListTableComponent } from "./vault-list-table.component";
 
@@ -28,13 +31,25 @@ describe("VaultListTableComponent", () => {
   let fixture: ComponentFixture<VaultListTableComponent<CipherViewLike>>;
   let component: VaultListTableComponent<CipherViewLike>;
   let mockGetRowActions: jest.Mock;
+  let cipherArchiveService: MockProxy<CipherArchiveService>;
+  let showSubscriptionEndedMessaging$: BehaviorSubject<boolean>;
 
   async function setup(extraProviders: unknown[] = []) {
     mockGetRowActions = jest.fn(() => []);
+    showSubscriptionEndedMessaging$ = new BehaviorSubject<boolean>(false);
+    cipherArchiveService = mock<CipherArchiveService>();
+    cipherArchiveService.showSubscriptionEndedMessaging$.mockReturnValue(
+      showSubscriptionEndedMessaging$,
+    );
+
+    const accountService = mock<AccountService>();
+    accountService.activeAccount$ = of({ id: "user-1" as UserId } as Account);
 
     await TestBed.configureTestingModule({
       imports: [VaultListTableComponent],
       providers: [
+        { provide: AccountService, useValue: accountService },
+        { provide: CipherArchiveService, useValue: cipherArchiveService },
         { provide: I18nService, useValue: { t: (key: string) => key } },
         { provide: PremiumUpgradePromptService, useValue: mock<PremiumUpgradePromptService>() },
         { provide: CipherRowMenuService, useValue: { getRowActions: mockGetRowActions } },
@@ -127,15 +142,25 @@ describe("VaultListTableComponent", () => {
   });
 
   describe("premium callout", () => {
-    it("renders when showPremiumCallout is true", () => {
-      fixture.componentRef.setInput("showPremiumCallout", true);
+    it("renders when scope is Archive and subscription has ended", () => {
+      fixture.componentRef.setInput("scope", { type: VaultScopeType.Archive });
+      showSubscriptionEndedMessaging$.next(true);
       fixture.detectChanges();
 
       expect(fixture.debugElement.query(By.css("bit-callout"))).not.toBeNull();
     });
 
-    it("is absent when showPremiumCallout is false", () => {
-      fixture.componentRef.setInput("showPremiumCallout", false);
+    it("is absent when scope is not Archive", () => {
+      fixture.componentRef.setInput("scope", { type: VaultScopeType.Trash });
+      showSubscriptionEndedMessaging$.next(true);
+      fixture.detectChanges();
+
+      expect(fixture.debugElement.query(By.css("bit-callout"))).toBeNull();
+    });
+
+    it("is absent when scope is Archive but subscription is active", () => {
+      fixture.componentRef.setInput("scope", { type: VaultScopeType.Archive });
+      showSubscriptionEndedMessaging$.next(false);
       fixture.detectChanges();
 
       expect(fixture.debugElement.query(By.css("bit-callout"))).toBeNull();

--- a/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.ts
+++ b/apps/desktop/src/vault/app/vault-v3/vault-list-table/vault-list-table.component.ts
@@ -7,15 +7,20 @@ import {
   output,
   viewChild,
 } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
+import { switchMap } from "rxjs";
 
 import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
+import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+import { getOptionalUserId } from "@bitwarden/common/auth/services/account.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
 import { PremiumUpgradePromptService } from "@bitwarden/common/vault/abstractions/premium-upgrade-prompt.service";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { FolderView } from "@bitwarden/common/vault/models/view/folder.view";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
+import { filterOutNullish } from "@bitwarden/common/vault/utils/observable-utilities";
 import { ButtonModule, CalloutComponent, LinkModule } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import {
@@ -26,6 +31,7 @@ import {
   VaultItemsTableComponent,
   VaultItemsTableRowAction,
   VaultScope,
+  VaultScopeType,
 } from "@bitwarden/vault";
 
 import { VaultItemEvent } from "../vault-items/vault-item-event";
@@ -47,11 +53,23 @@ import { VaultItemEvent } from "../vault-items/vault-item-event";
   },
 })
 export class VaultListTableComponent<C extends CipherViewLike> {
+  private readonly accountService = inject(AccountService);
+  private readonly cipherArchiveService = inject(CipherArchiveService);
   private readonly premiumUpgradePromptService = inject(PremiumUpgradePromptService);
   private readonly cipherRowMenuService = inject(CipherRowMenuService);
   private readonly batchBarService = inject<VaultBatchBarService<C>>(VaultBatchBarService, {
     optional: true,
   });
+
+  private readonly userId$ = this.accountService.activeAccount$.pipe(getOptionalUserId);
+
+  private readonly subscriptionEndedMessaging = toSignal(
+    this.userId$.pipe(
+      filterOutNullish(),
+      switchMap((userId) => this.cipherArchiveService.showSubscriptionEndedMessaging$(userId)),
+    ),
+    { initialValue: false },
+  );
 
   private readonly vaultItemsTable = viewChild(VaultItemsTableComponent);
 
@@ -70,7 +88,6 @@ export class VaultListTableComponent<C extends CipherViewLike> {
   readonly organizations = input<Organization[]>([]);
   readonly orgRequiresDataOwnership = input<boolean>(false);
   readonly loading = input<boolean>(false);
-  readonly showPremiumCallout = input<boolean>(false);
   readonly canCreateCipher = input<boolean>(true);
   readonly showAddCipherBtn = input<boolean>(true);
 
@@ -94,6 +111,10 @@ export class VaultListTableComponent<C extends CipherViewLike> {
   readonly onAddFolder = output<void>();
   readonly onAddItemDialog = output<void>();
   readonly onImport = output<void>();
+
+  protected readonly showPremiumCallout = computed(
+    () => this.scope()?.type === VaultScopeType.Archive && this.subscriptionEndedMessaging(),
+  );
 
   private readonly cipherRowMenuHandlers = computed<CipherRowMenuHandlers<C>>(() => ({
     edit: (item) => this.onEvent.emit({ type: "editCipher", item }),

--- a/apps/desktop/src/vault/app/vault-v3/vault.component.html
+++ b/apps/desktop/src/vault/app/vault-v3/vault.component.html
@@ -44,7 +44,6 @@
       [loading]="refreshing || performingInitialLoad"
       [canCreateCipher]="(canCreateCipher$ | async) ?? true"
       [showAddCipherBtn]="(showAddCipherBtn$ | async) ?? true"
-      [showPremiumCallout]="(showPremiumCallout$ | async) ?? false"
       [scope]="vaultScope()"
       [organizationName]="emptyVaultOrganizationName()"
       [defaultCollectionId]="defaultCollectionId()"

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.html
@@ -10,6 +10,15 @@
 <vault-organization-user-notifications></vault-organization-user-notifications>
 <app-vault-banners [organizations]="organizations()"></app-vault-banners>
 
+@if (showSubscriptionEndedMessaging()) {
+  <bit-callout type="subtle" [title]="'premiumSubscriptionEnded' | i18n">
+    <div>{{ "premiumSubscriptionEndedDesc" | i18n }}</div>
+    <a bitLink [routerLink]="['/settings/subscription/premium']">
+      {{ "restartPremium" | i18n }}
+    </a>
+  </bit-callout>
+}
+
 <app-vault-onboarding [ciphers]="activeCiphers()"></app-vault-onboarding>
 
 <vault-shared-folder-card-grid

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
@@ -13,6 +13,7 @@ import { Account, AccountService } from "@bitwarden/common/auth/abstractions/acc
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CollectionId, OrganizationId, UserId } from "@bitwarden/common/types/guid";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { CipherRepromptType, CipherType } from "@bitwarden/common/vault/enums";
@@ -56,6 +57,7 @@ describe("VaultNextComponent", () => {
 
   let fixture: ComponentFixture<VaultNextComponent>;
   let itemActions: MockProxy<WebVaultItemActionsService>;
+  let cipherArchiveService: MockProxy<CipherArchiveService>;
   let cipherRowMenuService: MockProxy<CipherRowMenuService>;
   let restrictedItemTypesService: MockProxy<RestrictedItemTypesService>;
   let addItemDialogOpen: jest.SpyInstance;
@@ -65,6 +67,7 @@ describe("VaultNextComponent", () => {
   let collections$: BehaviorSubject<CollectionView[]>;
   let organizations$: BehaviorSubject<Organization[]>;
   let showQuickCopyActions$: BehaviorSubject<boolean>;
+  let showSubscriptionEndedMessaging$: BehaviorSubject<boolean>;
   let paramMap$: BehaviorSubject<ParamMap>;
   let routeData$: BehaviorSubject<Data>;
   let vaultNav$: BehaviorSubject<VaultsNavViewModel>;
@@ -154,6 +157,7 @@ describe("VaultNextComponent", () => {
     collections$ = new BehaviorSubject<CollectionView[]>([]);
     organizations$ = new BehaviorSubject<Organization[]>([]);
     showQuickCopyActions$ = new BehaviorSubject<boolean>(false);
+    showSubscriptionEndedMessaging$ = new BehaviorSubject<boolean>(false);
     paramMap$ = new BehaviorSubject<ParamMap>(convertToParamMap({}));
     routeData$ = new BehaviorSubject<Data>({});
     // The multi-vault shape, matching the organizations most of this suite sets up.
@@ -167,6 +171,11 @@ describe("VaultNextComponent", () => {
     });
 
     itemActions = mock<WebVaultItemActionsService>();
+
+    cipherArchiveService = mock<CipherArchiveService>();
+    cipherArchiveService.showSubscriptionEndedMessaging$.mockReturnValue(
+      showSubscriptionEndedMessaging$,
+    );
 
     cipherRowMenuService = mock<CipherRowMenuService>();
     cipherRowMenuService.getRowActions.mockReturnValue([]);
@@ -213,6 +222,7 @@ describe("VaultNextComponent", () => {
       providers: [
         { provide: AccountService, useValue: accountService },
         { provide: ActivatedRoute, useValue: { paramMap: paramMap$, data: routeData$ } },
+        { provide: CipherArchiveService, useValue: cipherArchiveService },
         { provide: CipherRowMenuService, useValue: cipherRowMenuService },
         { provide: CipherService, useValue: cipherService },
         { provide: CollectionService, useValue: collectionService },
@@ -467,6 +477,37 @@ describe("VaultNextComponent", () => {
       it("offers no way to add an item to it", () => {
         expect(component().showItemCreation()).toBe(false);
         expect(creationActions()).toEqual([null, null]);
+      });
+    });
+
+    describe("subscription ended callout", () => {
+      beforeEach(() => {
+        ciphers$.next([]);
+        fixture.detectChanges();
+      });
+
+      it("shows when scope is Archive and subscription has ended", () => {
+        scopeTo(ARCHIVE_ROUTE);
+        showSubscriptionEndedMessaging$.next(true);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector("bit-callout")).not.toBeNull();
+      });
+
+      it("hides when scope is not Archive", () => {
+        scopeTo(TRASH_ROUTE);
+        showSubscriptionEndedMessaging$.next(true);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector("bit-callout")).toBeNull();
+      });
+
+      it("hides when scope is Archive but subscription is active", () => {
+        scopeTo(ARCHIVE_ROUTE);
+        showSubscriptionEndedMessaging$.next(false);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector("bit-callout")).toBeNull();
       });
     });
 

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { combineLatest, firstValueFrom, map, shareReplay, switchMap } from "rxjs";
 
 import { CollectionService } from "@bitwarden/admin-console/common";
@@ -10,13 +10,14 @@ import { AccountService } from "@bitwarden/common/auth/abstractions/account.serv
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { CollectionId } from "@bitwarden/common/types/guid";
+import { CipherArchiveService } from "@bitwarden/common/vault/abstractions/cipher-archive.service";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
 import { CipherType } from "@bitwarden/common/vault/enums";
 import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/restricted-item-types.service";
 import { CipherViewLike } from "@bitwarden/common/vault/utils/cipher-view-like-utils";
 import { filterOutNullish } from "@bitwarden/common/vault/utils/observable-utilities";
-import { ButtonModule, DialogService } from "@bitwarden/components";
+import { ButtonModule, CalloutModule, DialogService, LinkModule } from "@bitwarden/components";
 import { isGuid } from "@bitwarden/guid";
 import { PolicyType } from "@bitwarden/sdk-internal";
 import { I18nPipe, safeProvider } from "@bitwarden/ui-common";
@@ -66,8 +67,7 @@ import { VaultOnboardingComponent } from "./vault-onboarding/vault-onboarding.co
  * Every side-nav destination renders this one component, scoped by the `:vaultId` route segment —
  * see `VaultScope`.
  *
- * Not yet wired: the `?itemId=&action=` deep link that opens an item on load. The archive's
- * "premium subscription ended" callout has nowhere to surface yet.
+ * Not yet wired: the `?itemId=&action=` deep link that opens an item on load.
  */
 @Component({
   selector: "app-vault-next",
@@ -78,8 +78,11 @@ import { VaultOnboardingComponent } from "./vault-onboarding/vault-onboarding.co
   },
   imports: [
     ButtonModule,
+    CalloutModule,
     I18nPipe,
     HeaderModule,
+    LinkModule,
+    RouterLink,
     NewCipherMenuComponent,
     VaultBannersComponent,
     VaultCollectionBreadcrumbsComponent,
@@ -106,8 +109,10 @@ export class VaultNextComponent {
   private readonly restrictedItemTypesService = inject(RestrictedItemTypesService);
   private readonly vaultNavService = inject(VaultNavService);
   private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly cipherArchiveService = inject(CipherArchiveService);
   private readonly i18nService = inject(I18nService);
   private readonly policyService = inject(PolicyService);
+  private readonly router = inject(Router);
   private readonly userId$ = this.accountService.activeAccount$.pipe(getUserId);
 
   private readonly routeParams = toSignal(this.activatedRoute.paramMap);
@@ -290,6 +295,17 @@ export class VaultNextComponent {
     const { type } = this.vaultScope();
     return type !== VaultScopeType.Trash && type !== VaultScopeType.Archive;
   });
+
+  private readonly subscriptionEndedMessaging = toSignal(
+    this.userId$.pipe(
+      switchMap((userId) => this.cipherArchiveService.showSubscriptionEndedMessaging$(userId)),
+    ),
+    { initialValue: false },
+  );
+
+  protected readonly showSubscriptionEndedMessaging = computed(
+    () => this.vaultScope().type === VaultScopeType.Archive && this.subscriptionEndedMessaging(),
+  );
 
   protected readonly title = computed(() => {
     const scope = this.vaultScope();


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42878](https://bitwarden.atlassian.net/browse/PM-42878)

## 📔 Objective

Adds the "premium subscription ended" callout to the Archive view across all VFO1 clients.

**Web** (`vault-next.component`): The callout was missing entirely — the gap was noted in a TODO comment. Now derives `showSubscriptionEndedMessaging` from `CipherArchiveService` gated on the Archive scope, and renders a `bit-callout` with a "Restart Premium" `routerLink`.

**Desktop** (`vault-list-table.component`): Migrates `showPremiumCallout` from a parent-passed input to an internally derived signal using `CipherArchiveService`, matching the approach above and removing the need for the parent to wire it.

**Browser**: Already handled — no changes needed.

## 📸 Screenshots

[PM-42878]: https://bitwarden.atlassian.net/browse/PM-42878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ