### PR TITLE
[PM-39929] Billing Error Card

### DIFF
--- a/libs/subscription/src/components/error-card/error-card.component.html
+++ b/libs/subscription/src/components/error-card/error-card.component.html
@@ -1,0 +1,26 @@
+<bit-card
+  class="tw-flex tw-flex-col tw-items-center tw-border tw-rounded-xl tw-border-solid tw-border-secondary-100 tw-bg-background tw-gap-5 tw-p-6 tw-shadow-sm"
+>
+  <div
+    class="tw-flex tw-justify-center tw-items-center tw-bg-bg-warning-medium tw-p-2 tw-size-12 tw-border tw-rounded-lg tw-border-bg-warning-soft"
+  >
+    <bit-icon [name]="icon()" [class]="iconClass() + ' tw-flex-shrink-0 tw-aspect-square'" />
+  </div>
+
+  <div class="tw-flex tw-flex-col tw-gap-2 tw-align-middle tw-justify-center tw-text-center">
+    <h2 bitTypography="h4">{{ title() }}</h2>
+    <p bitTypography="body2" class="tw-max-w-lg tw-text-main tw-m-0">{{ description() }}</p>
+  </div>
+
+  @if (buttonText(); as buttonText) {
+    <button
+      bitButton
+      buttonType="secondary"
+      type="button"
+      [loading]="loading()"
+      (click)="actionClicked.emit()"
+    >
+      {{ buttonText }}
+    </button>
+  }
+</bit-card>

--- a/libs/subscription/src/components/error-card/error-card.component.html
+++ b/libs/subscription/src/components/error-card/error-card.component.html
@@ -1,12 +1,12 @@
 <bit-card class="tw-flex tw-flex-col tw-items-center tw-gap-5 tw-p-6 tw-shadow-sm">
   <div
-    class="tw-flex tw-justify-center tw-items-center tw-bg-bg-warning-medium tw-p-2 tw-size-12 tw-border tw-rounded-lg tw-border-bg-warning-soft"
+    class="tw-flex tw-justify-center tw-items-center tw-bg-bg-warning-medium tw-p-2 tw-size-12 tw-border tw-rounded-lg tw-border-border-warning-soft"
   >
     <bit-icon [name]="icon()" [class]="iconClass() + ' tw-flex-shrink-0 tw-aspect-square'" />
   </div>
 
   <div class="tw-flex tw-flex-col tw-gap-2 tw-align-middle tw-justify-center tw-text-center">
-    <h2 bitTypography="h4">{{ title() }}</h2>
+    <h2 bitTypography="h4" class="tw-m-0">{{ title() }}</h2>
     <p bitTypography="body2" class="tw-max-w-lg tw-text-main tw-m-0">{{ description() }}</p>
   </div>
 

--- a/libs/subscription/src/components/error-card/error-card.component.html
+++ b/libs/subscription/src/components/error-card/error-card.component.html
@@ -1,9 +1,5 @@
 <bit-card class="tw-flex tw-flex-col tw-items-center tw-gap-5 tw-p-6 tw-shadow-sm">
-  <div
-    class="tw-flex tw-justify-center tw-items-center tw-bg-bg-warning-medium tw-p-2 tw-size-12 tw-border tw-rounded-lg tw-border-border-warning-soft"
-  >
-    <bit-icon [name]="icon()" [class]="iconClass() + ' tw-flex-shrink-0 tw-aspect-square'" />
-  </div>
+  <bit-icon-tile [icon]="icon()" [variant]="variant()" size="lg" />
 
   <div class="tw-flex tw-flex-col tw-gap-2 tw-align-middle tw-justify-center tw-text-center">
     <h2 bitTypography="h4" class="tw-m-0">{{ title() }}</h2>

--- a/libs/subscription/src/components/error-card/error-card.component.html
+++ b/libs/subscription/src/components/error-card/error-card.component.html
@@ -1,7 +1,7 @@
-<bit-card class="tw-flex tw-flex-col tw-items-center tw-gap-5 tw-p-6 tw-shadow-sm">
+<bit-card class="tw-flex tw-flex-col tw-items-center tw-gap-5 !tw-p-6 tw-shadow-sm">
   <bit-icon-tile [icon]="icon()" [variant]="variant()" size="lg" />
 
-  <div class="tw-flex tw-flex-col tw-gap-2 tw-align-middle tw-justify-center tw-text-center">
+  <div class="tw-flex tw-flex-col tw-gap-2 tw-text-center">
     <h2 bitTypography="h4" class="tw-m-0">{{ title() }}</h2>
     <p bitTypography="body2" class="tw-max-w-lg tw-text-main tw-m-0">{{ description() }}</p>
   </div>

--- a/libs/subscription/src/components/error-card/error-card.component.html
+++ b/libs/subscription/src/components/error-card/error-card.component.html
@@ -1,6 +1,4 @@
-<bit-card
-  class="tw-flex tw-flex-col tw-items-center tw-border tw-rounded-xl tw-border-solid tw-border-secondary-100 tw-bg-background tw-gap-5 tw-p-6 tw-shadow-sm"
->
+<bit-card class="tw-flex tw-flex-col tw-items-center tw-gap-5 tw-p-6 tw-shadow-sm">
   <div
     class="tw-flex tw-justify-center tw-items-center tw-bg-bg-warning-medium tw-p-2 tw-size-12 tw-border tw-rounded-lg tw-border-bg-warning-soft"
   >

--- a/libs/subscription/src/components/error-card/error-card.component.mdx
+++ b/libs/subscription/src/components/error-card/error-card.component.mdx
@@ -1,0 +1,56 @@
+import { Meta, Canvas } from "@storybook/addon-docs/blocks";
+import * as ErrorCardStories from "./error-card.component.stories";
+
+<Meta of={ErrorCardStories} />
+
+# Error Card
+
+A generic billing error card: an icon badge, a title, a description, and an optional action button.
+All copy is passed in already-localized, so the card is reusable across surfaces (subscription
+failed to load, payment declined, etc.).
+
+<Canvas of={ErrorCardStories.SubscriptionFailedToLoad} />
+
+## Usage
+
+```ts
+import { ErrorCardComponent } from "@bitwarden/subscription";
+```
+
+```html
+<billing-error-card
+  [title]="'subscriptionDetailsNotLoading' | i18n"
+  [description]="'subscriptionDetailsNotLoadingDesc' | i18n"
+  [buttonText]="'refresh' | i18n"
+  icon="bwi-clear"
+  (actionClicked)="reload()"
+/>
+```
+
+## API
+
+### Inputs
+
+| Input         | Type            | Description                                                                      |
+| ------------- | --------------- | -------------------------------------------------------------------------------- |
+| `title`       | `string`        | Required. Heading text, already localized.                                       |
+| `description` | `string`        | Required. Body text explaining the error, already localized.                     |
+| `buttonText`  | `string`        | Optional. Action button label, already localized. Omit to hide the button.       |
+| `icon`        | `BitwardenIcon` | Optional. Icon in the header badge. Defaults to `bwi-error`.                     |
+| `iconClass`   | `string`        | Optional. Utility classes on the icon (e.g. color). Defaults to a warning color. |
+
+### Outputs
+
+| Output          | Type   | Description                                |
+| --------------- | ------ | ------------------------------------------ |
+| `actionClicked` | `void` | Emitted when the action button is clicked. |
+
+## Examples
+
+### Subscription Failed To Load
+
+<Canvas of={ErrorCardStories.SubscriptionFailedToLoad} />
+
+### Without Action Button
+
+<Canvas of={ErrorCardStories.WithoutAction} />

--- a/libs/subscription/src/components/error-card/error-card.component.mdx
+++ b/libs/subscription/src/components/error-card/error-card.component.mdx
@@ -36,6 +36,7 @@ import { ErrorCardComponent } from "@bitwarden/subscription";
 | `title`       | `string`          | Required. Heading text, already localized.                                            |
 | `description` | `string`          | Required. Body text explaining the error, already localized.                          |
 | `buttonText`  | `string`          | Optional. Action button label, already localized. Omit to hide the button.            |
+| `loading`     | `boolean`         | Optional. Shows a spinner and disables the action button. Defaults to `false`.        |
 | `icon`        | `BitwardenIcon`   | Optional. Icon in the header badge. Defaults to `bwi-error`.                          |
 | `variant`     | `IconTileVariant` | Optional. Badge color theme (fill, border, and icon together). Defaults to `warning`. |
 
@@ -50,6 +51,12 @@ import { ErrorCardComponent } from "@bitwarden/subscription";
 ### Subscription Failed To Load
 
 <Canvas of={ErrorCardStories.SubscriptionFailedToLoad} />
+
+### Refreshing
+
+The action button shows a spinner and is disabled while `loading` is true.
+
+<Canvas of={ErrorCardStories.Refreshing} />
 
 ### Without Action Button
 

--- a/libs/subscription/src/components/error-card/error-card.component.mdx
+++ b/libs/subscription/src/components/error-card/error-card.component.mdx
@@ -31,13 +31,13 @@ import { ErrorCardComponent } from "@bitwarden/subscription";
 
 ### Inputs
 
-| Input         | Type            | Description                                                                      |
-| ------------- | --------------- | -------------------------------------------------------------------------------- |
-| `title`       | `string`        | Required. Heading text, already localized.                                       |
-| `description` | `string`        | Required. Body text explaining the error, already localized.                     |
-| `buttonText`  | `string`        | Optional. Action button label, already localized. Omit to hide the button.       |
-| `icon`        | `BitwardenIcon` | Optional. Icon in the header badge. Defaults to `bwi-error`.                     |
-| `iconClass`   | `string`        | Optional. Utility classes on the icon (e.g. color). Defaults to a warning color. |
+| Input         | Type              | Description                                                                           |
+| ------------- | ----------------- | ------------------------------------------------------------------------------------- |
+| `title`       | `string`          | Required. Heading text, already localized.                                            |
+| `description` | `string`          | Required. Body text explaining the error, already localized.                          |
+| `buttonText`  | `string`          | Optional. Action button label, already localized. Omit to hide the button.            |
+| `icon`        | `BitwardenIcon`   | Optional. Icon in the header badge. Defaults to `bwi-error`.                          |
+| `variant`     | `IconTileVariant` | Optional. Badge color theme (fill, border, and icon together). Defaults to `warning`. |
 
 ### Outputs
 

--- a/libs/subscription/src/components/error-card/error-card.component.spec.ts
+++ b/libs/subscription/src/components/error-card/error-card.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { ErrorCardComponent } from "./error-card.component";
+
+describe("ErrorCardComponent", () => {
+  let fixture: ComponentFixture<ErrorCardComponent>;
+  let component: ErrorCardComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ErrorCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ErrorCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput("title", "Something went wrong");
+    fixture.componentRef.setInput("description", "We could not load your subscription.");
+  });
+
+  const textContent = () => (fixture.nativeElement as HTMLElement).textContent ?? "";
+
+  it("renders the title and description", () => {
+    fixture.detectChanges();
+
+    expect(textContent()).toContain("Something went wrong");
+    expect(textContent()).toContain("We could not load your subscription.");
+  });
+
+  it("does not render an action button when no button text is provided", () => {
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector("button")).toBeNull();
+  });
+
+  it("renders the action button when button text is provided", () => {
+    fixture.componentRef.setInput("buttonText", "Refresh");
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector("button") as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    expect(button.textContent).toContain("Refresh");
+  });
+
+  it("emits actionClicked when the button is clicked", () => {
+    fixture.componentRef.setInput("buttonText", "Refresh");
+    fixture.detectChanges();
+    const emit = jest.spyOn(component.actionClicked, "emit");
+
+    (fixture.nativeElement.querySelector("button") as HTMLButtonElement).click();
+
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/subscription/src/components/error-card/error-card.component.stories.ts
+++ b/libs/subscription/src/components/error-card/error-card.component.stories.ts
@@ -1,0 +1,41 @@
+import { Meta, StoryObj } from "@storybook/angular";
+
+import { ErrorCardComponent } from "./error-card.component";
+
+export default {
+  title: "Billing/Error Card",
+  component: ErrorCardComponent,
+  description:
+    "A generic billing error card with an icon badge, title, description, and an optional action button. All copy is passed in already-localized so the card is reusable across surfaces.",
+} as Meta<ErrorCardComponent>;
+
+type Story = StoryObj<ErrorCardComponent>;
+
+export const SubscriptionFailedToLoad: Story = {
+  args: {
+    title: "Subscription details aren't loading",
+    description: "We ran into a problem loading your subscription details. Refresh to try again.",
+    buttonText: "Refresh",
+    icon: "bwi-clear",
+  },
+};
+
+export const Refreshing: Story = {
+  name: "Refreshing (button loading)",
+  args: {
+    title: "Subscription details aren't loading",
+    description: "We ran into a problem loading your subscription details. Refresh to try again.",
+    buttonText: "Refresh",
+    icon: "bwi-clear",
+    loading: true,
+  },
+};
+
+export const WithoutAction: Story = {
+  name: "Without Action Button",
+  args: {
+    title: "Something went wrong",
+    description: "Please try again later.",
+    icon: "bwi-error",
+  },
+};

--- a/libs/subscription/src/components/error-card/error-card.component.ts
+++ b/libs/subscription/src/components/error-card/error-card.component.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, input, output } from "@angular/core";
+
+import {
+  BitwardenIcon,
+  ButtonModule,
+  CardComponent,
+  IconComponent,
+  TypographyModule,
+} from "@bitwarden/components";
+
+/**
+ * A generic billing error card: an icon badge, a title, a description, and an optional action
+ * button. All copy is passed in already-localized so the card is reusable across surfaces
+ * (subscription failed to load, payment declined, etc.).
+ */
+@Component({
+  selector: "billing-error-card",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./error-card.component.html",
+  imports: [ButtonModule, CardComponent, IconComponent, TypographyModule],
+})
+export class ErrorCardComponent {
+  /** Heading text, already localized. */
+  readonly title = input.required<string>();
+
+  /** Body text explaining the error, already localized. */
+  readonly description = input.required<string>();
+
+  /** Action button label, already localized. When omitted, no button renders. */
+  readonly buttonText = input<string>();
+
+  /** Shows a spinner and disables the action button while true. Driven by any signal/boolean. */
+  readonly loading = input<boolean>(false);
+
+  /** Icon shown in the header badge. */
+  readonly icon = input<BitwardenIcon>("bwi-error");
+
+  /** Utility classes applied to the icon, e.g. to change its color for a danger vs. warning error. */
+  readonly iconClass = input<string>("tw-text-2xl tw-text-fg-warning");
+
+  /** Emitted when the action button is clicked. */
+  readonly actionClicked = output<void>();
+}

--- a/libs/subscription/src/components/error-card/error-card.component.ts
+++ b/libs/subscription/src/components/error-card/error-card.component.ts
@@ -4,7 +4,8 @@ import {
   BitwardenIcon,
   ButtonModule,
   CardComponent,
-  IconComponent,
+  IconTileComponent,
+  IconTileVariant,
   TypographyModule,
 } from "@bitwarden/components";
 
@@ -17,7 +18,7 @@ import {
   selector: "billing-error-card",
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: "./error-card.component.html",
-  imports: [ButtonModule, CardComponent, IconComponent, TypographyModule],
+  imports: [ButtonModule, CardComponent, IconTileComponent, TypographyModule],
 })
 export class ErrorCardComponent {
   /** Heading text, already localized. */
@@ -35,8 +36,8 @@ export class ErrorCardComponent {
   /** Icon shown in the header badge. */
   readonly icon = input<BitwardenIcon>("bwi-error");
 
-  /** Utility classes applied to the icon, e.g. to change its color for a danger vs. warning error. */
-  readonly iconClass = input<string>("tw-text-2xl tw-text-fg-warning");
+  /** Badge color theme. Moves the fill, border, and icon color together (e.g. `warning`, `danger`). */
+  readonly variant = input<IconTileVariant>("warning");
 
   /** Emitted when the action button is clicked. */
   readonly actionClicked = output<void>();

--- a/libs/subscription/src/index.ts
+++ b/libs/subscription/src/index.ts
@@ -1,5 +1,6 @@
 // Components
 export * from "./components/additional-options-card/additional-options-card.component";
+export * from "./components/error-card/error-card.component";
 export * from "./components/subscription-card/subscription-card.component";
 export * from "./components/storage-card/storage-card.component";
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39929](https://bitwarden.atlassian.net/browse/PM-39929) — Redesign Organization Subscription Page

Part 1 of a stacked set that breaks the org subscription page redesign (previously #22489) into reviewable layers.

## 📔 Objective

### DESIGN REVIEWED

Adds a reusable `ErrorCardComponent` to `@bitwarden/subscription` for the redesigned subscription page's failure state.

Later in the stack the redesigned page uses it to render a **"Subscription details not loading"** card with a **Refresh** action when the subscription preview request fails — scoped to the card only, so the management, reseller, self-host, and provider sections still render.

- New standalone, OnPush `ErrorCardComponent` with `title`, `description`, `buttonText`, `icon`, and `loading` inputs and an `actionClicked` output.
- Exported from the library index.
- Covered by a unit spec, Storybook stories, and MDX docs.

## 📸 Screenshots
https://github.com/user-attachments/assets/51660037-b8a0-433c-b517-fe522d4888b1

[PM-39929]: https://bitwarden.atlassian.net/browse/PM-39929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ