### PR TITLE
[PM-43245] fix: Apply container-type to side nav scroll container

### DIFF
--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.stories.ts
+++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.stories.ts
@@ -12,6 +12,7 @@ import { ProviderService } from "@bitwarden/common/admin-console/abstractions/pr
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Provider } from "@bitwarden/common/admin-console/models/domain/provider";
 import { AccountService, Account } from "@bitwarden/common/auth/abstractions/account.service";
+import { AvatarService } from "@bitwarden/common/auth/abstractions/avatar.service";
 import { BillingAccountProfileStateService } from "@bitwarden/common/billing/abstractions";
 import { FeatureFlag } from "@bitwarden/common/enums/feature-flag.enum";
 import {
@@ -127,6 +128,10 @@ class MockLockService implements Partial<LockService> {
   async lock() {}
 }
 
+class MockAvatarService implements Partial<AvatarService> {
+  avatarColor$ = of("#175ddc");
+}
+
 class MockBillingAccountProfileStateService implements Partial<BillingAccountProfileStateService> {
   hasPremiumFromAnySource$(userId: UserId): Observable<boolean> {
     return of(false);
@@ -161,6 +166,12 @@ const translations: Record<string, string> = {
   upgradeNow: "Upgrade now",
   getAdvancedOnlineSecurityWithBitwardenPremium:
     "Get advanced online security with Bitwarden premium.",
+  loggedInAs: "Logged in as",
+  accountSettings: "Account settings",
+  getHelp: "Get help",
+  getApps: "Get the apps",
+  lockNow: "Lock now",
+  logOut: "Log out",
 };
 
 export default {
@@ -190,6 +201,7 @@ export default {
         { provide: VaultTimeoutSettingsService, useClass: MockVaultTimeoutSettingsService },
         { provide: LogoutService, useClass: MockLogoutService },
         { provide: LockService, useClass: MockLockService },
+        { provide: AvatarService, useClass: MockAvatarService },
         {
           provide: BillingAccountProfileStateService,
           useClass: MockBillingAccountProfileStateService,

--- a/libs/components/src/navigation/side-nav.component.html
+++ b/libs/components/src/navigation/side-nav.component.html
@@ -30,8 +30,7 @@
       (keydown)="handleKeyDown($event)"
     >
       <div
-        class="tw-flex-1 tw-min-h-0 tw-overflow-auto tw-overscroll-none"
-        style="container-type: size"
+        class="tw-flex-1 tw-min-h-0 tw-overflow-auto tw-overscroll-none tw-@container-[size]"
         id="bit-side-nav--scroll"
       >
         <div class="tw-flex tw-flex-col tw-min-h-full tw-group/side-nav">
@@ -125,8 +124,7 @@
       [attr.aria-label]="'sideNavigation' | i18n"
     >
       <div
-        class="tw-flex-1 tw-min-h-0 tw-overflow-auto tw-overscroll-none"
-        style="container-type: size"
+        class="tw-flex-1 tw-min-h-0 tw-overflow-auto tw-overscroll-none tw-@container-[size]"
         id="bit-side-nav--scroll"
       >
         <div class="tw-flex tw-flex-col tw-min-h-full">


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-43245

## 📔 Objective
Fix footer not remaining sticky in sidenav
-  Sticky side nav footer relies on container-type: size on the scroll container. Replace the inline style attribute with the equivalent @tailwindcss/container-queries utility on both scroll containers.

- Add the AvatarService mock and account-menu translations the navigation switcher story needs to render the side nav.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
