### PR TITLE
[CL-1296] Ensure table content does not have clipped focus rings

### DIFF
--- a/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
+++ b/libs/components/src/stories/kitchen-sink/components/dialog-virtual-scroll-block.component.ts
@@ -1,7 +1,7 @@
 import { DatePipe } from "@angular/common";
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from "@angular/core";
 
-import { BadgeListModule } from "../../../badge-list";
+import { BadgeGroupComponent, type BadgeGroupItem } from "../../../badge-group";
 import { DialogModule, DialogService } from "../../../dialog";
 import { IconButtonModule } from "../../../icon-button";
 import {
@@ -13,7 +13,7 @@ import {
   defineTable,
 } from "../../../table/v2";
 
-type Row = { id: number; name: string; updatedAt: Date; tags: string[] };
+type Row = { id: number; name: string; updatedAt: Date; tags: BadgeGroupItem[] };
 
 const TAG_POOL = ["Personal", "Work", "Shared", "Archived", "Favorite", "Family"];
 
@@ -22,7 +22,7 @@ const TAG_POOL = ["Personal", "Work", "Shared", "Archived", "Favorite", "Family"
   selector: "dialog-virtual-scroll-block",
   imports: [
     DatePipe,
-    BadgeListModule,
+    BadgeGroupComponent,
     DialogModule,
     IconButtonModule,
     BitTableV2Component,
@@ -52,8 +52,8 @@ const TAG_POOL = ["Personal", "Work", "Shared", "Archived", "Favorite", "Family"
     </bit-column>
     <bit-column sortable [sortFn]="sortByTags">
       <bit-header-cell>Tags</bit-header-cell>
-      <bit-cell *bitCellDef="table.columns.tags; let row" [truncate]="false">
-        <bit-badge-list [items]="row.tags" variant="subtle"></bit-badge-list>
+      <bit-cell *bitCellDef="table.columns.tags; let row">
+        <bit-badge-group [badges]="row.tags"></bit-badge-group>
       </bit-cell>
     </bit-column>
     <bit-column width="64px">
@@ -76,7 +76,10 @@ export class DialogVirtualScrollBlockComponent implements OnInit {
   protected readonly table = defineTable<Row, "actions">(this.rows);
 
   protected readonly sortByTags = (a: Row, b: Row) =>
-    a.tags.join(",").localeCompare(b.tags.join(","));
+    a.tags
+      .map((tag) => tag.label)
+      .join(",")
+      .localeCompare(b.tags.map((tag) => tag.label).join(","));
 
   ngOnInit(): void {
     const base = new Date(Date.UTC(2026, 0, 1));
@@ -88,7 +91,10 @@ export class DialogVirtualScrollBlockComponent implements OnInit {
           id: i,
           name: `name-${i}`,
           updatedAt: date,
-          tags: Array.from({ length: (i % 3) + 1 }, (_, j) => TAG_POOL[(i + j) % TAG_POOL.length]),
+          tags: Array.from({ length: (i % 3) + 1 }, (_, j) => ({
+            label: TAG_POOL[(i + j) % TAG_POOL.length],
+            variant: "subtle" as const,
+          })),
         };
       }),
     );

--- a/libs/components/src/table/v2/bit-cell.component.html
+++ b/libs/components/src/table/v2/bit-cell.component.html
@@ -2,13 +2,29 @@
   <ng-content select="[slot=start]"></ng-content>
 
   <div class="tw-flex tw-flex-col tw-min-w-0 tw-flex-grow">
-    <div [ngClass]="truncate() ? 'tw-truncate' : 'tw-text-wrap tw-break-words'">
+    <!--
+      not using `tw-truncate` here because it applies `overflow-hidden`, but we need `overflow-clip`
+      so the clip region can be pushed out by `overflow-clip-margin`. this allows the focus ring of
+      interactive content to appear properly instead of being clipped off. 4px covers the widest 
+      ring in the CL. text still ellipses: `text-overflow` applies to any non-`visible` overflow.
+    -->
+    <div
+      [ngClass]="
+        truncate()
+          ? 'tw-overflow-clip [overflow-clip-margin:4px] tw-text-ellipsis tw-whitespace-nowrap'
+          : 'tw-text-wrap tw-break-words'
+      "
+    >
       <ng-content></ng-content>
     </div>
     <div
       bitTypography="helper"
       class="tw-text-fg-body-subtle empty:tw-hidden"
-      [ngClass]="truncate() ? 'tw-truncate' : 'tw-text-wrap tw-break-words'"
+      [ngClass]="
+        truncate()
+          ? 'tw-overflow-clip [overflow-clip-margin:4px] tw-text-ellipsis tw-whitespace-nowrap'
+          : 'tw-text-wrap tw-break-words'
+      "
     >
       <ng-content select="[slot=secondary]"></ng-content>
     </div>

--- a/libs/components/src/table/v2/bit-cell.component.html
+++ b/libs/components/src/table/v2/bit-cell.component.html
@@ -2,29 +2,13 @@
   <ng-content select="[slot=start]"></ng-content>
 
   <div class="tw-flex tw-flex-col tw-min-w-0 tw-flex-grow">
-    <!--
-      not using `tw-truncate` here because it applies `overflow-hidden`, but we need `overflow-clip`
-      so the clip region can be pushed out by `overflow-clip-margin`. this allows the focus ring of
-      interactive content to appear properly instead of being clipped off. 4px covers the widest 
-      ring in the CL. text still ellipses: `text-overflow` applies to any non-`visible` overflow.
-    -->
-    <div
-      [ngClass]="
-        truncate()
-          ? 'tw-overflow-clip [overflow-clip-margin:4px] tw-text-ellipsis tw-whitespace-nowrap'
-          : 'tw-text-wrap tw-break-words'
-      "
-    >
+    <div [class]="contentClasses()">
       <ng-content></ng-content>
     </div>
     <div
       bitTypography="helper"
       class="tw-text-fg-body-subtle empty:tw-hidden"
-      [ngClass]="
-        truncate()
-          ? 'tw-overflow-clip [overflow-clip-margin:4px] tw-text-ellipsis tw-whitespace-nowrap'
-          : 'tw-text-wrap tw-break-words'
-      "
+      [class]="contentClasses()"
     >
       <ng-content select="[slot=secondary]"></ng-content>
     </div>

--- a/libs/components/src/table/v2/bit-cell.component.ts
+++ b/libs/components/src/table/v2/bit-cell.component.ts
@@ -36,10 +36,10 @@ export class BitCellComponent {
    * Overflow behavior shared by the default and secondary slots.
    *
    * Not using `tw-truncate` because it applies `overflow-hidden`, but we need `overflow-clip` so
-   * the clip region can be pushed out by `overflow-clip-margin`. That lets the focus ring of
-   * interactive content paint instead of being clipped off; 4px covers the widest ring in the
-   * library, and matches the clip margin `<bit-row>` uses for the same reason. Text still ellipses:
-   * `text-overflow` applies to any non-`visible` overflow.
+   * the clip region can be pushed out by `overflow-clip-margin`. This wrapper hugs its content, so
+   * without the margin the focus ring of an interactive child gets sliced off; 4px covers the
+   * widest ring in the library. Text still ellipses: `text-overflow` applies to any non-`visible`
+   * overflow.
    */
   protected readonly contentClasses = computed(() =>
     this.truncate()

--- a/libs/components/src/table/v2/bit-cell.component.ts
+++ b/libs/components/src/table/v2/bit-cell.component.ts
@@ -35,10 +35,9 @@ export class BitCellComponent {
   /**
    * Overflow behavior shared by the default and secondary slots.
    *
-   * Not using `tw-truncate` because it applies `overflow-hidden`, but we need `overflow-clip` so
-   * the clip region can be pushed out by `overflow-clip-margin`. This wrapper hugs its content, so
-   * without the margin the focus ring of an interactive child gets sliced off; 4px covers the
-   * widest ring in the library. Text still ellipses: `text-overflow` applies to any non-`visible`
+   * We are not using `tw-truncate` because it applies `overflow-hidden`; instead we need
+   * `overflow-clip` so we can use `overflow-clip-margin` and prevent focus rings of child elements
+   * from getting cut off. Text still ellipses: `text-overflow` applies to any non-`visible`
    * overflow.
    */
   protected readonly contentClasses = computed(() =>

--- a/libs/components/src/table/v2/bit-cell.component.ts
+++ b/libs/components/src/table/v2/bit-cell.component.ts
@@ -1,5 +1,4 @@
-import { NgClass } from "@angular/common";
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, input } from "@angular/core";
 
 import { TypographyModule } from "../../typography";
 
@@ -23,7 +22,7 @@ import { TypographyModule } from "../../typography";
 @Component({
   selector: "bit-cell, [bit-cell]",
   templateUrl: "./bit-cell.component.html",
-  imports: [NgClass, TypographyModule],
+  imports: [TypographyModule],
   host: {
     class: "tw-contents",
   },
@@ -32,4 +31,19 @@ import { TypographyModule } from "../../typography";
 export class BitCellComponent {
   /** Truncate the default and secondary slots on overflow. Default `true`. */
   readonly truncate = input(true);
+
+  /**
+   * Overflow behavior shared by the default and secondary slots.
+   *
+   * Not using `tw-truncate` because it applies `overflow-hidden`, but we need `overflow-clip` so
+   * the clip region can be pushed out by `overflow-clip-margin`. That lets the focus ring of
+   * interactive content paint instead of being clipped off; 4px covers the widest ring in the
+   * library, and matches the clip margin `<bit-row>` uses for the same reason. Text still ellipses:
+   * `text-overflow` applies to any non-`visible` overflow.
+   */
+  protected readonly contentClasses = computed(() =>
+    this.truncate()
+      ? "tw-overflow-clip [overflow-clip-margin:4px] tw-text-ellipsis tw-whitespace-nowrap"
+      : "tw-text-wrap tw-break-words",
+  );
 }

--- a/libs/components/src/table/v2/bit-row.component.ts
+++ b/libs/components/src/table/v2/bit-row.component.ts
@@ -58,7 +58,10 @@ export class BitRowComponent {
       "tw-grid-flow-col",
       "tw-auto-cols-fr",
       // A fixed height can't absorb a tall cell, so clip it rather than let it overlap the next row.
-      ...(this.fixedHeight() != null ? ["tw-overflow-clip"] : []),
+      // The clip margin lets a cell's focus ring (a box-shadow, drawn outside the element)
+      // paint past the row edge while the row still contains the cell itself; 4px covers the
+      // widest ring in the library. `overflow-clip` honors the margin where `hidden` would not.
+      ...(this.fixedHeight() != null ? ["tw-overflow-clip", "[overflow-clip-margin:4px]"] : []),
       ...(this.table?.presentation() === "list"
         ? // `list` rows size to content off a `bit-item`-style minimum height.
           [

--- a/libs/components/src/table/v2/bit-row.component.ts
+++ b/libs/components/src/table/v2/bit-row.component.ts
@@ -57,10 +57,8 @@ export class BitRowComponent {
       "tw-grid",
       "tw-grid-flow-col",
       "tw-auto-cols-fr",
-      // A fixed height can't absorb a tall cell, so clip it rather than let it overlap the next
-      // row. `grid-rows-1` pins the single row track to the row's own height instead of letting
-      // it stretch to the tallest cell's content, which would push that content out the bottom of
-      // the row and into the next one.
+      // If the row is fixed height, tall cell overflow should be clipped and the row should not
+      // expand its height to fit the tall cell's content
       ...(this.fixedHeight() != null ? ["tw-grid-rows-1", "tw-overflow-clip"] : []),
       ...(this.table?.presentation() === "list"
         ? // `list` rows size to content off a `bit-item`-style minimum height.

--- a/libs/components/src/table/v2/bit-row.component.ts
+++ b/libs/components/src/table/v2/bit-row.component.ts
@@ -57,11 +57,11 @@ export class BitRowComponent {
       "tw-grid",
       "tw-grid-flow-col",
       "tw-auto-cols-fr",
-      // A fixed height can't absorb a tall cell, so clip it rather than let it overlap the next row.
-      // The clip margin lets a cell's focus ring (a box-shadow, drawn outside the element)
-      // paint past the row edge while the row still contains the cell itself; 4px covers the
-      // widest ring in the library. `overflow-clip` honors the margin where `hidden` would not.
-      ...(this.fixedHeight() != null ? ["tw-overflow-clip", "[overflow-clip-margin:4px]"] : []),
+      // A fixed height can't absorb a tall cell, so clip it rather than let it overlap the next
+      // row. `grid-rows-1` pins the single row track to the row's own height instead of letting
+      // it stretch to the tallest cell's content, which would push that content out the bottom of
+      // the row and into the next one.
+      ...(this.fixedHeight() != null ? ["tw-grid-rows-1", "tw-overflow-clip"] : []),
       ...(this.table?.presentation() === "list"
         ? // `list` rows size to content off a `bit-item`-style minimum height.
           [

--- a/libs/components/src/table/v2/table-v2.stories.ts
+++ b/libs/components/src/table/v2/table-v2.stories.ts
@@ -16,9 +16,11 @@ import { BulkActionComponent } from "../../bulk-actions-bar/bulk-action.componen
 import { BulkActionsBarComponent } from "../../bulk-actions-bar/bulk-actions-bar.component";
 import { BulkAdditionalActionComponent } from "../../bulk-actions-bar/bulk-additional-action.component";
 import { ButtonModule } from "../../button";
+import { ChipActionComponent } from "../../chips/chip-action";
 import { DialogModule } from "../../dialog";
 import { FilterMenuModule, type FilterOptionIconTile } from "../../filter-menu";
 import { FormFieldModule } from "../../form-field";
+import { IconButtonModule } from "../../icon-button";
 import { IconTileComponent, type IconTileVariant } from "../../icon-tile/icon-tile.component";
 import { InputModule } from "../../input/input.module";
 import { LayoutComponent, PageComponent } from "../../layout";
@@ -836,6 +838,8 @@ export default {
         BulkActionComponent,
         BulkAdditionalActionComponent,
         IconTileComponent,
+        ChipActionComponent,
+        IconButtonModule,
         LayoutComponent,
         PageComponent,
         TypographyModule,
@@ -1054,6 +1058,40 @@ export const RichCells: Story = {
           <bit-cell *bitCellDef="table.columns.email; let row">
             {{ row.email }}
             <span slot="secondary">User #{{ row.id }}</span>
+          </bit-cell>
+        </bit-column>
+      </bit-table-v2>
+    `,
+  }),
+};
+
+export const CellFocusRings: Story = {
+  render: () => ({
+    props: { table: userTable },
+    template: /*html*/ `
+      <bit-table-v2 [tableDef]="table" [virtualRowHeight]="48" [height]="5">
+        <bit-column>
+          <bit-header-cell>Name</bit-header-cell>
+          <bit-cell *bitCellDef="table.columns.name; let row">
+            <button
+              type="button"
+              bit-chip-action
+              size="small"
+              [label]="row.name + ' with a name long enough to truncate'"
+              class="tw-test-focus-visible"
+            ></button>
+          </bit-cell>
+        </bit-column>
+        <bit-column>
+          <bit-header-cell>Actions</bit-header-cell>
+          <bit-cell *bitCellDef="table.columns.email; let row">
+            <button
+              type="button"
+              bitIconButton="bwi-ellipsis-v"
+              size="small"
+              label="Options"
+              class="tw-test-focus-visible"
+            ></button>
           </bit-cell>
         </bit-column>
       </bit-table-v2>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1296](https://bitwarden.atlassian.net/browse/CL-1296)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Focus rings for interactive elements inside of table-v2 were getting clipped off. This PR adjusts our overflow classes to allow some buffer for that while still maintaining proper cell size and text truncation.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="848" height="587" alt="Screenshot 2026-09-09 at 12 20 49 PM" src="https://github.com/user-attachments/assets/8a0dfa55-a361-4eaa-926b-f07eefe7a5c1" /> | <img width="848" height="587" alt="Screenshot 2026-09-09 at 12 20 43 PM" src="https://github.com/user-attachments/assets/627401f0-a369-4d89-b749-b267371f987d" /> |


[CL-1296]: https://bitwarden.atlassian.net/browse/CL-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ