### PR TITLE
[PM-42474] fix: validate initiator in auto-submit redirect handler

### DIFF
--- a/apps/browser/src/autofill/background/auto-submit-login.background.spec.ts
+++ b/apps/browser/src/autofill/background/auto-submit-login.background.spec.ts
@@ -271,6 +271,90 @@ describe("AutoSubmitLoginBackground", () => {
       });
     });
 
+    describe("promoting hosts from redirect chains", () => {
+      const attackerHost = "attacker.com";
+      const attackerUrl = `https://${attackerHost}/redirect`;
+      const targetUrl = `https://${validAutoSubmitHost}/login#autosubmit=1`;
+
+      beforeEach(async () => {
+        await autoSubmitLoginBackground.init();
+      });
+
+      it("promotes the target host when the redirecting URL is a policy-configured IdP", () => {
+        triggerWebRequestOnBeforeRedirectEvent(
+          mock<chrome.webRequest.OnBeforeRedirectDetails>({
+            url: validIpdUrl1,
+            redirectUrl: targetUrl,
+            type: "main_frame",
+          }),
+        );
+
+        expect(autoSubmitLoginBackground["validAutoSubmitHosts"].has(validAutoSubmitHost)).toBe(
+          true,
+        );
+      });
+
+      it("does not promote any host when the redirecting URL is untrusted", () => {
+        triggerWebRequestOnBeforeRedirectEvent(
+          mock<chrome.webRequest.OnBeforeRedirectDetails>({
+            url: attackerUrl,
+            redirectUrl: targetUrl,
+            type: "main_frame",
+          }),
+        );
+
+        expect(autoSubmitLoginBackground["validAutoSubmitHosts"].has(validAutoSubmitHost)).toBe(
+          false,
+        );
+        expect(autoSubmitLoginBackground["validAutoSubmitHosts"].has(attackerHost)).toBe(false);
+      });
+
+      it("allows a chained redirect from an already-promoted auto-submit host to continue", () => {
+        const intermediateHost = "intermediate.example.com";
+        autoSubmitLoginBackground["validAutoSubmitHosts"].add(intermediateHost);
+
+        triggerWebRequestOnBeforeRedirectEvent(
+          mock<chrome.webRequest.OnBeforeRedirectDetails>({
+            url: `https://${intermediateHost}/next`,
+            redirectUrl: targetUrl,
+            type: "main_frame",
+          }),
+        );
+
+        expect(autoSubmitLoginBackground["validAutoSubmitHosts"].has(validAutoSubmitHost)).toBe(
+          true,
+        );
+      });
+
+      it("does not promote when the redirectUrl does not carry the autosubmit fragment", () => {
+        triggerWebRequestOnBeforeRedirectEvent(
+          mock<chrome.webRequest.OnBeforeRedirectDetails>({
+            url: validIpdUrl1,
+            redirectUrl: `https://${validAutoSubmitHost}/login`,
+            type: "main_frame",
+          }),
+        );
+
+        expect(autoSubmitLoginBackground["validAutoSubmitHosts"].has(validAutoSubmitHost)).toBe(
+          false,
+        );
+      });
+
+      it("does not promote when the redirect occurs in a sub-frame", () => {
+        triggerWebRequestOnBeforeRedirectEvent(
+          mock<chrome.webRequest.OnBeforeRedirectDetails>({
+            url: validIpdUrl1,
+            redirectUrl: targetUrl,
+            type: "sub_frame",
+          }),
+        );
+
+        expect(autoSubmitLoginBackground["validAutoSubmitHosts"].has(validAutoSubmitHost)).toBe(
+          false,
+        );
+      });
+    });
+
     describe("when the extension is running on a Safari browser", () => {
       const tabId = 1;
       const tab = mock<chrome.tabs.Tab>({ id: tabId, url: validIpdUrl1 });

--- a/apps/browser/src/autofill/background/auto-submit-login.background.ts
+++ b/apps/browser/src/autofill/background/auto-submit-login.background.ts
@@ -293,18 +293,24 @@ export class AutoSubmitLoginBackground implements AutoSubmitLoginBackgroundAbstr
   };
 
   /**
-   * Handles web requests that are triggering a redirect. Stores the redirect URL as a valid
-   * auto-submit host if the redirectUrl should trigger an auto-submit.
+   * Promotes hosts from a redirect chain into validAutoSubmitHosts. The initiator check
+   * prevents any origin from 302'ing to `target#autosubmit=1` to force autofill there.
    *
    * @param details - The details of the request.
    */
   private handleWebRequestOnBeforeRedirect = (
     details: chrome.webRequest.OnBeforeRedirectDetails,
   ) => {
-    if (this.isRequestInMainFrame(details) && this.urlContainsAutoSubmitHash(details.redirectUrl)) {
-      this.validAutoSubmitHosts.add(this.getUrlHost(details.redirectUrl));
-      this.validAutoSubmitHosts.add(this.getUrlHost(details.url));
+    if (
+      !this.isRequestInMainFrame(details) ||
+      !this.urlContainsAutoSubmitHash(details.redirectUrl) ||
+      !this.isValidInitiator(details.url)
+    ) {
+      return;
     }
+
+    this.validAutoSubmitHosts.add(this.getUrlHost(details.redirectUrl));
+    this.validAutoSubmitHosts.add(this.getUrlHost(details.url));
   };
 
   /**


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-42474](https://bitwarden.atlassian.net/browse/PM-42474)

(to resolve [VULN-871](https://bitwarden.atlassian.net/browse/VULN-871))

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

`handleWebRequestOnBeforeRedirect` was promoting any host in a redirect chain that carried `#autosubmit=1` into `validAutoSubmitHosts` without checking the redirect source. Any origin could 302 to `target#autosubmit=1` and force autofill/submission against that target using the victim's personal vault credentials, turning the `AutomaticAppLogIn` policy into a login-CSRF vector against arbitrary sites.

The fix gates promotion on the redirecting URL (`details.url`) being trusted — either a policy-configured IdP host, or a host already promoted during the current chain. Uses `isValidInitiator`, the same helper the sibling `handleOnBeforeRequest` already relies on.

### Design notes

- Chose permissive (`isValidInitiator` — IdPs plus already-promoted hosts) rather than strict (`isValidIdpHost` — IdPs only). Mirrors the sibling `handleOnBeforeRequest` handler's model and preserves multi-hop chains from a legitimate IdP. Attacker origins are still blocked because they can never enter `validAutoSubmitHosts` without a trusted first hop. This is a straightforward one-line change if anyone prefers strict.

- Non-IdP intermediate hops in a redirect chain will no longer promote the target host. This shape is not documented as supported (admin UI only exposes `idpHost`); admins whose deployment relies on it will need to list the intermediate. Called out here in case QA sees a Safari-specific regression.

### Testing

- Unit tests added for the new gate: attack blocked, IdP promotes, chained-promotion continues, no-hash short-circuit, sub-frame short-circuit.
- **Live-IdP manual verification was not performed** — hoping QA can run the attack repro and legit `AutomaticAppLogIn` flow end-to-end.


[PM-42474]: https://bitwarden.atlassian.net/browse/PM-42474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-871]: https://bitwarden.atlassian.net/browse/VULN-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ