### PR TITLE
[PM-43253] Show suspended organization icon in the Password Manager side nav

### DIFF
--- a/libs/vault/src/components/vault-breadcrumbs/vault-breadcrumbs.component.spec.ts
+++ b/libs/vault/src/components/vault-breadcrumbs/vault-breadcrumbs.component.spec.ts
@@ -47,6 +47,7 @@ describe("VaultBreadcrumbsComponent", () => {
           icon: "bwi-business",
           type: VaultNavItemType.Organization,
           defaultUserCollectionId: myItemsCollectionId,
+          enabled: true,
         },
       ],
       organizationDataOwnership: true,

--- a/libs/vault/src/components/vault-nav-section/vault-nav-section.component.html
+++ b/libs/vault/src/components/vault-nav-section/vault-nav-section.component.html
@@ -43,6 +43,14 @@
             [emphasis]="vaultTile.emphasis ?? 'subtle'"
             size="sm"
           />
+          @if (!vault.enabled) {
+            <bit-icon
+              slot="end"
+              name="bwi-exclamation-triangle"
+              [ariaLabel]="'organizationIsDisabled' | i18n"
+              appA11yTitle="{{ 'organizationIsDisabled' | i18n }}"
+            ></bit-icon>
+          }
           <bit-nav-item
             icon="bwi-list-alt"
             [text]="'allVaultItems' | i18n"

--- a/libs/vault/src/components/vault-nav-section/vault-nav-section.component.spec.ts
+++ b/libs/vault/src/components/vault-nav-section/vault-nav-section.component.spec.ts
@@ -29,6 +29,7 @@ const personalItem: VaultNavItemViewModel = {
   color: "coral",
   icon: "bwi-user",
   type: VaultNavItemType.Personal,
+  enabled: true,
 };
 
 const orgA: VaultNavItemViewModel = {
@@ -36,6 +37,7 @@ const orgA: VaultNavItemViewModel = {
   label: "Acme corporation",
   icon: "bwi-business",
   type: VaultNavItemType.Organization,
+  enabled: true,
 };
 
 const family: VaultNavItemViewModel = {
@@ -43,6 +45,7 @@ const family: VaultNavItemViewModel = {
   label: "Smith family",
   icon: "bwi-family",
   type: VaultNavItemType.Family,
+  enabled: true,
 };
 
 const personalOnly: VaultsNavViewModel = {
@@ -336,6 +339,40 @@ describe("VaultNavSectionComponent", () => {
       const group = expandGroup("Acme corporation");
 
       expect(navItem(group, "myItemsV2")).toBeUndefined();
+    });
+  });
+
+  describe("a suspended organization", () => {
+    /** The suspended-org warning icons rendered in the nav, by the group each sits in. */
+    const suspendedIconGroups = () =>
+      fixture.debugElement
+        .queryAll(By.css("bit-nav-group"))
+        .filter(
+          (group) => group.nativeElement.querySelector("bit-icon.bwi-exclamation-triangle") != null,
+        )
+        .map((group) => group.componentInstance.text());
+
+    it("marks the suspended organization and leaves the enabled ones unmarked", () => {
+      viewModel$.next({ ...withOrgs, vaults: [personalItem, { ...orgA, enabled: false }, family] });
+      fixture.detectChanges();
+
+      expect(suspendedIconGroups()).toEqual(["Acme corporation"]);
+    });
+
+    it("labels the icon so it is not announced as decoration", () => {
+      viewModel$.next({ ...withOrgs, vaults: [personalItem, { ...orgA, enabled: false }, family] });
+      fixture.detectChanges();
+
+      const icon = fixture.nativeElement.querySelector("bit-icon.bwi-exclamation-triangle");
+
+      expect(icon.getAttribute("aria-label")).toBe("organizationIsDisabled");
+    });
+
+    it("marks no organization when every vault is enabled", () => {
+      viewModel$.next(withOrgs);
+      fixture.detectChanges();
+
+      expect(suspendedIconGroups()).toEqual([]);
     });
   });
 

--- a/libs/vault/src/components/vault-nav-section/vault-nav-section.component.ts
+++ b/libs/vault/src/components/vault-nav-section/vault-nav-section.component.ts
@@ -7,7 +7,13 @@ import { switchMap } from "rxjs";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { OrganizationId } from "@bitwarden/common/types/guid";
-import { IconTileComponent, IconTileOptions, NavigationModule } from "@bitwarden/components";
+import {
+  A11yTitleDirective,
+  IconModule,
+  IconTileComponent,
+  IconTileOptions,
+  NavigationModule,
+} from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { ALL_ITEMS_ICON_TILE, navIconTile } from "../../models/vault-icon-tile";
@@ -31,7 +37,14 @@ import { VaultNavService } from "../../services/vault-nav.service";
   selector: "vault-nav-section",
   templateUrl: "./vault-nav-section.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgTemplateOutlet, I18nPipe, NavigationModule, IconTileComponent],
+  imports: [
+    NgTemplateOutlet,
+    I18nPipe,
+    NavigationModule,
+    IconTileComponent,
+    IconModule,
+    A11yTitleDirective,
+  ],
 })
 export class VaultNavSectionComponent {
   protected readonly VaultNavItemType = VaultNavItemType;

--- a/libs/vault/src/models/vault-icon-tile.spec.ts
+++ b/libs/vault/src/models/vault-icon-tile.spec.ts
@@ -54,7 +54,7 @@ describe("navIconTile", () => {
     type: VaultNavItemType,
     icon: BitwardenIcon,
     color?: string,
-  ): VaultNavItemViewModel => ({ id: "1", label: "Vault", type, color, icon });
+  ): VaultNavItemViewModel => ({ id: "1", label: "Vault", type, color, icon, enabled: true });
 
   // Org tiles derive their color from `type` alone, so the view model carries no color for them.
   it("gives a family org the teal variant", () => {
@@ -104,6 +104,7 @@ describe("vaultScopeHeaderTile", () => {
         type: VaultNavItemType.Personal,
         color: "#abcdef",
         icon: "bwi-user",
+        enabled: true,
       },
     ],
     organizationDataOwnership: false,
@@ -117,6 +118,7 @@ describe("vaultScopeHeaderTile", () => {
         type: VaultNavItemType.Organization,
         icon: "bwi-business",
         defaultUserCollectionId: myItemsId,
+        enabled: true,
       },
     ],
     organizationDataOwnership: true,

--- a/libs/vault/src/models/vault-nav-view-model.ts
+++ b/libs/vault/src/models/vault-nav-view-model.ts
@@ -28,6 +28,8 @@ export interface VaultNavItemViewModel {
   type: VaultNavItemType;
   /** The org's default user collection ("My items"); set only on org items under data ownership. */
   defaultUserCollectionId?: CollectionId;
+  /** False when the organization is suspended */
+  enabled: boolean;
 }
 
 export interface VaultsNavViewModel {

--- a/libs/vault/src/models/vault-scope.spec.ts
+++ b/libs/vault/src/models/vault-scope.spec.ts
@@ -86,6 +86,7 @@ const buildNavItem = (
   icon: "bwi-user",
   type,
   defaultUserCollectionId: navDefaultUserCollectionId,
+  enabled: true,
 });
 
 const buildNav = (

--- a/libs/vault/src/routing/vault-scope.guard.spec.ts
+++ b/libs/vault/src/routing/vault-scope.guard.spec.ts
@@ -51,6 +51,7 @@ describe("vaultScopeGuard", () => {
     color: "coral",
     icon: "bwi-user",
     type: VaultNavItemType.Personal,
+    enabled: true,
   };
 
   const organizationVault: VaultNavItemViewModel = {
@@ -58,6 +59,7 @@ describe("vaultScopeGuard", () => {
     label: "Acme corporation",
     icon: "bwi-business",
     type: VaultNavItemType.Organization,
+    enabled: true,
   };
 
   /** The same organization under data ownership, which gives each member a "My items" collection. */

--- a/libs/vault/src/services/default-vault-nav.service.spec.ts
+++ b/libs/vault/src/services/default-vault-nav.service.spec.ts
@@ -21,11 +21,16 @@ import { VaultNavItemType } from "../models/vault-nav-view-model";
 import { DefaultVaultNavService } from "./default-vault-nav.service";
 
 /** Build a minimal Organization with just the fields the service reads. */
-function makeOrg(name: string, productTierType: ProductTierType): Organization {
+function makeOrg(
+  name: string,
+  productTierType: ProductTierType,
+  enabled: boolean = true,
+): Organization {
   const org = new Organization();
   org.id = newGuid() as OrganizationId;
   org.name = name;
   org.productTierType = productTierType;
+  org.enabled = enabled;
   return org;
 }
 
@@ -115,6 +120,20 @@ describe("DefaultVaultNavService", () => {
 
       const familyItems = vm.vaults.filter((v) => v.type === VaultNavItemType.Family);
       expect(familyItems).toHaveLength(2);
+    });
+
+    it("carries each organization's suspended state through to its nav item", async () => {
+      const suspended = makeOrg("Suspended Org", ProductTierType.Teams, false);
+      const active = makeOrg("Active Org", ProductTierType.Teams);
+      memberOrgs$.next([suspended, active]);
+
+      const vm = await firstValueFrom(service.viewModel$(userId));
+
+      expect(vm.vaults.map((v) => [v.label, v.enabled])).toEqual([
+        ["myVault", true],
+        ["Active Org", true],
+        ["Suspended Org", false],
+      ]);
     });
 
     it("leaves color unset on organization items", async () => {

--- a/libs/vault/src/services/default-vault-nav.service.ts
+++ b/libs/vault/src/services/default-vault-nav.service.ts
@@ -94,6 +94,7 @@ export class DefaultVaultNavService extends VaultNavService {
       color: personalColor,
       icon: "bwi-user",
       type: VaultNavItemType.Personal,
+      enabled: true,
     };
 
     const sortedOrgItems: VaultNavItemViewModel[] = [...orgs]
@@ -104,6 +105,7 @@ export class DefaultVaultNavService extends VaultNavService {
         icon: getOrgIconForTier(org.productTierType),
         type: this.orgType(org),
         defaultUserCollectionId: defaultUserCollectionIds.get(org.id),
+        enabled: org.enabled,
       }));
 
     const ownershipApplies = dataOwnership && sortedOrgItems.length > 0;


### PR DESCRIPTION
## 🎟️ Tracking

[PM-43253](https://bitwarden.atlassian.net/browse/PM-43253)

## 📔 Objective

The Password Manager side nav rendered no indicator for a suspended organization, while Admin Console showed one next to the org name.

`DefaultVaultNavService.buildViewModel` dropped `org.enabled` when mapping `Organization` to `VaultNavItemViewModel`, so the flag never reached the template. The data was available upstream — `memberOrganizations$` only filters out *provider* organizations, never disabled ones — but the view model was lossy, which is why Admin Console showed the icon and PM did not: the org switcher reads `Organization` directly.

Changes:

- Added `enabled` to `VaultNavItemViewModel` and populated it in `DefaultVaultNavService`. The personal vault is hardcoded `true`, since it cannot be suspended.
- Rendered the warning icon in the nav group's `slot="end"`, which places it beside the chevron.

`enabled` is required rather than optional so the compiler flags every construction site; that surfaced five specs silently building nav items, which are updated here.

The icon matches the Admin Console org switcher: `bwi-exclamation-triangle`, labelled with the existing `organizationIsDisabled` key (already present in all three app locales, so no new strings).

Note this surface is behind `VFO1Foundation`, which currently defaults to off.

## 📸 Screenshots

<img width="532" height="825" alt="Screenshot 2026-09-09 at 4 30 07 PM" src="https://github.com/user-attachments/assets/6e62ed6d-3907-41f5-a494-a40841ac48e1" />




[PM-43253]: https://bitwarden.atlassian.net/browse/PM-43253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ