### PR TITLE
[PM-42226, PM-42227] Wire search keyboard shortcuts into vault

### DIFF
--- a/libs/vault/src/components/vault-items-table/vault-items-table.component.html
+++ b/libs/vault/src/components/vault-items-table/vault-items-table.component.html
@@ -12,7 +12,11 @@
   (selectedChange)="selectedChange.emit($event)"
 >
   <bit-table-toolbar>
-    <bit-search class="tw-flex-1" [placeholder]="'search' | i18n"></bit-search>
+    <bit-search
+      class="tw-flex-1"
+      [placeholder]="'search' | i18n"
+      [useKeyShortcuts]="true"
+    ></bit-search>
 
     <!-- Page-level controls (Import, Add, ...) are the host's concern, not the table's. -->
     <ng-content select="[slot=toolbar]" slot="end"></ng-content>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42226](https://bitwarden.atlassian.net/browse/PM-42226)
[PM-42227](https://bitwarden.atlassian.net/browse/PM-42227)

> **Depends on:** #22830

## 📔 Objective

Enables the `useKeyShortcuts` on the vault search input for both web and desktop. `vault-items-table` is VFO1-only, so `[useKeyShortcuts]="true"` is hardcoded directly on its `<bit-search>`

**NOTE**
On desktop, the existing Electron menu accelerator (`CmdOrCtrl+F` → `focusSearch` broadcaster) is still wired in. Otherwise the menu item would stop working. They both focus the same input so I don't think this is problematic. It was not in my testing. 

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/e17ddbec-141d-414b-8784-ce4cabd548a6" />

[PM-42226]: https://bitwarden.atlassian.net/browse/PM-42226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-42227]: https://bitwarden.atlassian.net/browse/PM-42227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ