### PR TITLE
[PM-43292] feat: Allow creating folders and shared folders from the toolbar's new item menu

### DIFF
--- a/apps/web/src/app/vault/individual-vault/vault-next.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.html
@@ -49,7 +49,7 @@
       [canCreateFolder]="false"
       [canCreateCollection]="false"
       (cipherAdded)="addCipher($event)"
-      (onAddItemDialog)="openAddItemDialog()"
+      (onAddItemDialog)="openAddItemDialog('empty')"
       id="vault-next_empty-new-cipher-menu"
     />
   }
@@ -69,8 +69,10 @@
       <vault-new-cipher-menu
         [canCreateCipher]="true"
         [canCreateSshKey]="true"
+        [canCreateFolder]="true"
+        [canCreateCollection]="canCreateCollections()"
         (cipherAdded)="addCipher($event)"
-        (onAddItemDialog)="openAddItemDialog()"
+        (onAddItemDialog)="openAddItemDialog('toolbar')"
       />
     }
   </div>

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.html
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.html
@@ -73,6 +73,8 @@
         [canCreateCollection]="canCreateCollections()"
         (cipherAdded)="addCipher($event)"
         (onAddItemDialog)="openAddItemDialog('toolbar')"
+        (folderAdded)="addFolder()"
+        (collectionAdded)="addCollection()"
       />
     }
   </div>

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
@@ -1,3 +1,9 @@
+// jest.mock is hoisted before imports, allowing openCollectionDialog to be intercepted.
+jest.mock("../../admin-console/organizations/shared/components/collection-dialog", () => ({
+  ...jest.requireActual("../../admin-console/organizations/shared/components/collection-dialog"),
+  openCollectionDialog: jest.fn(),
+}));
+
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { ActivatedRoute, convertToParamMap, Data, ParamMap } from "@angular/router";
@@ -7,7 +13,10 @@ import { BehaviorSubject, of, Subject } from "rxjs";
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
-import { CollectionView } from "@bitwarden/common/admin-console/models/collections";
+import {
+  CollectionDetailsResponse,
+  CollectionView,
+} from "@bitwarden/common/admin-console/models/collections";
 import { Organization } from "@bitwarden/common/admin-console/models/domain/organization";
 import { Account, AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { ConfigService } from "@bitwarden/common/platform/abstractions/config/config.service";
@@ -22,6 +31,7 @@ import { RestrictedItemTypesService } from "@bitwarden/common/vault/services/res
 import { DialogRef, DialogService } from "@bitwarden/components";
 import { I18nPipe } from "@bitwarden/ui-common";
 import {
+  AddEditFolderDialogComponent,
   AddItemDialogComponent,
   AddItemDialogResult,
   CipherRowMenuHandlers,
@@ -39,6 +49,11 @@ import {
   Vfo1I18nPipe,
 } from "@bitwarden/vault";
 
+import {
+  CollectionDialogAction,
+  CollectionDialogResult,
+  openCollectionDialog,
+} from "../../admin-console/organizations/shared/components/collection-dialog";
 import { WebVaultItemActionsService } from "../services/vault-item-actions.service";
 
 import { VaultNextComponent } from "./vault-next.component";
@@ -58,7 +73,9 @@ describe("VaultNextComponent", () => {
   let itemActions: MockProxy<WebVaultItemActionsService>;
   let cipherRowMenuService: MockProxy<CipherRowMenuService>;
   let restrictedItemTypesService: MockProxy<RestrictedItemTypesService>;
+  let collectionService: MockProxy<CollectionService>;
   let addItemDialogOpen: jest.SpyInstance;
+  let addEditFolderDialogOpen: jest.SpyInstance;
 
   let ciphers$: Subject<CipherView[] | null>;
   let folders$: BehaviorSubject<FolderView[]>;
@@ -196,12 +213,15 @@ describe("VaultNextComponent", () => {
     const folderService = mock<FolderService>();
     folderService.folderViews$.mockReturnValue(folders$);
 
-    const collectionService = mock<CollectionService>();
+    collectionService = mock<CollectionService>();
     collectionService.decryptedCollections$.mockReturnValue(collections$);
 
     // Needed only by the projected toolbar button's i18n pipe.
     const i18nService = mock<I18nService>();
     i18nService.t.mockImplementation((key: string) => key);
+    // Used by `Utils.getSortFunction` to sort `addCollection`'s eligible organizations — the mock
+    // otherwise deep-mocks this into a truthy object whose `compare` isn't callable.
+    i18nService.collator = undefined;
 
     const organizationService = mock<OrganizationService>();
     organizationService.organizations$.mockReturnValue(organizations$);
@@ -215,9 +235,24 @@ describe("VaultNextComponent", () => {
       value: showQuickCopyActions$,
     });
 
+    // `jest.spyOn` returns the existing mock (rather than a fresh one) once a static method is
+    // already spied, so its call history survives across tests unless cleared explicitly here.
     addItemDialogOpen = jest
       .spyOn(AddItemDialogComponent, "open")
+      .mockClear()
       .mockReturnValue({ closed: of(undefined) } as unknown as DialogRef<never>);
+
+    addEditFolderDialogOpen = jest
+      .spyOn(AddEditFolderDialogComponent, "open")
+      .mockClear()
+      .mockReturnValue({ closed: of(undefined) } as unknown as DialogRef<never>);
+
+    // Same reasoning as above: the `jest.mock` factory creates `openCollectionDialog`'s jest.fn()
+    // once for the whole file, so it needs an explicit reset each test too.
+    jest
+      .mocked(openCollectionDialog)
+      .mockReset()
+      .mockReturnValue({ closed: of(undefined) } as unknown as DialogRef<CollectionDialogResult>);
 
     await TestBed.configureTestingModule({
       imports: [VaultNextComponent],
@@ -840,6 +875,29 @@ describe("VaultNextComponent", () => {
         canCreateCollection: true,
       });
     });
+
+    it("opens the add/edit folder dialog when Folder is picked from the picker dialog", async () => {
+      addItemDialogOpen.mockReturnValue({
+        closed: of({ result: AddItemDialogResult.Folder }),
+      } as unknown as DialogRef<never>);
+
+      await component().openAddItemDialog("toolbar");
+
+      expect(addEditFolderDialogOpen).toHaveBeenCalled();
+    });
+
+    it("opens the collection dialog when Shared folder is picked from the picker dialog", async () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      addItemDialogOpen.mockReturnValue({
+        closed: of({ result: AddItemDialogResult.Collection }),
+      } as unknown as DialogRef<never>);
+
+      await component().openAddItemDialog("toolbar");
+
+      expect(openCollectionDialog).toHaveBeenCalled();
+    });
   });
 
   describe("canCreateCollections", () => {
@@ -875,6 +933,101 @@ describe("VaultNextComponent", () => {
       fixture.detectChanges();
 
       expect(component().canCreateCollections()).toBe(false);
+    });
+  });
+
+  describe("addFolder", () => {
+    it("opens the add/edit folder dialog", () => {
+      component().addFolder();
+
+      expect(addEditFolderDialogOpen).toHaveBeenCalled();
+    });
+  });
+
+  describe("addCollection", () => {
+    it("does nothing when no organization allows creating collections", async () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: false }),
+      ]);
+      fixture.detectChanges();
+
+      await component().addCollection();
+
+      expect(openCollectionDialog).not.toHaveBeenCalled();
+    });
+
+    it("defaults the organization to the scoped organization when it can create collections", async () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+        buildOrganization(otherOrganizationId, "Smith family", { canCreateNewCollections: true }),
+      ]);
+      scopeTo(otherOrganizationId);
+
+      await component().addCollection();
+
+      expect(jest.mocked(openCollectionDialog).mock.calls.at(-1)![1].data).toMatchObject({
+        organizationId: otherOrganizationId,
+      });
+    });
+
+    it("falls back to the first eligible organization when the scoped organization can't create collections", async () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+        buildOrganization(otherOrganizationId, "Smith family", { canCreateNewCollections: false }),
+      ]);
+      scopeTo(otherOrganizationId);
+
+      await component().addCollection();
+
+      expect(jest.mocked(openCollectionDialog).mock.calls.at(-1)![1].data).toMatchObject({
+        organizationId,
+      });
+    });
+
+    it("passes the scoped shared folder as the parent collection", async () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      scopeTo(organizationId, engineeringId);
+
+      await component().addCollection();
+
+      expect(jest.mocked(openCollectionDialog).mock.calls.at(-1)![1].data).toMatchObject({
+        parentCollectionId: engineeringId,
+      });
+    });
+
+    it("upserts the saved collection into CollectionService", async () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      fixture.detectChanges();
+      const savedCollection = {
+        id: "new-collection-id",
+        organizationId,
+        name: "Engineering",
+      } as CollectionDetailsResponse;
+      jest.mocked(openCollectionDialog).mockReturnValue({
+        closed: of({ action: CollectionDialogAction.Saved, collection: savedCollection }),
+      } as unknown as DialogRef<CollectionDialogResult>);
+
+      await component().addCollection();
+
+      expect(collectionService.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "new-collection-id", organizationId, name: "Engineering" }),
+        userId,
+      );
+    });
+
+    it("does not upsert when the dialog is dismissed without saving", async () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      fixture.detectChanges();
+
+      await component().addCollection();
+
+      expect(collectionService.upsert).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
@@ -93,7 +93,18 @@ describe("VaultNextComponent", () => {
       name: id,
     });
 
-  const buildOrganization = (id: OrganizationId, name: string) => ({ id, name }) as Organization;
+  const buildOrganization = (
+    id: OrganizationId,
+    name: string,
+    overrides: Partial<Organization> = {},
+  ) =>
+    ({
+      id,
+      name,
+      canCreateNewCollections: false,
+      isProviderUser: false,
+      ...overrides,
+    }) as Organization;
 
   const personalNavItem: VaultNavItemViewModel = {
     id: userId,
@@ -751,7 +762,7 @@ describe("VaultNextComponent", () => {
         closed: of({ result: AddItemDialogResult.Cipher, cipherType: CipherType.Card }),
       } as unknown as DialogRef<never>);
 
-      await component().openAddItemDialog();
+      await component().openAddItemDialog("toolbar");
 
       expect(itemActions.add).toHaveBeenCalledWith(CipherType.Card, {
         organizationId: undefined,
@@ -760,7 +771,7 @@ describe("VaultNextComponent", () => {
     });
 
     it("does nothing if the picker dialog is dismissed without a selection", async () => {
-      await component().openAddItemDialog();
+      await component().openAddItemDialog("toolbar");
 
       expect(itemActions.add).not.toHaveBeenCalled();
     });
@@ -782,7 +793,7 @@ describe("VaultNextComponent", () => {
         closed: of({ result: AddItemDialogResult.Cipher, cipherType: CipherType.Card }),
       } as unknown as DialogRef<never>);
 
-      await component().openAddItemDialog();
+      await component().openAddItemDialog("toolbar");
 
       expect(itemActions.add).toHaveBeenCalledWith(CipherType.Card, {
         organizationId,
@@ -801,6 +812,69 @@ describe("VaultNextComponent", () => {
         organizationId: undefined,
         collectionId: undefined,
       });
+    });
+
+    it("only offers cipher creation when the picker opens from the empty state", async () => {
+      await component().openAddItemDialog("empty");
+
+      expect(addItemDialogOpen.mock.calls.at(-1)![1]).toEqual({
+        canCreateCipher: true,
+        canCreateSshKey: true,
+        canCreateFolder: false,
+        canCreateCollection: false,
+      });
+    });
+
+    it("also offers folder and shared folder creation when the picker opens from the toolbar", async () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      fixture.detectChanges();
+
+      await component().openAddItemDialog("toolbar");
+
+      expect(addItemDialogOpen.mock.calls.at(-1)![1]).toEqual({
+        canCreateCipher: true,
+        canCreateSshKey: true,
+        canCreateFolder: true,
+        canCreateCollection: true,
+      });
+    });
+  });
+
+  describe("canCreateCollections", () => {
+    it("is false when there are no organizations", () => {
+      expect(component().canCreateCollections()).toBeFalsy();
+    });
+
+    it("is false when no organization allows creating collections", () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: false }),
+      ]);
+      fixture.detectChanges();
+
+      expect(component().canCreateCollections()).toBe(false);
+    });
+
+    it("is true when an organization allows creating collections", () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      fixture.detectChanges();
+
+      expect(component().canCreateCollections()).toBe(true);
+    });
+
+    it("is false when the only organization allowing collection creation is a provider user", () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", {
+          canCreateNewCollections: true,
+          isProviderUser: true,
+        }),
+      ]);
+      fixture.detectChanges();
+
+      expect(component().canCreateCollections()).toBe(false);
     });
   });
 });

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.spec.ts
@@ -934,6 +934,42 @@ describe("VaultNextComponent", () => {
 
       expect(component().canCreateCollections()).toBe(false);
     });
+
+    it("is true for an organization vault scoped to an eligible organization", () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      scopeTo(organizationId);
+
+      expect(component().canCreateCollections()).toBe(true);
+    });
+
+    it("is false for the personal vault even when an organization is eligible", () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      scopeTo(MY_VAULT_ROUTE);
+
+      expect(component().canCreateCollections()).toBe(false);
+    });
+
+    it("is false for trash even when an organization is eligible", () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      scopeTo(TRASH_ROUTE);
+
+      expect(component().canCreateCollections()).toBe(false);
+    });
+
+    it("is false for the archive even when an organization is eligible", () => {
+      organizations$.next([
+        buildOrganization(organizationId, "Acme corporation", { canCreateNewCollections: true }),
+      ]);
+      scopeTo(ARCHIVE_ROUTE);
+
+      expect(component().canCreateCollections()).toBe(false);
+    });
   });
 
   describe("addFolder", () => {

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.ts
@@ -287,6 +287,10 @@ export class VaultNextComponent {
       : undefined,
   );
 
+  protected readonly canCreateCollections = computed(() => {
+    return this.organizations()?.some((o) => o.canCreateNewCollections && !o.isProviderUser);
+  });
+
   /**
    * Whether the page offers the toolbar's Import and New item actions. New items cannot be created
    * with a trashed or archived status and would "disappear" after creation on those views.
@@ -354,12 +358,24 @@ export class VaultNextComponent {
    * Handles `vault-new-cipher-menu`'s `onAddItemDialog`, which it only emits once
    * `PM32009NewItemTypes` is on.
    */
-  protected async openAddItemDialog(): Promise<void> {
+  protected async openAddItemDialog(eventOrigin: "empty" | "toolbar"): Promise<void> {
+    let toolbarOptions = {};
+    // The empty state should only give the user options that allow them to populate that
+    // empty state. Therefore folders and shared folders should only be included when the dialog
+    // is opened from the toolbar.
+    if (eventOrigin === "toolbar") {
+      toolbarOptions = {
+        canCreateFolder: true,
+        canCreateCollection: this.canCreateCollections(),
+      };
+    }
+
     const dialogRef = AddItemDialogComponent.open(this.dialogService, {
       canCreateCipher: true,
+      canCreateSshKey: true,
       canCreateFolder: false,
       canCreateCollection: false,
-      canCreateSshKey: true,
+      ...toolbarOptions,
     });
     const result = await firstValueFrom(dialogRef.closed);
     if (result?.result !== AddItemDialogResult.Cipher) {

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.ts
@@ -298,6 +298,13 @@ export class VaultNextComponent {
   );
 
   protected readonly canCreateCollections = computed(() => {
+    const scope = this.vaultScope();
+
+    // The "Add item" menu offers a "New collection" action only for organization vaults or when viewing all their items
+    if (scope.type !== VaultScopeType.Organization && scope.type !== VaultScopeType.AllItems) {
+      return false;
+    }
+
     return this.organizations()?.some((o) => o.canCreateNewCollections && !o.isProviderUser);
   });
 

--- a/apps/web/src/app/vault/individual-vault/vault-next.component.ts
+++ b/apps/web/src/app/vault/individual-vault/vault-next.component.ts
@@ -6,9 +6,14 @@ import { combineLatest, firstValueFrom, map, shareReplay, switchMap } from "rxjs
 import { CollectionService } from "@bitwarden/admin-console/common";
 import { OrganizationService } from "@bitwarden/common/admin-console/abstractions/organization/organization.service.abstraction";
 import { PolicyService } from "@bitwarden/common/admin-console/abstractions/policy/policy.service.abstraction";
+import {
+  CollectionData,
+  CollectionDetailsResponse,
+} from "@bitwarden/common/admin-console/models/collections";
 import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
 import { getUserId } from "@bitwarden/common/auth/services/account.service";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { Utils } from "@bitwarden/common/platform/misc/utils";
 import { CollectionId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 import { FolderService } from "@bitwarden/common/vault/abstractions/folder/folder.service.abstraction";
@@ -21,6 +26,7 @@ import { isGuid } from "@bitwarden/guid";
 import { PolicyType } from "@bitwarden/sdk-internal";
 import { I18nPipe, safeProvider } from "@bitwarden/ui-common";
 import {
+  AddEditFolderDialogComponent,
   AddItemDialogComponent,
   AddItemDialogResult,
   CipherRowMenuHandlers,
@@ -54,6 +60,10 @@ import {
   defaultUserCollectionId,
 } from "@bitwarden/vault";
 
+import {
+  CollectionDialogAction,
+  openCollectionDialog,
+} from "../../admin-console/organizations/shared/components/collection-dialog";
 import { HeaderModule } from "../../layouts/header/header.module";
 import { ImportDialogComponent } from "../../tools/import/import-dialog.component";
 import { WebVaultItemActionsService } from "../services/vault-item-actions.service";
@@ -378,14 +388,60 @@ export class VaultNextComponent {
       ...toolbarOptions,
     });
     const result = await firstValueFrom(dialogRef.closed);
-    if (result?.result !== AddItemDialogResult.Cipher) {
+    if (result == null) {
       return;
     }
 
-    await this.itemActions.add(result.cipherType, {
-      organizationId: this.scopedOrganizationId(),
-      collectionId: this.scopedCollectionId(),
+    if (result.result === AddItemDialogResult.Cipher) {
+      await this.itemActions.add(result.cipherType, {
+        organizationId: this.scopedOrganizationId(),
+        collectionId: this.scopedCollectionId(),
+      });
+    } else if (result.result === AddItemDialogResult.Folder) {
+      this.addFolder();
+    } else if (result.result === AddItemDialogResult.Collection) {
+      await this.addCollection();
+    }
+  }
+
+  /** Handles `vault-new-cipher-menu`'s `folderAdded`, emitted by its legacy dropdown. */
+  protected addFolder(): void {
+    AddEditFolderDialogComponent.open(this.dialogService);
+  }
+
+  /** Handles `vault-new-cipher-menu`'s `collectionAdded`, emitted by its legacy dropdown. */
+  protected async addCollection(): Promise<void> {
+    const eligibleOrganizations = this.organizations()
+      .filter((o) => o.canCreateNewCollections && !o.isProviderUser)
+      .sort(Utils.getSortFunction(this.i18nService, "name"));
+    if (eligibleOrganizations.length === 0) {
+      return;
+    }
+
+    const defaultOrganizationId =
+      eligibleOrganizations.find((o) => o.id === this.scopedOrganizationId())?.id ??
+      eligibleOrganizations[0].id;
+
+    const dialogRef = openCollectionDialog(this.dialogService, {
+      data: {
+        organizationId: defaultOrganizationId,
+        parentCollectionId: this.scopedCollectionId(),
+        showOrgSelector: true,
+        limitNestedCollections: true,
+      },
     });
+    const result = await firstValueFrom(dialogRef.closed);
+    if (result?.action !== CollectionDialogAction.Saved) {
+      return;
+    }
+
+    if (result.collection) {
+      const userId = await firstValueFrom(this.userId$);
+      await this.collectionService.upsert(
+        new CollectionData(result.collection as CollectionDetailsResponse),
+        userId,
+      );
+    }
   }
 
   protected openImportDialog(): void {

--- a/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.html
+++ b/libs/vault/src/components/new-cipher-menu/new-cipher-menu.component.html
@@ -40,16 +40,16 @@
     <bit-menu #addOptions>
       @for (item of cipherMenuItems$ | async; track item.type) {
         <button type="button" bitMenuItem (click)="cipherAdded.emit(item.type)">
-          <i class="bwi {{ item.icon }}" slot="start" aria-hidden="true"></i>
+          <bit-icon fixedWidth [name]="item.icon" slot="start" aria-hidden="true"></bit-icon>
           {{ item.labelKey | i18n }}
         </button>
       }
-      @if (canCreateCipher()) {
+      @if (canCreateFolder() || canCreateCollection()) {
         <bit-menu-divider></bit-menu-divider>
       }
       @if (canCreateFolder()) {
         <button type="button" bitMenuItem (click)="folderAdded.emit()">
-          <i class="bwi bwi-fw bwi-folder" aria-hidden="true"></i>
+          <bit-icon fixedWidth name="bwi-folder" slot="start" />
           {{ "folder" | i18n }}
         </button>
       }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-43292](https://bitwarden.atlassian.net/browse/PM-43292)

## 📔 Objective

Wires the toolbar's "New item" menu to support creating folders and shared folders, not just
ciphers — gated by whether the user has an organization that permits collection creation. The
empty-state menu still only offers cipher creation.

## 📸 Screenshots

<video src="https://github.com/user-attachments/assets/a83db933-b785-4de1-a88c-271a76fe6229" />


[PM-43292]: https://bitwarden.atlassian.net/browse/PM-43292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ