### PR TITLE
align `mark` and `measure` with abstraction docs

### DIFF
--- a/libs/logging/src/console-log.service.spec.ts
+++ b/libs/logging/src/console-log.service.spec.ts
@@ -110,7 +110,7 @@ describe("ConsoleLogService", () => {
     service.measure(0, "group", "track", "name");
 
     expect(recorder.record).toHaveBeenCalledWith(
-      LogLevel.Info,
+      LogLevel.Debug,
       expect.stringContaining("[track]: name took"),
       undefined,
     );

--- a/libs/logging/src/console-log.service.spec.ts
+++ b/libs/logging/src/console-log.service.spec.ts
@@ -104,7 +104,7 @@ describe("ConsoleLogService", () => {
     expect(consoleError).toHaveBeenCalledWith("still reaches the console");
   });
 
-  it("tees info-funneled measure calls to the recorder", () => {
+  it("tees debug-funneled measure calls to the recorder", () => {
     const service = new ConsoleLogService(true, null, recorder);
 
     service.measure(0, "group", "track", "name");

--- a/libs/logging/src/console-log.service.ts
+++ b/libs/logging/src/console-log.service.ts
@@ -84,7 +84,7 @@ export class ConsoleLogService implements LogService {
       },
     });
 
-    this.info(`${measureName} took ${measure.duration}`, properties);
+    this.debug(`${measureName} took ${measure.duration}`, properties);
     return measure;
   }
 
@@ -97,7 +97,7 @@ export class ConsoleLogService implements LogService {
       },
     });
 
-    this.info(mark.name, new Date().toISOString());
+    this.debug(mark.name, new Date().toISOString());
 
     return mark;
   }


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

`LogService` says that performance mark and measure [should issue debug logs](https://github.com/bitwarden/clients/blob/99ec1fa94e3bff8d30b7ba687d63dafbbe7fdb24/libs/logging/src/log.service.ts). They issue info logs. Fix that bug.

