### PR TITLE
Add beta templates for Github issue reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/browser-beta.yml
+++ b/.github/ISSUE_TEMPLATE/browser-beta.yml
@@ -1,0 +1,106 @@
+name: Browser Extension Beta Bug Report
+description: File a bug report for a Browser Extension beta build
+labels: [bug, browser, beta]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report for the browser extension **beta** build!
+
+        Please only use this template if you are running a beta version of the Bitwarden browser extension. For stable-release bugs, use the "Browser Extension Bug Report" instead.
+
+        Please do not submit feature requests. The [Community Forums](https://community.bitwarden.com) has a section for submitting, voting for, and discussing product feature requests.
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: How can we reproduce the behavior.
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. Click on '...'
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: A clear and concise description of what is happening.
+    validations:
+      required: true
+  - type: textarea
+    id: regression
+    attributes:
+      label: Regression
+      description: Did this work in the current stable release? If so, which version last worked?
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or Videos
+      description: If applicable, add screenshots and/or a short video to help explain your problem.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you seeing the problem on?
+      multiple: true
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating System Version
+      description: What version of the operating system(s) are you seeing the problem on?
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Web Browser
+      description: What browser(s) are you seeing the problem on?
+      multiple: true
+      options:
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Firefox
+        - Opera
+        - Brave
+        - Vivaldi
+    validations:
+      required: true
+  - type: input
+    id: browser-version
+    attributes:
+      label: Browser Version
+      description: What version of the browser(s) are you seeing the problem on?
+  - type: textarea
+    id: version
+    attributes:
+      label: Environment Versions
+      description: Copy from "Settings" → "About" → "About Bitwarden" in the extension. Should include the beta extension version and server environment.
+    validations:
+      required: true
+  - type: checkboxes
+    id: issue-tracking-info
+    attributes:
+      label: Issue Tracking Info
+      description: |
+        Issue tracking information
+      options:
+        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.

--- a/.github/ISSUE_TEMPLATE/browser-beta.yml
+++ b/.github/ISSUE_TEMPLATE/browser-beta.yml
@@ -103,4 +103,4 @@ body:
       description: |
         Issue tracking information
       options:
-        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.
+        - label: I understand that work is tracked outside of GitHub. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.

--- a/.github/ISSUE_TEMPLATE/browser.yml
+++ b/.github/ISSUE_TEMPLATE/browser.yml
@@ -98,4 +98,4 @@ body:
       description: |
         Issue tracking information
       options:
-        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.
+        - label: I understand that work is tracked outside of GitHub. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.

--- a/.github/ISSUE_TEMPLATE/cli.yml
+++ b/.github/ISSUE_TEMPLATE/cli.yml
@@ -87,4 +87,4 @@ body:
       description: |
         Issue tracking information
       options:
-        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.
+        - label: I understand that work is tracked outside of GitHub. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.

--- a/.github/ISSUE_TEMPLATE/desktop-beta.yml
+++ b/.github/ISSUE_TEMPLATE/desktop-beta.yml
@@ -1,0 +1,101 @@
+name: Desktop Beta Bug Report
+description: File a bug report for a Desktop beta build
+labels: [bug, desktop, beta]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report for a Desktop **beta** build!
+
+        Please only use this template if you are running the beta version of the Bitwarden Desktop app. For stable-release bugs, use the "Desktop Bug Report" instead.
+
+        Please do not submit feature requests. The [Community Forums](https://community.bitwarden.com) has a section for submitting, voting for, and discussing product feature requests.
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: How can we reproduce the behavior.
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. Click on '...'
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: A clear and concise description of what is happening.
+    validations:
+      required: true
+  - type: textarea
+    id: regression
+    attributes:
+      label: Regression
+      description: Did this work in the current stable release? If so, which version last worked?
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or Videos
+      description: If applicable, add screenshots and/or a short video to help explain your problem.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you seeing the problem on?
+      multiple: true
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: Operating System Version
+      description: What version of the operating system(s) are you seeing the problem on?
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      multiple: true
+      options:
+        - Direct Download (from bitwarden.com)
+        - Mac App Store
+        - Microsoft Store
+        - Homebrew
+        - Chocolatey
+        - Snap
+        - Flatpak
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Beta Build Version
+      description: What beta version of our software are you running? (go to "Help" → "About Bitwarden" in the app)
+    validations:
+      required: true
+  - type: checkboxes
+    id: issue-tracking-info
+    attributes:
+      label: Issue Tracking Info
+      description: |
+        Issue tracking information
+      options:
+        - label: I understand that work is tracked outside of GitHub. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.

--- a/.github/ISSUE_TEMPLATE/web.yml
+++ b/.github/ISSUE_TEMPLATE/web.yml
@@ -99,4 +99,4 @@ body:
       description: |
         Issue tracking information
       options:
-        - label: I understand that work is tracked outside of Github. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.
+        - label: I understand that work is tracked outside of GitHub. A PR will be linked to this issue should one be opened to address it, but Bitwarden doesn't use fields like "assigned", "milestone", or "project" to track progress.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-43355

## 📔 Objective

We want to be able to collect bug reports specific to the beta releases of the desktop and browser.

This is independent of feedback, which will be collected from public forums.  We would like to have a “sticky” format for users to report bugs, where we can collect details and maintain an engagement with the user to identify whether we can resolve it.

Different templates are necessary because we need to trigger on them in automations in order to route to specific Jira projects to ensure that it doesn’t get mixed with the other non-beta client issues.  We do not have the ability to deterministically query the contents of the issue (e.g. a version number or a question in the issue template) in order to route tickets - a separate template and label is required.

📓 Note that this template includes OSes and browsers on which we are not currently offering beta clients, but it is designed to be forward-looking to future betas across other configurations without having to be changed.
