### PR TITLE
[PM-42971] Ensure area around nav collapse button is clickable

### DIFF
--- a/libs/components/src/navigation/nav-item.component.html
+++ b/libs/components/src/navigation/nav-item.component.html
@@ -162,7 +162,7 @@
 
           @if (open) {
             <div
-              class="tw-flex tw-items-center tw-pe-2 tw-gap-1 empty:tw-hidden"
+              class="tw-flex tw-items-center tw-pe-2 tw-gap-1 empty:tw-hidden tw-self-stretch"
               (click)="onEndSlotClick($event)"
             >
               <ng-container *ngTemplateOutlet="endSlot"></ng-container>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-42971](https://bitwarden.atlassian.net/browse/PM-42971)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The space above and below the trailing expand/collapse arrow was not receiving click events, leading to dead space that did not trigger the action.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:


https://github.com/user-attachments/assets/840d22d2-1e5d-40a2-9544-b9e0250a79bd


After:


https://github.com/user-attachments/assets/01f9ae7f-ad4c-466a-bfe1-4646e39ab78c



[PM-42971]: https://bitwarden.atlassian.net/browse/PM-42971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ