### PR TITLE
feat(desktop): Add SSHAgentSetupDialog feature flag

### DIFF
--- a/libs/common/src/enums/feature-flag.enum.ts
+++ b/libs/common/src/enums/feature-flag.enum.ts
@@ -41,6 +41,7 @@ export enum FeatureFlag {
   WindowsDesktopAutotypeGA = "windows-desktop-autotype-ga",
   WindowsNativeCredentialSync = "windows-native-credential-sync",
   SSHecdsa = "ssh-ecdsa",
+  SSHAgentSetupDialog = "ssh-agent-setup-dialog",
 
   /* Billing */
   PM29108_EnablePersonalDiscounts = "pm-29108-enable-personal-discounts",
@@ -161,6 +162,7 @@ export const DefaultFeatureFlagValue = {
   [FeatureFlag.WindowsDesktopAutotypeGA]: FALSE,
   [FeatureFlag.WindowsNativeCredentialSync]: FALSE,
   [FeatureFlag.SSHecdsa]: FALSE,
+  [FeatureFlag.SSHAgentSetupDialog]: FALSE,
 
   /* Tools */
   [FeatureFlag.SendControls]: FALSE,


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Adds the `SSHAgentSetupDialog` feature flag (`ssh-agent-setup-dialog`), which gates the SSH agent setup dialog and the auto-configuration built on top of it.

Flag only — first consumed by the next PR in the stack.

## 📸 Screenshots
