### PR TITLE
feat(ssh-agent): Add SSH agent setup dialog

### DIFF
--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -424,6 +424,8 @@ export declare namespace sshagent {
     replace(newKeys: Array<SshKeyData>): void
   }
   export type SSHAgentState = SshAgentState
+  /** The address SSH clients connect to in order to reach the agent. */
+  export function getSocketAddress(): string
   /** SSH public key data */
   export interface PublicKey {
     alg: string

--- a/apps/desktop/desktop_native/napi/src/sshagent.rs
+++ b/apps/desktop/desktop_native/napi/src/sshagent.rs
@@ -106,6 +106,12 @@ pub mod sshagent {
         }
     }
 
+    /// The address SSH clients connect to in order to reach the agent.
+    #[napi]
+    pub fn get_socket_address() -> napi::Result<String> {
+        ssh_agent::socket_address().map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
     /// Wrapper for Electron to be able to interface with the agent directly.
     #[napi]
     pub struct SSHAgentState {

--- a/apps/desktop/desktop_native/ssh_agent/src/lib.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/lib.rs
@@ -35,7 +35,8 @@ pub use approval::{ApprovalError, ApprovalRequester, SignApprovalRequest};
 pub use authorization::BitwardenAuthPolicy;
 pub use crypto::PublicKey;
 pub use server::{
-    AuthRequest, ConnectionContext, SIGNamespace, SessionBindContext, SignFlags, SignRequest,
+    socket_address, AuthRequest, ConnectionContext, SIGNamespace, SessionBindContext, SignFlags,
+    SignRequest,
 };
 pub use storage::{
     keydata::{SSHKeyData, UnparsedSSHKeyData},

--- a/apps/desktop/desktop_native/ssh_agent/src/server/listener/mod.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/server/listener/mod.rs
@@ -38,6 +38,26 @@ pub(crate) fn create_listeners() -> Result<Vec<impl Listener>> {
     Ok(vec![windows::WindowsListener::new()?])
 }
 
+/// The address SSH clients must connect to in order to reach the agent.
+///
+/// # Errors
+///
+/// Returns an error if the unix socket path cannot be determined.
+#[cfg(unix)]
+pub fn socket_address() -> Result<String> {
+    Ok(unix::get_socket_path()?.to_string_lossy().into_owned())
+}
+
+/// The address SSH clients must connect to in order to reach the agent.
+///
+/// # Errors
+///
+/// Returns an error if the named pipe path cannot be determined.
+#[cfg(windows)]
+pub fn socket_address() -> Result<String> {
+    Ok(windows::pipe_name().to_string())
+}
+
 /// Spawns an independent tokio task for each listener in `listeners`.
 ///
 /// Each task loops calling `listener.accept()` and forwards accepted connections to `tx`.

--- a/apps/desktop/desktop_native/ssh_agent/src/server/listener/unix.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/server/listener/unix.rs
@@ -78,7 +78,7 @@ fn get_peer_info(stream: &UnixStream) -> Option<PeerInfo> {
     PeerInfo::from_pid(pid)
 }
 
-fn get_socket_path() -> Result<PathBuf> {
+pub(crate) fn get_socket_path() -> Result<PathBuf> {
     if let Ok(path) = std::env::var(ENV_BITWARDEN_SSH_AUTH_SOCK) {
         Ok(PathBuf::from(path))
     } else {

--- a/apps/desktop/desktop_native/ssh_agent/src/server/listener/windows.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/server/listener/windows.rs
@@ -13,6 +13,11 @@ use crate::server::{connection::Connection, peer_info::PeerInfo};
 /// The fixed named pipe path that OpenSSH clients expect on Windows
 const PIPE_NAME: &str = r"\\.\pipe\openssh-ssh-agent";
 
+/// The named pipe SSH clients connect to.
+pub(crate) fn pipe_name() -> &'static str {
+    PIPE_NAME
+}
+
 /// Windows named pipe listener for the SSH agent server
 pub(crate) struct WindowsListener {
     inner: NamedPipeServer,

--- a/apps/desktop/desktop_native/ssh_agent/src/server/mod.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/server/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use auth_policy::AuthPolicy;
 // external exports for napi
 pub use auth_policy::{AuthRequest, ConnectionContext, SessionBindContext, SignRequest};
 use connection::{Connection, ConnectionHandler};
+// external export for napi
+pub use listener::socket_address;
 pub(crate) use listener::Listener;
 pub use protocol::{SIGNamespace, SignFlags};
 use tokio::{sync::mpsc, task::JoinHandle};

--- a/apps/desktop/src/app/accounts/settings-dialog.component.html
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.html
@@ -188,6 +188,18 @@
             />
             <bit-hint>{{ "sshAgentPromptBehaviorDesc" | i18n }}</bit-hint>
           </bit-form-field>
+
+          @if (showSshAgentSetupDialog()) {
+            <button
+              bitLink
+              linkType="primary"
+              type="button"
+              class="tw-mb-4 tw-block"
+              (click)="openSshAgentSetupDialog()"
+            >
+              {{ "sshAgentShowSetupInstructions" | i18n }}
+            </button>
+          }
         }
 
         @if (!isLinux) {

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -50,7 +50,13 @@ import { ThemeStateService } from "@bitwarden/common/platform/theming/theme-stat
 import { FakeAccountService, mockAccountServiceWith } from "@bitwarden/common/spec";
 import { UserId } from "@bitwarden/common/types/guid";
 import { UserKey } from "@bitwarden/common/types/key";
-import { TabsModule, DialogRef, DialogService, ToastService } from "@bitwarden/components";
+import {
+  TabsModule,
+  CenterPositionStrategy,
+  DialogRef,
+  DialogService,
+  ToastService,
+} from "@bitwarden/components";
 import { BiometricStateService, BiometricsStatus, KeyService } from "@bitwarden/key-management";
 import { SessionTimeoutSettingsComponent } from "@bitwarden/key-management-ui";
 // eslint-disable-next-line no-restricted-imports
@@ -64,6 +70,7 @@ import { DesktopAutofillSettingsService } from "../../autofill/services/desktop-
 import { DesktopAutotypeMvpService } from "../../autofill/services/desktop-autotype-mvp.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
+import { SshAgentSetupDialogComponent } from "../components/ssh-agent-setup-dialog.component";
 import { NativeMessagingManifestService } from "../services/native-messaging-manifest.service";
 
 import { SettingsDialogComponent } from "./settings-dialog.component";
@@ -111,6 +118,8 @@ describe("SettingsDialogComponent", () => {
 
   const mockUserKey = new SymmetricCryptoKey(new Uint8Array(64)) as UserKey;
 
+  const TEST_SSH_SOCKET_ADDRESS = "/home/test/.bitwarden-ssh-agent.sock";
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -118,6 +127,11 @@ describe("SettingsDialogComponent", () => {
     (global as any).ipc = {
       auth: {
         loginRequest: jest.fn(),
+      },
+      autofill: {
+        sshAgent: {
+          getSocketAddress: jest.fn().mockResolvedValue(TEST_SSH_SOCKET_ADDRESS),
+        },
       },
       platform: {
         isDev: false,
@@ -128,6 +142,8 @@ describe("SettingsDialogComponent", () => {
         },
       },
     };
+
+    dialogService.open.mockReturnValue({ closed: of(undefined) } as any);
 
     i18nService.supportedTranslationLocales = [];
     i18nService.t.mockImplementation((key: string) => key);
@@ -1086,6 +1102,57 @@ describe("SettingsDialogComponent", () => {
       expect(autofillSettingsServiceAbstraction.setClearClipboardDelay).toHaveBeenLastCalledWith(
         ClearClipboardDelay.ThirtySeconds,
       );
+    });
+  });
+
+  describe("saveSshAgent", () => {
+    /**
+     * `showSshAgentSetupDialog` is a `toSignal()` initialized at class level, so the feature
+     * flag mock must be in place before the component is constructed.
+     */
+    function createComponentWithFlag(enabled: boolean) {
+      configService.getFeatureFlag$.mockImplementation((flag) =>
+        of(flag === FeatureFlag.SSHAgentSetupDialog ? enabled : false),
+      );
+
+      fixture = TestBed.createComponent(SettingsDialogComponent);
+      component = fixture.componentInstance;
+    }
+
+    it("opens the setup dialog with the agent socket address when enabling", async () => {
+      createComponentWithFlag(true);
+      await component.ngOnInit();
+      component["form"].controls.enableSshAgent.setValue(true, { emitEvent: false });
+
+      await component["saveSshAgent"]();
+
+      expect(desktopSettingsService.setSshAgentEnabled).toHaveBeenLastCalledWith(true);
+      expect(dialogService.open).toHaveBeenCalledWith(SshAgentSetupDialogComponent, {
+        data: { socketAddress: TEST_SSH_SOCKET_ADDRESS },
+        positionStrategy: expect.any(CenterPositionStrategy),
+      });
+    });
+
+    it("does not open the setup dialog when the feature flag is off", async () => {
+      createComponentWithFlag(false);
+      await component.ngOnInit();
+      component["form"].controls.enableSshAgent.setValue(true, { emitEvent: false });
+
+      await component["saveSshAgent"]();
+
+      expect(desktopSettingsService.setSshAgentEnabled).toHaveBeenLastCalledWith(true);
+      expect(dialogService.open).not.toHaveBeenCalled();
+    });
+
+    it("does not open the setup dialog when disabling", async () => {
+      createComponentWithFlag(true);
+      await component.ngOnInit();
+      component["form"].controls.enableSshAgent.setValue(false, { emitEvent: false });
+
+      await component["saveSshAgent"]();
+
+      expect(desktopSettingsService.setSshAgentEnabled).toHaveBeenLastCalledWith(false);
+      expect(dialogService.open).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -71,6 +71,7 @@ import { DesktopAutotypeMvpService } from "../../autofill/services/desktop-autot
 import { DesktopPremiumUpgradePromptService } from "../../billing/services/desktop-premium-upgrade-prompt.service";
 import { DesktopBiometricsService } from "../../key-management/biometrics/desktop.biometrics.service";
 import { DesktopSettingsService } from "../../platform/services/desktop-settings.service";
+import { SshAgentSetupDialogComponent } from "../components/ssh-agent-setup-dialog.component";
 import { NativeMessagingManifestService } from "../services/native-messaging-manifest.service";
 
 // eslint-disable-next-line @angular-eslint/prefer-on-push-component-change-detection
@@ -163,6 +164,12 @@ export class SettingsDialogComponent implements OnInit {
   /** Controls whether the quick copy actions setting is shown */
   protected readonly showQuickCopyActionsSetting = toSignal(
     this.configService.getFeatureFlag$(FeatureFlag.PM40435_QuickCopyIconSetting),
+    { initialValue: false },
+  );
+
+  /** Controls whether the SSH agent setup dialog and its entry point are shown */
+  protected readonly showSshAgentSetupDialog = toSignal(
+    this.configService.getFeatureFlag$(FeatureFlag.SSHAgentSetupDialog),
     { initialValue: false },
   );
 
@@ -622,6 +629,18 @@ export class SettingsDialogComponent implements OnInit {
 
   protected async saveSshAgent() {
     await this.desktopSettingsService.setSshAgentEnabled(this.form.value.enableSshAgent);
+
+    if (!this.form.value.enableSshAgent || !this.showSshAgentSetupDialog()) {
+      return;
+    }
+
+    await this.openSshAgentSetupDialog();
+  }
+
+  protected async openSshAgentSetupDialog() {
+    const socketAddress = await ipc.autofill.sshAgent.getSocketAddress();
+
+    SshAgentSetupDialogComponent.open(this.dialogService, { socketAddress });
   }
 
   private async saveSshAgentPromptBehavior(newValue: SshAgentPromptType) {

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.html
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.html
@@ -1,0 +1,34 @@
+<bit-dialog dialogSize="default">
+  <span bitDialogTitle>{{ "sshAgentSetupTitle" | i18n }}</span>
+
+  <ng-container bitDialogContent>
+    @if (isWindows) {
+      <p>{{ "sshAgentSetupWindowsDesc" | i18n }}</p>
+      <bit-callout type="info">{{ "sshAgentSetupWindowsService" | i18n }}</bit-callout>
+    } @else {
+      <p>{{ "sshAgentSetupUnixDesc" | i18n }}</p>
+
+      <div class="tw-flex tw-items-center tw-gap-2 tw-rounded tw-bg-secondary-100 tw-p-2">
+        <code class="tw-break-all">{{ envVarLine }}</code>
+        <button
+          type="button"
+          bitIconButton="bwi-clone"
+          size="small"
+          [label]="'copy' | i18n"
+          (click)="copyEnvVarLine()"
+        ></button>
+      </div>
+
+      <p class="tw-mt-4">{{ "sshAgentSetupUnixRestart" | i18n }}</p>
+    }
+  </ng-container>
+
+  <ng-container bitDialogFooter>
+    <button bitButton type="button" buttonType="primary" [bitDialogClose]="undefined">
+      {{ "ok" | i18n }}
+    </button>
+    <button bitButton type="button" buttonType="secondary" (click)="launchHelp()">
+      {{ "learnMore" | i18n }}
+    </button>
+  </ng-container>
+</bit-dialog>

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.spec.ts
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { mock } from "jest-mock-extended";
+
+import { DeviceType } from "@bitwarden/common/enums";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import { DIALOG_DATA, ToastService } from "@bitwarden/components";
+
+import { SshAgentSetupDialogComponent } from "./ssh-agent-setup-dialog.component";
+
+describe("SshAgentSetupDialogComponent", () => {
+  const SOCKET_ADDRESS = "/home/test/.bitwarden-ssh-agent.sock";
+
+  const platformUtilsService = mock<PlatformUtilsService>();
+  const i18nService = mock<I18nService>();
+  const toastService = mock<ToastService>();
+
+  async function createComponent(
+    device: DeviceType,
+  ): Promise<ComponentFixture<SshAgentSetupDialogComponent>> {
+    platformUtilsService.getDevice.mockReturnValue(device);
+
+    await TestBed.configureTestingModule({
+      imports: [SshAgentSetupDialogComponent],
+      providers: [
+        { provide: DIALOG_DATA, useValue: { socketAddress: SOCKET_ADDRESS } },
+        { provide: PlatformUtilsService, useValue: platformUtilsService },
+        { provide: I18nService, useValue: i18nService },
+        { provide: ToastService, useValue: toastService },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(SshAgentSetupDialogComponent);
+    fixture.detectChanges();
+
+    return fixture;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestBed.resetTestingModule();
+    i18nService.t.mockImplementation((key: string) => key);
+  });
+
+  it("shows the export line on unix", async () => {
+    const fixture = await createComponent(DeviceType.MacOsDesktop);
+
+    expect(fixture.componentInstance["isWindows"]).toBe(false);
+    expect(fixture.nativeElement.textContent).toContain(`export SSH_AUTH_SOCK=${SOCKET_ADDRESS}`);
+  });
+
+  it("shows no export line and no socket address on windows", async () => {
+    const fixture = await createComponent(DeviceType.WindowsDesktop);
+
+    expect(fixture.componentInstance["isWindows"]).toBe(true);
+    expect(fixture.nativeElement.textContent).not.toContain("export SSH_AUTH_SOCK");
+    expect(fixture.nativeElement.textContent).not.toContain(SOCKET_ADDRESS);
+    expect(fixture.nativeElement.textContent).toContain("sshAgentSetupWindowsService");
+  });
+
+  it("copies the export line to the clipboard", async () => {
+    const fixture = await createComponent(DeviceType.LinuxDesktop);
+
+    fixture.componentInstance["copyEnvVarLine"]();
+
+    expect(platformUtilsService.copyToClipboard).toHaveBeenCalledWith(
+      `export SSH_AUTH_SOCK=${SOCKET_ADDRESS}`,
+    );
+    expect(toastService.showToast).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.spec.ts
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.spec.ts
@@ -46,7 +46,7 @@ describe("SshAgentSetupDialogComponent", () => {
     const fixture = await createComponent(DeviceType.MacOsDesktop);
 
     expect(fixture.componentInstance["isWindows"]).toBe(false);
-    expect(fixture.nativeElement.textContent).toContain(`export SSH_AUTH_SOCK=${SOCKET_ADDRESS}`);
+    expect(fixture.nativeElement.textContent).toContain(`export SSH_AUTH_SOCK="${SOCKET_ADDRESS}"`);
   });
 
   it("shows no export line and no socket address on windows", async () => {
@@ -64,7 +64,7 @@ describe("SshAgentSetupDialogComponent", () => {
     fixture.componentInstance["copyEnvVarLine"]();
 
     expect(platformUtilsService.copyToClipboard).toHaveBeenCalledWith(
-      `export SSH_AUTH_SOCK=${SOCKET_ADDRESS}`,
+      `export SSH_AUTH_SOCK="${SOCKET_ADDRESS}"`,
     );
     expect(toastService.showToast).toHaveBeenCalled();
   });

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.ts
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.ts
@@ -39,7 +39,7 @@ export class SshAgentSetupDialogComponent {
   protected readonly isWindows =
     this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop;
 
-  protected readonly envVarLine = `export SSH_AUTH_SOCK=${this.data.socketAddress}`;
+  protected readonly envVarLine = `export SSH_AUTH_SOCK="${this.data.socketAddress}"`;
 
   static open(dialogService: DialogService, data: SshAgentSetupDialogData) {
     return dialogService.open<void>(SshAgentSetupDialogComponent, {

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.ts
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.ts
@@ -1,0 +1,63 @@
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+
+import { DeviceType } from "@bitwarden/common/enums";
+import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
+import {
+  DIALOG_DATA,
+  ButtonModule,
+  CalloutModule,
+  CenterPositionStrategy,
+  DialogModule,
+  DialogService,
+  IconButtonModule,
+  ToastService,
+} from "@bitwarden/components";
+import { I18nPipe } from "@bitwarden/ui-common";
+
+const SSH_AGENT_HELP_URI = "https://bitwarden.com/help/ssh-agent/";
+
+export type SshAgentSetupDialogData = {
+  /** Unix socket path, or the Windows named pipe, the agent listens on. */
+  socketAddress: string;
+};
+
+@Component({
+  templateUrl: "ssh-agent-setup-dialog.component.html",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [I18nPipe, ButtonModule, CalloutModule, DialogModule, IconButtonModule],
+})
+export class SshAgentSetupDialogComponent {
+  protected readonly data = inject<SshAgentSetupDialogData>(DIALOG_DATA);
+
+  private readonly platformUtilsService = inject(PlatformUtilsService);
+  private readonly i18nService = inject(I18nService);
+  private readonly toastService = inject(ToastService);
+
+  // Windows clients find the agent on the well-known OpenSSH named pipe, so there is
+  // nothing to export there; every other platform needs SSH_AUTH_SOCK pointed at us.
+  protected readonly isWindows =
+    this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop;
+
+  protected readonly envVarLine = `export SSH_AUTH_SOCK=${this.data.socketAddress}`;
+
+  static open(dialogService: DialogService, data: SshAgentSetupDialogData) {
+    return dialogService.open<void>(SshAgentSetupDialogComponent, {
+      data,
+      positionStrategy: new CenterPositionStrategy(),
+    });
+  }
+
+  protected copyEnvVarLine() {
+    this.platformUtilsService.copyToClipboard(this.envVarLine);
+    this.toastService.showToast({
+      variant: "success",
+      title: undefined,
+      message: this.i18nService.t("valueCopied", this.i18nService.t("sshAgentSocketPath")),
+    });
+  }
+
+  protected launchHelp() {
+    this.platformUtilsService.launchUri(SSH_AGENT_HELP_URI);
+  }
+}

--- a/apps/desktop/src/autofill/main/main-ssh-agent.service.ts
+++ b/apps/desktop/src/autofill/main/main-ssh-agent.service.ts
@@ -34,6 +34,10 @@ export class MainSshAgentService {
       await this.init();
     });
 
+    ipcMain.handle(SSH_AGENT_IPC_CHANNELS.GET_SOCKET_ADDRESS, async () => {
+      return sshagent.getSocketAddress();
+    });
+
     ipcMain.handle(SSH_AGENT_IPC_CHANNELS.IS_LOADED, async () => {
       return this.agentState?.isRunning() ?? false;
     });

--- a/apps/desktop/src/autofill/models/ipc-channels.ts
+++ b/apps/desktop/src/autofill/models/ipc-channels.ts
@@ -10,6 +10,7 @@ export const AUTOTYPE_MVP_IPC_CHANNELS = {
 export const SSH_AGENT_IPC_CHANNELS = {
   INIT: "sshagent.init",
   IS_LOADED: "sshagent.isloaded",
+  GET_SOCKET_ADDRESS: "sshagent.getsocketaddress",
   STOP: "sshagent.stop",
   REPLACE: "sshagent.replace",
   SIGN_REQUEST: "sshagent.signrequest",

--- a/apps/desktop/src/autofill/preload.ts
+++ b/apps/desktop/src/autofill/preload.ts
@@ -18,6 +18,9 @@ const sshAgent = {
   listRequestResponse: async (requestId: number, accepted: boolean) => {
     await ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.LIST_KEYS_RESPONSE, { requestId, accepted });
   },
+  // The address (unix socket path or Windows named pipe) SSH clients must connect to.
+  getSocketAddress: (): Promise<string> =>
+    ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.GET_SOCKET_ADDRESS),
   isLoaded(): Promise<boolean> {
     return ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.IS_LOADED);
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -756,6 +756,27 @@
   "enableSshAgentHelp": {
     "message": "The SSH agent is a service targeted at developers that allows you to sign SSH requests directly from your Bitwarden vault."
   },
+  "sshAgentSetupTitle": {
+    "message": "Set up the SSH agent"
+  },
+  "sshAgentSetupUnixDesc": {
+    "message": "To let SSH clients use your Bitwarden vault, add the following line to your shell profile, for example ~/.zshrc or ~/.bashrc:"
+  },
+  "sshAgentSetupUnixRestart": {
+    "message": "Restart your terminal for the change to take effect."
+  },
+  "sshAgentSetupWindowsDesc": {
+    "message": "Your SSH clients will use your Bitwarden vault automatically. There is nothing to configure."
+  },
+  "sshAgentSetupWindowsService": {
+    "message": "The built-in Windows OpenSSH Authentication Agent service must be disabled."
+  },
+  "sshAgentSocketPath": {
+    "message": "SSH agent socket path"
+  },
+  "sshAgentShowSetupInstructions": {
+    "message": "Show setup instructions"
+  },
   "sshAgentPromptBehavior": {
     "message": "Ask for authorization when using SSH agent"
   },


### PR DESCRIPTION
## 🎟️ Tracking

Stacked on #23108.

## 📔 Objective

Enabling the SSH agent leaves users without a working setup and the need to go to the wiki, which is bad UX.

This PR adds a setup dialog that shows the export line for the Bitwarden agent socket with a copy button. On windows, there is a different message for the openssh service.

## 📸 Screenshots
