### PR TITLE
feat(ssh-agent): Configure the SSH agent automatically

### DIFF
--- a/apps/desktop/desktop_native/napi/index.d.ts
+++ b/apps/desktop/desktop_native/napi/index.d.ts
@@ -424,8 +424,12 @@ export declare namespace sshagent {
     replace(newKeys: Array<SshKeyData>): void
   }
   export type SSHAgentState = SshAgentState
+  /** Configures the machine so that SSH clients reach the Bitwarden agent. */
+  export function applyConfiguration(): Promise<void>
   /** The address SSH clients connect to in order to reach the agent. */
   export function getSocketAddress(): string
+  /** Whether SSH clients on this machine already reach the Bitwarden agent. */
+  export function isConfigured(): Promise<boolean>
   /** SSH public key data */
   export interface PublicKey {
     alg: string

--- a/apps/desktop/desktop_native/napi/src/sshagent.rs
+++ b/apps/desktop/desktop_native/napi/src/sshagent.rs
@@ -112,6 +112,29 @@ pub mod sshagent {
         ssh_agent::socket_address().map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
+    /// Whether SSH clients on this machine already reach the Bitwarden agent.
+    #[napi]
+    pub async fn is_configured() -> napi::Result<bool> {
+        run_blocking(ssh_agent::is_configured).await
+    }
+
+    /// Configures the machine so that SSH clients reach the Bitwarden agent.
+    #[napi]
+    pub async fn apply_configuration() -> napi::Result<()> {
+        run_blocking(ssh_agent::apply_configuration).await
+    }
+
+    /// Setup inspects the filesystem and, on Windows, waits for a UAC prompt, so it
+    /// must stay off the main thread.
+    async fn run_blocking<T: Send + 'static>(
+        operation: impl FnOnce() -> anyhow::Result<T> + Send + 'static,
+    ) -> napi::Result<T> {
+        napi::tokio::task::spawn_blocking(operation)
+            .await
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
     /// Wrapper for Electron to be able to interface with the agent directly.
     #[napi]
     pub struct SSHAgentState {

--- a/apps/desktop/desktop_native/napi/src/sshagent.rs
+++ b/apps/desktop/desktop_native/napi/src/sshagent.rs
@@ -112,20 +112,20 @@ pub mod sshagent {
         ssh_agent::socket_address().map_err(|e| napi::Error::from_reason(e.to_string()))
     }
 
-    /// Whether SSH clients on this machine already reach the Bitwarden agent.
+    /// Whether the Bitwarden agent is expected to work.
+    /// This is defined by `SSH_AUTH_SOCK` being configured on unix or the
+    /// openssh service being disabled on windows.
     #[napi]
     pub async fn is_configured() -> napi::Result<bool> {
         run_blocking(ssh_agent::is_configured).await
     }
 
-    /// Configures the machine so that SSH clients reach the Bitwarden agent.
+    /// Appliy the Bitwarden agent configuration to the system.
     #[napi]
     pub async fn apply_configuration() -> napi::Result<()> {
         run_blocking(ssh_agent::apply_configuration).await
     }
 
-    /// Setup inspects the filesystem and, on Windows, waits for a UAC prompt, so it
-    /// must stay off the main thread.
     async fn run_blocking<T: Send + 'static>(
         operation: impl FnOnce() -> anyhow::Result<T> + Send + 'static,
     ) -> napi::Result<T> {

--- a/apps/desktop/desktop_native/ssh_agent/src/lib.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/lib.rs
@@ -27,6 +27,7 @@ mod approval;
 mod authorization;
 mod crypto;
 mod server;
+mod setup;
 mod storage;
 
 // external exports for napi
@@ -38,6 +39,7 @@ pub use server::{
     socket_address, AuthRequest, ConnectionContext, SIGNamespace, SessionBindContext, SignFlags,
     SignRequest,
 };
+pub use setup::{apply_configuration, is_configured};
 pub use storage::{
     keydata::{SSHKeyData, UnparsedSSHKeyData},
     keystore::{InMemoryEncryptedKeyStore, KeyStore},

--- a/apps/desktop/desktop_native/ssh_agent/src/setup/mod.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/setup/mod.rs
@@ -1,0 +1,18 @@
+//! Detection and automatic configuration of the host, so that SSH clients reach
+//! the Bitwarden agent instead of another agent.
+//!
+//! Each platform needs something different:
+//! - unix: `SSH_AUTH_SOCK` must point at the agent's socket, which means adding a line to the
+//!   user's shell profiles.
+//! - windows: clients always use the well-known OpenSSH named pipe, so the built-in `ssh-agent`
+//!   service must not be holding it.
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+#[cfg(unix)]
+pub use unix::{apply_configuration, is_configured};
+#[cfg(windows)]
+pub use windows::{apply_configuration, is_configured};

--- a/apps/desktop/desktop_native/ssh_agent/src/setup/unix.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/setup/unix.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Written above the generated line so users can recognize and remove it.
 const MARKER_COMMENT: &str = "# Bitwarden SSH agent";
@@ -44,14 +44,19 @@ pub fn is_configured() -> Result<bool> {
 /// # Errors
 ///
 /// Returns an error if the socket path or the home directory cannot be determined,
-/// or if a profile cannot be read or written.
+/// or if not a single profile could be configured.
 pub fn apply_configuration() -> Result<()> {
     let socket_path = crate::socket_address()?;
 
     apply_to_home(&home_dir()?, &socket_path)
 }
 
+/// Every profile is attempted before reporting: one unwritable file (an immutable
+/// `~/.zshrc` in a managed home, a sandbox denial) must not stop the profiles after
+/// it from being configured.
 fn apply_to_home(home: &Path, socket_path: &str) -> Result<()> {
+    let mut failed = false;
+
     for (profile, template) in PROFILES {
         let path = home.join(profile);
 
@@ -60,17 +65,31 @@ fn apply_to_home(home: &Path, socket_path: &str) -> Result<()> {
             continue;
         }
 
-        if profile_configured(&path, socket_path)? {
-            debug!(?path, "profile already configured, skipping");
-            continue;
+        if let Err(e) = apply_to_profile(&path, template, socket_path) {
+            warn!(?path, error = %e, "could not configure profile");
+            failed = true;
         }
-
-        append_line(
-            &path,
-            &template.replace(SOCKET_PATH_PLACEHOLDER, socket_path),
-        )?;
-        info!(?path, "appended SSH_AUTH_SOCK to profile");
     }
+
+    if failed {
+        return Err(anyhow!("Could not configure every shell profile"));
+    }
+
+    Ok(())
+}
+
+fn apply_to_profile(path: &Path, template: &str, socket_path: &str) -> Result<()> {
+    if profile_configured(path, socket_path)? {
+        debug!(?path, "profile already configured, skipping");
+
+        return Ok(());
+    }
+
+    append_line(
+        path,
+        &template.replace(SOCKET_PATH_PLACEHOLDER, socket_path),
+    )?;
+    info!(?path, "appended SSH_AUTH_SOCK to profile");
 
     Ok(())
 }
@@ -90,10 +109,9 @@ fn all_profiles_configured(home: &Path, socket_path: &str) -> Result<bool> {
 /// A profile is only written when its parent directory already exists.
 ///
 /// `~/.profile`, `~/.bashrc` and `~/.zshrc` sit directly in the home directory and
-/// are therefore always applicable, while `~/.config/fish/config.fish` is skipped on machines
-/// without fish. Creating the directory could fail under sandboxing, and the
-/// resulting error would leave `is_configured` permanently `false` even though the
-/// shells the user actually runs are configured.
+/// are therefore always applicable, while `~/.config/fish/config.fish` is skipped
+/// on machines without fish — the sandbox grants cover the file, not the creation
+/// of its parent directory.
 fn profile_applicable(path: &Path) -> bool {
     path.parent().is_some_and(Path::is_dir)
 }
@@ -113,11 +131,6 @@ fn profile_configured(path: &Path, socket_path: &str) -> Result<bool> {
 
 /// Appends at the very end of the file so it overrides anything set earlier.
 fn append_line(path: &Path, line: &str) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| anyhow!("Could not create {}: {e}", parent.display()))?;
-    }
-
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -144,9 +157,17 @@ fn home_dir() -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
     use rand::{distr::Alphanumeric, Rng};
 
     use super::*;
+
+    /// `r-x------`: readable and traversable, but nothing can be written into it.
+    const READ_EXECUTE_ONLY: u32 = 0o500;
+
+    /// `rwx------`, the mode the temporary home is created with.
+    const OWNER_ALL: u32 = 0o700;
 
     const SOCKET_PATH: &str = "/home/test/.bitwarden-ssh-agent.sock";
 
@@ -244,6 +265,49 @@ mod tests {
 
         apply_to_home(home.path(), SOCKET_PATH).unwrap();
         assert!(all_profiles_configured(home.path(), SOCKET_PATH).unwrap());
+    }
+
+    /// The failure is reported, but only after the profiles that can be written
+    /// have been: aborting the loop would leave later profiles untouched even on a
+    /// retry, because the same profile fails first every time.
+    #[test]
+    fn unwritable_profile_does_not_stop_the_others() {
+        let home = TempHome::new();
+        let unwritable = home.path().join(".profile");
+        fs::write(&unwritable, "").unwrap();
+        set_readonly(&unwritable);
+
+        let result = apply_to_home(home.path(), SOCKET_PATH);
+
+        assert!(result.is_err());
+        assert!(home.read(".profile").is_empty());
+        assert!(home.read(".bashrc").contains(SOCKET_PATH));
+        assert!(home.read(".zshrc").contains(SOCKET_PATH));
+    }
+
+    #[test]
+    fn apply_fails_when_no_profile_can_be_written() {
+        let home = TempHome::new();
+        set_readonly(home.path());
+
+        let result = apply_to_home(home.path(), SOCKET_PATH);
+
+        // Restored so the temporary directory can be cleaned up on drop.
+        set_writable(home.path());
+
+        assert!(result.is_err());
+    }
+
+    fn set_readonly(path: &Path) {
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(READ_EXECUTE_ONLY);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    fn set_writable(path: &Path) {
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(OWNER_ALL);
+        fs::set_permissions(path, permissions).unwrap();
     }
 
     /// Without fish installed, applying must still report configured afterwards —

--- a/apps/desktop/desktop_native/ssh_agent/src/setup/unix.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/setup/unix.rs
@@ -20,6 +20,7 @@ const SOCKET_PATH_PLACEHOLDER: &str = "{socket_path}";
 ///
 /// e.g. `~/.zshrc` receives `export SSH_AUTH_SOCK="/home/user/.bitwarden-ssh-agent.sock"`
 const PROFILES: &[(&str, &str)] = &[
+    (".profile", "export SSH_AUTH_SOCK=\"{socket_path}\""),
     (".bashrc", "export SSH_AUTH_SOCK=\"{socket_path}\""),
     (".zshrc", "export SSH_AUTH_SOCK=\"{socket_path}\""),
     (
@@ -29,9 +30,6 @@ const PROFILES: &[(&str, &str)] = &[
 ];
 
 /// Whether every shell profile already points `SSH_AUTH_SOCK` at the agent.
-///
-/// The profiles rather than the current environment are the signal: a
-/// desktop-launcher-started app does not inherit the user's shell environment.
 ///
 /// # Errors
 ///
@@ -57,6 +55,11 @@ fn apply_to_home(home: &Path, socket_path: &str) -> Result<()> {
     for (profile, template) in PROFILES {
         let path = home.join(profile);
 
+        if !profile_applicable(&path) {
+            debug!(?path, "shell not set up on this machine, skipping");
+            continue;
+        }
+
         if profile_configured(&path, socket_path)? {
             debug!(?path, "profile already configured, skipping");
             continue;
@@ -74,12 +77,25 @@ fn apply_to_home(home: &Path, socket_path: &str) -> Result<()> {
 
 fn all_profiles_configured(home: &Path, socket_path: &str) -> Result<bool> {
     for (profile, _) in PROFILES {
-        if !profile_configured(&home.join(profile), socket_path)? {
+        let path = home.join(profile);
+
+        if profile_applicable(&path) && !profile_configured(&path, socket_path)? {
             return Ok(false);
         }
     }
 
     Ok(true)
+}
+
+/// A profile is only written when its parent directory already exists.
+///
+/// `~/.profile`, `~/.bashrc` and `~/.zshrc` sit directly in the home directory and
+/// are therefore always applicable, while `~/.config/fish/config.fish` is skipped on machines
+/// without fish. Creating the directory could fail under sandboxing, and the
+/// resulting error would leave `is_configured` permanently `false` even though the
+/// shells the user actually runs are configured.
+fn profile_applicable(path: &Path) -> bool {
+    path.parent().is_some_and(Path::is_dir)
 }
 
 /// A profile counts as configured when it mentions the socket path, regardless of
@@ -157,6 +173,13 @@ mod tests {
         fn read(&self, profile: &str) -> String {
             fs::read_to_string(self.0.join(profile)).unwrap()
         }
+
+        /// Marks fish as installed by creating the directory its config lives in.
+        fn with_fish(self) -> Self {
+            fs::create_dir_all(self.0.join(".config/fish")).unwrap();
+
+            self
+        }
     }
 
     impl Drop for TempHome {
@@ -167,12 +190,16 @@ mod tests {
 
     #[test]
     fn apply_creates_missing_profiles() {
-        let home = TempHome::new();
+        let home = TempHome::new().with_fish();
 
         apply_to_home(home.path(), SOCKET_PATH).unwrap();
 
         assert_eq!(
             home.read(".zshrc"),
+            format!("\n{MARKER_COMMENT}\nexport SSH_AUTH_SOCK=\"{SOCKET_PATH}\"\n")
+        );
+        assert_eq!(
+            home.read(".profile"),
             format!("\n{MARKER_COMMENT}\nexport SSH_AUTH_SOCK=\"{SOCKET_PATH}\"\n")
         );
         assert!(home
@@ -208,7 +235,7 @@ mod tests {
 
     #[test]
     fn profiles_configured_only_once_all_contain_the_path() {
-        let home = TempHome::new();
+        let home = TempHome::new().with_fish();
 
         assert!(!all_profiles_configured(home.path(), SOCKET_PATH).unwrap());
 
@@ -216,6 +243,18 @@ mod tests {
         assert!(!all_profiles_configured(home.path(), SOCKET_PATH).unwrap());
 
         apply_to_home(home.path(), SOCKET_PATH).unwrap();
+        assert!(all_profiles_configured(home.path(), SOCKET_PATH).unwrap());
+    }
+
+    /// Without fish installed, applying must still report configured afterwards —
+    /// otherwise the setup dialog would re-open forever.
+    #[test]
+    fn missing_fish_does_not_block_configuration() {
+        let home = TempHome::new();
+
+        apply_to_home(home.path(), SOCKET_PATH).unwrap();
+
+        assert!(!home.path().join(".config/fish").exists());
         assert!(all_profiles_configured(home.path(), SOCKET_PATH).unwrap());
     }
 }

--- a/apps/desktop/desktop_native/ssh_agent/src/setup/unix.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/setup/unix.rs
@@ -1,0 +1,221 @@
+//! Shell profile based configuration of `SSH_AUTH_SOCK`.
+
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Result};
+use tracing::{debug, info};
+
+/// Written above the generated line so users can recognize and remove it.
+const MARKER_COMMENT: &str = "# Bitwarden SSH agent";
+
+/// Placeholder replaced by the socket path in the profile templates below.
+const SOCKET_PATH_PLACEHOLDER: &str = "{socket_path}";
+
+/// Shell profiles the export line is appended to, paired with the syntax the
+/// shell owning the profile uses.
+///
+/// e.g. `~/.zshrc` receives `export SSH_AUTH_SOCK="/home/user/.bitwarden-ssh-agent.sock"`
+const PROFILES: &[(&str, &str)] = &[
+    (".bashrc", "export SSH_AUTH_SOCK=\"{socket_path}\""),
+    (".zshrc", "export SSH_AUTH_SOCK=\"{socket_path}\""),
+    (
+        ".config/fish/config.fish",
+        "set -gx SSH_AUTH_SOCK \"{socket_path}\"",
+    ),
+];
+
+/// Whether every shell profile already points `SSH_AUTH_SOCK` at the agent.
+///
+/// The profiles rather than the current environment are the signal: a
+/// desktop-launcher-started app does not inherit the user's shell environment.
+///
+/// # Errors
+///
+/// Returns an error if the socket path or the home directory cannot be determined,
+/// or if a profile cannot be read.
+pub fn is_configured() -> Result<bool> {
+    all_profiles_configured(&home_dir()?, &crate::socket_address()?)
+}
+
+/// Appends the export line to every shell profile that does not have it yet.
+///
+/// # Errors
+///
+/// Returns an error if the socket path or the home directory cannot be determined,
+/// or if a profile cannot be read or written.
+pub fn apply_configuration() -> Result<()> {
+    let socket_path = crate::socket_address()?;
+
+    apply_to_home(&home_dir()?, &socket_path)
+}
+
+fn apply_to_home(home: &Path, socket_path: &str) -> Result<()> {
+    for (profile, template) in PROFILES {
+        let path = home.join(profile);
+
+        if profile_configured(&path, socket_path)? {
+            debug!(?path, "profile already configured, skipping");
+            continue;
+        }
+
+        append_line(
+            &path,
+            &template.replace(SOCKET_PATH_PLACEHOLDER, socket_path),
+        )?;
+        info!(?path, "appended SSH_AUTH_SOCK to profile");
+    }
+
+    Ok(())
+}
+
+fn all_profiles_configured(home: &Path, socket_path: &str) -> Result<bool> {
+    for (profile, _) in PROFILES {
+        if !profile_configured(&home.join(profile), socket_path)? {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+/// A profile counts as configured when it mentions the socket path, regardless of
+/// whether we or the user put it there.
+fn profile_configured(path: &Path, socket_path: &str) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let contents = fs::read_to_string(path)
+        .map_err(|e| anyhow!("Could not read profile {}: {e}", path.display()))?;
+
+    Ok(contents.contains(socket_path))
+}
+
+/// Appends at the very end of the file so it overrides anything set earlier.
+fn append_line(path: &Path, line: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| anyhow!("Could not create {}: {e}", parent.display()))?;
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| anyhow!("Could not open profile {}: {e}", path.display()))?;
+
+    write!(file, "\n{MARKER_COMMENT}\n{line}\n")
+        .map_err(|e| anyhow!("Could not write profile {}: {e}", path.display()))
+}
+
+/// The user's real home directory, taken from the passwd entry rather than `$HOME`.
+///
+/// Sandboxed packages point `$HOME` at their own private data directory (the
+/// snap revision directory, the macOS app container), so `$HOME` would send the
+/// profile writes somewhere no shell ever reads. The sandbox exceptions granted
+/// in the snap, flatpak and MAS manifests are all for the real home.
+fn home_dir() -> Result<PathBuf> {
+    homedir::unix::UserIdentifier::my_id()
+        .and_then(|id| id.to_home())
+        .ok()
+        .flatten()
+        .ok_or_else(|| anyhow!("Could not determine home directory"))
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{distr::Alphanumeric, Rng};
+
+    use super::*;
+
+    const SOCKET_PATH: &str = "/home/test/.bitwarden-ssh-agent.sock";
+
+    /// Temporary home directory, removed on drop.
+    struct TempHome(PathBuf);
+
+    impl TempHome {
+        fn new() -> Self {
+            let suffix: String = rand::rng()
+                .sample_iter(Alphanumeric)
+                .take(12)
+                .map(char::from)
+                .collect();
+            let path = std::env::temp_dir().join(format!("bw-ssh-setup-{suffix}"));
+            fs::create_dir_all(&path).unwrap();
+
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        fn read(&self, profile: &str) -> String {
+            fs::read_to_string(self.0.join(profile)).unwrap()
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn apply_creates_missing_profiles() {
+        let home = TempHome::new();
+
+        apply_to_home(home.path(), SOCKET_PATH).unwrap();
+
+        assert_eq!(
+            home.read(".zshrc"),
+            format!("\n{MARKER_COMMENT}\nexport SSH_AUTH_SOCK=\"{SOCKET_PATH}\"\n")
+        );
+        assert!(home
+            .read(".config/fish/config.fish")
+            .contains(&format!("set -gx SSH_AUTH_SOCK \"{SOCKET_PATH}\"")));
+    }
+
+    #[test]
+    fn apply_appends_to_existing_profile() {
+        let home = TempHome::new();
+        fs::write(home.path().join(".bashrc"), "alias ll='ls -l'\n").unwrap();
+
+        apply_to_home(home.path(), SOCKET_PATH).unwrap();
+
+        assert_eq!(
+            home.read(".bashrc"),
+            format!(
+                "alias ll='ls -l'\n\n{MARKER_COMMENT}\nexport SSH_AUTH_SOCK=\"{SOCKET_PATH}\"\n"
+            )
+        );
+    }
+
+    #[test]
+    fn apply_is_idempotent() {
+        let home = TempHome::new();
+
+        apply_to_home(home.path(), SOCKET_PATH).unwrap();
+        let after_first = home.read(".zshrc");
+        apply_to_home(home.path(), SOCKET_PATH).unwrap();
+
+        assert_eq!(home.read(".zshrc"), after_first);
+    }
+
+    #[test]
+    fn profiles_configured_only_once_all_contain_the_path() {
+        let home = TempHome::new();
+
+        assert!(!all_profiles_configured(home.path(), SOCKET_PATH).unwrap());
+
+        fs::write(home.path().join(".bashrc"), SOCKET_PATH).unwrap();
+        assert!(!all_profiles_configured(home.path(), SOCKET_PATH).unwrap());
+
+        apply_to_home(home.path(), SOCKET_PATH).unwrap();
+        assert!(all_profiles_configured(home.path(), SOCKET_PATH).unwrap());
+    }
+}

--- a/apps/desktop/desktop_native/ssh_agent/src/setup/windows.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/setup/windows.rs
@@ -4,7 +4,7 @@
 //! `\\.\pipe\openssh-ssh-agent` named pipe, so the only thing standing between
 //! them and Bitwarden is the built-in `ssh-agent` service owning that pipe.
 
-use std::{os::windows::process::CommandExt, process::Command};
+use std::{os::windows::process::CommandExt, path::PathBuf, process::Command};
 
 use anyhow::{anyhow, Result};
 use tracing::info;
@@ -19,16 +19,34 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 /// Exit code the query script uses to report a running service.
 const EXIT_SERVICE_RUNNING: i32 = 1;
 
+/// Exit code the elevating script uses when the elevated child never started.
+const EXIT_ELEVATION_FAILED: i32 = 1;
+
+/// Location of `powershell.exe` below the Windows directory.
+const POWERSHELL_RELATIVE_PATH: &str = r"System32\WindowsPowerShell\v1.0\powershell.exe";
+
+/// PowerShell expression evaluating to the full path of `powershell.exe`.
+const POWERSHELL_PATH: &str =
+    r"(Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe')";
+
+/// Fallback used when `SystemRoot` is not set in the environment.
+const DEFAULT_WINDOWS_DIR: &str = r"C:\Windows";
+
 /// Reports whether the built-in service is out of the way.
 ///
 /// # Errors
 ///
 /// Returns an error if the query helper cannot be run or reports an unexpected result.
 pub fn is_configured() -> Result<bool> {
-    // The exit code carries the answer; `Status -eq 'Running'` compares a .NET enum,
-    // so it is not affected by the system language.
+    // The exit code carries the answer; `Status` and `StartType` are .NET enums,
+    // so the comparisons are not affected by the system language.
+    //
+    // A stopped service that is still allowed to start counts as not configured:
+    // it would grab the named pipe again at the next boot.
     let status = run_powershell(&format!(
-        "if ((Get-Service {SSH_AGENT_SERVICE} -ErrorAction SilentlyContinue).Status -eq 'Running') \
+        "$service = Get-Service {SSH_AGENT_SERVICE} -ErrorAction SilentlyContinue; \
+         if ($null -ne $service -and \
+         ($service.Status -eq 'Running' -or $service.StartType -ne 'Disabled')) \
          {{ exit {EXIT_SERVICE_RUNNING} }} else {{ exit 0 }}"
     ))?;
 
@@ -58,9 +76,15 @@ pub fn apply_configuration() -> Result<()> {
          Set-Service {SSH_AGENT_SERVICE} -StartupType Disabled -ErrorAction Stop"
     );
 
+    // `Start-Process` is given the full path so the elevated child cannot be
+    // hijacked by a `powershell.exe` planted earlier on the user's PATH.
+    // A declined UAC prompt is made deterministic: `-ErrorAction Stop` turns it into
+    // a terminating error, and the null check covers a non-terminating failure that
+    // would otherwise leave `exit $null` reporting success.
     let status = run_powershell(&format!(
-        "$process = Start-Process powershell -Verb RunAs -Wait -PassThru -WindowStyle Hidden \
-         -ArgumentList '-NoProfile','-Command','{elevated_script}'; exit $process.ExitCode"
+        "$process = Start-Process {POWERSHELL_PATH} -Verb RunAs -Wait -PassThru -WindowStyle Hidden \
+         -ErrorAction Stop -ArgumentList '-NoProfile','-Command','{elevated_script}'; \
+         if ($null -eq $process) {{ exit {EXIT_ELEVATION_FAILED} }} else {{ exit $process.ExitCode }}"
     ))?;
 
     if status != Some(0) {
@@ -74,8 +98,11 @@ pub fn apply_configuration() -> Result<()> {
     Ok(())
 }
 
+/// Runs a script with the system `powershell.exe` rather than the first one on PATH.
 fn run_powershell(script: &str) -> Result<Option<i32>> {
-    let output = Command::new("powershell.exe")
+    let windows_dir = std::env::var("SystemRoot").unwrap_or_else(|_| DEFAULT_WINDOWS_DIR.into());
+
+    let output = Command::new(PathBuf::from(windows_dir).join(POWERSHELL_RELATIVE_PATH))
         .args(["-NoProfile", "-NonInteractive", "-Command", script])
         .creation_flags(CREATE_NO_WINDOW)
         .output()

--- a/apps/desktop/desktop_native/ssh_agent/src/setup/windows.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/setup/windows.rs
@@ -1,0 +1,85 @@
+//! Detection and disabling of the built-in Windows OpenSSH agent service.
+//!
+//! SSH clients on Windows always connect to the well-known
+//! `\\.\pipe\openssh-ssh-agent` named pipe, so the only thing standing between
+//! them and Bitwarden is the built-in `ssh-agent` service owning that pipe.
+
+use std::{os::windows::process::CommandExt, process::Command};
+
+use anyhow::{anyhow, Result};
+use tracing::info;
+
+/// Name of the built-in OpenSSH Authentication Agent service.
+const SSH_AGENT_SERVICE: &str = "ssh-agent";
+
+/// Keeps the helper processes from flashing a console window.
+/// <https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags>
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Exit code the query script uses to report a running service.
+const EXIT_SERVICE_RUNNING: i32 = 1;
+
+/// Reports whether the built-in service is out of the way.
+///
+/// # Errors
+///
+/// Returns an error if the query helper cannot be run or reports an unexpected result.
+pub fn is_configured() -> Result<bool> {
+    // The exit code carries the answer; `Status -eq 'Running'` compares a .NET enum,
+    // so it is not affected by the system language.
+    let status = run_powershell(&format!(
+        "if ((Get-Service {SSH_AGENT_SERVICE} -ErrorAction SilentlyContinue).Status -eq 'Running') \
+         {{ exit {EXIT_SERVICE_RUNNING} }} else {{ exit 0 }}"
+    ))?;
+
+    match status {
+        Some(0) => Ok(true),
+        Some(EXIT_SERVICE_RUNNING) => Ok(false),
+        other => Err(anyhow!(
+            "Could not determine the state of the {SSH_AGENT_SERVICE} service (exit code {other:?})"
+        )),
+    }
+}
+
+/// Stops the built-in service and prevents it from starting again.
+///
+/// Both operations require administrator rights, which the app does not have, so
+/// the work is delegated to an elevated child process. The user sees a UAC prompt
+/// and cancelling it surfaces as an error.
+///
+/// # Errors
+///
+/// Returns an error if the elevated process cannot be started, is declined, or fails.
+pub fn apply_configuration() -> Result<()> {
+    // Single-quoted and free of `$` so it survives being nested inside the outer
+    // script that elevates it.
+    let elevated_script = format!(
+        "Stop-Service {SSH_AGENT_SERVICE} -Force -ErrorAction Stop; \
+         Set-Service {SSH_AGENT_SERVICE} -StartupType Disabled -ErrorAction Stop"
+    );
+
+    let status = run_powershell(&format!(
+        "$process = Start-Process powershell -Verb RunAs -Wait -PassThru -WindowStyle Hidden \
+         -ArgumentList '-NoProfile','-Command','{elevated_script}'; exit $process.ExitCode"
+    ))?;
+
+    if status != Some(0) {
+        return Err(anyhow!(
+            "Could not disable the {SSH_AGENT_SERVICE} service (exit code {status:?})"
+        ));
+    }
+
+    info!(service = SSH_AGENT_SERVICE, "service stopped and disabled");
+
+    Ok(())
+}
+
+fn run_powershell(script: &str) -> Result<Option<i32>> {
+    let output = Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Command", script])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map_err(|e| anyhow!("Could not run powershell: {e}"))?;
+
+    Ok(output.status.code())
+}

--- a/apps/desktop/desktop_native/ssh_agent/src/setup/windows.rs
+++ b/apps/desktop/desktop_native/ssh_agent/src/setup/windows.rs
@@ -25,10 +25,6 @@ const EXIT_ELEVATION_FAILED: i32 = 1;
 /// Location of `powershell.exe` below the Windows directory.
 const POWERSHELL_RELATIVE_PATH: &str = r"System32\WindowsPowerShell\v1.0\powershell.exe";
 
-/// PowerShell expression evaluating to the full path of `powershell.exe`.
-const POWERSHELL_PATH: &str =
-    r"(Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe')";
-
 /// Fallback used when `SystemRoot` is not set in the environment.
 const DEFAULT_WINDOWS_DIR: &str = r"C:\Windows";
 
@@ -76,13 +72,13 @@ pub fn apply_configuration() -> Result<()> {
          Set-Service {SSH_AGENT_SERVICE} -StartupType Disabled -ErrorAction Stop"
     );
 
-    // `Start-Process` is given the full path so the elevated child cannot be
-    // hijacked by a `powershell.exe` planted earlier on the user's PATH.
+    let powershell = format!(r"(Join-Path $env:SystemRoot '{POWERSHELL_RELATIVE_PATH}')");
+
     // A declined UAC prompt is made deterministic: `-ErrorAction Stop` turns it into
     // a terminating error, and the null check covers a non-terminating failure that
     // would otherwise leave `exit $null` reporting success.
     let status = run_powershell(&format!(
-        "$process = Start-Process {POWERSHELL_PATH} -Verb RunAs -Wait -PassThru -WindowStyle Hidden \
+        "$process = Start-Process {powershell} -Verb RunAs -Wait -PassThru -WindowStyle Hidden \
          -ErrorAction Stop -ArgumentList '-NoProfile','-Command','{elevated_script}'; \
          if ($null -eq $process) {{ exit {EXIT_ELEVATION_FAILED} }} else {{ exit $process.ExitCode }}"
     ))?;

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -293,7 +293,12 @@
         "dot-shell-profiles": {
           "interface": "personal-files",
           "read": [],
-          "write": ["$HOME/.bashrc", "$HOME/.zshrc", "$HOME/.config/fish/config.fish"]
+          "write": [
+            "$HOME/.profile",
+            "$HOME/.bashrc",
+            "$HOME/.zshrc",
+            "$HOME/.config/fish/config.fish"
+          ]
         }
       },
       {

--- a/apps/desktop/electron-builder.json
+++ b/apps/desktop/electron-builder.json
@@ -290,6 +290,13 @@
         }
       },
       {
+        "dot-shell-profiles": {
+          "interface": "personal-files",
+          "read": [],
+          "write": ["$HOME/.bashrc", "$HOME/.zshrc", "$HOME/.config/fish/config.fish"]
+        }
+      },
+      {
         "dot-native-messaging": {
           "interface": "personal-files",
           "read": [],

--- a/apps/desktop/resources/com.bitwarden.desktop.devel.yaml
+++ b/apps/desktop/resources/com.bitwarden.desktop.devel.yaml
@@ -28,6 +28,11 @@ finish-args:
   - --filesystem=xdg-download
   - --device=all
 
+  # SSH agent setup writes the SSH_AUTH_SOCK export line to the shell profiles
+  - --filesystem=home/.bashrc
+  - --filesystem=home/.zshrc
+  - --filesystem=home/.config/fish/config.fish
+
   # Browser integration
   # The config directory is needed to write manifests for non-flatpak
   # Sockets are mounted in each app's directory

--- a/apps/desktop/resources/com.bitwarden.desktop.devel.yaml
+++ b/apps/desktop/resources/com.bitwarden.desktop.devel.yaml
@@ -29,6 +29,7 @@ finish-args:
   - --device=all
 
   # SSH agent setup writes the SSH_AUTH_SOCK export line to the shell profiles
+  - --filesystem=home/.profile
   - --filesystem=home/.bashrc
   - --filesystem=home/.zshrc
   - --filesystem=home/.config/fish/config.fish

--- a/apps/desktop/resources/entitlements.mas.autofill-enabled.plist
+++ b/apps/desktop/resources/entitlements.mas.autofill-enabled.plist
@@ -24,6 +24,10 @@
 	<true/>
 	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
 	<array>
+		<string>/.profile</string>
+		<string>/.bashrc</string>
+		<string>/.zshrc</string>
+		<string>/.config/fish/config.fish</string>
 		<string>/Library/Application Support/Mozilla/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Google/Chrome/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts/</string>

--- a/apps/desktop/resources/entitlements.mas.plist
+++ b/apps/desktop/resources/entitlements.mas.plist
@@ -24,6 +24,9 @@
 	<true/>
 	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
 	<array>
+		<string>/.bashrc</string>
+		<string>/.zshrc</string>
+		<string>/.config/fish/config.fish</string>
 		<string>/Library/Application Support/Mozilla/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Google/Chrome/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts/</string>

--- a/apps/desktop/resources/entitlements.mas.plist
+++ b/apps/desktop/resources/entitlements.mas.plist
@@ -24,6 +24,7 @@
 	<true/>
 	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
 	<array>
+		<string>/.profile</string>
 		<string>/.bashrc</string>
 		<string>/.zshrc</string>
 		<string>/.config/fish/config.fish</string>

--- a/apps/desktop/src/app/accounts/settings-dialog.component.html
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.html
@@ -189,7 +189,7 @@
             <bit-hint>{{ "sshAgentPromptBehaviorDesc" | i18n }}</bit-hint>
           </bit-form-field>
 
-          @if (showSshAgentSetupDialog()) {
+          @if (showSshAgentSetupDialog() && !sshAgentConfigured()) {
             <button
               bitLink
               linkType="primary"

--- a/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.spec.ts
@@ -131,6 +131,7 @@ describe("SettingsDialogComponent", () => {
       autofill: {
         sshAgent: {
           getSocketAddress: jest.fn().mockResolvedValue(TEST_SSH_SOCKET_ADDRESS),
+          isConfigured: jest.fn().mockResolvedValue(false),
         },
       },
       platform: {
@@ -1142,6 +1143,37 @@ describe("SettingsDialogComponent", () => {
 
       expect(desktopSettingsService.setSshAgentEnabled).toHaveBeenLastCalledWith(true);
       expect(dialogService.open).not.toHaveBeenCalled();
+    });
+
+    it("does not open the setup dialog when the machine is already configured", async () => {
+      (global as any).ipc.autofill.sshAgent.isConfigured.mockResolvedValue(true);
+      createComponentWithFlag(true);
+      await component.ngOnInit();
+      component["form"].controls.enableSshAgent.setValue(true, { emitEvent: false });
+
+      await component["saveSshAgent"]();
+
+      expect(desktopSettingsService.setSshAgentEnabled).toHaveBeenLastCalledWith(true);
+      expect(dialogService.open).not.toHaveBeenCalled();
+    });
+
+    it("hides the setup instructions link when the machine is configured", async () => {
+      (global as any).ipc.autofill.sshAgent.isConfigured.mockResolvedValue(true);
+      createComponentWithFlag(true);
+
+      await component.ngOnInit();
+
+      expect(component["sshAgentConfigured"]()).toBe(true);
+    });
+
+    it("re-checks the machine after the dialog closes", async () => {
+      createComponentWithFlag(true);
+      await component.ngOnInit();
+      (global as any).ipc.autofill.sshAgent.isConfigured.mockResolvedValue(true);
+
+      await component["openSshAgentSetupDialog"]();
+
+      expect(component["sshAgentConfigured"]()).toBe(true);
     });
 
     it("does not open the setup dialog when disabling", async () => {

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -281,8 +281,6 @@ export class SettingsDialogComponent implements OnInit {
         });
     }
 
-    await this.refreshSshAgentConfigured();
-
     this.userHasMasterPassword.set(await this.userVerificationService.hasMasterPassword());
 
     this.userHasPinSet.set(await this.pinService.isPinSet(this.currentUserId()));
@@ -325,6 +323,9 @@ export class SettingsDialogComponent implements OnInit {
       locale: await firstValueFrom(this.i18nService.userSetLocale$),
     };
     this.form.setValue(initialValues, { emitEvent: false });
+
+    // Kept off the critical render path: it shells out on Windows.
+    await this.refreshSshAgentConfigured();
 
     if (this.isWindows) {
       this.billingAccountProfileStateService
@@ -656,8 +657,22 @@ export class SettingsDialogComponent implements OnInit {
     await this.refreshSshAgentConfigured();
   }
 
+  /**
+   * The native check reads shell profiles / queries a Windows service, so it is
+   * fallible. A failure must not take the rest of the dialog down with it; falling
+   * back to "not configured" only means the setup link stays visible.
+   */
   private async refreshSshAgentConfigured() {
-    this.sshAgentConfigured.set(await ipc.autofill.sshAgent.isConfigured());
+    if (!this.showSshAgentSetupDialog()) {
+      return;
+    }
+
+    try {
+      this.sshAgentConfigured.set(await ipc.autofill.sshAgent.isConfigured());
+    } catch (e) {
+      this.logService.error("Could not determine SSH agent configuration state", e);
+      this.sshAgentConfigured.set(false);
+    }
   }
 
   private async saveSshAgentPromptBehavior(newValue: SshAgentPromptType) {

--- a/apps/desktop/src/app/accounts/settings-dialog.component.ts
+++ b/apps/desktop/src/app/accounts/settings-dialog.component.ts
@@ -153,6 +153,8 @@ export class SettingsDialogComponent implements OnInit {
 
   protected readonly supportsBiometric = signal(false);
   protected readonly showEnableAutotype = signal(false);
+  /** Whether SSH clients on this machine already reach the agent. */
+  protected readonly sshAgentConfigured = signal(false);
   private readonly activeAccount = toSignal(this.accountService.activeAccount$, {
     requireSync: true,
   });
@@ -278,6 +280,8 @@ export class SettingsDialogComponent implements OnInit {
           this.showEnableAutotype.set(enabled);
         });
     }
+
+    await this.refreshSshAgentConfigured();
 
     this.userHasMasterPassword.set(await this.userVerificationService.hasMasterPassword());
 
@@ -634,13 +638,26 @@ export class SettingsDialogComponent implements OnInit {
       return;
     }
 
+    // Machines that already reach the agent need no instructions.
+    await this.refreshSshAgentConfigured();
+    if (this.sshAgentConfigured()) {
+      return;
+    }
+
     await this.openSshAgentSetupDialog();
   }
 
   protected async openSshAgentSetupDialog() {
     const socketAddress = await ipc.autofill.sshAgent.getSocketAddress();
+    const dialogRef = SshAgentSetupDialogComponent.open(this.dialogService, { socketAddress });
 
-    SshAgentSetupDialogComponent.open(this.dialogService, { socketAddress });
+    // The dialog can configure the machine itself, so re-check once it is gone.
+    await firstValueFrom(dialogRef.closed);
+    await this.refreshSshAgentConfigured();
+  }
+
+  private async refreshSshAgentConfigured() {
+    this.sshAgentConfigured.set(await ipc.autofill.sshAgent.isConfigured());
   }
 
   private async saveSshAgentPromptBehavior(newValue: SshAgentPromptType) {

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.html
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.html
@@ -19,12 +19,16 @@
         ></button>
       </div>
 
-      <p class="tw-mt-4">{{ "sshAgentSetupUnixRestart" | i18n }}</p>
+      <p class="tw-mt-4">{{ "sshAgentSetupUnixApplyDesc" | i18n }}</p>
+      <p>{{ "sshAgentSetupUnixRestart" | i18n }}</p>
     }
   </ng-container>
 
   <ng-container bitDialogFooter>
-    <button bitButton type="button" buttonType="primary" [bitDialogClose]="undefined">
+    <button bitButton type="button" buttonType="primary" [bitAction]="applyAutomatically">
+      {{ "sshAgentSetupApplyAutomatically" | i18n }}
+    </button>
+    <button bitButton type="button" buttonType="secondary" [bitDialogClose]="undefined">
       {{ "ok" | i18n }}
     </button>
     <button bitButton type="button" buttonType="secondary" (click)="launchHelp()">

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.spec.ts
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.spec.ts
@@ -4,7 +4,7 @@ import { mock } from "jest-mock-extended";
 import { DeviceType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
-import { DIALOG_DATA, ToastService } from "@bitwarden/components";
+import { DIALOG_DATA, DialogRef, ToastService } from "@bitwarden/components";
 
 import { SshAgentSetupDialogComponent } from "./ssh-agent-setup-dialog.component";
 
@@ -14,6 +14,10 @@ describe("SshAgentSetupDialogComponent", () => {
   const platformUtilsService = mock<PlatformUtilsService>();
   const i18nService = mock<I18nService>();
   const toastService = mock<ToastService>();
+  const dialogRef = mock<DialogRef>();
+
+  let originalIpc: any;
+  const applyConfiguration = jest.fn();
 
   async function createComponent(
     device: DeviceType,
@@ -24,6 +28,7 @@ describe("SshAgentSetupDialogComponent", () => {
       imports: [SshAgentSetupDialogComponent],
       providers: [
         { provide: DIALOG_DATA, useValue: { socketAddress: SOCKET_ADDRESS } },
+        { provide: DialogRef, useValue: dialogRef },
         { provide: PlatformUtilsService, useValue: platformUtilsService },
         { provide: I18nService, useValue: i18nService },
         { provide: ToastService, useValue: toastService },
@@ -40,6 +45,14 @@ describe("SshAgentSetupDialogComponent", () => {
     jest.clearAllMocks();
     TestBed.resetTestingModule();
     i18nService.t.mockImplementation((key: string) => key);
+
+    applyConfiguration.mockResolvedValue(undefined);
+    originalIpc = (global as any).ipc;
+    (global as any).ipc = { autofill: { sshAgent: { applyConfiguration } } };
+  });
+
+  afterEach(() => {
+    (global as any).ipc = originalIpc;
   });
 
   it("shows the export line on unix", async () => {
@@ -67,5 +80,29 @@ describe("SshAgentSetupDialogComponent", () => {
       `export SSH_AUTH_SOCK="${SOCKET_ADDRESS}"`,
     );
     expect(toastService.showToast).toHaveBeenCalled();
+  });
+
+  it("applies the configuration and closes on success", async () => {
+    const fixture = await createComponent(DeviceType.LinuxDesktop);
+
+    await fixture.componentInstance["applyAutomatically"]();
+
+    expect(applyConfiguration).toHaveBeenCalled();
+    expect(toastService.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "success", message: "sshAgentSetupApplied" }),
+    );
+    expect(dialogRef.close).toHaveBeenCalled();
+  });
+
+  it("keeps the dialog open and toasts when applying fails", async () => {
+    applyConfiguration.mockRejectedValue(new Error("elevation declined"));
+    const fixture = await createComponent(DeviceType.WindowsDesktop);
+
+    await fixture.componentInstance["applyAutomatically"]();
+
+    expect(toastService.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "error", message: "sshAgentSetupApplyFailed" }),
+    );
+    expect(dialogRef.close).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.spec.ts
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.spec.ts
@@ -3,6 +3,7 @@ import { mock } from "jest-mock-extended";
 
 import { DeviceType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import { DIALOG_DATA, DialogRef, ToastService } from "@bitwarden/components";
 
@@ -14,6 +15,7 @@ describe("SshAgentSetupDialogComponent", () => {
   const platformUtilsService = mock<PlatformUtilsService>();
   const i18nService = mock<I18nService>();
   const toastService = mock<ToastService>();
+  const logService = mock<LogService>();
   const dialogRef = mock<DialogRef>();
 
   let originalIpc: any;
@@ -32,6 +34,7 @@ describe("SshAgentSetupDialogComponent", () => {
         { provide: PlatformUtilsService, useValue: platformUtilsService },
         { provide: I18nService, useValue: i18nService },
         { provide: ToastService, useValue: toastService },
+        { provide: LogService, useValue: logService },
       ],
     }).compileComponents();
 

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.ts
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 
 import { DeviceType } from "@bitwarden/common/enums";
 import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+import { LogService } from "@bitwarden/common/platform/abstractions/log.service";
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import {
   DIALOG_DATA,
@@ -43,6 +44,7 @@ export class SshAgentSetupDialogComponent {
   private readonly platformUtilsService = inject(PlatformUtilsService);
   private readonly i18nService = inject(I18nService);
   private readonly toastService = inject(ToastService);
+  private readonly logService = inject(LogService);
 
   // Windows clients find the agent on the well-known OpenSSH named pipe, so there is
   // nothing to export there; every other platform needs SSH_AUTH_SOCK pointed at us.
@@ -74,7 +76,8 @@ export class SshAgentSetupDialogComponent {
   protected readonly applyAutomatically = async () => {
     try {
       await ipc.autofill.sshAgent.applyConfiguration();
-    } catch {
+    } catch (e) {
+      this.logService.error("Could not configure the SSH agent", e);
       this.toastService.showToast({
         variant: "error",
         title: undefined,

--- a/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.ts
+++ b/apps/desktop/src/app/components/ssh-agent-setup-dialog.component.ts
@@ -5,10 +5,12 @@ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.servic
 import { PlatformUtilsService } from "@bitwarden/common/platform/abstractions/platform-utils.service";
 import {
   DIALOG_DATA,
+  AsyncActionsModule,
   ButtonModule,
   CalloutModule,
   CenterPositionStrategy,
   DialogModule,
+  DialogRef,
   DialogService,
   IconButtonModule,
   ToastService,
@@ -25,11 +27,19 @@ export type SshAgentSetupDialogData = {
 @Component({
   templateUrl: "ssh-agent-setup-dialog.component.html",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [I18nPipe, ButtonModule, CalloutModule, DialogModule, IconButtonModule],
+  imports: [
+    I18nPipe,
+    AsyncActionsModule,
+    ButtonModule,
+    CalloutModule,
+    DialogModule,
+    IconButtonModule,
+  ],
 })
 export class SshAgentSetupDialogComponent {
   protected readonly data = inject<SshAgentSetupDialogData>(DIALOG_DATA);
 
+  private readonly dialogRef = inject(DialogRef);
   private readonly platformUtilsService = inject(PlatformUtilsService);
   private readonly i18nService = inject(I18nService);
   private readonly toastService = inject(ToastService);
@@ -56,6 +66,30 @@ export class SshAgentSetupDialogComponent {
       message: this.i18nService.t("valueCopied", this.i18nService.t("sshAgentSocketPath")),
     });
   }
+
+  /**
+   * Configures the machine for the user: appends the export line to the shell
+   * profiles on unix, disables the built-in OpenSSH agent service on Windows.
+   */
+  protected readonly applyAutomatically = async () => {
+    try {
+      await ipc.autofill.sshAgent.applyConfiguration();
+    } catch {
+      this.toastService.showToast({
+        variant: "error",
+        title: undefined,
+        message: this.i18nService.t("sshAgentSetupApplyFailed"),
+      });
+      return;
+    }
+
+    this.toastService.showToast({
+      variant: "success",
+      title: undefined,
+      message: this.i18nService.t("sshAgentSetupApplied"),
+    });
+    await this.dialogRef.close();
+  };
 
   protected launchHelp() {
     this.platformUtilsService.launchUri(SSH_AGENT_HELP_URI);

--- a/apps/desktop/src/autofill/main/main-ssh-agent.service.ts
+++ b/apps/desktop/src/autofill/main/main-ssh-agent.service.ts
@@ -38,6 +38,14 @@ export class MainSshAgentService {
       return sshagent.getSocketAddress();
     });
 
+    ipcMain.handle(SSH_AGENT_IPC_CHANNELS.IS_CONFIGURED, async () => {
+      return await sshagent.isConfigured();
+    });
+
+    ipcMain.handle(SSH_AGENT_IPC_CHANNELS.APPLY_CONFIGURATION, async () => {
+      return await sshagent.applyConfiguration();
+    });
+
     ipcMain.handle(SSH_AGENT_IPC_CHANNELS.IS_LOADED, async () => {
       return this.agentState?.isRunning() ?? false;
     });

--- a/apps/desktop/src/autofill/models/ipc-channels.ts
+++ b/apps/desktop/src/autofill/models/ipc-channels.ts
@@ -11,6 +11,8 @@ export const SSH_AGENT_IPC_CHANNELS = {
   INIT: "sshagent.init",
   IS_LOADED: "sshagent.isloaded",
   GET_SOCKET_ADDRESS: "sshagent.getsocketaddress",
+  IS_CONFIGURED: "sshagent.isconfigured",
+  APPLY_CONFIGURATION: "sshagent.applyconfiguration",
   STOP: "sshagent.stop",
   REPLACE: "sshagent.replace",
   SIGN_REQUEST: "sshagent.signrequest",

--- a/apps/desktop/src/autofill/preload.ts
+++ b/apps/desktop/src/autofill/preload.ts
@@ -21,6 +21,11 @@ const sshAgent = {
   // The address (unix socket path or Windows named pipe) SSH clients must connect to.
   getSocketAddress: (): Promise<string> =>
     ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.GET_SOCKET_ADDRESS),
+  // Whether SSH clients on this machine already reach the Bitwarden agent.
+  isConfigured: (): Promise<boolean> => ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.IS_CONFIGURED),
+  // Configures the machine so that SSH clients reach the Bitwarden agent.
+  applyConfiguration: (): Promise<void> =>
+    ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.APPLY_CONFIGURATION),
   isLoaded(): Promise<boolean> {
     return ipcRenderer.invoke(SSH_AGENT_IPC_CHANNELS.IS_LOADED);
   },

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -766,10 +766,22 @@
     "message": "Restart your terminal for the change to take effect."
   },
   "sshAgentSetupWindowsDesc": {
-    "message": "Your SSH clients will use your Bitwarden vault automatically. There is nothing to configure."
+    "message": "Your SSH clients will use your Bitwarden vault automatically."
   },
   "sshAgentSetupWindowsService": {
     "message": "The built-in Windows OpenSSH Authentication Agent service must be disabled."
+  },
+  "sshAgentSetupUnixApplyDesc": {
+    "message": "Applying automatically adds the line to the end of your ~/.bashrc, ~/.zshrc and fish configuration files."
+  },
+  "sshAgentSetupApplyAutomatically": {
+    "message": "Apply automatically"
+  },
+  "sshAgentSetupApplied": {
+    "message": "SSH agent configuration applied"
+  },
+  "sshAgentSetupApplyFailed": {
+    "message": "Could not apply the SSH agent configuration"
   },
   "sshAgentSocketPath": {
     "message": "SSH agent socket path"

--- a/apps/desktop/src/locales/en/messages.json
+++ b/apps/desktop/src/locales/en/messages.json
@@ -772,7 +772,7 @@
     "message": "The built-in Windows OpenSSH Authentication Agent service must be disabled."
   },
   "sshAgentSetupUnixApplyDesc": {
-    "message": "Applying automatically adds the line to the end of your ~/.bashrc, ~/.zshrc and fish configuration files."
+    "message": "Applying automatically adds the line to the end of your ~/.profile, ~/.bashrc, ~/.zshrc and fish configuration files."
   },
   "sshAgentSetupApplyAutomatically": {
     "message": "Apply automatically"


### PR DESCRIPTION
## 🎟️ Tracking

Stacked on #23109.

## 📔 Objective

The setup dialog now offers to auto-configure the SSH agent:

- unix — appends the export line to `~/.bashrc`, `~/.zshrc` and the fish config behind a marker comment.
- Windows — stops and disables the built-in OpenSSH Authentication Agent service via an elevated helper (UAC).

Machines that already reach the agent are detected, so the dialog is skipped on enable and the settings link is hidden.

Sandbox manifests (snap, flatpak, MAS entitlements) gain write access to the three profile files.

## 📸 Screenshots
