### PR TITLE
[CL-1321] Animate dialog open direction based on its position on the page, not its size

### DIFF
--- a/libs/components/src/dialog/dialog-position.ts
+++ b/libs/components/src/dialog/dialog-position.ts
@@ -1,0 +1,35 @@
+import { PositionStrategy } from "@angular/cdk/overlay";
+import { InjectionToken, Signal } from "@angular/core";
+
+/**
+ * Where a dialog is currently anchored in the viewport.
+ *
+ * - `center` — centered vertically and horizontally
+ * - `bottom` — docked to the bottom edge, as a mobile bottom sheet
+ */
+export type DialogPosition = "center" | "bottom";
+
+/**
+ * A position strategy a dialog can be opened with. Strategies that move the dialog around the
+ * viewport should report where they placed it, so dialog content can adapt to its own placement
+ * — e.g. animating in from the bottom of the screen rather than the top. `DialogService` passes
+ * that signal to the dialog as {@link DIALOG_POSITION}.
+ *
+ * `position` is optional because CDK's own strategies don't report one; they are treated as
+ * centered.
+ */
+export interface DialogPositionStrategy extends PositionStrategy {
+  readonly position?: Signal<DialogPosition>;
+}
+
+/**
+ * The position of the dialog that this component is rendered in, kept up to date as the
+ * viewport changes. Provided by `DialogService` when the dialog's position strategy reports its
+ * position.
+ *
+ * Inject optionally: the token is absent for dialogs opened with a strategy that doesn't report
+ * a position, and for dialogs rendered outside of `DialogService`. Absent means centered.
+ *
+ * @see {@link DialogPositionStrategy}
+ */
+export const DIALOG_POSITION = new InjectionToken<Signal<DialogPosition>>("DialogPosition");

--- a/libs/components/src/dialog/dialog.service.spec.ts
+++ b/libs/components/src/dialog/dialog.service.spec.ts
@@ -1,4 +1,5 @@
 import { Dialog as CdkDialog } from "@angular/cdk/dialog";
+import { GlobalPositionStrategy, PositionStrategy } from "@angular/cdk/overlay";
 import { ChangeDetectionStrategy, Component } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { provideRouter } from "@angular/router";
@@ -10,8 +11,16 @@ import { AuthService } from "@bitwarden/common/auth/abstractions/auth.service";
 import { AuthenticationStatus } from "@bitwarden/common/auth/enums/authentication-status";
 import { LogService } from "@bitwarden/logging";
 
-import { DialogService } from "./dialog.service";
+import { DIALOG_POSITION } from "./dialog-position";
+import { CenterPositionStrategy, DialogService } from "./dialog.service";
 import { DrawerService } from "./drawer.service";
+
+@Component({
+  selector: "test-dialog",
+  template: "",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestDialogComponent {}
 
 @Component({
   selector: "test-drawer",
@@ -73,6 +82,72 @@ describe("DialogService", () => {
     service = TestBed.inject(DialogService);
     drawerService = TestBed.inject(DrawerService);
     jest.spyOn(drawerService, "forceCloseAll");
+  });
+
+  describe("dialog position", () => {
+    /** Whether the viewport is at or larger than the `md` breakpoint. */
+    let largeScreen: boolean;
+
+    const setScreenSize = (large: boolean) => {
+      largeScreen = large;
+      window.dispatchEvent(new Event("resize"));
+    };
+
+    /** Opens a dialog and returns the position signal handed to it, if any. */
+    const openDialogPosition = (positionStrategy?: PositionStrategy) => {
+      // `restoreFocus` is set so the service skips the async focus capture, which needs a real
+      // CDK dialog ref.
+      service.open(TestDialogComponent, { positionStrategy, restoreFocus: false });
+      const config = cdkDialog.open.mock.calls.at(-1)![1]!;
+      return config.injector!.get(DIALOG_POSITION, null);
+    };
+
+    beforeEach(() => {
+      largeScreen = true;
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+          matches: largeScreen,
+          media: query,
+        })),
+      });
+    });
+
+    it("reports `center` on large screens", () => {
+      setScreenSize(true);
+
+      expect(openDialogPosition()!()).toBe("center");
+    });
+
+    it("reports `bottom` on small screens, where the dialog docks to the bottom edge", () => {
+      setScreenSize(false);
+
+      expect(openDialogPosition()!()).toBe("bottom");
+    });
+
+    it("updates when the viewport crosses the breakpoint", () => {
+      setScreenSize(true);
+      const position = openDialogPosition()!;
+
+      setScreenSize(false);
+      expect(position()).toBe("bottom");
+
+      setScreenSize(true);
+      expect(position()).toBe("center");
+    });
+
+    // Dialogs fall back to `center` when no position is provided.
+    it("provides no position for a centered strategy", () => {
+      setScreenSize(false);
+
+      expect(openDialogPosition(new CenterPositionStrategy())).toBeNull();
+    });
+
+    it("provides no position for strategies that do not report one", () => {
+      setScreenSize(false);
+
+      expect(openDialogPosition(new GlobalPositionStrategy())).toBeNull();
+    });
   });
 
   describe("close drawer on navigation", () => {

--- a/libs/components/src/dialog/dialog.service.stories.ts
+++ b/libs/components/src/dialog/dialog.service.stories.ts
@@ -30,6 +30,9 @@ interface DrawerLevel {
   template: `
     <bit-layout>
       <button class="tw-mr-2" bitButton type="button" (click)="openDialog()">Open Dialog</button>
+      <button class="tw-mr-2" bitButton size="small" type="button" (click)="openSmallDialog()">
+        Open Small Dialog
+      </button>
       <button class="tw-mr-2" bitButton type="button" (click)="openDialogNonDismissable()">
         Open Non-Dismissable Dialog
       </button>
@@ -51,6 +54,14 @@ class StoryDialogComponent {
 
   openDialog() {
     this.dialogService.open(StoryDialogContentComponent, {
+      data: {
+        animal: "panda",
+      },
+    });
+  }
+
+  openSmallDialog() {
+    this.dialogService.open(StorySmallDialogContentComponent, {
       data: {
         animal: "panda",
       },
@@ -125,6 +136,34 @@ class StoryDialogComponent {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class StoryDialogContentComponent {
+  dialogRef = inject(DialogRef);
+  private data = inject<Animal>(DIALOG_DATA);
+
+  get animal() {
+    return this.data?.animal;
+  }
+}
+
+@Component({
+  template: `
+    <bit-dialog title="Dialog Title" dialogSize="small">
+      <span bitDialogContent>
+        Dialog body text goes here.
+        <br />
+        Animal: {{ animal }}
+      </span>
+      <ng-container bitDialogFooter>
+        <button type="button" bitButton buttonType="primary" (click)="dialogRef.close()">
+          Save
+        </button>
+        <button type="button" bitButton buttonType="secondary" bitDialogClose>Cancel</button>
+      </ng-container>
+    </bit-dialog>
+  `,
+  imports: [DialogModule, ButtonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class StorySmallDialogContentComponent {
   dialogRef = inject(DialogRef);
   private data = inject<Animal>(DIALOG_DATA);
 

--- a/libs/components/src/dialog/dialog.service.ts
+++ b/libs/components/src/dialog/dialog.service.ts
@@ -5,7 +5,7 @@ import {
 } from "@angular/cdk/dialog";
 import { ComponentType, GlobalPositionStrategy, ScrollStrategy } from "@angular/cdk/overlay";
 import { ComponentPortal } from "@angular/cdk/portal";
-import { Injectable, Injector, TemplateRef, inject } from "@angular/core";
+import { Injectable, Injector, Signal, TemplateRef, inject, signal } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { NavigationEnd, Router } from "@angular/router";
 import { filter, firstValueFrom, map, switchMap, take } from "rxjs";
@@ -16,6 +16,7 @@ import { LogService } from "@bitwarden/logging";
 
 import { isAtOrLargerThanBreakpoint } from "../utils/responsive-utils";
 
+import { DIALOG_POSITION, DialogPosition, DialogPositionStrategy } from "./dialog-position";
 import { CdkDialogRef, DialogConfig, DialogRef, DrawerRef } from "./dialog-ref";
 import { DrawerService } from "./drawer.service";
 import { SimpleConfigurableDialogComponent } from "./simple-dialog/simple-configurable-dialog/simple-configurable-dialog.component";
@@ -45,8 +46,13 @@ class CustomBlockScrollStrategy implements ScrollStrategy {
 /**
  * A responsive position strategy that adjusts the dialog position based on the screen size.
  */
-class ResponsivePositionStrategy extends GlobalPositionStrategy {
+class ResponsivePositionStrategy extends GlobalPositionStrategy implements DialogPositionStrategy {
   private abortController: AbortController | null = null;
+
+  private readonly _position = signal<DialogPosition>("center");
+
+  /** Where this strategy has currently placed the dialog. */
+  readonly position = this._position.asReadonly();
 
   /**
    * The previous breakpoint to avoid unnecessary updates.
@@ -83,6 +89,7 @@ class ResponsivePositionStrategy extends GlobalPositionStrategy {
     } else {
       this.centerVertically().centerHorizontally();
     }
+    this._position.set(isSmallScreen ? "bottom" : "center");
     this.apply();
   }
 }
@@ -150,19 +157,22 @@ export class DialogService {
      * This allows us to create the class instance and provide the base instance later, almost like "deferred inheritance".
      **/
     const ref = new CdkDialogRef<R, C>(this.logService, closePredicate);
+    const positionStrategy: DialogPositionStrategy =
+      config?.positionStrategy ?? new ResponsivePositionStrategy();
     const injector = this.createInjector({
       data: config?.data,
       dialogRef: ref,
+      position: positionStrategy.position,
     });
 
     // Merge the custom config with the default config
     const _config = {
       backdropClass: this.backDropClasses,
       scrollStrategy: this.defaultScrollStrategy,
-      positionStrategy: config?.positionStrategy ?? new ResponsivePositionStrategy(),
       closeOnNavigation: config?.closeOnNavigation,
       injector,
       ...otherConfig,
+      positionStrategy,
     };
 
     ref.cdkDialogRefBase = this.dialog.open<R, D, C>(componentOrTemplateRef, _config);
@@ -304,6 +314,8 @@ export class DialogService {
     data: unknown;
     dialogRef: DialogRef<any, any>;
     drawerRef?: DrawerRef<any, any>;
+    /** Absent when the dialog's position strategy doesn't report a position. */
+    position?: Signal<DialogPosition>;
   }): Injector {
     return Injector.create({
       providers: [
@@ -320,6 +332,7 @@ export class DialogService {
           useValue: opts.dialogRef,
         },
         ...(opts.drawerRef ? [{ provide: DrawerRef, useValue: opts.drawerRef }] : []),
+        ...(opts.position ? [{ provide: DIALOG_POSITION, useValue: opts.position }] : []),
       ],
       parent: this.injector,
     });

--- a/libs/components/src/dialog/dialog/dialog.component.ts
+++ b/libs/components/src/dialog/dialog/dialog.component.ts
@@ -26,6 +26,7 @@ import { SpinnerComponent } from "../../spinner";
 import { TypographyDirective } from "../../typography/typography.directive";
 import { hasScrollableContent$ } from "../../utils/";
 import { hasScrolledFrom } from "../../utils/has-scrolled-from";
+import { DIALOG_POSITION } from "../dialog-position";
 import { DialogRef } from "../dialog-ref";
 import { DialogCloseDirective } from "../directives/dialog-close.directive";
 import { DialogTitleContainerDirective } from "../directives/dialog-title-container.directive";
@@ -97,6 +98,13 @@ export class DialogComponent implements AfterViewInit {
   private readonly scrollBottom = viewChild.required<ElementRef<HTMLDivElement>>("scrollBottom");
 
   protected dialogRef = inject(DialogRef, { optional: true });
+
+  /**
+   * Where the dialog is placed in the viewport, per the position strategy it was opened with.
+   * Absent for a dialog that is centered or rendered outside of `DialogService`.
+   */
+  private readonly position = inject(DIALOG_POSITION, { optional: true });
+
   protected bodyHasScrolledFrom = hasScrolledFrom(this.scrollableBody);
   private scrollableBody$ = toObservable(this.scrollableBody);
   private scrollBottom$ = toObservable(this.scrollBottom);
@@ -164,13 +172,12 @@ export class DialogComponent implements AfterViewInit {
           "tw-max-h-[90vh]", // needed to prevent dialogs from overlapping the desktop header
         ];
 
-    const size = this.dialogSize();
     const animationClasses =
-      this.disableAnimations() || this.animationCompleted() || this.dialogRef?.isDrawer
+      this.disableAnimations() || this.animationCompleted() || isDrawer
         ? []
-        : size === "small"
-          ? ["tw-animate-slide-down"]
-          : ["tw-animate-slide-up", "md:tw-animate-slide-down"];
+        : this.position?.() === "bottom"
+          ? ["tw-animate-slide-up"]
+          : ["tw-animate-slide-down"];
 
     return [...baseClasses, this.width(), ...sizeClasses, ...animationClasses];
   });

--- a/libs/components/src/dialog/index.ts
+++ b/libs/components/src/dialog/index.ts
@@ -1,5 +1,6 @@
 export * from "./dialog.module";
 export * from "./simple-dialog/types";
+export * from "./dialog-position";
 export * from "./dialog-ref";
 export * from "./dialog.service";
 export { DIALOG_DATA } from "@angular/cdk/dialog";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[CL-1321](https://bitwarden.atlassian.net/browse/CL-1321)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Previously, we were animating the direction of the dialog entrance animation based on whether it was small size or not. However, this did not account for the positioning of the dialog on the page, which means that in a responsive dialog, the bottom sheet view could end up animating the wrong direction. 

Instead of basing the animation direction off of size, we are now animating based on the positioning on the page, so that all centered dialogs animate downward (entering from the top of the page), and all bottom sheet dialogs animate upwards (entering from the bottom of the page).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before (bottom sheet):

https://github.com/user-attachments/assets/98fc49a8-3b89-415f-b1f7-4787a19709e5


After (bottom sheet):


https://github.com/user-attachments/assets/54e0ada4-73c3-4236-9293-4000d134962a


Regression check on centered dialogs:

https://github.com/user-attachments/assets/c55d5006-ff01-4ff7-acd3-d23c1bbdd7de



[CL-1321]: https://bitwarden.atlassian.net/browse/CL-1321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ