### PR TITLE
[PM-42608] Include default collections in organization collection details for Access Intelligence

### DIFF
--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
@@ -5,6 +5,7 @@ import {
   OrganizationUserUserDetailsResponse,
 } from "@bitwarden/admin-console/common";
 import { ApiService } from "@bitwarden/common/abstractions/api.service";
+import { CollectionTypes } from "@bitwarden/common/admin-console/models/collections";
 import { OrganizationId, OrganizationReportId } from "@bitwarden/common/types/guid";
 import { CipherService } from "@bitwarden/common/vault/abstractions/cipher.service";
 // eslint-disable-next-line no-restricted-imports
@@ -19,6 +20,7 @@ import {
 } from "../../../../reports/risk-insights/testing/test-helpers";
 import { ReportGenerationService } from "../../abstractions/report-generation.service";
 import { ReportPersistenceService } from "../../abstractions/report-persistence.service";
+import { DefaultMemberCipherMappingService } from "../domain/default-member-cipher-mapping.service";
 
 import { DefaultAccessIntelligenceDataService } from "./default-access-intelligence-data.service";
 
@@ -603,6 +605,78 @@ describe("DefaultAccessIntelligenceDataService", () => {
           { groupId: "group-2", users: new Set(["user-2"]) },
         ]),
         expect.anything(),
+      );
+    });
+  });
+
+  describe("Default Collection Member Attribution", () => {
+    it("resolves a cipher whose only collection is a default collection to its owner", async () => {
+      // Guards the whole attribution chain end to end — the collections request, the
+      // transform, and the mapping service. A break anywhere along it shows up in the UI as
+      // an application with a member count of zero.
+      const myItemsCollectionId = "my-items-alice";
+      const cipher = createCipher("cipher-1", ["alice-app.com"], [myItemsCollectionId]);
+
+      // Mirrors the server: default collections are withheld unless they are asked for, so
+      // dropping the opt-in fails this test rather than silently returning them anyway.
+      apiService.getManyCollectionsWithAccessDetails.mockImplementation(
+        (_orgId: string, includeDefaultCollections?: boolean) =>
+          Promise.resolve({
+            data: includeDefaultCollections
+              ? [
+                  {
+                    id: myItemsCollectionId,
+                    name: "My Items",
+                    organizationId: orgId,
+                    type: CollectionTypes.DefaultUserCollection,
+                    users: [{ id: "user-1" }],
+                    groups: [],
+                  },
+                ]
+              : [],
+          } as any),
+      );
+      cipherService.getAllFromApiForOrganization.mockResolvedValue([cipher]);
+      organizationUserApiService.getAllUsers.mockResolvedValue({
+        data: [
+          {
+            id: "user-1",
+            name: "Alice",
+            email: "alice@example.com",
+            collections: [
+              { id: myItemsCollectionId, readOnly: false, hidePasswords: false, manage: true },
+            ],
+            groups: [] as string[],
+          } as OrganizationUserUserDetailsResponse,
+        ],
+      } as any);
+      reportGenerationService.generateReport$.mockReturnValue(of(testReport));
+      reportPersistenceService.loadLastReport$.mockReturnValue(of(null));
+      reportPersistenceService.saveReport$.mockReturnValue(
+        of({ id: "report-id" as OrganizationReportId, contentEncryptionKey: new EncString("") }),
+      );
+
+      await firstValueFrom(service.generateNewReport$(orgId));
+
+      // Feed the real mapping service exactly what the data service produced.
+      const [ciphers, members, collectionAccess, groupMemberships] =
+        reportGenerationService.generateReport$.mock.calls[0];
+      const { mapping, registry } = await firstValueFrom(
+        new DefaultMemberCipherMappingService().mapCiphersToMembers$(
+          ciphers,
+          members,
+          collectionAccess,
+          groupMemberships,
+        ),
+      );
+
+      expect(mapping.get(cipher.id!)).toEqual(["user-1"]);
+      expect(registry["user-1"]).toEqual(
+        expect.objectContaining({
+          id: "user-1",
+          userName: "Alice",
+          email: "alice@example.com",
+        }),
       );
     });
   });

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.spec.ts
@@ -242,6 +242,14 @@ describe("DefaultAccessIntelligenceDataService", () => {
       expect(cipherService.getAllFromApiForOrganization).toHaveBeenCalledWith(orgId, true);
     });
 
+    it("requests default collections so My Items ciphers can be attributed to a member", async () => {
+      await firstValueFrom(service.generateNewReport$(orgId));
+
+      // Without the second argument the server returns only shared collections, leaving
+      // ciphers in a member's "My Items" collection with no collection access to resolve.
+      expect(apiService.getManyCollectionsWithAccessDetails).toHaveBeenCalledWith(orgId, true);
+    });
+
     it("requests member items when refreshing an existing report", async () => {
       await firstValueFrom(service.refreshReport$(orgId));
 

--- a/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
+++ b/bitwarden_license/bit-common/src/dirt/access-intelligence/services/implementations/view/default-access-intelligence-data.service.ts
@@ -461,7 +461,9 @@ export class DefaultAccessIntelligenceDataService extends AccessIntelligenceData
           includeGroups: true,
         }),
       ),
-      collections: from(this.apiService.getManyCollectionsWithAccessDetails(orgId)),
+      // Default collections must be included, or a cipher whose only collection is a
+      // member's "My Items" resolves to no members.
+      collections: from(this.apiService.getManyCollectionsWithAccessDetails(orgId, true)),
     });
   }
 

--- a/libs/common/src/abstractions/api.service.ts
+++ b/libs/common/src/abstractions/api.service.ts
@@ -266,6 +266,7 @@ export abstract class ApiService {
   ): Promise<CollectionAccessDetailsResponse>;
   abstract getManyCollectionsWithAccessDetails(
     orgId: string,
+    includeDefaultCollections?: boolean,
   ): Promise<ListResponse<CollectionAccessDetailsResponse>>;
   abstract postCollection(
     organizationId: string,

--- a/libs/common/src/services/api.service.spec.ts
+++ b/libs/common/src/services/api.service.spec.ts
@@ -1307,4 +1307,48 @@ describe("ApiService", () => {
       );
     });
   });
+
+  describe("getManyCollectionsWithAccessDetails", () => {
+    let nativeFetch: jest.Mock<Promise<Response>, [request: Request]>;
+
+    beforeEach(() => {
+      environmentService.getEnvironment$.mockReturnValue(
+        of({
+          getApiUrl: () => "https://example.com",
+        } satisfies Partial<Environment> as Environment),
+      );
+
+      tokenService.getAccessToken.mockResolvedValue("access_token");
+      tokenService.tokenNeedsRefresh.mockResolvedValue(false);
+
+      nativeFetch = jest.fn<Promise<Response>, [request: Request]>();
+      nativeFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ Data: [] }),
+        headers: new Headers({
+          "content-type": "application/json",
+        }),
+      } satisfies Partial<Response> as Response);
+
+      sut.nativeFetch = nativeFetch;
+    });
+
+    it("omits the query string when includeDefaultCollections is not passed", async () => {
+      // Callers outside Access Intelligence rely on this URL being unchanged.
+      await sut.getManyCollectionsWithAccessDetails("org-1");
+
+      const request = nativeFetch.mock.calls[0][0];
+      expect(request.url).toBe("https://example.com/organizations/org-1/collections/details");
+    });
+
+    it("asks for default collections when includeDefaultCollections is true", async () => {
+      await sut.getManyCollectionsWithAccessDetails("org-1", true);
+
+      const request = nativeFetch.mock.calls[0][0];
+      expect(request.url).toBe(
+        "https://example.com/organizations/org-1/collections/details?includeDefaultCollections=true",
+      );
+    });
+  });
 });

--- a/libs/common/src/services/api.service.ts
+++ b/libs/common/src/services/api.service.ts
@@ -671,14 +671,13 @@ export class ApiService implements ApiServiceAbstraction {
 
   async getManyCollectionsWithAccessDetails(
     organizationId: string,
+    includeDefaultCollections?: boolean,
   ): Promise<ListResponse<CollectionAccessDetailsResponse>> {
-    const r = await this.send(
-      "GET",
-      "/organizations/" + organizationId + "/collections/details",
-      null,
-      true,
-      true,
-    );
+    let url = "/organizations/" + organizationId + "/collections/details";
+    if (includeDefaultCollections) {
+      url += `?includeDefaultCollections=${includeDefaultCollections}`;
+    }
+    const r = await this.send("GET", url, null, true, true);
     return new ListResponse(r, CollectionAccessDetailsResponse);
   }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42608](https://bitwarden.atlassian.net/browse/PM-42608)

Server PR: https://github.com/bitwarden/server/pull/8344

## 📔 Objective

Access Intelligence V2 builds its cipher-to-member mapping client-side. `DefaultMemberCipherMappingService` walks each cipher's `collectionIds`, looks each ID up in a collection-access map, and unions that collection's users and groups. A cipher whose only collection is a member's default "My Items" collection finds no entry in that map, so it resolves to zero members and the application shows a member count of 0.

The gap source of the issue is in `GET /organizations/{orgId}/collections/details` which returns only shared collections. The #8344 adds an opt-in `includeDefaultCollections` query parameter that makes the endpoint also return default collections, along with the AccessReports permission needed to read them org-wide.

### Changes

- Added `includeDefaultCollections` to `getManyCollectionsWithAccessDetails`
- Updated `default-access-intelligence-data.service.ts` to use `includeDefaultCollections`

### Notes

- **Deprecated `ApiService` usage**: `default-access-intelligence-data.service.ts` imports the deprecated `ApiService`. That is pre-existing and unavoidable here since the endpoint lives on it

## 📸 Screenshots

### Access Intelligence with my items and correct counts:

<img width="1907" height="1341" alt="Screenshot 2026-09-11 at 9 36 29 AM" src="https://github.com/user-attachments/assets/fad31f31-0793-4117-8aa9-5fdbcec13903" />


[PM-42608]: https://bitwarden.atlassian.net/browse/PM-42608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ