### PR TITLE
[CL-1321][CL-1322] misc filter dialog fixes

### DIFF
--- a/libs/components/src/filter-menu/filter-dialog.component.html
+++ b/libs/components/src/filter-menu/filter-dialog.component.html
@@ -1,4 +1,4 @@
-<bit-dialog [title]="activeFilter()?.label() ?? ('filter' | i18n)" dialogSize="small">
+<bit-dialog [title]="activeFilter()?.label() ?? ('filter' | i18n)" dialogSize="default">
   @if (activeFilter()) {
     <button
       bitDialogHeaderStart
@@ -77,16 +77,6 @@
           {{ "clear" | i18n }}
         </button>
       }
-      <button
-        bitButton
-        buttonType="primary"
-        type="button"
-        [class.tw-ms-auto]="!activeSelectedCount()"
-        (click)="back()"
-        #doneButton
-      >
-        {{ "done" | i18n }}
-      </button>
     } @else {
       @if (selectedCount()) {
         <span class="tw-text-sm tw-text-muted">{{
@@ -103,16 +93,16 @@
           {{ "clearAll" | i18n }}
         </button>
       }
-      <button
-        bitButton
-        buttonType="primary"
-        type="button"
-        [class.tw-ms-auto]="!selectedCount()"
-        (click)="close()"
-        #doneButton
-      >
-        {{ "done" | i18n }}
-      </button>
     }
+    <button
+      bitButton
+      buttonType="primary"
+      type="button"
+      [class.tw-ms-auto]="!footerSelectedCount()"
+      bitDialogClose
+      #doneButton
+    >
+      {{ "done" | i18n }}
+    </button>
   </ng-container>
 </bit-dialog>

--- a/libs/components/src/filter-menu/filter-dialog.component.ts
+++ b/libs/components/src/filter-menu/filter-dialog.component.ts
@@ -13,7 +13,7 @@ import {
 import { I18nPipe } from "@bitwarden/ui-common";
 
 import { ButtonModule } from "../button";
-import { DIALOG_DATA, DialogModule, DialogRef } from "../dialog";
+import { DIALOG_DATA, DialogModule } from "../dialog";
 import { IconComponent } from "../icon";
 import { IconButtonModule } from "../icon-button";
 import {
@@ -54,7 +54,6 @@ function optionCount(filter: FilterPresenter): number {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FilterDialogComponent {
-  private readonly dialogRef = inject(DialogRef);
   private readonly injector = inject(Injector);
 
   private readonly doneButtonEl = viewChild("doneButton", { read: ElementRef<HTMLElement> });
@@ -75,6 +74,11 @@ export class FilterDialogComponent {
     const filter = this.activeFilter();
     return filter ? optionCount(filter) : 0;
   });
+
+  /** Whichever count the footer is showing — the drilled-into filter's, or every filter's. */
+  protected readonly footerSelectedCount = computed(() =>
+    this.activeFilter() ? this.activeSelectedCount() : this.selectedCount(),
+  );
 
   /** Kept out of the template so no whitespace lands between the label and the colon. */
   protected rowLabel(filter: FilterPresenter): string {
@@ -149,10 +153,5 @@ export class FilterDialogComponent {
   /** Clearing removes the button that was clicked, so move focus rather than drop it. */
   private keepFocusOnDone(): void {
     focusAfterRender(this.injector, () => this.doneButtonEl()?.nativeElement);
-  }
-
-  /** Dismiss the dialog. Selections apply live, so this just closes. */
-  protected close(): void {
-    void this.dialogRef.close();
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking


https://bitwarden.atlassian.net/browse/CL-1321
https://bitwarden.atlassian.net/browse/CL-1322

## 📔 Objective

- Done returned to the filter list from a drill-in page instead of closing, so dismissing the dialog took two taps. It now uses `bitDialogClose`, which closes from either level; the header back arrow still goes up a level.
- Also sizes the dialog `default` rather than `small`, which animates up instead of down on creation

## 📸 Screenshots

https://github.com/user-attachments/assets/38dcc351-f469-437a-93f6-edec52f10301


