### PR TITLE
[PM-43363] fix: Wrap long unbroken text in status lockup

### DIFF
--- a/libs/components/src/status-lockup/status-lockup.component.html
+++ b/libs/components/src/status-lockup/status-lockup.component.html
@@ -1,21 +1,24 @@
 <div class="tw-mx-auto tw-flex tw-flex-col tw-items-center tw-justify-center tw-p-6">
   <div
-    class="tw-flex tw-flex-col tw-gap-6 tw-items-center"
+    class="tw-flex tw-flex-col tw-gap-6 tw-items-center tw-w-full"
     [class.tw-max-w-[600px]]="effectiveSize() === 'base'"
     [class.tw-max-w-[480px]]="effectiveSize() === 'small'"
   >
     <div class="tw-flex tw-items-center tw-justify-center [&_bit-svg]:tw-size-20 empty:tw-hidden">
       <ng-content select="[slot=graphic]"></ng-content>
     </div>
-    <div class="tw-flex tw-flex-col tw-gap-2">
+    <div class="tw-flex tw-flex-col tw-gap-2 tw-w-full">
       <h3
-        class="tw-font-medium tw-text-center !tw-mb-0 tw-text-fg-heading"
+        class="tw-font-medium tw-text-center !tw-mb-0 tw-text-fg-heading tw-break-words"
         [class.tw-text-base]="effectiveSize() === 'base'"
         [class.tw-text-sm]="effectiveSize() === 'small'"
       >
         <ng-content select="[slot=title]"></ng-content>
       </h3>
-      <div bitTypography="body2" class="tw-text-center empty:tw-hidden tw-text-fg-body">
+      <div
+        bitTypography="body2"
+        class="tw-text-center empty:tw-hidden tw-text-fg-body tw-break-words"
+      >
         <ng-content select="[slot=description]"></ng-content>
       </div>
     </div>

--- a/libs/components/src/status-lockup/status-lockup.stories.ts
+++ b/libs/components/src/status-lockup/status-lockup.stories.ts
@@ -263,3 +263,37 @@ export const NoButton: Story = {
     },
   },
 };
+
+/** An unbroken search term has no break opportunity, so it must wrap mid-word to stay in bounds. */
+export const LongUnbrokenTitle: Story = {
+  render: (args) => ({
+    props: args,
+    template: /*html*/ `
+    <div class="tw-border tw-border-solid tw-border-secondary-300" style="width: 380px;">
+      <bit-status-lockup class="tw-text-main">
+        <bit-svg slot="graphic" [content]="svg"></bit-svg>
+        <ng-container slot="title">No items match "WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWO"</ng-container>
+        <button
+            slot="button"
+            type="button"
+            bitButton
+            buttonType="secondary"
+        >
+            <bit-icon name="bwi-plus" />
+            New item
+        </button>
+      </bit-status-lockup>
+    </div>
+    `,
+  }),
+  args: {
+    svg: NoResults,
+  },
+  argTypes: {
+    svg: {
+      options: Object.keys(Svgs),
+      mapping: Svgs,
+      control: { type: "select" },
+    },
+  },
+};


### PR DESCRIPTION
## 🎟️ Tracking

[PM-43363](https://bitwarden.atlassian.net/browse/PM-43363)

## 📔 Objective

A search term containing a long string with no spaces overflowed the "no items match" empty state in the extension popup, running out of bounds instead of wrapping.

Two things had to be wrong together, which is why this only reproduces with an unbroken string:

1. **No cross-axis width cap.** The lockup's inner column is a flex item in a `flex-col` container with `tw-items-center`. With no explicit width, such an item sizes to its *content*, so a 480px-wide unbreakable word made the item 480px inside a 378px popup — stretching past the container rather than being clamped by it.
2. **No wrap rule.** Nothing set `overflow-wrap`, so the long term had no break opportunity even once constrained.

The fix binds the two column wrappers to the container width (`tw-w-full`) and lets the title and description break mid-word (`tw-break-words`). Note that `tw-break-words` alone does **not** fix this — `overflow-wrap: break-word` only breaks a word once the line box is actually constrained, so the width cap was the necessary other half.

The change lives in the shared `bit-status-lockup`, so it also covers the desktop/web empty states and the legacy popup block, not just the reported screen.

### Verification

Measured in Chrome against the new `LongUnbrokenTitle` story at the 380px popup width:

- **Before:** title 480px wide in a 380px container, right edge 50px past the boundary.
- **After:** title 330px, wraps mid-word, fully in bounds.
- **No regressions:** `base` still caps at 600px/16px, `small` at 480px/14px, and the responsive story still shrinks to 334px and switches to small sizing.

Tests: 1693 tests across all `bit-status-lockup` consumers pass; lint, Prettier, and `test:types` clean.

## 📸 Screenshots

|Before|After|
---|---
|<img width="494" height="607" alt="Screenshot 2026-09-11 at 10 41 33 AM" src="https://github.com/user-attachments/assets/6872cfe2-efcd-4207-98a5-fe0b37415b97" />|<img width="490" height="607" alt="Screenshot 2026-09-11 at 10 41 44 AM" src="https://github.com/user-attachments/assets/7279781c-a17b-457e-a960-7d494adde8a1" />



[PM-43363]: https://bitwarden.atlassian.net/browse/PM-43363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ