### PR TITLE
[PM-43451] fix: Rename and separate the no-folder filter option

### DIFF
--- a/apps/browser/src/_locales/en/messages.json
+++ b/apps/browser/src/_locales/en/messages.json
@@ -451,6 +451,9 @@
   "noFolders": {
     "message": "There are no folders to list."
   },
+  "noFoldersFilter": {
+    "message": "No folders"
+  },
   "helpFeedback": {
     "message": "Help & feedback"
   },

--- a/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
+++ b/apps/browser/src/vault/popup/components/vault/vault-popup-list-table/vault-popup-list-table.component.html
@@ -95,6 +95,10 @@
             [count]="optionCount('folder', [option.value.id ?? NO_FOLDER])"
             >{{ option.label }}</bit-filter-option
           >
+          <!-- "No folders" leads the list and stands apart from the real folders. -->
+          @if (!option.value.id) {
+            <bit-filter-option-divider></bit-filter-option-divider>
+          }
         }
       </bit-filter-menu>
     }

--- a/apps/browser/src/vault/popup/services/vault-popup-list-table-filters.service.ts
+++ b/apps/browser/src/vault/popup/services/vault-popup-list-table-filters.service.ts
@@ -344,8 +344,9 @@ export class VaultPopupListTableFiltersService {
           const noFolder = folders.find((f) => !f.id);
 
           if (noFolder) {
-            const updatedNoFolder = { ...noFolder, name: this.i18nService.t("itemsWithNoFolder") };
-            arrangedFolders = [...folders.filter((f) => f.id), updatedNoFolder];
+            const updatedNoFolder = { ...noFolder, name: this.i18nService.t("noFoldersFilter") };
+            // Leads the list, and the menu rules it off from the real folders.
+            arrangedFolders = [updatedNoFolder, ...folders.filter((f) => f.id)];
           }
 
           return [selectedOrgs, arrangedFolders, cipherViews] as const;


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-43451

## 📔 Objective

In the extension's "My folders" filter, the option for items with no folder
membership was mislabeled. It used `itemsWithNoFolder` ("Items with no folder")
instead of the "No folders" copy the design calls for. This adds a dedicated
`noFoldersFilter` string and points the filter at it.

While in here, the same option also sorted in at the end of the real folders with
no separation, so it read as just another folder. The Figma comp places it on its
own, ahead of the folder list. It now leads the list and is ruled off with a
`bit-filter-option-divider` — the popover draws a rule between the groups, and the
dialog starts a new card, matching the comp.

Note the divider is gated on `index > 0` inside `bit-filter-menu`, so a search that
hides the "No folders" row won't leave a rule dangling above the first result.

Scope note: this touches only `VaultPopupListTableFiltersService` (the VFO1 table
filter path). The legacy `VaultPopupListFiltersService` still uses
`itemsWithNoFolder`, so that key is intentionally left in place.

## 📸 Screenshots

|Before|After|
---|---
|<img width="485" height="605" alt="Screenshot 2026-09-11 at 12 24 32 PM" src="https://github.com/user-attachments/assets/91833dab-5bcc-4ea0-abcb-ec524e940465" />|<img width="482" height="599" alt="Screenshot 2026-09-11 at 12 20 57 PM" src="https://github.com/user-attachments/assets/c1eb234f-764e-4ec5-b5c0-e96d652fb921" />|

