### PR TITLE
[PM-41425] fix: apply untrusted iframe check to fill assist targeted fields

### DIFF
--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -2294,6 +2294,26 @@ describe("AutofillService", () => {
 
         expect(autofillService["inUntrustedIframe"]).not.toHaveBeenCalled();
       });
+
+      it("skips the iframe check on the password-generation path", async () => {
+        const newPasswordField = buildTargetedField({
+          opid: "targeted_field_0_newPassword",
+          type: "password",
+          fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+        });
+        const options = createGenerateFillScriptOptionsMock();
+        options.cipher.type = CipherType.Login;
+        options.cipher.login = mock<LoginView>({ password: "generated-pass", uris: [] });
+        options.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+        jest.spyOn(autofillService as any, "inUntrustedIframe");
+
+        await autofillService["generateTargetedFillScript"](
+          buildTargetedPageDetails([newPasswordField]),
+          options,
+        );
+
+        expect(autofillService["inUntrustedIframe"]).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -2256,6 +2256,45 @@ describe("AutofillService", () => {
 
       expect(result).toBeNull();
     });
+
+    describe("cross-origin iframe (VULN-752)", () => {
+      it("flags the fill script when the frame is untrusted", async () => {
+        const usernameField = buildTargetedField({
+          opid: "targeted_field_0_username",
+          fieldQualifier: AutofillTargetingRuleTypes.username,
+          formCategory: FormPurposeCategories.AccountLogin,
+        });
+        const options = createGenerateFillScriptOptionsMock();
+        options.cipher.type = CipherType.Login;
+        options.cipher.login = mock<LoginView>({ username: "victim", uris: [] });
+        jest.spyOn(autofillService as any, "inUntrustedIframe").mockResolvedValueOnce(true);
+
+        const result = await autofillService["generateTargetedFillScript"](
+          buildTargetedPageDetails([usernameField]),
+          options,
+        );
+
+        expect(result?.untrustedIframe).toBe(true);
+      });
+
+      it("skips the iframe check for non-Login ciphers", async () => {
+        const cardholderField = buildTargetedField({
+          opid: "targeted_field_0_cardholderName",
+          fieldQualifier: AutofillTargetingRuleTypes.cardholderName,
+        });
+        const options = createGenerateFillScriptOptionsMock();
+        options.cipher.type = CipherType.Card;
+        options.cipher.card = mock<CardView>({ cardholderName: "M. Moss" });
+        jest.spyOn(autofillService as any, "inUntrustedIframe");
+
+        await autofillService["generateTargetedFillScript"](
+          buildTargetedPageDetails([cardholderField]),
+          options,
+        );
+
+        expect(autofillService["inUntrustedIframe"]).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("generateLoginFillScript", () => {

--- a/apps/browser/src/autofill/services/autofill.service.spec.ts
+++ b/apps/browser/src/autofill/services/autofill.service.spec.ts
@@ -2295,7 +2295,7 @@ describe("AutofillService", () => {
         expect(autofillService["inUntrustedIframe"]).not.toHaveBeenCalled();
       });
 
-      it("skips the iframe check on the password-generation path", async () => {
+      it("skips the iframe check for the transient generated-password cipher", async () => {
         const newPasswordField = buildTargetedField({
           opid: "targeted_field_0_newPassword",
           type: "password",
@@ -2303,6 +2303,7 @@ describe("AutofillService", () => {
         });
         const options = createGenerateFillScriptOptionsMock();
         options.cipher.type = CipherType.Login;
+        options.cipher.id = "";
         options.cipher.login = mock<LoginView>({ password: "generated-pass", uris: [] });
         options.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
         jest.spyOn(autofillService as any, "inUntrustedIframe");
@@ -2313,6 +2314,30 @@ describe("AutofillService", () => {
         );
 
         expect(autofillService["inUntrustedIframe"]).not.toHaveBeenCalled();
+      });
+
+      it("still runs the iframe check when a saved cipher is filled into a targeted newPassword field", async () => {
+        // A saved cipher can be selected while a targeted newPassword field is focused,
+        // producing PasswordGeneration inlineMenuFillType with a real (id-bearing) cipher.
+        const newPasswordField = buildTargetedField({
+          opid: "targeted_field_0_newPassword",
+          type: "password",
+          fieldQualifier: AutofillTargetingRuleTypes.newPassword,
+        });
+        const options = createGenerateFillScriptOptionsMock();
+        options.cipher.type = CipherType.Login;
+        options.cipher.id = "saved-cipher-id";
+        options.cipher.login = mock<LoginView>({ password: "stored-pass", uris: [] });
+        options.inlineMenuFillType = InlineMenuFillTypes.PasswordGeneration;
+        jest.spyOn(autofillService as any, "inUntrustedIframe").mockResolvedValueOnce(true);
+
+        const result = await autofillService["generateTargetedFillScript"](
+          buildTargetedPageDetails([newPasswordField]),
+          options,
+        );
+
+        expect(autofillService["inUntrustedIframe"]).toHaveBeenCalled();
+        expect(result?.untrustedIframe).toBe(true);
       });
     });
   });

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -944,12 +944,17 @@ export default class AutofillService implements AutofillServiceInterface {
         ?.filter((u) => u.match != UriMatchStrategy.Never && u.uri != null)
         .map((u) => u.uri!) ?? [];
 
-    // Note, targeted fields intentionally skip the untrusted iframe check. The
-    // presence of targeting rules represents explicit expectations of the target
+    const isLoginCipher = cipher.type === CipherType.Login;
+
+    // Targeting rules match on the frame's hostname alone and say nothing about
+    // whether this cipher belongs there. Run the same origin check the heuristic
+    // path uses so the confirm prompt still fires on cross-origin frames.
+    if (isLoginCipher) {
+      fillScript.untrustedIframe = await this.inUntrustedIframe(pageDetails.url, options);
+    }
 
     // For a Login cipher, `login.username` fills only the single highest-priority
     // identifier field present in an `account-login` form (see the priority list).
-    const isLoginCipher = cipher.type === CipherType.Login;
     const loginIdentifierQualifier = isLoginCipher
       ? this.resolveLoginIdentifierQualifier(pageDetails)
       : null;

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -946,15 +946,10 @@ export default class AutofillService implements AutofillServiceInterface {
 
     const isLoginCipher = cipher.type === CipherType.Login;
 
-    // Targeting rules match on the frame's hostname alone and say nothing about
-    // whether this cipher belongs there. Run the same origin check the heuristic
-    // path uses so the confirm prompt still fires on cross-origin frames.
-    // The transient cipher from `buildLoginCipherView` (no id, empty URI) is the
-    // only case skipped: nothing stored is at risk, and `matchesUri` would flag
-    // every cross-origin frame with copy referencing a nonexistent saved login.
-    // The guard keys on `cipher.id` rather than `inlineMenuFillType` because a
-    // saved cipher can be selected while a targeted newPassword field is focused,
-    // and that path still needs the check.
+    // Targeting rules vet only the frame's hostname, so run the heuristic path's
+    // origin check. Skip only the transient cipher from `buildLoginCipherView`
+    // (no id, nothing stored at risk). Check `cipher.id`, not `inlineMenuFillType`:
+    // a saved cipher can reach here with `PasswordGeneration` set.
     const isGeneratedPasswordCipher = isPasswordGeneration && !cipher.id;
     if (isLoginCipher && !isGeneratedPasswordCipher) {
       fillScript.untrustedIframe = await this.inUntrustedIframe(pageDetails.url, options);

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -949,10 +949,14 @@ export default class AutofillService implements AutofillServiceInterface {
     // Targeting rules match on the frame's hostname alone and say nothing about
     // whether this cipher belongs there. Run the same origin check the heuristic
     // path uses so the confirm prompt still fires on cross-origin frames.
-    // Password generation is excluded: no stored credential is at risk, and the
-    // transient cipher's empty URI would trigger the prompt on every cross-origin
-    // frame with copy that references a saved login that doesn't exist yet.
-    if (isLoginCipher && !isPasswordGeneration) {
+    // The transient cipher from `buildLoginCipherView` (no id, empty URI) is the
+    // only case skipped: nothing stored is at risk, and `matchesUri` would flag
+    // every cross-origin frame with copy referencing a nonexistent saved login.
+    // The guard keys on `cipher.id` rather than `inlineMenuFillType` because a
+    // saved cipher can be selected while a targeted newPassword field is focused,
+    // and that path still needs the check.
+    const isGeneratedPasswordCipher = isPasswordGeneration && !cipher.id;
+    if (isLoginCipher && !isGeneratedPasswordCipher) {
       fillScript.untrustedIframe = await this.inUntrustedIframe(pageDetails.url, options);
     }
 

--- a/apps/browser/src/autofill/services/autofill.service.ts
+++ b/apps/browser/src/autofill/services/autofill.service.ts
@@ -949,7 +949,10 @@ export default class AutofillService implements AutofillServiceInterface {
     // Targeting rules match on the frame's hostname alone and say nothing about
     // whether this cipher belongs there. Run the same origin check the heuristic
     // path uses so the confirm prompt still fires on cross-origin frames.
-    if (isLoginCipher) {
+    // Password generation is excluded: no stored credential is at risk, and the
+    // transient cipher's empty URI would trigger the prompt on every cross-origin
+    // frame with copy that references a saved login that doesn't exist yet.
+    if (isLoginCipher && !isPasswordGeneration) {
       fillScript.untrustedIframe = await this.inUntrustedIframe(pageDetails.url, options);
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-41425](https://bitwarden.atlassian.net/browse/PM-41425)

Resolves [VULN-752](https://bitwarden.atlassian.net/browse/VULN-752) ([HackerOne #3908934](https://hackerone.com/reports/3908934))

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Background / issue / VULN: `generateTargetedFillScript` never set `untrustedIframe` on the fill script, so the confirm prompt in `insert-autofill-content.service.ts` never fired for the targeted (fill assist) fill path. A fill assist rule matches on the frame's hostname alone and says nothing about whether the selected cipher belongs there — a cross-origin iframe with a targeted hostname could silently receive credentials saved for a different origin.

Fix: run the same origin check `generateLoginFillScript` uses (`inUntrustedIframe`, comparing the frame URL against the cipher's saved URIs) inside `generateTargetedFillScript`. Gated to Login ciphers, mirroring the heuristic path.

## Notes

- **Password generation is intentionally excluded from the check.** The transient cipher wrapping a freshly-generated password has an empty URI, so `matchesUri` returns `false` unconditionally — the prompt would fire on every cross-origin frame with copy that references "your saved login" (which doesn't exist yet). No stored credential is at risk during generation, and sandboxed cross-origin frames would silently no-fill (`confirm()` is blocked in sandboxes). The `!isPasswordGeneration` guard keeps the fix narrowly targeted at the VULN.
- **Non-Login ciphers stay unchecked** in the targeted path, matching heuristic-path behavior. If Product wants cross-origin protection for Card / Identity fills, that's a separate ticket touching both paths.
- **No new i18n strings** — reuses the existing `autofillIframeWarning` / `autofillIframeWarningTip`.

## Scope

VULN-752 proposes a three-part fix. This PR only implements the first one:

- In scope: Set `untrustedIframe` in the targeted path.
- Out of scope: Restrict `doAutoFill`'s fan-out across all frames. 
  - Why omitted? Larger design change; affects the heuristic path equally. With this PR, each fanned-out frame does correctly get its own origin check.
- Out of scope: Fail-closed on omitted `allowUntrustedIframe` in the background gate. 
  - Why omitted? The content-script confirm is the primary defense. The background check is a secondary suppression only used by the auto-submit on page load path.


[PM-41425]: https://bitwarden.atlassian.net/browse/PM-41425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VULN-752]: https://bitwarden.atlassian.net/browse/VULN-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ