### PR TITLE
[PM-41920] Add WiFi network and unknown item type handling to Proton Pass

### DIFF
--- a/libs/importer/src/importers/protonpass/protonpass-json-importer.spec.ts
+++ b/libs/importer/src/importers/protonpass/protonpass-json-importer.spec.ts
@@ -37,7 +37,7 @@ describe("Protonpass Json Importer", () => {
   });
 
   it("should parse login data", async () => {
-    const result = await expectParse(importer, testData, 8);
+    const result = await expectParse(importer, testData, 10);
 
     // The first item in the results is a login
     const cipher = result.ciphers[0];
@@ -59,7 +59,7 @@ describe("Protonpass Json Importer", () => {
   });
 
   it("should parse note data", async () => {
-    const result = await expectParse(importer, testData, 8);
+    const result = await expectParse(importer, testData, 10);
 
     // The second item in the results is a note
     const noteCipher = result.ciphers[1];
@@ -74,7 +74,7 @@ describe("Protonpass Json Importer", () => {
   });
 
   it("should parse credit card data", async () => {
-    const result = await expectParse(importer, testData, 8);
+    const result = await expectParse(importer, testData, 10);
 
     // The third item in the results is a credit card
     const creditCardCipher = result.ciphers[2];
@@ -92,7 +92,7 @@ describe("Protonpass Json Importer", () => {
   });
 
   it("should create folders if not part of an organization", async () => {
-    const result = await expectParse(importer, testData, 8);
+    const result = await expectParse(importer, testData, 10);
 
     const folders = result.folders;
     expect(folders.length).toBe(2);
@@ -102,12 +102,12 @@ describe("Protonpass Json Importer", () => {
     // "My Secure Note" is assigned to folder "Personal"
     expect(result.folderRelationships[1]).toEqual([1, 0]);
     // "Other vault login" is assigned to folder "Test"
-    expect(result.folderRelationships[7]).toEqual([7, 1]);
+    expect(result.folderRelationships[9]).toEqual([9, 1]);
   });
 
   it("should create collections if part of an organization", async () => {
     importer.organizationId = Utils.newGuid() as OrganizationId;
-    const result = await expectParse(importer, testData, 8);
+    const result = await expectParse(importer, testData, 10);
 
     const collections = result.collections;
     expect(collections.length).toBe(2);
@@ -117,22 +117,22 @@ describe("Protonpass Json Importer", () => {
     // "My Secure Note" is assigned to folder "Personal"
     expect(result.collectionRelationships[1]).toEqual([1, 0]);
     // "Other vault login" is assigned to folder "Test"
-    expect(result.collectionRelationships[7]).toEqual([7, 1]);
+    expect(result.collectionRelationships[9]).toEqual([9, 1]);
   });
 
   it("should not add deleted items", async () => {
-    const result = await expectParse(importer, testData, 8);
+    const result = await expectParse(importer, testData, 10);
 
     const ciphers = result.ciphers;
     for (const cipher of ciphers) {
       expect(cipher.name).not.toBe("My Deleted Note");
     }
 
-    expect(ciphers.length).toBe(8);
+    expect(ciphers.length).toBe(10);
   });
 
   it("should set favorites", async () => {
-    const result = await expectParse(importer, testData, 8);
+    const result = await expectParse(importer, testData, 10);
 
     const ciphers = result.ciphers;
     expect(ciphers[0].favorite).toBe(true);
@@ -187,7 +187,7 @@ describe("Protonpass Json Importer", () => {
 
   describe("should parse identity data", () => {
     it("with new item types feature flag OFF", async () => {
-      const result = await expectParse(importer, testData, 8);
+      const result = await expectParse(importer, testData, 10);
 
       // The fourth item in the results (when the feature flag is off) is an identity
       const cipher = result.ciphers[3];
@@ -230,7 +230,7 @@ describe("Protonpass Json Importer", () => {
       configService.getFeatureFlag.mockResolvedValueOnce(true);
       // Since the test data has an identity that includes both a driver's
       // license number and a passport number there are two extra ciphers
-      const result = await expectParse(importer, testData, 10);
+      const result = await expectParse(importer, testData, 12);
 
       const identityCipherFolderRels = result.folderRelationships.filter((rel) => rel[0] === 5);
       expect(identityCipherFolderRels.length).toEqual(1);
@@ -398,5 +398,42 @@ describe("Protonpass Json Importer", () => {
       expect(passportCipher.passport.dateOfBirth).toEqual("2890-09-22");
       expect(passportCipher.passport.issuingAuthority).toEqual("Hobbiton Consulate");
     });
+  });
+
+  it("should parse WiFi network data", async () => {
+    const passwordTranslation = "PASSWORD_TRANSLATED";
+    const securityTranslation = "SECURITY_TRANSLATED";
+    i18nService.t.mockImplementation((k) => {
+      if (k === "password") {
+        return passwordTranslation;
+      } else if (k === "security") {
+        return securityTranslation;
+      }
+      return k;
+    });
+    const result = await expectParse(importer, testData, 10);
+
+    // The eighth item in the results is a WiFi network
+    const wifiCipher = result.ciphers[7];
+    expect(wifiCipher.type).toEqual(CipherType.SecureNote);
+    assertCustomFieldsStructure(wifiCipher.fields, [
+      [passwordTranslation, "SECRETSECRETSECRET", FieldType.Hidden],
+      ["SSID", "Test Network", FieldType.Text],
+      [securityTranslation, "WPA3", FieldType.Text],
+      ["Custom Field", "Custom Field Value", FieldType.Text],
+    ]);
+  });
+
+  it("should parse data for a new item type with no explicit handling", async () => {
+    const result = await expectParse(importer, testData, 10);
+
+    // The ninth item in the results is of a type that we have no handling for
+    const unknownTypeCipher = result.ciphers[8];
+    expect(unknownTypeCipher.type).toEqual(CipherType.SecureNote);
+    assertCustomFieldsStructure(unknownTypeCipher.fields, [
+      ["newNumberProperty", "1", FieldType.Text],
+      ["newStringProperty", "test", FieldType.Text],
+      ["Custom Field", "Custom Field Value", FieldType.Text],
+    ]);
   });
 });

--- a/libs/importer/src/importers/protonpass/protonpass-json-importer.ts
+++ b/libs/importer/src/importers/protonpass/protonpass-json-importer.ts
@@ -27,13 +27,15 @@ import {
   ProtonPassCreditCardItemContent,
   ProtonPassCustomItemContent,
   ProtonPassIdentityItemContent,
-  ProtonPassIdentityItemExtraSection,
+  ProtonPassItemDataSection,
   ProtonPassItem,
   ProtonPassItemExtraField,
   ProtonPassItemState,
   ProtonPassJsonFile,
   ProtonPassLoginItemContent,
   ProtonPassSshKeyItemContent,
+  ProtonPassWifiItemContent,
+  ProtonPassWifiSecurityType,
 } from "./types/protonpass-json-type";
 
 export class ProtonPassJsonImporter extends BaseImporter implements Importer {
@@ -111,7 +113,7 @@ export class ProtonPassJsonImporter extends BaseImporter implements Importer {
         } else {
           const extraSections = identityItem[
             key as keyof ProtonPassIdentityItemContent
-          ] as ProtonPassIdentityItemExtraSection[];
+          ] as ProtonPassItemDataSection[];
 
           extraSections?.forEach((extraSection) => {
             this.processExtraFields(cipher, extraSection.sectionFields);
@@ -121,14 +123,14 @@ export class ProtonPassJsonImporter extends BaseImporter implements Importer {
     });
   }
 
-  private processSections(cipher: CipherView, sections: ProtonPassIdentityItemExtraSection[]) {
-    sections?.forEach((section) => {
+  private processSections(cipher: CipherView, sections: ProtonPassItemDataSection[] = []) {
+    sections.forEach((section) => {
       section.sectionFields?.forEach((field) => {
         this.processKvp(
           cipher,
           field.fieldName,
           this.getExtraFieldValue(field),
-          field.type === "hidden" ? FieldType.Hidden : FieldType.Text,
+          this.getExtraFieldType(field),
         );
       });
     });
@@ -204,7 +206,6 @@ export class ProtonPassJsonImporter extends BaseImporter implements Importer {
             if (!this.isNullOrWhitespace(creditCardContent.pin)) {
               this.processKvp(cipher, "PIN", creditCardContent.pin, FieldType.Hidden);
             }
-
             this.processExtraFields(cipher, item.data.extraFields);
             break;
           }
@@ -276,7 +277,6 @@ export class ProtonPassJsonImporter extends BaseImporter implements Importer {
             // An alias is an email-forwarding address; map it to a login with the
             // alias address as the username so the item (and its data) is preserved.
             cipher.login.username = this.getValueOrDefault(item.aliasEmail);
-            this.processExtraFields(cipher, item.data.extraFields);
             break;
           }
           case "sshKey": {
@@ -316,8 +316,35 @@ export class ProtonPassJsonImporter extends BaseImporter implements Importer {
             }
             break;
           }
-          default:
-            continue;
+          case "wifi": {
+            cipher.type = CipherType.SecureNote;
+            const wifiContent = item.data.content as ProtonPassWifiItemContent;
+            this.processWifiFields(cipher, wifiContent);
+            this.processExtraFields(cipher, item.data.extraFields);
+            this.processSections(cipher, wifiContent.sections);
+            break;
+          }
+          default: {
+            cipher.type = CipherType.SecureNote;
+            this.processExtraFields(cipher, item.data.extraFields);
+            const otherContent = item.data.content as any;
+            for (const [key, value] of Object.entries(otherContent)) {
+              if (key === "sections") {
+                this.processSections(cipher, otherContent.sections);
+              } else {
+                if (typeof value === "string") {
+                  this.processKvp(cipher, key, value);
+                } else if (typeof value === "number") {
+                  this.processKvp(cipher, key, value.toString());
+                } else {
+                  // We do basic handling of new string and number fields, but anything
+                  // more complicated should be added to this importer explicitly
+                  continue;
+                }
+              }
+            }
+            break;
+          }
         }
 
         this.processFolder(result, vault.name);
@@ -426,6 +453,38 @@ export class ProtonPassJsonImporter extends BaseImporter implements Importer {
       } else {
         this.processKvp(cipher, field.fieldName, fieldValue, this.getExtraFieldType(field));
       }
+    }
+  }
+
+  private processWifiFields(cipher: CipherView, itemContent: ProtonPassWifiItemContent) {
+    if (itemContent.password) {
+      this.processKvp(
+        cipher,
+        this.i18nService.t("password"),
+        itemContent.password,
+        FieldType.Hidden,
+      );
+    }
+    if (itemContent.ssid) {
+      this.processKvp(cipher, "SSID", itemContent.ssid, FieldType.Text);
+    }
+    if (itemContent.security != null) {
+      let securityString = this.i18nService.t("unknown");
+      switch (itemContent.security) {
+        case ProtonPassWifiSecurityType.WPA:
+          securityString = "WPA";
+          break;
+        case ProtonPassWifiSecurityType.WPA2:
+          securityString = "WPA2";
+          break;
+        case ProtonPassWifiSecurityType.WPA3:
+          securityString = "WPA3";
+          break;
+        case ProtonPassWifiSecurityType.WEP:
+          securityString = "WEP";
+          break;
+      }
+      this.processKvp(cipher, this.i18nService.t("security"), securityString, FieldType.Text);
     }
   }
 }

--- a/libs/importer/src/importers/protonpass/types/protonpass-json-type.ts
+++ b/libs/importer/src/importers/protonpass/types/protonpass-json-type.ts
@@ -25,6 +25,8 @@ export type ProtonPassItem = {
   createTime: number;
   modifyTime: number;
   pinned: boolean;
+  shareCount?: number;
+  files?: unknown[];
 };
 
 /**
@@ -45,13 +47,14 @@ export type ProtonPassItemData = {
   metadata: ProtonPassItemMetadata;
   extraFields: ProtonPassItemExtraField[];
   platformSpecific?: any;
-  type: "login" | "alias" | "creditCard" | "note" | "identity" | "custom" | "sshKey";
+  type: "login" | "alias" | "creditCard" | "note" | "identity" | "custom" | "sshKey" | "wifi";
   content:
     | ProtonPassLoginItemContent
     | ProtonPassCreditCardItemContent
     | ProtonPassIdentityItemContent
     | ProtonPassCustomItemContent
-    | ProtonPassSshKeyItemContent;
+    | ProtonPassSshKeyItemContent
+    | ProtonPassWifiItemContent;
 };
 
 export type ProtonPassItemMetadata = {
@@ -107,21 +110,38 @@ export type ProtonPassCreditCardItemContent = {
   pin?: string;
 };
 
-export type ProtonPassIdentityItemExtraSection = {
+export type ProtonPassItemDataSection = {
   sectionName?: string;
   sectionFields?: ProtonPassItemExtraField[];
 };
 
 export type ProtonPassCustomItemContent = {
-  sections?: ProtonPassIdentityItemExtraSection[];
+  sections?: ProtonPassItemDataSection[];
 };
 
 export type ProtonPassSshKeyItemContent = {
   privateKey?: string;
   publicKey?: string;
   fingerprint?: string;
-  sections?: ProtonPassIdentityItemExtraSection[];
+  sections?: ProtonPassItemDataSection[];
 };
+
+export type ProtonPassWifiItemContent = {
+  ssid?: string;
+  password?: string;
+  security?: ProtonPassWifiSecurityType;
+  sections?: ProtonPassItemDataSection[];
+};
+
+export const ProtonPassWifiSecurityType = Object.freeze({
+  UNSPECIFIED: 0,
+  WPA: 1,
+  WPA2: 2,
+  WPA3: 3,
+  WEP: 4,
+} as const);
+export type ProtonPassWifiSecurityType =
+  (typeof ProtonPassWifiSecurityType)[keyof typeof ProtonPassWifiSecurityType];
 
 export type ProtonPassIdentityItemContent = {
   fullName?: string;
@@ -160,5 +180,5 @@ export type ProtonPassIdentityItemContent = {
   workPhoneNumber?: string;
   workEmail?: string;
   extraWorkDetails?: ProtonPassItemExtraField[];
-  extraSections?: ProtonPassIdentityItemExtraSection[];
+  extraSections?: ProtonPassItemDataSection[];
 };

--- a/libs/importer/src/importers/spec-data/protonpass-json/protonpass.json.ts
+++ b/libs/importer/src/importers/spec-data/protonpass-json/protonpass.json.ts
@@ -391,6 +391,93 @@ export const testData: ProtonPassJsonFile = {
           modifyTime: 1777041700,
           pinned: false,
         },
+        {
+          itemId: "REDACTED_WIFI_NETWORK_ITEM_ID",
+          shareId:
+            "SN5uWo4WZF2uT5wIDqtbdpkjuxCbNTOIdf-JQ_DYZcKYKURHiZB5csS1a1p9lklvju9ni42l08IKzwQG0B2ySg==",
+          data: {
+            metadata: {
+              name: "Test WiFi Network (WPA3)",
+              note: "",
+              itemUuid: "309a1451",
+            },
+            extraFields: [],
+            type: "wifi",
+            content: {
+              ssid: "Test Network",
+              password: "SECRETSECRETSECRET",
+              security: 3,
+              sections: [
+                {
+                  sectionName: "Custom Section",
+                  sectionFields: [
+                    {
+                      fieldName: "Custom Field",
+                      type: "text",
+                      data: {
+                        content: "Custom Field Value",
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          state: 1,
+          aliasEmail: null,
+          contentFormatVersion: 8,
+          createTime: 1788191504,
+          modifyTime: 1788879440,
+          pinned: false,
+          shareCount: 0,
+          files: [],
+        },
+        {
+          itemId: "REDACTED_UNKNOWN_TYPE_ITEM_ID",
+          shareId:
+            "SN5uWo4WZF2uT5wIDqtbdpkjuxCbNTOIdf-JQ_DYZcKYKURHiZB5csS1a1p9lklvju9ni42l08IKzwQG0B2ySg==",
+          data: {
+            metadata: {
+              name: "Test Item",
+              note: "",
+              itemUuid: "00000009",
+            },
+            extraFields: [],
+            // Test the handling of some new type from Proton Pass that we don't support explicitly yet
+            type: "UNKNOWN_TYPE" as any,
+            content: {
+              newNumberProperty: 1,
+              newStringProperty: "test",
+              // This field will be ignored by the importer since it's more complicated than a single string or number
+              newObjectProperty: {
+                foo: "bar",
+              },
+              // Sections' general format is known, so this *will* be parsed by the importer
+              sections: [
+                {
+                  sectionName: "Custom Section",
+                  sectionFields: [
+                    {
+                      fieldName: "Custom Field",
+                      type: "text",
+                      data: {
+                        content: "Custom Field Value",
+                      },
+                    },
+                  ],
+                },
+              ],
+            } as any,
+          },
+          state: 1,
+          aliasEmail: null,
+          contentFormatVersion: 8,
+          createTime: 1788191504,
+          modifyTime: 1788879440,
+          pinned: false,
+          shareCount: 0,
+          files: [],
+        },
       ],
     },
     REDACTED_VAULT_ID_B: {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41920

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds specific handling for the "WiFi Network" type that can be exported from Proton Pass. It also adds fallback handling for unknown types, which will be imported as Secure Notes. Any extra fields or section fields will be imported to our cipher's custom fields, and we'll try our best to add fields that are specific to the new type (e.g. "SSID" for WiFi networks) to custom fields as well. Currently this handling only applies to strings and numbers; anything more complicated is ignored because it should likely have specific handling added to the importer.