### PR TITLE
[PM-43469] Add favicon to browser extension popout

### DIFF
--- a/apps/browser/src/popup/index.ejs
+++ b/apps/browser/src/popup/index.ejs
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Bitwarden</title>
+    <link rel="icon" href="/images/icon128.png">
     <base href="" />
   </head>
   <body>


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

When opening the extension's url in a normal browser tab, there is no favicon. By adding a favicon, it means that it's a lot clearer what tab is Bitwarden

## 📸 Screenshots

N/A